### PR TITLE
build downstream deps in CI

### DIFF
--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -1,0 +1,112 @@
+name: Build Downstream Dependencies
+
+on:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+jobs:
+  cedar-drt:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo fmt --all --check
+      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+      - name: Checkout cedar-spec
+        uses: actions/checkout@v3
+        with:
+          repository: cedar-policy/cedar-spec
+          ref: main
+          path: ./cedar-spec
+          ssh-key: ${{ secrets.CEDARSPEC }}
+      - name: copy cedar to cedar-spec/cedar
+        working-directory: cedar-spec
+        run: cp -r ../cedar ./cedar
+      - name: build cedar-drt
+        working-directory: cedar-spec/cedar-drt
+        run: |
+              RUSTFLAGS="-D warnings" cargo build
+              cargo test
+      - name: build cedar-drt/fuzz
+        working-directory: cedar-spec/cedar-drt/fuzz
+        run: |
+              RUSTFLAGS="--cfg=fuzzing -D warnings" cargo build
+              cargo test
+
+  cedar-java:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo fmt --all --check
+      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+      - name: Checkout cedar-java
+        uses: actions/checkout@v3
+        with:
+          repository: cedar-policy/cedar-java
+          ref: main
+          path: ./cedar-java
+          ssh-key: ${{ secrets.CEDARJAVA }}
+      - name: copy cedar to cedar-java/cedar
+        working-directory: cedar-java
+        run: cp -r ../cedar ./cedar
+      - name: build cedar-java/CedarJavaFFI
+        working-directory: cedar-spec/cedar-java/CedarJavaFFI
+        run: RUSTFLAGS="-D warnings" cargo build
+      - name: build cedar-java/CedarJava
+        working-directory: cedar-spec/cedar-java/CedarJava
+        run: ./gradlew build
+      
+
+  cedar-examples:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+      - name: Checkout cedar-examples
+        uses: actions/checkout@v3
+        with:
+          repository: cedar-policy/cedar-examples
+          ref: main
+          path: ./cedar-examples
+          ssh-key: ${{ secrets.CEDAREXAMPLES }}
+      - name: copy cedar to cedar-examples/cedar
+        working-directory: cedar-examples
+        run: cp -r ../cedar ./cedar
+      - name: build rust-hello-world
+        working-directory: cedar-examples/cedar-rust-hello-world
+        run: |
+             printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
+             cargo build
+             cargo test
+      - name: build github-model-app
+        working-directory: cedar-examples/cedar-github-model-app
+        run: |
+             printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
+             cargo build
+             cargo test
+      - name: build tinytodo
+        working-directory: cedar-examples/tinytodo
+        run: |
+             printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
+             cargo build
+             cargo test
+      
+      


### PR DESCRIPTION
Build downstream dependencies in CI. We want to be aware of any breaking changes, but we can't always block them because we can't make atomic changes to `cedar-spec` and `cedar`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
