### PR TITLE
Merge Cargo.toml change from release/2.0.x into main (#53)

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -2,8 +2,9 @@
 name = "cedar-policy-cli"
 edition = "2021"
 
-version = "2.0.2"
+version = "2.0.3"
 license-file = "../LICENSE"
+license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "CLI interface for the Cedar Policy language."
 keywords = ["cedar", "authorization", "policy", "security"]

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -3,8 +3,9 @@ name = "cedar-policy-core"
 edition = "2021"
 build = "build.rs"
 
-version = "2.0.2"
+version = "2.0.3"
 license-file = "../LICENSE"
+license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Core implemenation of the Cedar Policy language."
 keywords = ["cedar", "authorization", "policy", "security"]

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "cedar-policy-formatter"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 license-file = "../LICENSE"
+license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Policy formatter for the Cedar Policy Language."
 keywords = ["cedar", "authorization", "policy", "security"]

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -2,8 +2,9 @@
 name = "cedar-policy-validator"
 edition = "2021"
 
-version = "2.0.1"
+version = "2.0.2"
 license-file = "../LICENSE"
+license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Validator for the Cedar Policy language."
 keywords = ["cedar", "authorization", "policy", "security"]

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -2,8 +2,9 @@
 name = "cedar-policy"
 edition = "2021"
 
-version = "2.0.2"
+version = "2.0.3"
 license-file = "../LICENSE"
+license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Cedar is a language for defining permissions as policies, which describe who should have access to what."
 keywords = ["cedar", "authorization", "policy", "security"]


### PR DESCRIPTION
The change to `Cargo.toml` made in the last PR was made on `release/2.0.x` since that's what needed to go to crates.io as a patch. This PR merges the change into main.