### PR TITLE
Removed `license-file` from cargo toml

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -3,7 +3,6 @@ name = "cedar-policy-cli"
 edition = "2021"
 
 version = "2.0.3"
-license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "CLI interface for the Cedar Policy language."

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -4,7 +4,6 @@ edition = "2021"
 build = "build.rs"
 
 version = "2.0.3"
-license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Core implemenation of the Cedar Policy language."

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -2,7 +2,6 @@
 name = "cedar-policy-formatter"
 version = "2.0.2"
 edition = "2021"
-license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Policy formatter for the Cedar Policy Language."

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -3,7 +3,6 @@ name = "cedar-policy-validator"
 edition = "2021"
 
 version = "2.0.2"
-license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Validator for the Cedar Policy language."

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -3,7 +3,6 @@ name = "cedar-policy"
 edition = "2021"
 
 version = "2.0.3"
-license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Cedar is a language for defining permissions as policies, which describe who should have access to what."


### PR DESCRIPTION
Fixes cargo warning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
