### PR TITLE
Removed `ExtensionFunctionOp`

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -158,9 +158,7 @@ impl ExtensionFunction {
                     func()
                 } else {
                     Err(evaluator::EvaluationError::WrongNumArguments {
-                        op: ExtensionFunctionOp {
-                            function_name: name.clone(),
-                        },
+                        function_name: name.clone(),
                         expected: 0,
                         actual: args.len(),
                     })
@@ -185,11 +183,8 @@ impl ExtensionFunction {
                 if args.len() == 1 {
                     func(args[0].clone())
                 } else {
-                    let op = ExtensionFunctionOp {
-                        function_name: name.clone(),
-                    };
                     Err(evaluator::EvaluationError::WrongNumArguments {
-                        op,
+                        function_name: name.clone(),
                         expected: 1,
                         actual: args.len(),
                     })
@@ -215,11 +210,8 @@ impl ExtensionFunction {
                 if args.len() == 1 {
                     func(args[0].clone())
                 } else {
-                    let op = ExtensionFunctionOp {
-                        function_name: name.clone(),
-                    };
                     Err(evaluator::EvaluationError::WrongNumArguments {
-                        op,
+                        function_name: name.clone(),
                         expected: 1,
                         actual: args.len(),
                     })
@@ -248,9 +240,7 @@ impl ExtensionFunction {
                     func(args[0].clone(), args[1].clone())
                 } else {
                     Err(evaluator::EvaluationError::WrongNumArguments {
-                        op: ExtensionFunctionOp {
-                            function_name: name.clone(),
-                        },
+                        function_name: name.clone(),
                         expected: 2,
                         actual: args.len(),
                     })
@@ -282,9 +272,7 @@ impl ExtensionFunction {
                     func(args[0].clone(), args[1].clone(), args[2].clone())
                 } else {
                     Err(evaluator::EvaluationError::WrongNumArguments {
-                        op: ExtensionFunctionOp {
-                            function_name: name.clone(),
-                        },
+                        function_name: name.clone(),
                         expected: 3,
                         actual: args.len(),
                     })
@@ -374,7 +362,7 @@ impl<V: ExtensionValue> StaticallyTyped for V {
 pub struct ExtensionValueWithArgs {
     value: Arc<dyn InternalExtensionValue>,
     args: Vec<Expr>,
-    constructor: ExtensionFunctionOp,
+    constructor: Name,
 }
 
 impl ExtensionValueWithArgs {
@@ -389,11 +377,7 @@ impl ExtensionValueWithArgs {
     }
 
     /// Constructor
-    pub fn new(
-        value: Arc<dyn InternalExtensionValue>,
-        args: Vec<Expr>,
-        constructor: ExtensionFunctionOp,
-    ) -> Self {
+    pub fn new(value: Arc<dyn InternalExtensionValue>, args: Vec<Expr>, constructor: Name) -> Self {
         Self {
             value,
             args,
@@ -404,7 +388,7 @@ impl ExtensionValueWithArgs {
 
 impl From<ExtensionValueWithArgs> for Expr {
     fn from(val: ExtensionValueWithArgs) -> Self {
-        ExprBuilder::new().call_extension_fn(val.constructor.function_name, val.args)
+        ExprBuilder::new().call_extension_fn(val.constructor, val.args)
     }
 }
 

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::ast::{CallStyle, Name};
+use crate::ast::CallStyle;
 use serde::{Deserialize, Serialize};
 
 /// Built-in operators with exactly one argument
@@ -86,14 +86,6 @@ pub enum BinaryOp {
     ContainsAny,
 }
 
-/// Extension functions
-/// Clone is O(1).
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash)]
-pub struct ExtensionFunctionOp {
-    /// Name of the function being called
-    pub function_name: Name,
-}
-
 impl std::fmt::Display for UnaryOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -116,12 +108,6 @@ impl std::fmt::Display for BinaryOp {
             BinaryOp::ContainsAll => write!(f, "containsAll"),
             BinaryOp::ContainsAny => write!(f, "containsAny"),
         }
-    }
-}
-
-impl std::fmt::Display for ExtensionFunctionOp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.function_name)
     }
 }
 

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -205,16 +205,13 @@ impl JSONValue {
     pub fn from_expr(expr: BorrowedRestrictedExpr<'_>) -> Result<Self, JsonSerializationError> {
         match expr.as_ref().expr_kind() {
             ExprKind::Lit(lit) => Ok(Self::from_lit(lit.clone())),
-            ExprKind::ExtensionFunctionApp {
-                function_name,
-                args,
-            } => match args.len() {
+            ExprKind::ExtensionFunctionApp { fn_name, args } => match args.len() {
                 0 => Err(JsonSerializationError::ExtnCall0Arguments {
-                    func: function_name.clone(),
+                    func: fn_name.clone(),
                 }),
                 1 => Ok(Self::ExtnEscape {
                     __extn: FnAndArg {
-                        ext_fn: function_name.to_string().into(),
+                        ext_fn: fn_name.to_string().into(),
                         arg: Box::new(JSONValue::from_expr(
                             BorrowedRestrictedExpr::new_unchecked(
                                 // assuming the invariant holds for `expr`, it must also hold here
@@ -224,7 +221,7 @@ impl JSONValue {
                     },
                 }),
                 _ => Err(JsonSerializationError::ExtnCall2OrMoreArguments {
-                    func: function_name.clone(),
+                    func: fn_name.clone(),
                 }),
             },
             ExprKind::Set(exprs) => Ok(Self::Set(
@@ -538,8 +535,8 @@ impl<'e> ValueParser<'e> {
                     }).collect::<Result<HashMap<_,_>, JsonDeserializationError>>()?
                 }})
             }
-            ExprKind::ExtensionFunctionApp { function_name, .. } => {
-                let efunc = self.extensions.func(function_name)?;
+            ExprKind::ExtensionFunctionApp { fn_name, .. } => {
+                let efunc = self.extensions.func(fn_name)?;
                 Ok(efunc.return_type().cloned().ok_or_else(|| ExtensionsError::HasNoType {
                     name: efunc.name().clone()
                 })?)

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -205,13 +205,16 @@ impl JSONValue {
     pub fn from_expr(expr: BorrowedRestrictedExpr<'_>) -> Result<Self, JsonSerializationError> {
         match expr.as_ref().expr_kind() {
             ExprKind::Lit(lit) => Ok(Self::from_lit(lit.clone())),
-            ExprKind::ExtensionFunctionApp { op, args } => match args.len() {
+            ExprKind::ExtensionFunctionApp {
+                function_name,
+                args,
+            } => match args.len() {
                 0 => Err(JsonSerializationError::ExtnCall0Arguments {
-                    func: op.function_name.clone(),
+                    func: function_name.clone(),
                 }),
                 1 => Ok(Self::ExtnEscape {
                     __extn: FnAndArg {
-                        ext_fn: op.function_name.to_string().into(),
+                        ext_fn: function_name.to_string().into(),
                         arg: Box::new(JSONValue::from_expr(
                             BorrowedRestrictedExpr::new_unchecked(
                                 // assuming the invariant holds for `expr`, it must also hold here
@@ -221,7 +224,7 @@ impl JSONValue {
                     },
                 }),
                 _ => Err(JsonSerializationError::ExtnCall2OrMoreArguments {
-                    func: op.function_name.clone(),
+                    func: function_name.clone(),
                 }),
             },
             ExprKind::Set(exprs) => Ok(Self::Set(
@@ -535,8 +538,8 @@ impl<'e> ValueParser<'e> {
                     }).collect::<Result<HashMap<_,_>, JsonDeserializationError>>()?
                 }})
             }
-            ExprKind::ExtensionFunctionApp { op, .. } => {
-                let efunc = self.extensions.func(&op.function_name)?;
+            ExprKind::ExtensionFunctionApp { function_name, .. } => {
+                let efunc = self.extensions.func(function_name)?;
                 Ok(efunc.return_type().cloned().ok_or_else(|| ExtensionsError::HasNoType {
                     name: efunc.name().clone()
                 })?)

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -664,12 +664,9 @@ impl From<ast::Expr> for Expr {
                 unwrap_or_clone(arg).into(),
                 Expr::lit(JSONValue::Long(constant)),
             ),
-            ast::ExprKind::ExtensionFunctionApp {
-                function_name,
-                args,
-            } => {
+            ast::ExprKind::ExtensionFunctionApp { fn_name, args } => {
                 let args = unwrap_or_clone(args).into_iter().map(Into::into).collect();
-                Expr::ext_call(function_name.to_string().into(), args)
+                Expr::ext_call(fn_name.to_string().into(), args)
             }
             ast::ExprKind::GetAttr { expr, attr } => {
                 Expr::get_attr(unwrap_or_clone(expr).into(), attr)

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -665,7 +665,7 @@ impl From<ast::Expr> for Expr {
                 Expr::lit(JSONValue::Long(constant)),
             ),
             ast::ExprKind::ExtensionFunctionApp {
-                op: ast::ExtensionFunctionOp { function_name },
+                function_name,
                 args,
             } => {
                 let args = unwrap_or_clone(args).into_iter().map(Into::into).collect();

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -111,7 +111,7 @@ impl<'e> RestrictedEvaluator<'e> {
                     Either::Right(residuals) => Ok(Expr::record(names.into_iter().zip(residuals)).into()),
                 }
             }
-            ExprKind::ExtensionFunctionApp { function_name, args } => {
+            ExprKind::ExtensionFunctionApp { fn_name, args } => {
                 let args = args
                     .iter()
                     .map(|arg| self.partial_interpret(BorrowedRestrictedExpr::new_unchecked(arg))) // assuming the invariant holds for `e`, it will hold here
@@ -119,10 +119,10 @@ impl<'e> RestrictedEvaluator<'e> {
                 match split(args) {
                     Either::Left(values) => {
                         let values : Vec<_> = values.collect();
-                        let efunc = self.extensions.func(function_name)?;
+                        let efunc = self.extensions.func(fn_name)?;
                         efunc.call(&values)
                     },
-                    Either::Right(residuals) => Ok(Expr::call_extension_fn(function_name.clone(), residuals.collect()).into()),
+                    Either::Right(residuals) => Ok(Expr::call_extension_fn(fn_name.clone(), residuals.collect()).into()),
                 }
             },
             expr => panic!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
@@ -511,10 +511,7 @@ impl<'q, 'e> Evaluator<'e> {
                 }
                 PartialValue::Residual(r) => Ok(PartialValue::Residual(Expr::mul(r, *constant))),
             },
-            ExprKind::ExtensionFunctionApp {
-                function_name,
-                args,
-            } => {
+            ExprKind::ExtensionFunctionApp { fn_name, args } => {
                 let args = args
                     .iter()
                     .map(|arg| self.partial_interpret(arg, slots))
@@ -522,11 +519,11 @@ impl<'q, 'e> Evaluator<'e> {
                 match split(args) {
                     Either::Left(vals) => {
                         let vals: Vec<_> = vals.collect();
-                        let efunc = self.extensions.func(function_name)?;
+                        let efunc = self.extensions.func(fn_name)?;
                         efunc.call(&vals)
                     }
                     Either::Right(residuals) => Ok(PartialValue::Residual(
-                        Expr::call_extension_fn(function_name.clone(), residuals.collect()),
+                        Expr::call_extension_fn(fn_name.clone(), residuals.collect()),
                     )),
                 }
             }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -111,7 +111,7 @@ impl<'e> RestrictedEvaluator<'e> {
                     Either::Right(residuals) => Ok(Expr::record(names.into_iter().zip(residuals)).into()),
                 }
             }
-            ExprKind::ExtensionFunctionApp { op, args } => {
+            ExprKind::ExtensionFunctionApp { function_name, args } => {
                 let args = args
                     .iter()
                     .map(|arg| self.partial_interpret(BorrowedRestrictedExpr::new_unchecked(arg))) // assuming the invariant holds for `e`, it will hold here
@@ -119,10 +119,10 @@ impl<'e> RestrictedEvaluator<'e> {
                 match split(args) {
                     Either::Left(values) => {
                         let values : Vec<_> = values.collect();
-                        let efunc = self.extensions.func(&op.function_name)?;
+                        let efunc = self.extensions.func(function_name)?;
                         efunc.call(&values)
                     },
-                    Either::Right(residuals) => Ok(Expr::call_extension_fn(op.function_name.clone(), residuals.collect()).into()),
+                    Either::Right(residuals) => Ok(Expr::call_extension_fn(function_name.clone(), residuals.collect()).into()),
                 }
             },
             expr => panic!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
@@ -511,7 +511,10 @@ impl<'q, 'e> Evaluator<'e> {
                 }
                 PartialValue::Residual(r) => Ok(PartialValue::Residual(Expr::mul(r, *constant))),
             },
-            ExprKind::ExtensionFunctionApp { op, args } => {
+            ExprKind::ExtensionFunctionApp {
+                function_name,
+                args,
+            } => {
                 let args = args
                     .iter()
                     .map(|arg| self.partial_interpret(arg, slots))
@@ -519,11 +522,11 @@ impl<'q, 'e> Evaluator<'e> {
                 match split(args) {
                     Either::Left(vals) => {
                         let vals: Vec<_> = vals.collect();
-                        let efunc = self.extensions.func(&op.function_name)?;
+                        let efunc = self.extensions.func(function_name)?;
                         efunc.call(&vals)
                     }
                     Either::Right(residuals) => Ok(PartialValue::Residual(
-                        Expr::call_extension_fn(op.function_name.clone(), residuals.collect()),
+                        Expr::call_extension_fn(function_name.clone(), residuals.collect()),
                     )),
                 }
             }

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -63,10 +63,10 @@ pub enum EvaluationError {
     },
 
     /// Wrong number of arguments to an extension function
-    #[error("wrong number of arguments to {op}: expected {expected}, got {actual}")]
+    #[error("wrong number of arguments to {function_name}: expected {expected}, got {actual}")]
     WrongNumArguments {
         /// arguments to this function
-        op: ExtensionFunctionOp,
+        function_name: Name,
         /// expected number of arguments
         expected: usize,
         /// actual number of arguments

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -19,8 +19,8 @@
 use regex::Regex;
 
 use crate::ast::{
-    CallStyle, Extension, ExtensionFunction, ExtensionFunctionOp, ExtensionOutputValue,
-    ExtensionValue, ExtensionValueWithArgs, Name, StaticallyTyped, Type, Value,
+    CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, ExtensionValue,
+    ExtensionValueWithArgs, Name, StaticallyTyped, Type, Value,
 };
 use crate::entities::SchemaType;
 use crate::evaluator;
@@ -161,10 +161,8 @@ lazy_static::lazy_static! {
 fn decimal_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
     let decimal = Decimal::from_str(str.as_str()).map_err(|e| extension_err(e.to_string()))?;
-    let op = ExtensionFunctionOp {
-        function_name: DECIMAL_FROM_STR_NAME.clone(),
-    };
-    let e = ExtensionValueWithArgs::new(Arc::new(decimal), vec![arg.into()], op);
+    let function_name = DECIMAL_FROM_STR_NAME.clone();
+    let e = ExtensionValueWithArgs::new(Arc::new(decimal), vec![arg.into()], function_name);
     Ok(Value::ExtensionValue(Arc::new(e)).into())
 }
 

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -17,8 +17,8 @@
 //! This module contains the Cedar 'ipaddr' extension.
 
 use crate::ast::{
-    CallStyle, Extension, ExtensionFunction, ExtensionFunctionOp, ExtensionOutputValue,
-    ExtensionValue, ExtensionValueWithArgs, Name, StaticallyTyped, Type, Value,
+    CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, ExtensionValue,
+    ExtensionValueWithArgs, Name, StaticallyTyped, Type, Value,
 };
 use crate::entities::SchemaType;
 use crate::evaluator;
@@ -164,13 +164,11 @@ fn str_contains_colons_and_dots(s: &str) -> Result<(), String> {
 /// Cedar string
 fn ip_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
-    let op = ExtensionFunctionOp {
-        function_name: IP_FROM_STR_NAME.clone(),
-    };
+    let function_name = IP_FROM_STR_NAME.clone();
     let ipaddr = ExtensionValueWithArgs::new(
         Arc::new(IPAddr::from_str(str.as_str()).map_err(extension_err)?),
         vec![arg.into()],
-        op,
+        function_name,
     );
     Ok(Value::ExtensionValue(Arc::new(ipaddr)).into())
 }

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -59,7 +59,9 @@ pub(super) fn expr_text(e: &'_ Expr) -> impl Iterator<Item = TextKind<'_>> {
 fn text_in_expr(e: &'_ Expr) -> impl IntoIterator<Item = TextKind<'_>> {
     match e.expr_kind() {
         ExprKind::Lit(l) => text_in_lit(l).into_iter().collect(),
-        ExprKind::ExtensionFunctionApp { op, .. } => text_in_name(&op.function_name).collect(),
+        ExprKind::ExtensionFunctionApp { function_name, .. } => {
+            text_in_name(function_name).collect()
+        }
         ExprKind::GetAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::HasAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::Like { pattern, .. } => vec![TextKind::Pattern(pattern.get_elems())],

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -59,9 +59,7 @@ pub(super) fn expr_text(e: &'_ Expr) -> impl Iterator<Item = TextKind<'_>> {
 fn text_in_expr(e: &'_ Expr) -> impl IntoIterator<Item = TextKind<'_>> {
     match e.expr_kind() {
         ExprKind::Lit(l) => text_in_lit(l).into_iter().collect(),
-        ExprKind::ExtensionFunctionApp { function_name, .. } => {
-            text_in_name(function_name).collect()
-        }
+        ExprKind::ExtensionFunctionApp { fn_name, .. } => text_in_name(fn_name).collect(),
         ExprKind::GetAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::HasAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::Like { pattern, .. } => vec![TextKind::Pattern(pattern.get_elems())],

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -669,10 +669,7 @@ impl<'a> Typechecker<'a> {
                 // parsed.  The standard validator, however, allows calling
                 // these functions with non-literal expression that might not
                 // parse, so we have a
-                ExprKind::ExtensionFunctionApp {
-                    function_name,
-                    args,
-                } => {
+                ExprKind::ExtensionFunctionApp { fn_name, args } => {
                     let args_strict_answers = args
                         .iter()
                         .map(|e| self.strict_transform(e, type_errors))
@@ -683,17 +680,16 @@ impl<'a> Typechecker<'a> {
                         |args_strict_unwrapped| {
                             let strict_expr = ExprBuilder::with_data(e.data().clone())
                                 .call_extension_fn(
-                                    function_name.clone(),
+                                    fn_name.clone(),
                                     args_strict_unwrapped.into_iter().map(|a| a.0).collect(),
                                 );
-                            let fn_has_arg_check =
-                                match self.lookup_extension_function(function_name) {
-                                    Ok(f) => f.has_argument_check(),
-                                    // The function is not defined or is defined
-                                    // multiple times. An error was already raised by
-                                    // the standard typechecker.
-                                    Err(_) => false,
-                                };
+                            let fn_has_arg_check = match self.lookup_extension_function(fn_name) {
+                                Ok(f) => f.has_argument_check(),
+                                // The function is not defined or is defined
+                                // multiple times. An error was already raised by
+                                // the standard typechecker.
+                                Err(_) => false,
+                            };
                             let args_args_lit = args
                                 .iter()
                                 .all(|e| matches!(e.expr_kind(), ExprKind::Lit(_)));
@@ -2521,7 +2517,7 @@ impl<'a> Typechecker<'a> {
         ext_expr: &'b Expr,
         type_errors: &mut Vec<TypeError>,
     ) -> TypecheckAnswer<'b> {
-        let ExprKind::ExtensionFunctionApp { function_name, args } = ext_expr.expr_kind() else {
+        let ExprKind::ExtensionFunctionApp { fn_name, args } = ext_expr.expr_kind() else {
             panic!("`typecheck_extension` called with an expression kind other than `ExtensionFunctionApp`");
         };
 
@@ -2534,7 +2530,7 @@ impl<'a> Typechecker<'a> {
                 .collect::<Option<Vec<_>>>()
         };
 
-        match self.lookup_extension_function(function_name) {
+        match self.lookup_extension_function(fn_name) {
             Ok(efunc) => {
                 let arg_tys = efunc.argument_types();
                 let ret_ty = efunc.return_type();
@@ -2556,7 +2552,7 @@ impl<'a> Typechecker<'a> {
                         Some(exprs) => TypecheckAnswer::fail(
                             ExprBuilder::with_data(Some(ret_ty.clone()))
                                 .with_same_source_info(ext_expr)
-                                .call_extension_fn(function_name.clone(), exprs),
+                                .call_extension_fn(fn_name.clone(), exprs),
                         ),
                         None => TypecheckAnswer::RecursionLimit,
                     }
@@ -2572,7 +2568,7 @@ impl<'a> Typechecker<'a> {
                             TypecheckAnswer::success(
                                 ExprBuilder::with_data(Some(ret_ty.clone()))
                                     .with_same_source_info(ext_expr)
-                                    .call_extension_fn(function_name.clone(), typed_arg_exprs),
+                                    .call_extension_fn(fn_name.clone(), typed_arg_exprs),
                             )
                         },
                     )
@@ -2584,7 +2580,7 @@ impl<'a> Typechecker<'a> {
                     Some(typed_args) => TypecheckAnswer::fail(
                         ExprBuilder::with_data(None)
                             .with_same_source_info(ext_expr)
-                            .call_extension_fn(function_name.clone(), typed_args),
+                            .call_extension_fn(fn_name.clone(), typed_args),
                     ),
                     None => TypecheckAnswer::RecursionLimit,
                 }

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -110,7 +110,7 @@ impl Type {
         match entity.entity_type() {
             EntityType::Unspecified => None,
             EntityType::Concrete(name) => {
-                if is_action_entity_type(&name) {
+                if is_action_entity_type(name) {
                     schema
                         .get_action_id(&entity)
                         .and_then(Type::entity_reference_from_action_id)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`ExtensionFunctionOp` used to contain just a `Name` and didn't do anything special. So, I replaced it with just a `Name`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
