### PR TITLE
Fix crash in parser

### DIFF
--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -56,6 +56,7 @@ pub fn parse_policyset_to_ests_and_pset(
     let mut errs = Vec::new();
     let cst = text_to_cst::parse_policies(text).map_err(err::ParseErrors)?;
     let pset = cst.to_policyset(&mut errs);
+    if let Some(pset) = pset { 
     let ests = cst
         .with_generated_policyids()
         .expect("shouldn't be None since parse_policies() didn't return Err")
@@ -64,9 +65,12 @@ pub fn parse_policyset_to_ests_and_pset(
             None => Ok(None),
         })
         .collect::<Result<Option<HashMap<ast::PolicyID, est::Policy>>, err::ParseErrors>>()?;
-    match (errs.is_empty(), ests, pset) {
-        (true, Some(ests), Some(pset)) => Ok((ests, pset)),
-        (_, _, _) => Err(err::ParseErrors(errs)),
+    match (errs.is_empty(), ests) {
+        (true, Some(ests)) => Ok((ests, pset)),
+        (_, _) => Err(err::ParseErrors(errs)),
+    }
+    } else { 
+        Err(err::ParseErrors(errs))
     }
 }
 
@@ -564,4 +568,14 @@ mod parse_tests {
         parse_internal_string(r#"oh, no, a "! "#).expect_err("double quote not allowed");
         parse_internal_string(r#"oh, no, a \"! and a \'! "#).expect("escaped quotes should parse");
     }
+
+    #[test]
+    fn good_cst_bad_ast() { 
+        let src = r#"
+            permit(principal, action, resource) when { principal.name.like == "3" };
+            "#;
+        let _ = parse_policyset_to_ests_and_pset(src);
+    }
+
+
 }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -56,20 +56,20 @@ pub fn parse_policyset_to_ests_and_pset(
     let mut errs = Vec::new();
     let cst = text_to_cst::parse_policies(text).map_err(err::ParseErrors)?;
     let pset = cst.to_policyset(&mut errs);
-    if let Some(pset) = pset { 
-    let ests = cst
-        .with_generated_policyids()
-        .expect("shouldn't be None since parse_policies() didn't return Err")
-        .map(|(id, policy)| match &policy.node {
-            Some(p) => Ok(Some((id, p.clone().try_into()?))),
-            None => Ok(None),
-        })
-        .collect::<Result<Option<HashMap<ast::PolicyID, est::Policy>>, err::ParseErrors>>()?;
-    match (errs.is_empty(), ests) {
-        (true, Some(ests)) => Ok((ests, pset)),
-        (_, _) => Err(err::ParseErrors(errs)),
-    }
-    } else { 
+    if let Some(pset) = pset {
+        let ests = cst
+            .with_generated_policyids()
+            .expect("shouldn't be None since parse_policies() didn't return Err")
+            .map(|(id, policy)| match &policy.node {
+                Some(p) => Ok(Some((id, p.clone().try_into()?))),
+                None => Ok(None),
+            })
+            .collect::<Result<Option<HashMap<ast::PolicyID, est::Policy>>, err::ParseErrors>>()?;
+        match (errs.is_empty(), ests) {
+            (true, Some(ests)) => Ok((ests, pset)),
+            (_, _) => Err(err::ParseErrors(errs)),
+        }
+    } else {
         Err(err::ParseErrors(errs))
     }
 }
@@ -570,12 +570,10 @@ mod parse_tests {
     }
 
     #[test]
-    fn good_cst_bad_ast() { 
+    fn good_cst_bad_ast() {
         let src = r#"
             permit(principal, action, resource) when { principal.name.like == "3" };
             "#;
         let _ = parse_policyset_to_ests_and_pset(src);
     }
-
-
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -19,7 +19,7 @@ use std::fmt::Display;
 use thiserror::Error;
 
 /// For errors during parsing
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Clone)]
 pub enum ParseError {
     /// Error from the lalrpop parser, no additional information
     #[error("{0}")]


### PR DESCRIPTION
Fixes crash in parser when generating ESTs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
