### PR TITLE
Partial schema validation

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -19,6 +19,11 @@ serde_json = "1.0"
 miette = { version = "5.9.0", features = ["fancy"] }
 thiserror = "1.0"
 
+[features]
+default = []
+experimental = ["partial-validate"]
+partial-validate = ["cedar-policy/partial-validate"]
+
 [dev-dependencies]
 assert_cmd = "2.0"
 tempfile = "3"

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -446,6 +446,7 @@ fn run_validate_test(policies_file: &str, schema_file: &str, exit_code: CedarExi
         schema_file: schema_file.into(),
         policies_file: policies_file.into(),
         deny_warnings: false,
+        partial_validate: false,
     };
     let output = validate(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd);

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1767,11 +1767,13 @@ mod schema_based_parsing_tests {
                                 )]
                                 .into_iter()
                                 .collect(),
+                                open_attrs: false,
                             }),
                         ),
                     ]
                     .into_iter()
                     .collect(),
+                    open_attrs: false,
                 }),
                 "home_ip" => Some(SchemaType::Extension {
                     name: Name::parse_unqualified_name("ipaddr").expect("valid"),
@@ -1789,6 +1791,7 @@ mod schema_based_parsing_tests {
                     ]
                     .into_iter()
                     .collect(),
+                    open_attrs: false,
                 }),
                 _ => None,
             }
@@ -1814,6 +1817,10 @@ mod schema_based_parsing_tests {
 
         fn allowed_parent_types(&self) -> Arc<HashSet<EntityType>> {
             Arc::new(HashSet::new())
+        }
+
+        fn open_attributes(&self) -> bool {
+            false
         }
     }
 
@@ -2877,6 +2884,10 @@ mod schema_based_parsing_tests {
 
             fn allowed_parent_types(&self) -> Arc<HashSet<EntityType>> {
                 Arc::new(HashSet::new())
+            }
+
+            fn open_attributes(&self) -> bool {
+                false
             }
         }
 

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -167,10 +167,12 @@ impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
                     None => {
                         // `None` indicates the attribute shouldn't exist -- see
                         // docs on the `attr_type()` trait method
-                        return Err(EntitySchemaConformanceError::UnexpectedEntityAttr {
-                            uid: uid.clone(),
-                            attr: attr.clone(),
-                        });
+                        if !schema_etype.open_attributes() {
+                            return Err(EntitySchemaConformanceError::UnexpectedEntityAttr {
+                                uid: uid.clone(),
+                                attr: attr.clone(),
+                            });
+                        }
                     }
                     Some(expected_ty) => {
                         // typecheck: ensure that the entity attribute value matches

--- a/cedar-policy-core/src/entities/json/context.rs
+++ b/cedar-policy-core/src/entities/json/context.rs
@@ -33,6 +33,7 @@ impl ContextSchema for NullContextSchema {
     fn context_type(&self) -> SchemaType {
         SchemaType::Record {
             attrs: HashMap::new(),
+            open_attrs: false,
         }
     }
 }

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -274,12 +274,21 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                         // `None` indicates the attribute shouldn't exist -- see
                         // docs on the `attr_type()` trait method
                         None => {
-                            return Err(JsonDeserializationError::EntitySchemaConformance(
-                                EntitySchemaConformanceError::UnexpectedEntityAttr {
-                                    uid: uid.clone(),
-                                    attr: k,
-                                },
-                            ))
+                            if desc.open_attributes() {
+                                vparser.val_into_restricted_expr(v.into(), None, || {
+                                    JsonDeserializationErrorContext::EntityAttribute {
+                                        uid: uid.clone(),
+                                        attr: k.clone(),
+                                    }
+                                })?
+                            } else {
+                                return Err(JsonDeserializationError::EntitySchemaConformance(
+                                    EntitySchemaConformanceError::UnexpectedEntityAttr {
+                                        uid: uid.clone(),
+                                        attr: k,
+                                    },
+                                ));
+                            }
                         }
                         Some(expected_ty) => vparser.val_into_restricted_expr(
                             v.into(),

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -110,6 +110,10 @@ pub trait EntityTypeDescription {
 
     /// Get the entity types which are allowed to be parents of this entity type.
     fn allowed_parent_types(&self) -> Arc<HashSet<EntityType>>;
+
+    /// May entities with this type have attributes other than those specified
+    /// in the schema
+    fn open_attributes(&self) -> bool;
 }
 
 /// Simple type that implements `EntityTypeDescription` by expecting no
@@ -131,5 +135,8 @@ impl EntityTypeDescription for NullEntityTypeDescription {
     }
     fn allowed_parent_types(&self) -> Arc<HashSet<EntityType>> {
         Arc::new(HashSet::new())
+    }
+    fn open_attributes(&self) -> bool {
+        false
     }
 }

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -32,5 +32,8 @@ decimal = ["cedar-policy-core/decimal"]
 # Enables `Arbitrary` implementations for several types in this crate
 arbitrary = ["dep:arbitrary"]
 
+# Experimental features.
+partial-validate = []
+
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -128,6 +128,10 @@ impl entities::EntityTypeDescription for EntityTypeDescription {
     fn allowed_parent_types(&self) -> Arc<HashSet<ast::EntityType>> {
         Arc::clone(&self.allowed_parent_types)
     }
+
+    fn open_attributes(&self) -> bool {
+        self.validator_type.open_attributes.is_open()
+    }
 }
 
 impl ast::RequestSchema for ValidatorSchema {

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -159,7 +159,7 @@ impl std::fmt::Display for UnsupportedFeature {
         match self {
             Self::OpenRecordsAndEntities => write!(
                 f,
-                "records and entities with additional attributes are not yet implemented"
+                "records and entities with `additionalAttributes` are experimental, but the experimental `partial-validate` feature is not enabled"
             ),
             Self::ActionAttributes(attrs) => write!(
                 f,

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -50,14 +50,28 @@ pub enum ValidationMode {
     #[default]
     Strict,
     Permissive,
+    #[cfg(feature = "partial-validate")]
+    Partial,
 }
 
 impl ValidationMode {
+    /// Does this mode use partial validation. We could conceivably have a
+    /// strict/partial validation mode.
+    fn is_partial(self) -> bool {
+        match self {
+            ValidationMode::Strict | ValidationMode::Permissive => false,
+            #[cfg(feature = "partial-validate")]
+            ValidationMode::Partial => true,
+        }
+    }
+
     /// Does this mode apply strict validation rules.
     fn is_strict(self) -> bool {
         match self {
             ValidationMode::Strict => true,
             ValidationMode::Permissive => false,
+            #[cfg(feature = "partial-validate")]
+            ValidationMode::Partial => false,
         }
     }
 }

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
 
-use crate::types::{Attributes, OpenTag, Type};
+use crate::types::{Attributes, Type};
 
 /// Contains information about actions used by the validator.  The contents of
 /// the struct are the same as the schema entity type structure, but the
@@ -28,9 +28,8 @@ pub struct ValidatorActionId {
     /// descendants before it is used in any validation.
     pub(crate) descendants: HashSet<EntityUID>,
 
-    /// The context attributes associated with this action. Keys are the context
-    /// attribute identifiers while the values are the type of the attribute.
-    pub(crate) context: Attributes,
+    /// The type of the context record associated with this action.
+    pub(crate) context: Type,
 
     /// The attribute types for this action, used for typechecking.
     pub(crate) attribute_types: Attributes,
@@ -49,10 +48,7 @@ impl ValidatorActionId {
     ///
     /// This always returns a closed record type.
     pub fn context_type(&self) -> Type {
-        Type::record_with_attributes(
-            self.context.iter().map(|(k, v)| (k.clone(), v.clone())),
-            OpenTag::ClosedAttributes,
-        )
+        self.context.clone()
     }
 }
 

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -9,7 +9,7 @@ use cedar_policy_core::{
     transitive_closure::TCNode,
 };
 
-use crate::types::{AttributeType, Attributes};
+use crate::types::{AttributeType, Attributes, OpenTag};
 
 /// Contains entity type information for use by the validator. The contents of
 /// the struct are the same as the schema entity type structure, but the
@@ -28,6 +28,13 @@ pub struct ValidatorEntityType {
     /// The attributes associated with this entity. Keys are the attribute
     /// identifiers while the values are the type of the attribute.
     pub(crate) attributes: Attributes,
+
+    /// Indicates that this entity type may have additional attributes
+    /// other than the declared attributes that may be accessed under partial
+    /// schema validation. We do not know if they are present, and do not know
+    /// their type when they are present. Attempting to access an undeclared
+    /// attribute under standard validation is an error regardless of this flag.
+    pub(crate) open_attributes: OpenTag,
 }
 
 impl ValidatorEntityType {

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -680,14 +680,23 @@ impl ValidatorNamespaceDef {
                 attributes,
                 additional_attributes,
             }) => {
-                if additional_attributes {
+                if cfg!(not(feature = "partial-validate")) && additional_attributes {
                     Err(SchemaError::UnsupportedFeature(
                         UnsupportedFeature::OpenRecordsAndEntities,
                     ))
                 } else {
                     Ok(
                         Self::parse_record_attributes(default_namespace, attributes)?.map(
-                            |attrs| Type::record_with_attributes(attrs, OpenTag::ClosedAttributes),
+                            move |attrs| {
+                                Type::record_with_attributes(
+                                    attrs,
+                                    if additional_attributes {
+                                        OpenTag::OpenAttributes
+                                    } else {
+                                        OpenTag::ClosedAttributes
+                                    },
+                                )
+                            },
                         ),
                     )
                 }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -111,7 +111,7 @@ impl Default for AttributesOrContext {
     fn default() -> Self {
         Self(SchemaType::Type(SchemaTypeVariant::Record {
             attributes: BTreeMap::new(),
-            additional_attributes: false,
+            additional_attributes: partial_schema_default(),
         }))
     }
 }
@@ -412,7 +412,7 @@ impl SchemaTypeVisitor {
 
                 if let Some(attributes) = attributes {
                     let additional_attributes =
-                        additional_attributes.unwrap_or(Ok(additional_attributes_default()));
+                        additional_attributes.unwrap_or(Ok(partial_schema_default()));
                     Ok(SchemaType::Type(SchemaTypeVariant::Record {
                         attributes: attributes?.0,
                         additional_attributes: additional_attributes?,
@@ -596,9 +596,9 @@ pub struct TypeOfAttribute {
     pub required: bool,
 }
 
-/// Defines the default value for `additionalAttributes` on records and
-/// entities
-fn additional_attributes_default() -> bool {
+/// By default schema properties which enable parts of partial schema validation
+/// should be `false`.  Defines the default value for `additionalAttributes`.
+fn partial_schema_default() -> bool {
     false
 }
 

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -378,7 +378,10 @@ impl AttributeAccess {
             if let Some(Type::EntityOrRecord(EntityRecordKind::Entity(lub))) = expr.data() {
                 return AttributeAccess::EntityLUB(lub.clone(), attrs);
             } else if let ExprKind::Var(Var::Context) = expr.expr_kind() {
-                return AttributeAccess::Context(req_env.action.clone(), attrs);
+                return match req_env.action_entity_uid() {
+                    Some(action) => AttributeAccess::Context(action.clone(), attrs),
+                    None => AttributeAccess::Other(attrs),
+                };
             } else if let ExprKind::GetAttr {
                 expr: sub_expr,
                 attr,

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -399,24 +399,34 @@ impl<'a> Typechecker<'a> {
 
         // For every action compute the cross product of the principal and
         // resource applies_to sets.
-        all_actions.flat_map(move |action| {
-            action
-                .applies_to
-                .applicable_principal_types()
-                .flat_map(move |principal| {
-                    action
-                        .applies_to
-                        .applicable_resource_types()
-                        .map(move |resource| RequestEnv {
-                            principal,
-                            action: &action.name,
-                            resource,
-                            context: &action.context,
-                            principal_slot: None,
-                            resource_slot: None,
-                        })
-                })
-        })
+        all_actions
+            .flat_map(|action| {
+                action
+                    .applies_to
+                    .applicable_principal_types()
+                    .flat_map(|principal| {
+                        action
+                            .applies_to
+                            .applicable_resource_types()
+                            .map(|resource| RequestEnv::Known {
+                                principal,
+                                action: &action.name,
+                                resource,
+                                context: &action.context,
+                                principal_slot: None,
+                                resource_slot: None,
+                            })
+                    })
+            })
+            .chain(if self.mode.is_partial() {
+                // A partial schema might not list all actions, and may not
+                // include all principal and resource types for the listed ones.
+                // So we typecheck with a fully unknown request to handle these
+                // missing cases.
+                Some(RequestEnv::Unknown)
+            } else {
+                None
+            })
     }
 
     /// Given a request environment and a template, return new environments
@@ -425,29 +435,40 @@ impl<'a> Typechecker<'a> {
         &'b self,
         env: RequestEnv<'b>,
         t: &'b Template,
-    ) -> impl Iterator<Item = RequestEnv> + 'b {
-        self.possible_slot_instantiations(
-            t,
-            SlotId::principal(),
-            env.principal,
-            t.principal_constraint().as_inner(),
-        )
-        .flat_map(move |p_slot| {
-            self.possible_slot_instantiations(
-                t,
-                SlotId::resource(),
-                env.resource,
-                t.resource_constraint().as_inner(),
-            )
-            .map(move |r_slot| RequestEnv {
-                principal: env.principal,
-                action: env.action,
-                resource: env.resource,
-                context: env.context,
-                principal_slot: p_slot.clone(),
-                resource_slot: r_slot.clone(),
-            })
-        })
+    ) -> Box<dyn Iterator<Item = RequestEnv> + 'b> {
+        match env {
+            RequestEnv::Unknown => Box::new(std::iter::once(RequestEnv::Unknown)),
+            RequestEnv::Known {
+                principal,
+                action,
+                resource,
+                context,
+                ..
+            } => Box::new(
+                self.possible_slot_instantiations(
+                    t,
+                    SlotId::principal(),
+                    principal,
+                    t.principal_constraint().as_inner(),
+                )
+                .flat_map(move |p_slot| {
+                    self.possible_slot_instantiations(
+                        t,
+                        SlotId::resource(),
+                        resource,
+                        t.resource_constraint().as_inner(),
+                    )
+                    .map(move |r_slot| RequestEnv::Known {
+                        principal,
+                        action,
+                        resource,
+                        context,
+                        principal_slot: p_slot.clone(),
+                        resource_slot: r_slot.clone(),
+                    })
+                }),
+            ),
+        }
     }
 
     /// Get the entity types which could instantiate the slot given in this
@@ -521,48 +542,39 @@ impl<'a> Typechecker<'a> {
             // Principal, resource, and context have types defined by
             // the request type.
             ExprKind::Var(Var::Principal) => TypecheckAnswer::success(
-                ExprBuilder::with_data(Some(Type::possibly_unspecified_entity_reference(
-                    request_env.principal.clone(),
-                )))
-                .with_same_source_info(e)
-                .var(Var::Principal),
+                ExprBuilder::with_data(Some(request_env.principal_type()))
+                    .with_same_source_info(e)
+                    .var(Var::Principal),
             ),
             // While the EntityUID for Action is held in the request context,
             // entity types do not consider the id of the entity (only the
             // entity type), so the type of Action is only the entity type name
             // taken from the euid.
             ExprKind::Var(Var::Action) => {
-                let ty = if matches!(request_env.action.entity_type(), EntityType::Unspecified) {
-                    // The action entity may be unspecified. In this case it has
-                    // type AnyEntity
-                    Some(Type::any_entity_reference())
-                } else {
-                    // This returns `None` if the action entity is not defined
-                    // in the schema which will cause a typecheck fail in the
-                    // match below.
-                    Type::euid_literal(request_env.action.clone(), self.schema)
-                };
-
-                match ty {
+                match request_env.action_type(self.schema) {
                     Some(ty) => TypecheckAnswer::success(
                         ExprBuilder::with_data(Some(ty))
                             .with_same_source_info(e)
                             .var(Var::Action),
                     ),
+                    // `None` if the action entity is not defined in the schema.
+                    // This will only show up if we're typechecking with a
+                    // request environment that was not constructed from the
+                    // schema cross product, which will not happen through our
+                    // public entry points, but it can occur if calling
+                    // `typecheck` directly which happens in our tests.
                     None => TypecheckAnswer::fail(
                         ExprBuilder::new().with_same_source_info(e).var(Var::Action),
                     ),
                 }
             }
             ExprKind::Var(Var::Resource) => TypecheckAnswer::success(
-                ExprBuilder::with_data(Some(Type::possibly_unspecified_entity_reference(
-                    request_env.resource.clone(),
-                )))
-                .with_same_source_info(e)
-                .var(Var::Resource),
+                ExprBuilder::with_data(Some(request_env.resource_type()))
+                    .with_same_source_info(e)
+                    .var(Var::Resource),
             ),
             ExprKind::Var(Var::Context) => TypecheckAnswer::success(
-                ExprBuilder::with_data(Some(request_env.context.clone()))
+                ExprBuilder::with_data(Some(request_env.context_type()))
                     .with_same_source_info(e)
                     .var(Var::Context),
             ),
@@ -573,13 +585,13 @@ impl<'a> Typechecker<'a> {
             ExprKind::Slot(slotid) => TypecheckAnswer::success(
                 ExprBuilder::with_data(Some(if slotid.is_principal() {
                     request_env
-                        .principal_slot
+                        .principal_slot()
                         .clone()
                         .map(Type::possibly_unspecified_entity_reference)
                         .unwrap_or(Type::any_entity_reference())
                 } else if slotid.is_resource() {
                     request_env
-                        .resource_slot
+                        .resource_slot()
                         .clone()
                         .map(Type::possibly_unspecified_entity_reference)
                         .unwrap_or(Type::any_entity_reference())
@@ -616,6 +628,17 @@ impl<'a> Typechecker<'a> {
                 // not generated here. We still return `TypecheckFail` so that
                 // typechecking is not considered successful.
                 match Type::euid_literal((**euid).clone(), self.schema) {
+                    // The entity type is undeclared, but that's OK for a
+                    // partial schema. The attributes record will be empty if we
+                    // try to access it later, so all attributes will have the
+                    // bottom type.
+                    None if self.mode.is_partial() => TypecheckAnswer::success(
+                        ExprBuilder::with_data(Some(Type::possibly_unspecified_entity_reference(
+                            euid.entity_type().clone(),
+                        )))
+                        .with_same_source_info(e)
+                        .val(euid.clone()),
+                    ),
                     Some(ty) => TypecheckAnswer::success(
                         ExprBuilder::with_data(Some(ty))
                             .with_same_source_info(e)
@@ -1720,7 +1743,11 @@ impl<'a> Typechecker<'a> {
                             ),
 
                         // If none of the cases apply, then all we know is that `in` has
-                        // type boolean.
+                        // type boolean. Importantly for partial schema
+                        // validation, this case captures an `in` between entity
+                        // literals where the LHS is not an action defined in
+                        // the schema and does not have an entity type defined
+                        // in the schema.
                         _ => TypecheckAnswer::success(
                             ExprBuilder::with_data(Some(Type::primitive_boolean()))
                                 .with_same_source_info(in_expr)
@@ -1824,10 +1851,19 @@ impl<'a> Typechecker<'a> {
 
     fn is_unspecified_entity(query_env: &RequestEnv, expr: &Expr) -> bool {
         match expr.expr_kind() {
-            ExprKind::Var(Var::Principal) => matches!(query_env.principal, EntityType::Unspecified),
-            ExprKind::Var(Var::Resource) => matches!(query_env.resource, EntityType::Unspecified),
+            ExprKind::Var(Var::Principal) => matches!(
+                query_env.principal_entity_type(),
+                Some(EntityType::Unspecified)
+            ),
+            ExprKind::Var(Var::Resource) => matches!(
+                query_env.resource_entity_type(),
+                Some(EntityType::Unspecified)
+            ),
             ExprKind::Var(Var::Action) => {
-                matches!(query_env.action.entity_type(), EntityType::Unspecified)
+                matches!(
+                    query_env.action_entity_uid().map(EntityUID::entity_type),
+                    Some(EntityType::Unspecified)
+                )
             }
             _ => false,
         }
@@ -1846,22 +1882,39 @@ impl<'a> Typechecker<'a> {
     ) -> TypecheckAnswer<'c> {
         if let Some(rhs) = Typechecker::euids_from_euid_literals_or_action(request_env, rhs_elems) {
             let var_euid = if matches!(lhs_var, Var::Principal) {
-                request_env.principal
+                request_env.principal_entity_type()
             } else {
-                request_env.resource
+                request_env.resource_entity_type()
             };
             let descendants = self.schema.get_entity_types_in_set(rhs.iter());
-            match var_euid {
-                EntityType::Specified(var_name) => Typechecker::entity_in_descendants(
-                    var_name,
-                    descendants,
-                    in_expr,
-                    lhs_expr,
-                    rhs_expr,
-                ),
+            match (var_euid, descendants) {
+                // We failed to lookup the descendants because the entity type
+                // is not declared in the schema, or we failed to get the
+                // principal/resource entity type because the request is
+                // unknown.  We don't know if the euid would be in the
+                // descendants or not, so give it type boolean.
+                (_, None) | (None, _) => {
+                    let in_expr = ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                        .with_same_source_info(in_expr)
+                        .is_in(lhs_expr, rhs_expr);
+                    if self.mode.is_partial() {
+                        TypecheckAnswer::success(in_expr)
+                    } else {
+                        TypecheckAnswer::fail(in_expr)
+                    }
+                }
+                (Some(EntityType::Specified(var_name)), Some(descendants)) => {
+                    Typechecker::entity_in_descendants(
+                        var_name,
+                        descendants,
+                        in_expr,
+                        lhs_expr,
+                        rhs_expr,
+                    )
+                }
                 // Unspecified entities will be detected by a different part of the validator.
                 // Still return `TypecheckFail` so that typechecking is not considered successful.
-                EntityType::Unspecified => TypecheckAnswer::fail(
+                (Some(EntityType::Unspecified), _) => TypecheckAnswer::fail(
                     ExprBuilder::with_data(Some(Type::primitive_boolean()))
                         .with_same_source_info(in_expr)
                         .is_in(lhs_expr, rhs_expr),
@@ -1892,8 +1945,8 @@ impl<'a> Typechecker<'a> {
             match lhs_euid.entity_type() {
                 EntityType::Specified(name) => {
                     // We don't want to apply the action hierarchy check to
-                    // non-action entities.  We have a set of entities, so We
-                    // can apply the check as long as any are actions. The
+                    // non-action entities, but now we have a set of entities.
+                    // We can apply the check as long as any are actions. The
                     // non-actions are omitted from the check, but they can
                     // never be an ancestor of `Action`.
                     let lhs_is_action = is_action_entity_type(name);
@@ -1963,7 +2016,18 @@ impl<'a> Typechecker<'a> {
         rhs_expr: Expr<Option<Type>>,
     ) -> TypecheckAnswer<'b> {
         let rhs_descendants = self.schema.get_actions_in_set(rhs);
-        Typechecker::entity_in_descendants(lhs, rhs_descendants, in_expr, lhs_expr, rhs_expr)
+        if let Some(rhs_descendants) = rhs_descendants {
+            Typechecker::entity_in_descendants(lhs, rhs_descendants, in_expr, lhs_expr, rhs_expr)
+        } else {
+            let annotated_expr = ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                .with_same_source_info(in_expr)
+                .is_in(lhs_expr, rhs_expr);
+            if self.mode.is_partial() {
+                TypecheckAnswer::success(annotated_expr)
+            } else {
+                TypecheckAnswer::fail(annotated_expr)
+            }
+        }
     }
 
     // Get the type for `in` when it is applied to an non-action EUID literal
@@ -1982,13 +2046,28 @@ impl<'a> Typechecker<'a> {
         match lhs.entity_type() {
             EntityType::Specified(lhs_ety) => {
                 let rhs_descendants = self.schema.get_entity_types_in_set(rhs);
-                Typechecker::entity_in_descendants(
-                    lhs_ety,
-                    rhs_descendants,
-                    in_expr,
-                    lhs_expr,
-                    rhs_expr,
-                )
+                match rhs_descendants {
+                    Some(rhs_descendants) if self.schema.is_known_entity_type(lhs_ety) => {
+                        Typechecker::entity_in_descendants(
+                            lhs_ety,
+                            rhs_descendants,
+                            in_expr,
+                            lhs_expr,
+                            rhs_expr,
+                        )
+                    }
+                    _ => {
+                        let annotated_expr =
+                            ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                                .with_same_source_info(in_expr)
+                                .is_in(lhs_expr, rhs_expr);
+                        if self.mode.is_partial() {
+                            TypecheckAnswer::success(annotated_expr)
+                        } else {
+                            TypecheckAnswer::fail(annotated_expr)
+                        }
+                    }
+                }
             }
             EntityType::Unspecified => {
                 // Unspecified entities will be detected by a different part of the validator.
@@ -2201,7 +2280,10 @@ impl<'a> Typechecker<'a> {
         maybe_action_var: &'a Expr,
     ) -> Cow<'a, Expr> {
         match maybe_action_var.expr_kind() {
-            ExprKind::Var(Var::Action) => Cow::Owned(Expr::val(request_env.action.clone())),
+            ExprKind::Var(Var::Action) => match request_env.action_entity_uid() {
+                Some(action) => Cow::Owned(Expr::val(action.clone())),
+                None => Cow::Borrowed(maybe_action_var),
+            },
             _ => Cow::Borrowed(maybe_action_var),
         }
     }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -408,7 +408,7 @@ impl<'a> Typechecker<'a> {
                         action
                             .applies_to
                             .applicable_resource_types()
-                            .map(|resource| RequestEnv::Known {
+                            .map(|resource| RequestEnv::DeclaredAction {
                                 principal,
                                 action: &action.name,
                                 resource,
@@ -423,7 +423,7 @@ impl<'a> Typechecker<'a> {
                 // include all principal and resource types for the listed ones.
                 // So we typecheck with a fully unknown request to handle these
                 // missing cases.
-                Some(RequestEnv::Unknown)
+                Some(RequestEnv::UndeclaredAction)
             } else {
                 None
             })
@@ -437,8 +437,8 @@ impl<'a> Typechecker<'a> {
         t: &'b Template,
     ) -> Box<dyn Iterator<Item = RequestEnv> + 'b> {
         match env {
-            RequestEnv::Unknown => Box::new(std::iter::once(RequestEnv::Unknown)),
-            RequestEnv::Known {
+            RequestEnv::UndeclaredAction => Box::new(std::iter::once(RequestEnv::UndeclaredAction)),
+            RequestEnv::DeclaredAction {
                 principal,
                 action,
                 resource,
@@ -458,7 +458,7 @@ impl<'a> Typechecker<'a> {
                         resource,
                         t.resource_constraint().as_inner(),
                     )
-                    .map(move |r_slot| RequestEnv::Known {
+                    .map(move |r_slot| RequestEnv::DeclaredAction {
                         principal,
                         action,
                         resource,

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -505,7 +505,7 @@ fn eq_typecheck_entity_literals_false() {
 fn entity_has_typechecks() {
     assert_typechecks_empty_schema(
         Expr::has_attr(Expr::var(Var::Principal), "attr".into()),
-        Type::singleton_boolean(false),
+        Type::primitive_boolean(),
     );
 }
 

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -13,6 +13,8 @@ use crate::typecheck::Typechecker;
 use crate::types::{EntityLUB, Type};
 use crate::{AttributeAccess, NamespaceDefinition, TypeError, ValidationMode, ValidatorSchema};
 
+use super::test_utils::empty_schema_file;
+
 pub(crate) fn assert_partial_typecheck(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: StaticPolicy,
@@ -42,6 +44,394 @@ pub(crate) fn assert_partial_typecheck_fail(
     );
     assert_expected_type_errors(&expected_type_errors, &type_errors);
     assert!(!typechecked, "Expected that policy would not typecheck.");
+}
+
+pub(crate) fn assert_typechecks_empty_schema(policy: StaticPolicy) {
+    assert_partial_typecheck(empty_schema_file(), policy)
+}
+
+pub(crate) fn assert_typecheck_fails_empty_schema(
+    policy: StaticPolicy,
+    expected_type_errors: Vec<TypeError>,
+) {
+    assert_partial_typecheck_fail(empty_schema_file(), policy, expected_type_errors)
+}
+
+mod passes_empty_schema {
+
+    use super::*;
+
+    #[test]
+    fn principal_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal.is_admin };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn action_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) unless { action.is_restricted };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resource_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { resource.is_public };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn literal_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { User::"alice".is_admin };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn get_nested_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { resource.foo.bar.baz.buz };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn principal_has_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal has is_admin };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn action_has_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) unless { action has is_restricted };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resource_has_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { resource has is_public };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn literal_has_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { User::"alice" has is_admin };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn has_nested_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { resource.foo has bar };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn principal_eq() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal == User::"alice", action, resource);"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn action_eq() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action == Action::"view", resource);"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resource_eq() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource == Photo::"vacation.jpg");"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn principal_in() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal in User::"alice", action, resource);"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn action_in() {
+        // Test case with `in` are  interesting because, for an undeclared
+        // entity type or action we don't know what should be `in` it, so the
+        // expression has type boolean (not known to be true or false).
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action in Action::"view", resource);"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resource_in() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource in Photo::"vacation.jpg");"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn principal_in_set() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when {  principal in [User::"alice", Admin::"bob"] };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn action_in_set() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action in [Action::"view", Action::"edit"], resource);"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn in_attr() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal in resource.owner };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn attr_in() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { resource.owner in principal };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn resource_in_set() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { resource in [Photo::"vacation.jpg", Album::"vacation_photos"] } ;"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn if_both_branches_undefined() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { if principal.foo then action.bar else resource.bar };"#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn if_one_branch_undefined() {
+        assert_typechecks_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { 0 < (if principal.foo then action.bar else 1) };"#
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn context_attr() {
+        let p = parse_policy(
+            Some("0".to_string()),
+            r#"permit(principal, action, resource) when { context.foo };"#,
+        )
+        .expect("Policy should parse.");
+        assert_typechecks_partial_schema(p);
+        let p = parse_policy(
+            Some("0".to_string()),
+            r#"permit(principal, action, resource) when { context.foo.bar };"#,
+        )
+        .expect("Policy should parse.");
+        assert_typechecks_partial_schema(p);
+    }
+}
+
+mod fails_empty_schema {
+    use std::str::FromStr;
+
+    use cedar_policy_core::ast::Expr;
+
+    use crate::types::Type;
+
+    use super::*;
+
+    #[test]
+    fn operator_type_error() {
+        // We expect to see a type error for the incorrect literal argument to
+        // various operators. No error should be generated for missing
+        // attributes or the type of the attributes.
+        assert_typecheck_fails_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal.foo > "a" };"#,
+            )
+            .unwrap(),
+            vec![TypeError::expected_type(
+                Expr::val("a"),
+                Type::primitive_long(),
+                Type::primitive_string(),
+            )],
+        );
+        assert_typecheck_fails_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { 1.contains(principal.foo) };"#,
+            )
+            .unwrap(),
+            vec![TypeError::expected_type(
+                Expr::val(1),
+                Type::any_set(),
+                Type::primitive_long(),
+            )],
+        );
+        assert_typecheck_fails_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal.foo.containsAll(1) };"#,
+            )
+            .unwrap(),
+            vec![TypeError::expected_type(
+                Expr::val(1),
+                Type::any_set(),
+                Type::primitive_long(),
+            )],
+        );
+    }
+
+    #[test]
+    fn top_level_type_error() {
+        assert_typecheck_fails_empty_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal.foo + 1 };"#,
+            )
+            .unwrap(),
+            vec![TypeError::expected_type(
+                Expr::from_str("principal.foo + 1").unwrap(),
+                Type::primitive_boolean(),
+                Type::primitive_long(),
+            )],
+        )
+    }
+
+    #[test]
+    fn impossible_policy() {
+        let p = parse_policy(
+            None,
+            r#"permit(principal, action, resource) when { resource.bar && false };"#,
+        )
+        .unwrap();
+        assert_typecheck_fails_empty_schema(
+            p.clone(),
+            vec![TypeError::impossible_policy(p.condition())],
+        )
+    }
+
+    #[test]
+    fn record_lit_bad_attr() {
+        let p = parse_policy(
+            None,
+            r#"permit(principal, action, resource) when { {foo: 1}.bar };"#,
+        )
+        .unwrap();
+        assert_typecheck_fails_empty_schema(
+            p.clone(),
+            vec![TypeError::unsafe_attribute_access(
+                Expr::from_str("{foo: 1}.bar").unwrap(),
+                AttributeAccess::Other(vec!["bar".into()]),
+                Some("foo".into()),
+                false,
+            )],
+        )
+    }
 }
 
 fn partial_schema_file() -> NamespaceDefinition {
@@ -124,6 +514,41 @@ mod passes_partial_schema {
             parse_policy(
                 None,
                 r#"permit(principal, action, resource) when { User::"alice" has unknown };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn undeclared_entity_type_in_declared_entity_type() {
+        assert_typechecks_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { Admin::"alice" in User::"alice" };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn undeclared_action_in_declared_action() {
+        assert_typechecks_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { Action::"undeclared" in Action::"view" };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn principal_wrong_for_known_actions() {
+        // `resource` can't be a `Group` for the defined actions, but there
+        // might be an undefined action where that's OK.
+        assert_typechecks_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource == Group::"owners");"#,
             )
             .unwrap(),
         );

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -1,0 +1,230 @@
+//! Contains test for typechecking with partial schema files.
+#![cfg(test)]
+#![cfg(feature = "partial-validate")]
+// GRCOV_STOP_COVERAGE
+
+use std::collections::HashSet;
+
+use cedar_policy_core::ast::{Expr, Template, Var};
+use cedar_policy_core::{ast::StaticPolicy, parser::parse_policy};
+
+use crate::typecheck::test_utils::assert_expected_type_errors;
+use crate::typecheck::Typechecker;
+use crate::types::{EntityLUB, Type};
+use crate::{AttributeAccess, NamespaceDefinition, TypeError, ValidationMode, ValidatorSchema};
+
+pub(crate) fn assert_partial_typecheck(
+    schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
+    policy: StaticPolicy,
+) {
+    let schema = schema.try_into().expect("Failed to construct schema.");
+    let typechecker = Typechecker::new(&schema, ValidationMode::Partial);
+    let mut type_errors: HashSet<TypeError> = HashSet::new();
+    let typechecked = typechecker.typecheck_policy(
+        &Template::link_static_policy(policy.clone()).0,
+        &mut type_errors,
+    );
+    assert_eq!(type_errors, HashSet::new(), "Did not expect any errors.");
+    assert!(typechecked, "Expected that policy would typecheck.");
+}
+
+pub(crate) fn assert_partial_typecheck_fail(
+    schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
+    policy: StaticPolicy,
+    expected_type_errors: Vec<TypeError>,
+) {
+    let schema = schema.try_into().expect("Failed to construct schema.");
+    let typechecker = Typechecker::new(&schema, ValidationMode::Partial);
+    let mut type_errors: HashSet<TypeError> = HashSet::new();
+    let typechecked = typechecker.typecheck_policy(
+        &Template::link_static_policy(policy.clone()).0,
+        &mut type_errors,
+    );
+    assert_expected_type_errors(&expected_type_errors, &type_errors);
+    assert!(!typechecked, "Expected that policy would not typecheck.");
+}
+
+fn partial_schema_file() -> NamespaceDefinition {
+    serde_json::from_value(serde_json::json!(
+        {
+            "entityTypes": {
+                "User": {
+                    "memberOfTypes": [ "Group" ],
+                    "shape": {
+                        "type": "Record",
+                        "additionalAttributes": true,
+                        "attributes": {
+                            "name": { "type": "String", "required": true},
+                            "age": { "type": "Long", "required": true},
+                            "favorite": { "type": "Entity", "name": "Photo", "required": true}
+                        }
+                    }
+                },
+                "Group": {
+                    "shape": {
+                        "type": "Record",
+                        "additionalAttributes": false,
+                        "attributes": {}
+                    }
+                },
+                "Photo": {
+                    "shape": {
+                        "type": "Record",
+                        "additionalAttributes": true,
+                        "attributes": {}
+                    }
+                }
+            },
+            "actions": {
+                "view_photo": {
+                    "appliesTo": {
+                        "principalTypes": ["User", "Group"],
+                        "resourceTypes": ["Photo"],
+                        "context": {
+                            "type": "Record",
+                            "additionalAttributes": true,
+                            "attributes": {}
+                        }
+                    }
+                }
+            }
+        }
+    ))
+    .expect("Expected valid schema")
+}
+
+pub(crate) fn assert_typechecks_partial_schema(policy: StaticPolicy) {
+    assert_partial_typecheck(partial_schema_file(), policy)
+}
+
+pub(crate) fn assert_typecheck_fails_partial_schema(
+    policy: StaticPolicy,
+    expected_type_errors: Vec<TypeError>,
+) {
+    assert_partial_typecheck_fail(partial_schema_file(), policy, expected_type_errors)
+}
+
+mod passes_partial_schema {
+    use super::*;
+
+    #[test]
+    fn unknown_attr_on_declared_entity_type() {
+        assert_typechecks_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { User::"alice".unknown };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn has_unknown_attr_on_declared_entity_type() {
+        assert_typechecks_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { User::"alice" has unknown };"#,
+            )
+            .unwrap(),
+        );
+    }
+
+    #[test]
+    fn policy_in_set_action_and_other() {
+        let p = parse_policy(
+            Some("0".to_string()),
+            r#"permit(principal, action, resource) when { User::"alice" in [action, User::"alice"] };"#,
+        ).expect("Policy should parse.");
+        assert_typechecks_partial_schema(p);
+    }
+
+    #[test]
+    fn policy_action_in_set_action_and_other() {
+        let p = parse_policy(
+            Some("0".to_string()),
+            r#"permit(principal, action, resource) when { action in [action, User::"alice"] };"#,
+        )
+        .expect("Policy should parse.");
+        assert_typechecks_partial_schema(p);
+    }
+
+    #[test]
+    fn context_attr() {
+        let p = parse_policy(
+            Some("0".to_string()),
+            r#"permit(principal, action == Action::"view_photo", resource) when { context.foo };"#,
+        )
+        .expect("Policy should parse.");
+        assert_typechecks_partial_schema(p);
+    }
+}
+
+mod fail_partial_schema {
+
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn error_on_declared_attr() {
+        // `name` is declared as a `String` in the partial schema, so we can
+        // error even though `principal.unknown` is not declared.
+        assert_typecheck_fails_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal == User::"alice", action, resource) when { principal.name > principal.unknown };"#,
+            )
+            .unwrap(),
+            vec![TypeError::expected_type(
+                Expr::get_attr(Expr::var(Var::Principal), "name".into()),
+                Type::primitive_long(),
+                Type::primitive_string(),
+            )],
+        );
+    }
+
+    #[test]
+    fn incompatible_attrs() {
+        assert_typecheck_fails_partial_schema(
+            // `age` and `name` are defined with incompatible types, while
+            // `unknown` is not defined. The conflict is noticed and an error is
+            // raised.
+            parse_policy(
+                None,
+                r#"permit(principal == User::"alice", action, resource) when {
+                        (if resource.foo then
+                            principal.age
+                        else (if resource.bar then
+                            principal.name
+                        else
+                            principal.unknown
+                        )) == "alice"};"#,
+            )
+            .unwrap(),
+            vec![TypeError::incompatible_types(
+                Expr::from_str("if resource.foo then principal.age else (if resource.bar then principal.name else principal.unknown)").unwrap(),
+                vec![Type::primitive_long(), Type::primitive_string()],
+            )],
+        );
+    }
+
+    #[test]
+    fn unknown_attr_on_closed_entity_type() {
+        assert_typecheck_fails_partial_schema(
+            parse_policy(
+                None,
+                r#"permit(principal, action, resource) when { principal.is_foo };"#,
+            )
+            .unwrap(),
+            vec![TypeError::unsafe_attribute_access(
+                Expr::from_str("principal.is_foo").unwrap(),
+                AttributeAccess::EntityLUB(
+                    EntityLUB::single_entity("Group".parse().unwrap()),
+                    vec!["is_foo".into()],
+                ),
+                None,
+                false,
+            )],
+        );
+    }
+}

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -430,6 +430,19 @@ fn policy_in_action_impossible() {
 }
 
 #[test]
+fn policy_action_in_impossible() {
+    let p = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action, resource) when { action in [User::"alice"] };"#,
+    )
+    .expect("Policy should parse.");
+    assert_policy_typecheck_fails_simple_schema(
+        p.clone(),
+        vec![TypeError::impossible_policy(p.condition())],
+    );
+}
+
+#[test]
 fn policy_entity_has_then_get() {
     assert_policy_typechecks_simple_schema(parse_policy(
             Some("0".to_string()),

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -28,7 +28,7 @@ use std::str::FromStr;
 use cedar_policy_core::ast::{EntityType, EntityUID, Expr};
 
 use crate::{
-    types::{Attributes, EffectSet, RequestEnv, Type},
+    types::{EffectSet, OpenTag, RequestEnv, Type},
     IncompatibleTypes, SchemaFragment, TypeErrorKind, ValidationMode,
 };
 
@@ -149,7 +149,7 @@ where
             principal: &EntityType::Specified("User".parse().unwrap()),
             action: &EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
             resource: &EntityType::Specified("Photo".parse().unwrap()),
-            context: &Attributes::with_attributes(None),
+            context: &Type::record_with_attributes(None, OpenTag::ClosedAttributes),
             principal_slot: None,
             resource_slot: None,
         },

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -145,7 +145,7 @@ where
 {
     f(
         simple_schema_file(),
-        RequestEnv::Known {
+        RequestEnv::DeclaredAction {
             principal: &EntityType::Specified("User".parse().unwrap()),
             action: &EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
             resource: &EntityType::Specified("Photo".parse().unwrap()),

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -145,7 +145,7 @@ where
 {
     f(
         simple_schema_file(),
-        RequestEnv {
+        RequestEnv::Known {
             principal: &EntityType::Specified("User".parse().unwrap()),
             action: &EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
             resource: &EntityType::Specified("Photo".parse().unwrap()),

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -65,7 +65,7 @@ impl Typechecker<'_> {
     ) -> TypecheckAnswer<'a> {
         // Using bogus entity type names here for testing. They'll be treated as
         // having empty attribute records, so tests will behave as expected.
-        let request_env = RequestEnv::Known {
+        let request_env = RequestEnv::DeclaredAction {
             principal: &EntityType::Specified(
                 "Principal"
                     .parse()

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -65,7 +65,7 @@ impl Typechecker<'_> {
     ) -> TypecheckAnswer<'a> {
         // Using bogus entity type names here for testing. They'll be treated as
         // having empty attribute records, so tests will behave as expected.
-        let request_env = RequestEnv {
+        let request_env = RequestEnv::Known {
             principal: &EntityType::Specified(
                 "Principal"
                     .parse()

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,11 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing `Entities` structure. (#276)
 - Export the `cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind}` and
   `cedar_policy_core::authorizer::AuthorizationError` error types. (#260, #271)
-- `ParseError::primary_source_span` to get the primary source span locating an error.
+- `ParseError::primary_source_span` to get the primary source span locating an
+  error. (#324)
 - Experimental API `PolicySet::unknown_entities` to collect unknown entity UIDs
-  from a `PartialResponse`. (#353)
+  from a `PartialResponse`. (#353, resolving #321)
 - `PolicySet::remove_static`, `PolicySet::remove_template` and
-  `PolicySet::unlink` to remove policies from the policy set. (#337)
+  `PolicySet::unlink` to remove policies from the policy set. (#337, resolving #328)
 - `PolicySet::get_linked_policies` to get the policies linked to a `Template`. (#337)
 - `ValidationResult::validation_warnings` to access non-fatal warnings returned
   by the validator and `ValidationResult::validation_passed_without_warnings`.
@@ -27,13 +28,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [RFC 5](https://github.com/cedar-policy/rfcs/blob/main/text/0005-is-operator.md).
   (#396)
 - `Entity::new_no_attrs()` which provides an infallible constructor for `Entity`
-  in the case that there are no attributes. (See changes to `Entity::new()` below.)
+  in the case that there are no attributes. (See changes to `Entity::new()`
+  below.) (#430)
 - `RestrictedExpression::new_entity_uid()` (#442, resolving #350)
 
 ### Changed
 
-- Removed `__expr` escape from Cedar JSON formats, which has been deprecated
-  since Cedar 1.2. (#333)
 - Rename `cedar_policy_core::est::EstToAstError` to
   `cedar_policy_core::est::FromJsonError`. (#197)
 - Rename `cedar_policy_core::entities::JsonDeserializationError::ExtensionsError`
@@ -59,14 +59,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   optional schema argument. (#360)
 - `Request::new()` now takes an optional schema argument, and validates the request
   against that schema. To signal validation errors, it now returns a `Result`.
-  (#393)
+  (#393, resolving #191)
 - Change the semantics of equality for IP ranges. For example,
   `ip("192.168.0.1/24") == ip("192.168.0.3/24")` was previously `true` and is now
   `false`. The behavior of equality on single IP addresses is unchanged, and so is
   the behavior of `.isInRange()`. (#348)
 - Standardize on duplicates being errors instead of last-write-wins in the
   JSON-based APIs in the `frontend` module. This also means some error types
-  have changed.
+  have changed. (#365, #448)
 - `Entity::new()` now eagerly evaluates entity attributes, leading to
   performance improvements (particularly when entity data is reused across
   multiple `is_authorized` calls). As a result, it returns `Result`, because
@@ -78,35 +78,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Context::from_*()` methods also now eagerly evaluate the `Context`, and as
   a result return errors when evaluation fails. (#430)
 - `<EntityId as FromStr>::Error` is now `Infallible` instead of `ParseErrors`.
+  (#372)
 - Improve the `Display` impls for `Policy` and `PolicySet`, and add a `Display`
   impl for `Template`.  The displayed representations now more closely match the
-  original input, whether the input was in string or JSON form. (#167)
+  original input, whether the input was in string or JSON form. (#167, resolving
+  #125)
 - `ValidationWarning::location` and `ValidationWarning::to_kind_and_location`
   now return `&SourceLocation<'a>` instead of `&'a PolicyID`, matching
   `ValidationError::location`. (#405)
 - `ValidationWarningKind` is now `non_exhaustive`, allowing future warnings to
   be added without a breaking change. (#404)
 - Improve schema parsing error messages when a cycle exists in the action
-  hierarchy to includes an action which is part of the cycle (#436, resolving #416).
+  hierarchy to includes an action which is part of the cycle (#436, resolving
+  #416).
 
 ### Fixed
 
-- Evaluation order of operand to `>` and `>=` (#112). They now evaluate left to right,
+- Evaluation order of operand to `>` and `>=`. They now evaluate left to right,
   matching all other operators. This affects what error is reported when there is
   an evaluation error in both operands, but does not otherwise change the result
-  of evaluation. (#402)
+  of evaluation. (#402, resolving #112)
 - Updated `PolicySet::link` to not mutate internal state when failing to link a static
   policy. With this fix it is possible to create a link with a policy id
   after previously failing to create that link with the same id from a static
   policy. (#412)
 - Fixed schema-based parsing of entity data that includes unknowns (for the
-  `partial-eval` experimental feature). (#419)
+  `partial-eval` experimental feature). (#419, resolving #418)
 
 ### Removed
 
+- Removed `__expr` escape from Cedar JSON formats, which has been deprecated
+  since Cedar 1.2. (#333)
 - Move `ValidationMode::Permissive` behind an experimental feature flag.
-  To continue using this feature you must enable the `permissive-validate` feature
-  flag.
+  To continue using this feature you must enable the `permissive-validate`
+  feature flag. (#428)
 
 ## [2.4.2] - 2023-10-23
 Cedar Language Version: 2.1.2
@@ -115,7 +120,7 @@ Cedar Language Version: 2.1.2
 
 - Issue #370 related to how the validator handles template-linked policies.
   The validator will now produce the same result for an equivalent static
-  and template-linked policy. (#371)
+  and template-linked policy. (#371, resolving #370)
 
 ## [2.4.1] - 2023-10-12
 Cedar Language Version: 2.1.1
@@ -128,7 +133,7 @@ Cedar Language Version: 2.1.1
 
 - Improve validation error messages for access to undeclared attributes and
   unsafe access to optional attributes to report the target of the access. (#295)
-- `EntityUid`'s impl of `FromStr` is no longer marked as deprecated.
+- `EntityUid`'s impl of `FromStr` is no longer marked as deprecated. (#319)
 
 ### Fixed
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -40,9 +40,10 @@ integration_testing = []
 
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
-experimental = ["partial-eval", "permissive-validate"]
+experimental = ["partial-eval", "permissive-validate", "partial-validate"]
 partial-eval = ["cedar-policy-core/partial-eval"]
 permissive-validate = []
+partial-validate = ["cedar-policy-validator/partial-validate"]
 
 [lib]
 crate_type = ["rlib"]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -990,6 +990,9 @@ pub enum ValidationMode {
     #[cfg(feature = "permissive-validate")]
     /// Validate that policies do not contain any type errors.
     Permissive,
+    /// Validate using a partial schema. Policies may contain type errors.
+    #[cfg(feature = "partial-validate")]
+    Partial,
 }
 
 impl From<ValidationMode> for cedar_policy_validator::ValidationMode {
@@ -998,6 +1001,8 @@ impl From<ValidationMode> for cedar_policy_validator::ValidationMode {
             ValidationMode::Strict => Self::Strict,
             #[cfg(feature = "permissive-validate")]
             ValidationMode::Permissive => Self::Permissive,
+            #[cfg(feature = "partial-validate")]
+            ValidationMode::Partial => Self::Partial,
         }
     }
 }

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -2673,7 +2673,6 @@ fn partial_schema_unsupported() {
 #[cfg(feature = "partial-validate")]
 mod partial_schema {
     use super::*;
-    use cedar_policy_core::ast::EntityUID;
     use serde_json::json;
 
     fn partial_schema() -> Schema {

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -2184,74 +2184,6 @@ mod schema_based_parsing_tests {
         );
     }
 
-    /// Test that involves open entities
-    #[test]
-    #[should_panic(
-        expected = "UnsupportedFeature(\"records and entities with additional attributes are not yet implemented\")"
-    )]
-    fn open_entities() {
-        let schema = Schema::from_str(
-            r#"
-        {"": {
-            "entityTypes": {
-                "Employee": {
-                    "memberOfTypes": [],
-                    "shape": {
-                        "type": "Record",
-                        "attributes": {
-                            "isFullTime": { "type": "Boolean" },
-                            "department": { "type": "String", "required": false },
-                            "manager": { "type": "Entity", "name": "Employee" }
-                        },
-                        "additionalAttributes": true
-                    }
-                }
-            },
-            "actions": {
-                "view": {}
-            }
-        }}
-        "#,
-        )
-        .expect("should be a valid schema");
-
-        // all good here
-        let entitiesjson = json!(
-            [
-                {
-                    "uid": { "type": "Employee", "id": "12UA45" },
-                    "attrs": {
-                        "isFullTime": true,
-                        "department": "Sales",
-                        "manager": { "type": "Employee", "id": "34FB87" }
-                    },
-                    "parents": []
-                }
-            ]
-        );
-        let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
-            .expect("Should parse without error");
-        assert_eq!(parsed.iter().count(), 1);
-
-        // providing another attribute "foobar" should be OK
-        let entitiesjson = json!(
-            [
-                {
-                    "uid": { "type": "Employee", "id": "12UA45" },
-                    "attrs": {
-                        "isFullTime": true,
-                        "foobar": 234,
-                        "manager": { "type": "Employee", "id": "34FB87" }
-                    },
-                    "parents": []
-                }
-            ]
-        );
-        let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
-            .expect("Should parse without error");
-        assert_eq!(parsed.iter().count(), 1);
-    }
-
     #[test]
     fn schema_sanity_check() {
         let src = "{ , .. }";
@@ -2724,5 +2656,92 @@ mod schema_based_parsing_tests {
             parsed.attr("tricky"),
             Some(Err(e)) => assert_contains_unknown(&e.to_string(), "ttt")
         );
+    }
+}
+
+#[cfg(not(feature = "partial-validate"))]
+#[test]
+fn partial_schema_unsupported() {
+    use cool_asserts::assert_panics;
+    use serde_json::json;
+    assert_panics!(
+        Schema::from_json_value( json!({"": { "entityTypes": { "A": { "shape": { "type": "Record", "attributes": {}, "additionalAttributes": true } } }, "actions": {} }})).unwrap(),
+        includes("records and entities with `additionalAttributes` are experimental, but the experimental `partial-validate` feature is not enabled")
+    );
+}
+
+#[cfg(feature = "partial-validate")]
+mod partial_schema {
+    use super::*;
+    use cedar_policy_core::ast::EntityUID;
+    use serde_json::json;
+
+    fn partial_schema() -> Schema {
+        Schema::from_json_value(json!(
+        {
+            "": {
+                "entityTypes": {
+                    "Employee": {
+                        "memberOfTypes": [],
+                        "shape": {
+                            "type": "Record",
+                            "attributes": { },
+                            "additionalAttributes": true,
+                        },
+                    }
+                },
+                "actions": {
+                    "Act": {
+                        "appliesTo": {
+                            "context": {
+                                "type": "Record",
+                                "attributes": {},
+                                "additionalAttributes": true,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        ))
+        .unwrap()
+    }
+
+    #[test]
+    fn entity_extra_attr() {
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "foobar": 234,
+                        "manager": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+            ]
+        );
+
+        let schema = partial_schema();
+        let parsed = Entities::from_json_value(entitiesjson.clone(), Some(&schema))
+            .expect("Parsing with a partial schema should allow unknown attributes.");
+        let parsed_without_schema = Entities::from_json_value(entitiesjson, None).unwrap();
+
+        let uid = EntityUid::from_strs("Employee", "12UA45");
+        assert_eq!(
+            parsed.get(&uid),
+            parsed_without_schema.get(&uid),
+            "Parsing with a partial schema should give the same result as parsing without a schema"
+        );
+    }
+
+    #[test]
+    fn context_extra_attr() {
+        Context::from_json_value(
+            json!({"foo": true, "bar": 123}),
+            Some((&partial_schema(), &EntityUid::from_strs("Action", "Act"))),
+        )
+        .unwrap();
     }
 }


### PR DESCRIPTION
Experimental implementation of partial schema validation as described in https://github.com/cedar-policy/rfcs/pull/8.

The experimental implementation does not include the `additionalMemberOfTypes` and `additionalMemberOf` fields discussed in the RFC. I'm not convinced these are neccecary for the feature as a whole to be useful, and they require additional changes inside existing validation code.

I'm marking this ready for review as an experimental feature, so reviewers do not need to review the semantics of partial schema validation. They should be sure to review:

1. Changes which ensure partial schema validation is in fact experimental, i.e., it's properly placed behind the `partial-schema` feature.
2. That the code changes are should not effect the behavior of the strict validator.
