### PR TITLE
Reexport EntitiesError

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -143,6 +143,8 @@ impl std::fmt::Display for Entity {
 #[derive(Debug, Clone, Default, PartialEq, Eq, RefCast)]
 pub struct Entities(pub(crate) entities::Entities);
 
+pub use entities::EntitiesError;
+
 impl Entities {
     /// Create a fresh `Entities` with no entities
     pub fn empty() -> Self {


### PR DESCRIPTION
*Description of changes:*

Since various [`Entities` methods](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str) return `EntitiesError`, which is [only exposed](https://docs.rs/cedar-policy-core/2.2.0/cedar_policy_core/entities/enum.EntitiesError.html) in `cedar_policy_core`, reexporting it allows users to handle the error without adding a separate dependency.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
