### PR TITLE
Update `criterion` to version 0.5

### DIFF
--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -51,7 +51,7 @@ crate_type = ["rlib"]
 # could replace this hack.
 cedar-policy = { path = ".", default-features = false, features = ["integration_testing"] }
 cool_asserts = "2.0"
-criterion = "0.4"
+criterion = "0.5"
 globset = "0.4"
 
 [[bench]]


### PR DESCRIPTION
This removes the dependency on `atty` fixing #33.

`cargo audit` reports no findings after this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
