### PR TITLE
remove rustsec ignore for yanked atty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo install cargo-audit
-      - run: cargo audit --deny warnings --ignore RUSTSEC-2021-0145
+      - run: cargo audit --deny warnings


### PR DESCRIPTION
https://github.com/cedar-policy/cedar/pull/93 updated atty. This PR removes the rustsec ignore for the old, .yanked atty

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
