### PR TITLE
Stricter rules around panicking functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: cargo fmt --all --check
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - run: cargo test --verbose
+      - run: cargo clippy
       - run: ./panic_safety.sh
       - run: cargo test --verbose -- --ignored
       - run: cargo bench --no-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       - run: cargo fmt --all --check
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - run: cargo test --verbose
+      - run: ./panic_safety.sh
       - run: cargo test --verbose -- --ignored
       - run: cargo bench --no-run
   

--- a/cedar-policy-core/clippy.toml
+++ b/cedar-policy-core/clippy.toml
@@ -1,0 +1,3 @@
+
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1406,6 +1406,8 @@ impl From<PrincipalOrResource> for Var {
     }
 }
 
+// PANIC SAFETY Tested by `test::all_vars_are_ids`. Never panics.
+#[allow(clippy::fallible_impl_from)]
 impl From<Var> for Id {
     fn from(var: Var) -> Self {
         // PANIC SAFETY: `Var` is a simple enum and all vars are formatted as valid `Id`. Tested by `test::all_vars_are_ids`

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1408,7 +1408,9 @@ impl From<PrincipalOrResource> for Var {
 
 impl From<Var> for Id {
     fn from(var: Var) -> Self {
-        format!("{var}").parse().expect("Invalid Identifier")
+        // PANIC SAFETY: `Var` is a simple enum and all vars are formatted as valid `Id`. Tested by `test::all_vars_are_ids`
+        #[allow(clippy::unwrap_used)]
+        format!("{var}").parse().unwrap()
     }
 }
 

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -676,9 +676,9 @@ impl std::fmt::Display for Expr {
                         None
                     }
                 });
+                // PANIC SAFETY Args list must be non empty by INVARIANT (MethodStyleArgs)
+                #[allow(clippy::indexing_slicing)]
                 if matches!(style, Some(CallStyle::MethodStyle)) && !args.is_empty() {
-                    // This indexing operation is safe, as MethodStyle calls MUST have a non-empty args list.
-                    // See INVARIANT (MethodStyleArgs)
                     write!(
                         f,
                         "{}.{}({})",

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -179,16 +179,13 @@ impl ExtensionFunction {
         Self::new(
             name.clone(),
             style,
-            Box::new(move |args: &[Value]| {
-                if args.len() == 1 {
-                    func(args[0].clone())
-                } else {
-                    Err(evaluator::EvaluationError::WrongNumArguments {
-                        function_name: name.clone(),
-                        expected: 1,
-                        actual: args.len(),
-                    })
-                }
+            Box::new(move |args: &[Value]| match args.get(0) {
+                Some(arg) => func(arg.clone()),
+                None => Err(evaluator::EvaluationError::WrongNumArguments {
+                    function_name: name.clone(),
+                    expected: 1,
+                    actual: args.len(),
+                }),
             }),
             None,
             vec![arg_type],
@@ -206,16 +203,13 @@ impl ExtensionFunction {
         Self::new(
             name.clone(),
             style,
-            Box::new(move |args: &[Value]| {
-                if args.len() == 1 {
-                    func(args[0].clone())
-                } else {
-                    Err(evaluator::EvaluationError::WrongNumArguments {
-                        function_name: name.clone(),
-                        expected: 1,
-                        actual: args.len(),
-                    })
-                }
+            Box::new(move |args: &[Value]| match &args {
+                &[arg] => func(arg.clone()),
+                _ => Err(evaluator::EvaluationError::WrongNumArguments {
+                    function_name: name.clone(),
+                    expected: 1,
+                    actual: args.len(),
+                }),
             }),
             Some(return_type),
             vec![arg_type],
@@ -235,16 +229,13 @@ impl ExtensionFunction {
         Self::new(
             name.clone(),
             style,
-            Box::new(move |args: &[Value]| {
-                if args.len() == 2 {
-                    func(args[0].clone(), args[1].clone())
-                } else {
-                    Err(evaluator::EvaluationError::WrongNumArguments {
-                        function_name: name.clone(),
-                        expected: 2,
-                        actual: args.len(),
-                    })
-                }
+            Box::new(move |args: &[Value]| match &args {
+                &[first, second] => func(first.clone(), second.clone()),
+                _ => Err(evaluator::EvaluationError::WrongNumArguments {
+                    function_name: name.clone(),
+                    expected: 2,
+                    actual: args.len(),
+                }),
             }),
             Some(return_type),
             vec![arg_types.0, arg_types.1],
@@ -267,16 +258,13 @@ impl ExtensionFunction {
         Self::new(
             name.clone(),
             style,
-            Box::new(move |args: &[Value]| {
-                if args.len() == 3 {
-                    func(args[0].clone(), args[1].clone(), args[2].clone())
-                } else {
-                    Err(evaluator::EvaluationError::WrongNumArguments {
-                        function_name: name.clone(),
-                        expected: 3,
-                        actual: args.len(),
-                    })
-                }
+            Box::new(move |args: &[Value]| match &args {
+                &[first, second, third] => func(first.clone(), second.clone(), third.clone()),
+                _ => Err(evaluator::EvaluationError::WrongNumArguments {
+                    function_name: name.clone(),
+                    expected: 3,
+                    actual: args.len(),
+                }),
             }),
             Some(return_type),
             vec![arg_types.0, arg_types.1, arg_types.2],

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -134,6 +134,8 @@ impl Pattern {
         let pattern_len = pattern.len();
 
         while i < text_len && (!contains_star || star_idx != pattern_len - 1) {
+            // PANIC SAFETY `j` is checked to be less than length
+            #[allow(clippy::indexing_slicing)]
             if j < pattern_len && pattern[j].is_wildcard() {
                 contains_star = true;
                 star_idx = j;
@@ -151,6 +153,8 @@ impl Pattern {
             }
         }
 
+        // PANIC SAFETY `j` is checked to be less than length
+        #[allow(clippy::indexing_slicing)]
         while j < pattern_len && pattern[j].is_wildcard() {
             j += 1;
         }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -276,7 +276,9 @@ impl LinkingError {
 
 fn describe_arity_error(unbound_values: &[SlotId], extra_values: &[SlotId]) -> String {
     match (unbound_values.len(), extra_values.len()) {
-        (0,0) => panic!("Unreachable"),
+        // PANIC SAFETY 0,0 case is not an error
+        #[allow(clippy::unreachable)]
+        (0,0) => unreachable!(),
         (_unbound, 0) => format!("The following slots were unbound: {}", unbound_values.iter().join(",")),
         (0, _extra) => format!("The following slots were provided as arguments, but did not exist in the template: {}", extra_values.iter().join(",")),
         (_unbound, _extra) => format!("The following slots were unbound: {}\nThe following slots were provided as arguments, but did not exist in the template: {}", unbound_values.iter().join(","), extra_values.iter().join(","))

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -270,6 +270,8 @@ impl std::fmt::Display for PolicySet {
     }
 }
 
+// PANIC SAFETY tests
+#[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod test {
     use std::collections::{BTreeMap, HashMap};

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -147,22 +147,16 @@ impl PolicySet {
 
         // TODO: Use `try_insert` when stabilized.
         // https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.try_insert
-        if self.templates.contains_key(t.id()) || self.links.contains_key(p.id()) {
-            Err(PolicySetError::Occupied)
-        } else {
-            // PANIC SAFETY Checked that templates did not contain this key above
-            #[allow(clippy::unreachable)]
-            if self.templates.insert(t.id().clone(), t).is_some() {
-                unreachable!("Template key was already present");
+        match (
+            self.templates.entry(t.id().clone()),
+            self.links.entry(t.id().clone()),
+        ) {
+            (Entry::Vacant(templates_entry), Entry::Vacant(links_entry)) => {
+                templates_entry.insert(t);
+                links_entry.insert(p);
+                Ok(())
             }
-
-            // PANIC SAFETY Checked that links did not contain this key above
-            #[allow(clippy::unreachable)]
-            if self.links.insert(p.id().clone(), p).is_some() {
-                unreachable!("Link key was already present");
-            }
-
-            Ok(())
+            _ => Err(PolicySetError::Occupied),
         }
     }
 
@@ -170,15 +164,12 @@ impl PolicySet {
     pub fn add_template(&mut self, t: Template) -> Result<(), PolicySetError> {
         // TODO: Use `try_insert` when stabilized.
         // https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.try_insert
-        if self.templates.contains_key(t.id()) {
-            Err(PolicySetError::Occupied)
-        } else {
-            // PANIC SAFETY Checked templates did not contain this key above
-            #[allow(clippy::unreachable)]
-            if self.templates.insert(t.id().clone(), Arc::new(t)).is_some() {
-                unreachable!("Template key was already present");
+        match self.templates.entry(t.id().clone()) {
+            Entry::Occupied(_) => Err(PolicySetError::Occupied),
+            Entry::Vacant(entry) => {
+                entry.insert(Arc::new(t));
+                Ok(())
             }
-            Ok(())
         }
     }
 
@@ -190,21 +181,23 @@ impl PolicySet {
         &mut self,
         template_id: PolicyID,
         new_id: PolicyID,
-        vals: HashMap<SlotId, EntityUID>,
+        values: HashMap<SlotId, EntityUID>,
     ) -> Result<(), LinkingError> {
         let t = self
             .get_template(&template_id)
             .ok_or_else(|| LinkingError::NoSuchTemplate(template_id.clone()))?;
-        let r = Template::link(t, new_id.clone(), vals)?;
-        if self.links.contains_key(&new_id) || self.templates.contains_key(&new_id) {
-            Err(LinkingError::PolicyIdConflict)
-        } else {
-            // PANIC SAFETY Checked links did not contain this key above
-            #[allow(clippy::unreachable)]
-            if self.links.insert(new_id, r).is_some() {
-                unreachable!("Links already has `new_id` as a key!")
+        let r = Template::link(t, new_id.clone(), values)?;
+
+        // Both maps must not contain the `new_id`
+        match (
+            self.links.entry(new_id.clone()),
+            self.templates.entry(new_id),
+        ) {
+            (Entry::Vacant(links_entry), Entry::Vacant(_)) => {
+                links_entry.insert(r);
+                Ok(())
             }
-            Ok(())
+            _ => Err(LinkingError::PolicyIdConflict),
         }
     }
 

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -150,10 +150,14 @@ impl PolicySet {
         if self.templates.contains_key(t.id()) || self.links.contains_key(p.id()) {
             Err(PolicySetError::Occupied)
         } else {
+            // PANIC SAFETY Checked that templates did not contain this key above
+            #[allow(clippy::unreachable)]
             if self.templates.insert(t.id().clone(), t).is_some() {
                 unreachable!("Template key was already present");
             }
 
+            // PANIC SAFETY Checked that links did not contain this key above
+            #[allow(clippy::unreachable)]
             if self.links.insert(p.id().clone(), p).is_some() {
                 unreachable!("Link key was already present");
             }
@@ -169,6 +173,8 @@ impl PolicySet {
         if self.templates.contains_key(t.id()) {
             Err(PolicySetError::Occupied)
         } else {
+            // PANIC SAFETY Checked templates did not contain this key above
+            #[allow(clippy::unreachable)]
             if self.templates.insert(t.id().clone(), Arc::new(t)).is_some() {
                 unreachable!("Template key was already present");
             }
@@ -193,6 +199,8 @@ impl PolicySet {
         if self.links.contains_key(&new_id) || self.templates.contains_key(&new_id) {
             Err(LinkingError::PolicyIdConflict)
         } else {
+            // PANIC SAFETY Checked links did not contain this key above
+            #[allow(clippy::unreachable)]
             if self.links.insert(new_id, r).is_some() {
                 unreachable!("Links already has `new_id` as a key!")
             }

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -72,6 +72,8 @@ impl RestrictedExpr {
     pub fn new_unchecked(expr: Expr) -> Self {
         // in debug builds, this does the check anyway, panicking if it fails
         if cfg!(debug_assertions) {
+            // PANIC SAFETY: We're in debug mode and panicking intentionally
+            #[allow(clippy::unwrap_used)]
             Self::new(expr).unwrap()
         } else {
             Self(expr)
@@ -144,6 +146,8 @@ impl<'a> BorrowedRestrictedExpr<'a> {
     pub fn new_unchecked(expr: &'a Expr) -> Self {
         // in debug builds, this does the check anyway, panicking if it fails
         if cfg!(debug_assertions) {
+            // PANIC SAFETY: We're in debug mode and panicking intentionally
+            #[allow(clippy::unwrap_used)]
             Self::new(expr).unwrap()
         } else {
             Self(expr)

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -217,7 +217,9 @@ impl FromIterator<Value> for Set {
                         .into_iter()
                         .map(|v| match v {
                             Value::Lit(l) => l,
-                            _ => unreachable!(), // SAFETY: This is unreachable as every item in `literals` matches Value::Lit
+                            // PANIC SAFETY: This is unreachable as every item in `literals` matches Value::Lit
+                            #[allow(clippy::unreachable)]
+                            _ => unreachable!(),
                         })
                         .collect(),
                 )),

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -244,7 +244,6 @@ impl Authorizer {
                         .chain(once(trivial_true)),
                 )
                 .unwrap();
-                // This unwrap should be safe, all policy IDs should already be unique
                 ResponseKind::Partial(PartialResponse::new(
                     policy_set,
                     idset,

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -360,19 +360,22 @@ impl Authorizer {
     /// Private helper function which determines if policy `p1` overrides policy
     /// `p2`.
     ///
+    /// INVARIANT: p1 and p2 must have differing effects.
     /// This only makes sense to call with one `Permit` and one `Forbid` policy.
     /// If you call this with two `Permit`s or two `Forbid`s, this will panic.
     fn overrides(p1: &Policy, p2: &Policy) -> bool {
         // For now, we only support the default:
         // all Forbid policies override all Permit policies.
+        // PANIC SAFETY p1 and p2s effect cannot be equal by invariant
+        #[allow(clippy::unreachable)]
         match (p1.effect(), p2.effect()) {
             (Effect::Forbid, Effect::Permit) => true,
             (Effect::Permit, Effect::Forbid) => false,
             (Effect::Permit, Effect::Permit) => {
-                panic!("Shouldn't call overrides() with two Permits")
+                unreachable!("Shouldn't call overrides() with two Permits")
             }
             (Effect::Forbid, Effect::Forbid) => {
-                panic!("Shouldn't call overrides() with two Forbids")
+                unreachable!("Shouldn't call overrides() with two Forbids")
             }
         }
     }

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -189,7 +189,7 @@ impl JSONValue {
                             parser::err::ParseError::WithContext {
                                 context: format!(
                                     "contents of __entity escape {} do not make a valid entity reference",
-                                    serde_json::to_string_pretty(&entity).unwrap()
+                                    serde_json::to_string_pretty(&entity).unwrap_or_else(|_| format!("{:?}", &entity))
                                 ),
                                 errs,
                             },
@@ -638,6 +638,8 @@ impl EntityUidJSON {
                         // We'll give them the `ExpectedLiteralEntityRef` error
                         // message instead of the `ExprParseError` error message,
                         // as it's likely to be more helpful in my opinion
+                        // PANIC SAFETY: Every `String` can be turned into a restricted expression
+                        #[allow(clippy::unwrap_used)]
                         JsonDeserializationError::ExpectedLiteralEntityRef {
                             ctx: ctx(),
                             got: Box::new(JSONValue::String(__expr).into_expr().unwrap().into()),

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -342,9 +342,8 @@ impl<'e> ValueParser<'e> {
             // for instance, the `__extn` escape can optionally be omitted. What
             // this means is that we parse the contents as `ExtnValueJSON`, and then
             // convert that into an extension-function-call `RestrictedExpr`
-            Some(expected_ty @ SchemaType::Extension { .. }) => {
+            Some(SchemaType::Extension { ref name, .. }) => {
                 let extjson: ExtnValueJSON = serde_json::from_value(val)?;
-                let SchemaType::Extension { ref name, .. } = &expected_ty else { panic!("already checked it was Type::Extension above")};
                 self.extn_value_json_into_rexpr(extjson, name.clone(), ctx)
             }
             // The expected type is a set type. No special parsing rules apply, but
@@ -541,7 +540,9 @@ impl<'e> ValueParser<'e> {
                     name: efunc.name().clone()
                 })?)
             }
-            expr => panic!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
+            // PANIC SAFETY. Unreachable by invariant on restricted expressions
+            #[allow(clippy::unreachable)]
+            expr => unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
         }
     }
 }

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -209,6 +209,8 @@ impl JSONValue {
                 0 => Err(JsonSerializationError::ExtnCall0Arguments {
                     func: fn_name.clone(),
                 }),
+                // PANIC SAFETY. We've checked that `args` is of length 1, fine to index at 0
+                #[allow(clippy::indexing_slicing)]
                 1 => Ok(Self::ExtnEscape {
                     __extn: FnAndArg {
                         ext_fn: fn_name.to_string().into(),

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -168,6 +168,8 @@ impl TryFrom<cst::Cond> for Clause {
 
         if let (Some(expr), true) = (expr, errs.is_empty()) {
             Ok(match is_when {
+                // PANIC SAFETY errs should be non empty if is_when is None
+                #[allow(clippy::unreachable)]
                 None => unreachable!("should have had an err in this case"),
                 Some(true) => Clause::When(expr),
                 Some(false) => Clause::Unless(expr),

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -109,11 +109,9 @@ impl TryFrom<cst::Policy> for Policy {
         let mut errs = vec![];
         let effect = policy.effect.to_effect(&mut errs);
         let (principal, action, resource) = policy.extract_head(&mut errs);
-        if errs.is_empty() {
-            let effect = effect.expect("should be Some if errs.is_empty()");
-            let principal = principal.expect("should be Some if errs.is_empty()");
-            let action = action.expect("should be Some if errs.is_empty()");
-            let resource = resource.expect("should be Some if errs.is_empty()");
+        if let (Some(effect), Some(principal), Some(action), Some(resource), true) =
+            (effect, principal, action, resource, errs.is_empty())
+        {
             let conditions = policy
                 .conds
                 .into_iter()
@@ -168,8 +166,7 @@ impl TryFrom<cst::Cond> for Clause {
 
         let is_when = cond.cond.to_cond_is_when(&mut errs);
 
-        if errs.is_empty() {
-            let expr = expr.expect("should be Some since errs.is_empty()");
+        if let (Some(expr), true) = (expr, errs.is_empty()) {
             Ok(match is_when {
                 None => unreachable!("should have had an err in this case"),
                 Some(true) => Clause::When(expr),
@@ -208,6 +205,8 @@ impl Policy {
             0 => ast::Expr::val(true),
             _ => {
                 let mut conditions = self.conditions.into_iter().map(ast::Expr::try_from);
+                // PANIC SAFETY checked above that `conditions` has at least 1 element
+                #[allow(clippy::expect_used)]
                 let first = conditions
                     .next()
                     .expect("already checked there is at least 1")?;

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1277,7 +1277,10 @@ impl TryFrom<cst::Member> for Expr {
     }
 }
 
-fn extract_single_argument(es: Vec<Expr>, fn_name: &str) -> Result<Expr, ParseErrors> {
+fn extract_single_argument(
+    es: impl IntoIterator<Item = Expr>,
+    fn_name: &str,
+) -> Result<Expr, ParseErrors> {
     let mut iter = es.into_iter().fuse().peekable();
     let first = iter.next();
     let second = iter.next();

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -134,7 +134,9 @@ impl<'e> RestrictedEvaluator<'e> {
                     Either::Right(residuals) => Ok(Expr::call_extension_fn(fn_name.clone(), residuals.collect()).into()),
                 }
             },
-            expr => panic!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
+            // PANIC SAFETY Unreachable via invariant on restricted expressions 
+            #[allow(clippy::unreachable)]
+            expr =>unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
         }
     }
 }
@@ -430,7 +432,11 @@ impl<'q, 'e> Evaluator<'e> {
                                     },
                                 )),
                             },
-                            _ => panic!("Should have already checked that op was one of these"),
+                            // PANIC SAFETY `op` is checked to be one of the above
+                            #[allow(clippy::unreachable)]
+                            _ => {
+                                unreachable!("Should have already checked that op was one of these")
+                            }
                         }
                     }
                     // hierarchy membership operator; see note on `BinaryOp::In`
@@ -473,7 +479,9 @@ impl<'q, 'e> Evaluator<'e> {
                                     BinaryOp::ContainsAny => {
                                         Ok((!arg1_set.is_disjoint(arg2_set)).into())
                                     }
-                                    _ => panic!(
+                                    // PANIC SAFETY `op` is checked to be one of thse two above
+                                    #[allow(clippy::unreachable)]
+                                    _ => unreachable!(
                                         "Should have already checked that op was one of these"
                                     ),
                                 }
@@ -496,7 +504,9 @@ impl<'q, 'e> Evaluator<'e> {
                                             .any(|item| arg2_set.authoritative.contains(item));
                                         Ok(not_disjoint.into())
                                     }
-                                    _ => panic!(
+                                    // PANIC SAFETY `op` is checked to be one of thse two above
+                                    #[allow(clippy::unreachable)]
+                                    _ => unreachable!(
                                         "Should have already checked that op was one of these"
                                     ),
                                 }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -250,11 +250,11 @@ impl<'q, 'e> Evaluator<'e> {
             Ok(e) => (e, None),
             Err(err) => {
                 let arg = Expr::val(format!("{err}"));
+                // PANIC SAFETY: Input to `parse` is fully static and a valid extension function name
+                #[allow(clippy::unwrap_used)]
+                let fn_name = "error".parse().unwrap();
                 (
-                    PartialValue::Residual(Expr::call_extension_fn(
-                        "error".parse().unwrap(),
-                        vec![arg],
-                    )),
+                    PartialValue::Residual(Expr::call_extension_fn(fn_name, vec![arg])),
                     Some(err),
                 )
             }
@@ -716,13 +716,17 @@ impl<'q, 'e> Evaluator<'e> {
                         .cloned(),
                 }
             }
-            PartialValue::Value(v) => Err(EvaluationError::TypeError {
-                expected: vec![
-                    Type::Record,
-                    Type::entity_type(Name::parse_unqualified_name("any_entity_type").unwrap()),
-                ],
-                actual: v.type_of(),
-            }),
+            PartialValue::Value(v) => {
+                // PANIC SAFETY Entity type name is fully static and a valid unqualified `Name`
+                #[allow(clippy::unwrap_used)]
+                Err(EvaluationError::TypeError {
+                    expected: vec![
+                        Type::Record,
+                        Type::entity_type(Name::parse_unqualified_name("any_entity_type").unwrap()),
+                    ],
+                    actual: v.type_of(),
+                })
+            }
         }
     }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -479,7 +479,7 @@ impl<'q, 'e> Evaluator<'e> {
                                     BinaryOp::ContainsAny => {
                                         Ok((!arg1_set.is_disjoint(arg2_set)).into())
                                     }
-                                    // PANIC SAFETY `op` is checked to be one of thse two above
+                                    // PANIC SAFETY `op` is checked to be one of these two above
                                     #[allow(clippy::unreachable)]
                                     _ => unreachable!(
                                         "Should have already checked that op was one of these"
@@ -504,7 +504,7 @@ impl<'q, 'e> Evaluator<'e> {
                                             .any(|item| arg2_set.authoritative.contains(item));
                                         Ok(not_disjoint.into())
                                     }
-                                    // PANIC SAFETY `op` is checked to be one of thse two above
+                                    // PANIC SAFETY `op` is checked to be one of these two above
                                     #[allow(clippy::unreachable)]
                                     _ => unreachable!(
                                         "Should have already checked that op was one of these"

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -30,6 +30,15 @@ use smol_str::SmolStr;
 
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
+// PANIC SAFETY `Name`s in here are valid `Name`s
+#[allow(clippy::expect_used)]
+mod names {
+    use super::Name;
+    lazy_static::lazy_static! {
+        pub static ref ANY_ENTITY_TYPE : Name = Name::parse_unqualified_name("any_entity_type").expect("valid identifier");
+    }
+}
+
 /// Evaluator object.
 ///
 /// Conceptually keeps the evaluation environment as part of its internal state,
@@ -542,10 +551,7 @@ impl<'q, 'e> Evaluator<'e> {
                 PartialValue::Value(val) => Err(err::EvaluationError::TypeError {
                     expected: vec![
                         Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier"),
-                        ),
+                        Type::entity_type(names::ANY_ENTITY_TYPE.clone()),
                     ],
                     actual: val.type_of(),
                 }),
@@ -604,13 +610,7 @@ impl<'q, 'e> Evaluator<'e> {
                 .collect::<Result<Vec<EntityUID>>>()?,
             _ => {
                 return Err(EvaluationError::TypeError {
-                    expected: vec![
-                        Type::Set,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier"),
-                        ),
-                    ],
+                    expected: vec![Type::Set, Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
                     actual: arg2.type_of(),
                 })
             }
@@ -818,9 +818,7 @@ impl Value {
         match self {
             Value::Lit(Literal::EntityUID(uid)) => Ok(uid.as_ref()),
             _ => Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(
-                    Name::parse_unqualified_name("any_entity_type").expect("valid identifier"),
-                )],
+                expected: vec![Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
                 actual: self.type_of(),
             }),
         }

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -54,6 +54,7 @@ pub enum EvaluationError {
     ExtensionsError(#[from] crate::extensions::ExtensionsError),
 
     /// Type error, showing the expected type and actual type
+    /// INVARIANT `expected` must be non-empty
     #[error("{}", pretty_type_error(expected, actual))]
     TypeError {
         /// Expected (one of) these types
@@ -104,9 +105,12 @@ pub enum EvaluationError {
 }
 
 /// helper function for pretty-printing type errors
+/// INVARIANT: `expected` must have at least one value
 fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
     match expected.len() {
-        0 => panic!("should expect at least one type"),
+        // PANIC SAFETY, `expected` is non-empty by invariant
+        #[allow(clippy::unreachable)]
+        0 => unreachable!("should expect at least one type"),
         1 => format!("type error: expected {}, got {}", expected[0], actual),
         _ => {
             use itertools::Itertools;

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -111,6 +111,8 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
         // PANIC SAFETY, `expected` is non-empty by invariant
         #[allow(clippy::unreachable)]
         0 => unreachable!("should expect at least one type"),
+        // PANIC SAFETY. `len` is 1 in this branch
+        #[allow(clippy::indexing_slicing)]
         1 => format!("type error: expected {}, got {}", expected[0], actual),
         _ => {
             use itertools::Itertools;

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -84,12 +84,12 @@ impl<'a> Extensions<'a> {
             .iter()
             .filter_map(|ext| ext.get_func(name))
             .collect();
-        match extension_funcs.len() {
-            0 => Err(ExtensionsError::FuncDoesNotExist { name: name.clone() }),
-            1 => Ok(extension_funcs[0]),
-            num_defs => Err(ExtensionsError::FuncMultiplyDefined {
+        match extension_funcs.get(0) {
+            None => Err(ExtensionsError::FuncDoesNotExist { name: name.clone() }),
+            Some(first) if extension_funcs.len() == 1 => Ok(first),
+            _ => Err(ExtensionsError::FuncMultiplyDefined {
                 name: name.clone(),
-                num_defs,
+                num_defs: extension_funcs.len(),
             }),
         }
     }
@@ -116,13 +116,12 @@ impl<'a> Extensions<'a> {
             .filter(|f| {
                 f.is_constructor()
                     && f.return_type() == Some(return_type)
-                    && f.arg_types().len() == 1
-                    && f.arg_types()[0].as_ref() == Some(arg_type)
+                    && f.arg_types().get(0).map(Option::as_ref) == Some(Some(arg_type))
             })
             .collect::<Vec<_>>();
-        match matches.len() {
-            0 => Ok(None),
-            1 => Ok(Some(matches[0])),
+        match matches.get(0) {
+            None => Ok(None),
+            Some(first) if matches.len() == 1 => Ok(Some(first)),
             _ => Err(ExtensionsError::MultipleConstructorsSameSignature {
                 return_type: Box::new(return_type.clone()),
                 arg_type: Box::new(arg_type.clone()),

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -82,6 +82,8 @@ impl Decimal {
     /// `d * 10 ^ NUM_DIGITS`; this function will error on overflow.
     fn from_str(str: impl AsRef<str>) -> Result<Self, Error> {
         // check that the string matches the regex
+        // PANIC SAFETY: This regex does parse
+        #[allow(clippy::unwrap_used)]
         let re = Regex::new(r#"^(-?\d+)\.(\d+)$"#).unwrap();
         if !re.is_match(str.as_ref()) {
             return Err(Error::FailedParse(str.as_ref().to_owned()));

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -135,6 +135,8 @@ fn contains_at_least_two(s: &str, c: char) -> bool {
     let idx = s.find(c);
     match idx {
         Some(i) => {
+            // PANIC SAFETY `i` is guaranteed to be < `s.len()`, so this won't panic
+            #[allow(clippy::indexing_slicing)]
             let idx = s[i + 1..].find(c);
             idx.is_some()
         }

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -27,6 +27,8 @@ fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
 
 fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {
     let msg = v.get_as_string()?;
+    // PANIC SAFETY: This name is fully static, and is a valid extension name
+    #[allow(clippy::unwrap_used)]
     let err = EvaluationError::ExtensionError {
         extension_name: "partial_evaluation".parse().unwrap(),
         msg: msg.to_string(),
@@ -35,6 +37,8 @@ fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {
 }
 
 /// Construct the extension
+// PANIC SAFETY: all uses of `unwrap` here on on parsing extension names are correct names
+#[allow(clippy::unwrap_used)]
 pub fn extension() -> Extension {
     Extension::new(
         "partial_evaluation".parse().unwrap(),

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -37,7 +37,7 @@ fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {
 }
 
 /// Construct the extension
-// PANIC SAFETY: all uses of `unwrap` here on on parsing extension names are correct names
+// PANIC SAFETY: all uses of `unwrap` here on parsing extension names are correct names
 #[allow(clippy::unwrap_used)]
 pub fn extension() -> Extension {
     Extension::new(

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,6 +17,9 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+// Clippy configuration
+#![deny(clippy::unwrap_used)]
+//#![deny(clippy::expect_used)]
 
 #[macro_use]
 extern crate lalrpop_util;
@@ -27,5 +30,7 @@ pub mod entities;
 pub mod est;
 pub mod evaluator;
 pub mod extensions;
+
 pub mod parser;
+
 pub mod transitive_closure;

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -19,7 +19,8 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 // Clippy configuration
 #![deny(clippy::unwrap_used)]
-//#![deny(clippy::expect_used)]
+#![deny(clippy::expect_used)]
+#![deny(clippy::fallible_impl_from)]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -21,6 +21,7 @@
 #![deny(clippy::unwrap_used)]
 #![deny(clippy::expect_used)]
 #![deny(clippy::fallible_impl_from)]
+#![deny(clippy::unreachable)]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -22,6 +22,7 @@
 #![deny(clippy::expect_used)]
 #![deny(clippy::fallible_impl_from)]
 #![deny(clippy::unreachable)]
+#![deny(clippy::indexing_slicing)]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -58,6 +58,8 @@ pub fn parse_policyset_to_ests_and_pset(
     let pset = cst
         .to_policyset(&mut errs)
         .ok_or_else(|| err::ParseErrors(errs.clone()))?;
+    // PANIC SAFETY Shouldn't be `none` since `parse_policies()` an d`to_policyset` didn't return `Err`
+    #[allow(clippy::expect_used)]
     let ests = cst
         .with_generated_policyids()
         .expect("shouldn't be None since parse_policies() and to_policyset didn't return Err")

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -58,7 +58,7 @@ pub fn parse_policyset_to_ests_and_pset(
     let pset = cst
         .to_policyset(&mut errs)
         .ok_or_else(|| err::ParseErrors(errs.clone()))?;
-    // PANIC SAFETY Shouldn't be `none` since `parse_policies()` an d`to_policyset` didn't return `Err`
+    // PANIC SAFETY Shouldn't be `none` since `parse_policies()` and `to_policyset` didn't return `Err`
     #[allow(clippy::expect_used)]
     let ests = cst
         .with_generated_policyids()

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1231,6 +1231,8 @@ impl ASTNode<Option<cst::Mult>> {
                     src.clone(),
                 )))
             } else {
+                // PANIC SAFETY Checked above that `nonconstantints` has at leats one element
+                #[allow(clippy::expect_used)]
                 let nonconstantint: ast::Expr = nonconstantints
                     .into_iter()
                     .next()

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1213,6 +1213,8 @@ impl ASTNode<Option<cst::Mult>> {
                 .into_iter()
                 .map(|e| match e.expr_kind() {
                     ast::ExprKind::Lit(ast::Literal::Long(i)) => *i,
+                    // PANIC SAFETY Checked the match above via the call to `partition`
+                    #[allow(clippy::unreachable)]
                     _ => unreachable!(
                         "checked it matched ast::ExprKind::Lit(ast::Literal::Long(_)) above"
                     ),

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1227,13 +1227,15 @@ impl ASTNode<Option<cst::Mult>> {
                 ));
                 None
             } else if nonconstantints.is_empty() {
+                // PANIC SAFETY If nonconstantints is empty then constantints must have at least one value
+                #[allow(clippy::indexing_slicing)]
                 Some(ExprOrSpecial::Expr(construct_expr_mul(
                     construct_expr_num(constantints[0], src.clone()),
                     constantints[1..].iter().copied(),
                     src.clone(),
                 )))
             } else {
-                // PANIC SAFETY Checked above that `nonconstantints` has at leats one element
+                // PANIC SAFETY Checked above that `nonconstantints` has at least one element
                 #[allow(clippy::expect_used)]
                 let nonconstantint: ast::Expr = nonconstantints
                     .into_iter()

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -133,22 +133,15 @@ impl fmt::Display for VariableDef {
 }
 impl fmt::Display for Cond {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.expr.is_none() {
-            write!(f, "{} {{ }}", View(&self.cond))
-        } else if f.alternate() {
-            write!(
-                f,
-                "{} {{\n  {:#}\n}}",
-                View(&self.cond),
-                View(self.expr.as_ref().unwrap())
-            )
-        } else {
-            write!(
-                f,
-                "{} {{{}}}",
-                View(&self.cond),
-                View(self.expr.as_ref().unwrap())
-            )
+        match self.expr.as_ref() {
+            Some(expr_ref) => {
+                if f.alternate() {
+                    write!(f, "{} {{\n  {:#}\n}}", View(&self.cond), View(expr_ref))
+                } else {
+                    write!(f, "{} {{{}}}", View(&self.cond), View(expr_ref))
+                }
+            }
+            None => write!(f, "{} {{ }}", View(&self.cond)),
         }
     }
 }

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -19,8 +19,12 @@
 
 lalrpop_mod!(
     #[allow(warnings, unused)]
-    //PANIC SAFETY: lalrpop uses unwraps, and we are trusted lalrpop to generate correct code
+    //PANIC SAFETY: lalrpop uses unwraps, and we are trusting lalrpop to generate correct code
     #[allow(clippy::unwrap_used)]
+    //PANIC SAFETY: lalrpop uses slicing, and we are trusting lalrpop to generate correct code
+    #[allow(clippy::indexing_slicing)]
+    //PANIC SAFETY: lalrpop uses unreachable, and we are trusting lalrpop to generate correct code
+    #[allow(clippy::unreachable)]
     pub grammar,
     "/src/parser/grammar.rs"
 );

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -19,6 +19,8 @@
 
 lalrpop_mod!(
     #[allow(warnings, unused)]
+    //PANIC SAFETY: lalrpop uses unwraps, and we are trusted lalrpop to generate correct code
+    #[allow(clippy::unwrap_used)]
     pub grammar,
     "/src/parser/grammar.rs"
 );

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -45,6 +45,8 @@ pub(crate) fn to_pattern(s: &str) -> Result<Vec<PatternElem>, Vec<UnescapeError>
     let bytes = s.as_bytes(); // to inspect string element in O(1) time
     let mut callback = |range: Range<usize>, r| match r {
         Ok(c) => unescaped_str.push(if c == '*' { PatternElem::Wildcard }else { PatternElem::Char(c) }),
+        // PANIC SAFETY By invariant, all passed in ranges must be in range
+        #[allow(clippy::indexing_slicing)]
         Err(EscapeError::InvalidEscape)
         // note that the range argument refers to the *byte* offset into the string.
         // so we can compare the byte slice against the bytes of the ``star'' escape sequence.
@@ -71,10 +73,13 @@ pub struct UnescapeError {
     /// copy of the input string which had the error
     input: String,
     /// Range of the input string where the error occurred
+    /// This range must be within the length of `input`
     range: Range<usize>,
 }
 
 impl std::fmt::Display for UnescapeError {
+    // PANIC SAFETY By invariant, the range will always be within the bounds of `input`
+    #[allow(clippy::indexing_slicing)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}: {}", self.err, &self.input[self.range.clone()])
     }

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -183,6 +183,8 @@ where
     Ok(())
 }
 
+// PANIC SAFETY test cases
+#[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod tests {
     use crate::ast::{Entity, EntityUID};

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -82,6 +82,8 @@ where
         add_ancestors_to_set(node, nodes, this_node_ancestors)?;
     }
     for node in nodes.values_mut() {
+        // PANIC SAFETY All nodes in `ancestors` came from `nodes`
+        #[allow(clippy::expect_used)]
         for ancestor_uid in ancestors
             .get(&node.get_key())
             .expect("shouldn't have added any new values to the `nodes` map")

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1989,48 +1989,26 @@ impl<'a> Typechecker<'a> {
                             .is_in(lhs_expr, rhs_expr),
                     )
                 } else {
-                    match (
-                        Typechecker::replace_action_var_with_euid(request_env, lhs)
-                            .as_ref()
-                            .expr_kind(),
-                        Typechecker::replace_action_var_with_euid(request_env, rhs)
-                            .as_ref()
-                            .expr_kind(),
-                    ) {
+                    let lhs_as_euid_lit =
+                        Typechecker::replace_action_var_with_euid(request_env, lhs);
+                    let rhs_as_euid_lit =
+                        Typechecker::replace_action_var_with_euid(request_env, rhs);
+                    match (lhs_as_euid_lit.expr_kind(), rhs_as_euid_lit.expr_kind()) {
                         // var in EntityLiteral. Lookup the descendant types of the entity
                         // literals.  If the principal/resource type is not one of the
-                        // descendants, than it can never `in` the literals (return false).
+                        // descendants, than it can never be `in` the literals (return false).
                         // Otherwise, it could be (return boolean).
                         (
                             ExprKind::Var(var @ (Var::Principal | Var::Resource)),
-                            ExprKind::Lit(Literal::EntityUID(euid)),
-                        ) => {
-                            let var_euid = if matches!(var, Var::Principal) {
-                                request_env.principal
-                            } else {
-                                request_env.resource
-                            };
-                            let descendants = self.schema.get_entities_in(
-                                PrincipalOrResourceHeadVar::PrincipalOrResource,
-                                (**euid).clone(),
-                            );
-                            match var_euid {
-                                EntityType::Concrete(var_name) => {
-                                    Typechecker::entity_in_descendants(
-                                        var_name,
-                                        descendants,
-                                        in_expr,
-                                        lhs_expr,
-                                        rhs_expr,
-                                    )
-                                }
-                                EntityType::Unspecified => TypecheckAnswer::fail(
-                                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                        .with_same_source_info(in_expr)
-                                        .is_in(lhs_expr, rhs_expr),
-                                ),
-                            }
-                        }
+                            ExprKind::Lit(Literal::EntityUID(_)),
+                        ) => self.type_of_var_in_entity_literals(
+                            request_env,
+                            *var,
+                            [rhs_as_euid_lit.as_ref()],
+                            in_expr,
+                            lhs_expr,
+                            rhs_expr,
+                        ),
 
                         // var in [EntityLiteral, ...]. As above, but now the
                         // principal/resource just needs to be in the descendants sets for
@@ -2038,44 +2016,14 @@ impl<'a> Typechecker<'a> {
                         (
                             ExprKind::Var(var @ (Var::Principal | Var::Resource)),
                             ExprKind::Set(elems),
-                        ) => {
-                            if let Some(rhs) = Typechecker::euids_from_euid_literals_or_action(
-                                request_env,
-                                elems.as_ref(),
-                            ) {
-                                let var_euid = if matches!(var, Var::Principal) {
-                                    request_env.principal
-                                } else {
-                                    request_env.resource
-                                };
-                                let descendants = self.schema.get_entities_in_set(
-                                    PrincipalOrResourceHeadVar::PrincipalOrResource,
-                                    rhs,
-                                );
-                                match var_euid {
-                                    EntityType::Concrete(var_name) => {
-                                        Typechecker::entity_in_descendants(
-                                            var_name,
-                                            descendants,
-                                            in_expr,
-                                            lhs_expr,
-                                            rhs_expr,
-                                        )
-                                    }
-                                    EntityType::Unspecified => TypecheckAnswer::fail(
-                                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                            .with_same_source_info(in_expr)
-                                            .is_in(lhs_expr, rhs_expr),
-                                    ),
-                                }
-                            } else {
-                                TypecheckAnswer::success(
-                                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                        .with_same_source_info(in_expr)
-                                        .is_in(lhs_expr, rhs_expr),
-                                )
-                            }
-                        }
+                        ) => self.type_of_var_in_entity_literals(
+                            request_env,
+                            *var,
+                            elems.as_ref(),
+                            in_expr,
+                            lhs_expr,
+                            rhs_expr,
+                        ),
 
                         // EntityLiteral in EntityLiteral. Follows similar logic to the
                         // first case, but with the added complication that this case
@@ -2085,92 +2033,26 @@ impl<'a> Typechecker<'a> {
                         // entity type names.
                         (
                             ExprKind::Lit(Literal::EntityUID(euid0)),
-                            ExprKind::Lit(Literal::EntityUID(euid1)),
-                        ) => {
-                            let lhs = (**euid0).clone();
-                            let rhs = (**euid1).clone();
-                            // Unspecified entities are detected by a different part of the validator.
-                            // Still return `TypecheckFail` so that typechecking is not considered successful.
-                            match lhs.entity_type() {
-                                EntityType::Concrete(name) => {
-                                    if is_action_entity_type(name) {
-                                        // This case will apply when lhs has entity type
-                                        // `Action` even when rhs does not. This is fine because
-                                        // we compare the complete Euid, so an non-`Action`
-                                        // entity will never be in the `member_of` set of an
-                                        // `Action` entity, so this correctly returns `false`.
-                                        self.type_of_euid_in_euid(
-                                            lhs,
-                                            rhs,
-                                            ActionHeadVar::Action,
-                                            in_expr,
-                                            lhs_expr,
-                                            rhs_expr,
-                                        )
-                                    } else {
-                                        self.type_of_euid_in_euid(
-                                            lhs,
-                                            rhs,
-                                            PrincipalOrResourceHeadVar::PrincipalOrResource,
-                                            in_expr,
-                                            lhs_expr,
-                                            rhs_expr,
-                                        )
-                                    }
-                                }
-                                EntityType::Unspecified => TypecheckAnswer::fail(
-                                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                        .with_same_source_info(in_expr)
-                                        .is_in(lhs_expr, rhs_expr),
-                                ),
-                            }
-                        }
+                            ExprKind::Lit(Literal::EntityUID(_)),
+                        ) => self.type_of_entity_literal_in_entity_literals(
+                            request_env,
+                            (**euid0).clone(),
+                            [rhs_as_euid_lit.as_ref()],
+                            in_expr,
+                            lhs_expr,
+                            rhs_expr,
+                        ),
 
                         // As above, with the same complication, but applied to set of entities.
-                        (ExprKind::Lit(Literal::EntityUID(euid)), ExprKind::Set(elems)) => {
-                            if let Some(rhs) = Typechecker::euids_from_euid_literals_or_action(
+                        (ExprKind::Lit(Literal::EntityUID(euid)), ExprKind::Set(elems)) => self
+                            .type_of_entity_literal_in_entity_literals(
                                 request_env,
+                                (**euid).clone(),
                                 elems.as_ref(),
-                            ) {
-                                let lhs = (**euid).clone();
-                                // Unspecified entities are detected by a different part of the validator.
-                                // Still return `TypecheckFail` so that typechecking is not considered successful.
-                                match lhs.entity_type() {
-                                    EntityType::Concrete(name) => {
-                                        if is_action_entity_type(name) {
-                                            self.type_of_euid_in_euid_set(
-                                                lhs,
-                                                rhs,
-                                                ActionHeadVar::Action,
-                                                in_expr,
-                                                lhs_expr,
-                                                rhs_expr,
-                                            )
-                                        } else {
-                                            self.type_of_euid_in_euid_set(
-                                                lhs,
-                                                rhs,
-                                                PrincipalOrResourceHeadVar::PrincipalOrResource,
-                                                in_expr,
-                                                lhs_expr,
-                                                rhs_expr,
-                                            )
-                                        }
-                                    }
-                                    EntityType::Unspecified => TypecheckAnswer::fail(
-                                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                            .with_same_source_info(in_expr)
-                                            .is_in(lhs_expr, rhs_expr),
-                                    ),
-                                }
-                            } else {
-                                TypecheckAnswer::success(
-                                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                        .with_same_source_info(in_expr)
-                                        .is_in(lhs_expr, rhs_expr),
-                                )
-                            }
-                        }
+                                in_expr,
+                                lhs_expr,
+                                rhs_expr,
+                            ),
 
                         // If none of the cases apply, then all we know is that `in` has
                         // type boolean.
@@ -2221,34 +2103,120 @@ impl<'a> Typechecker<'a> {
         }
     }
 
-    // Get the type for `in` when it is applied to an EUID literal and a EUID
-    // literal. The type depends on if we know the LHS entity literal cannot be
-    // in the RHS entity literal.
-    fn type_of_euid_in_euid<'b, K>(
+    /// Handles `in` expression where the `principal` or `resource` is `in` an
+    /// entity literal or set of entity literals.
+    fn type_of_var_in_entity_literals<'b, 'c>(
         &self,
-        lhs: EntityUID,
-        rhs: EntityUID,
-        var: impl HeadVar<K>,
+        request_env: &RequestEnv,
+        lhs_var: Var,
+        rhs_elems: impl IntoIterator<Item = &'b Expr>,
         in_expr: &Expr,
         lhs_expr: Expr<Option<Type>>,
         rhs_expr: Expr<Option<Type>>,
-    ) -> TypecheckAnswer<'b>
-    where
-        K: Clone + PartialEq,
-    {
-        if let Some(lhs_entity) = self.schema.get_entity_eq(var, lhs) {
-            let rhs_descendants = self.schema.get_entities_in(var, rhs);
-            Typechecker::entity_in_descendants(
-                &lhs_entity,
-                rhs_descendants,
-                in_expr,
-                lhs_expr,
-                rhs_expr,
-            )
+    ) -> TypecheckAnswer<'c> {
+        if let Some(rhs) = Typechecker::euids_from_euid_literals_or_action(request_env, rhs_elems) {
+            let var_euid = if matches!(lhs_var, Var::Principal) {
+                request_env.principal
+            } else {
+                request_env.resource
+            };
+            let descendants = self
+                .schema
+                .get_entities_in_set(PrincipalOrResourceHeadVar::PrincipalOrResource, rhs);
+            match var_euid {
+                EntityType::Concrete(var_name) => Typechecker::entity_in_descendants(
+                    var_name,
+                    descendants,
+                    in_expr,
+                    lhs_expr,
+                    rhs_expr,
+                ),
+                // Unspecified entities will be detected by a different part of the validator.
+                // Still return `TypecheckFail` so that typechecking is not considered successful.
+                EntityType::Unspecified => TypecheckAnswer::fail(
+                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                        .with_same_source_info(in_expr)
+                        .is_in(lhs_expr, rhs_expr),
+                ),
+            }
         } else {
-            // Unspecified entities will be detected by a different part of the validator.
-            // Still return `TypecheckFail` so that typechecking is not considered successful.
-            TypecheckAnswer::fail(
+            // One or more of the elements on the right is not an entity
+            // literal, so this does not apply. The `in` is still valid, so
+            // typechecking succeeds with type Boolean.
+            TypecheckAnswer::success(
+                ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                    .with_same_source_info(in_expr)
+                    .is_in(lhs_expr, rhs_expr),
+            )
+        }
+    }
+
+    fn type_of_entity_literal_in_entity_literals<'b, 'c>(
+        &self,
+        request_env: &RequestEnv,
+        lhs_euid: EntityUID,
+        rhs_elems: impl IntoIterator<Item = &'b Expr>,
+        in_expr: &Expr,
+        lhs_expr: Expr<Option<Type>>,
+        rhs_expr: Expr<Option<Type>>,
+    ) -> TypecheckAnswer<'c> {
+        if let Some(rhs) = Typechecker::euids_from_euid_literals_or_action(request_env, rhs_elems) {
+            match lhs_euid.entity_type() {
+                EntityType::Concrete(name) => {
+                    // We don't want to apply the action hierarchy check to
+                    // non-action entities.  We have a set of entities, so We
+                    // can apply the check as long as any are actions. The
+                    // non-actions are omitted from the check, but they can
+                    // never be an ancestor of `Action`.
+                    let lhs_is_action = is_action_entity_type(name);
+                    let (actions, non_actions): (Vec<_>, Vec<_>) =
+                        rhs.into_iter().partition(|e| match e.entity_type() {
+                            EntityType::Concrete(e_name) => is_action_entity_type(e_name),
+                            EntityType::Unspecified => false,
+                        });
+                    if lhs_is_action && !actions.is_empty() {
+                        self.type_of_euid_in_euids(
+                            lhs_euid,
+                            actions,
+                            ActionHeadVar::Action,
+                            in_expr,
+                            lhs_expr,
+                            rhs_expr,
+                        )
+                    } else if !lhs_is_action && !non_actions.is_empty() {
+                        self.type_of_euid_in_euids(
+                            lhs_euid,
+                            non_actions,
+                            PrincipalOrResourceHeadVar::PrincipalOrResource,
+                            in_expr,
+                            lhs_expr,
+                            rhs_expr,
+                        )
+                    } else {
+                        // This hard codes the assumption that `Action` can
+                        // never be a member of any other entity type, and no
+                        // other entity type can ever be a member of `Action`,
+                        // and by extension any particular action entity.
+                        TypecheckAnswer::success(
+                            ExprBuilder::with_data(Some(Type::False))
+                                .with_same_source_info(in_expr)
+                                .is_in(lhs_expr, rhs_expr),
+                        )
+                    }
+                }
+                // Unspecified entities will be detected by a different part of the validator.
+                // Still return `TypecheckFail` so that typechecking is not considered successful.
+                EntityType::Unspecified => TypecheckAnswer::fail(
+                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                        .with_same_source_info(in_expr)
+                        .is_in(lhs_expr, rhs_expr),
+                ),
+            }
+        } else {
+            // One or more of the elements on the right is not an entity
+            // literal, so this does not apply. The `in` is still valid, so
+            // typechecking succeeds with type Boolean.
+            TypecheckAnswer::success(
                 ExprBuilder::with_data(Some(Type::primitive_boolean()))
                     .with_same_source_info(in_expr)
                     .is_in(lhs_expr, rhs_expr),
@@ -2257,9 +2225,9 @@ impl<'a> Typechecker<'a> {
     }
 
     // Get the type for `in` when it is applied to an EUID literal and a set of
-    // EUID literal. The type depends on if we know the LHS entity literal
+    // EUID literals. The type depends on if we know the LHS entity literal
     // cannot be in the RHS set.
-    fn type_of_euid_in_euid_set<'b, K>(
+    fn type_of_euid_in_euids<'b, K>(
         &self,
         lhs: EntityUID,
         rhs: impl IntoIterator<Item = EntityUID>,

--- a/panic_safety.sh
+++ b/panic_safety.sh
@@ -21,7 +21,7 @@ total_panics=0
 failed=0
 
 crates=("cedar-policy-core")
-panic_markers=("unwrap_used expect_used fallible_impl_from unreachable")
+panic_markers=("unwrap_used expect_used fallible_impl_from unreachable indexing_slicing")
 
 for crate in ${crates[@]}; do
     for panic_marker in ${panic_markers[@]}; do

--- a/panic_safety.sh
+++ b/panic_safety.sh
@@ -21,7 +21,7 @@ total_panics=0
 failed=0
 
 crates=("cedar-policy-core")
-panic_markers=("unwrap_used expect_used fallible_impl_from")
+panic_markers=("unwrap_used expect_used fallible_impl_from unreachable")
 
 for crate in ${crates[@]}; do
     for panic_marker in ${panic_markers[@]}; do

--- a/panic_safety.sh
+++ b/panic_safety.sh
@@ -21,7 +21,7 @@ total_panics=0
 failed=0
 
 crates=("cedar-policy-core")
-panic_markers=("unwrap_used")
+panic_markers=("unwrap_used expect_used fallible_impl_from")
 
 for crate in ${crates[@]}; do
     for panic_marker in ${panic_markers[@]}; do

--- a/panic_safety.sh
+++ b/panic_safety.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Copyright 2022-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script ensures that exceptions to the clippy lints have explanations in the comments
+
+total_checked_panics=0
+total_panics=0
+failed=0
+
+crates=("cedar-policy-core")
+panic_markers=("unwrap_used")
+
+for crate in ${crates[@]}; do
+    for panic_marker in ${panic_markers[@]}; do
+        while read -r filename linenum ; do 
+            msg_line=$(($linenum - 1))
+            if sed "$msg_line!d" $filename | grep 'PANIC SAFETY' > /dev/null ; then 
+                total_checked_panics=$(($total_checked_panics + 1))
+                total_panics=$(($total_panics + 1))
+            else
+                echo "Unchecked panic at $filename:$linenum"
+                total_panics=$(($total_panics + 1))
+                failed=1
+            fi
+        done < <(grep -n -r "allow(clippy::$panic_marker)" ./"$crate" | awk -F ':' '{ print $1 " " $2 }')
+    done
+done
+
+echo $total_checked_panics
+
+exit $failed


### PR DESCRIPTION
1. By default, clippy will forbid calling functions like `unwrap`, `expect`, or `unreachable`. 
2. This can be overridden with a local annotation, but that annotation must include a comment explaining correctness

This PR is meant as a draft to discuss these rules, and decide if they are too onerous or not onerous enough.
For now, only `unwrap` is tracked/annotated, if we like these rules this PR will expand. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
