### PR TITLE
refactor `SchemaError` to be declared using `thiserror`

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -130,9 +130,7 @@ pub type Result<T> = std::result::Result<T, SchemaError>;
 
 impl SchemaError {
     fn format_parse_errs(errs: &[ParseError]) -> String {
-        errs.iter()
-            .map(|e| e.to_string())
-            .join(", ")
+        errs.iter().map(|e| e.to_string()).join(", ")
     }
 }
 

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -22,64 +22,83 @@ use cedar_policy_core::{
     transitive_closure,
 };
 use itertools::Itertools;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum SchemaError {
     /// Errors loading and parsing schema files
+    #[error("JSON Schema file could not be parsed: {0}")]
     ParseFileFormat(serde_json::Error),
     /// Errors occurring while computing or enforcing transitive closure on
     /// action id hierarchy.
+    #[error("Transitive closure error on action hierarchy: {0}")]
     ActionTransitiveClosureError(Box<transitive_closure::Err<EntityUID>>),
     /// Errors occurring while computing or enforcing transitive closure on
     /// entity type hierarchy.
+    #[error("Transitive closure error on entity hierarchy: {0}")]
     EntityTransitiveClosureError(transitive_closure::Err<Name>),
     /// Error generated when processing a schema file that uses features which
     /// are not yet supported by the implementation.
+    #[error("Unsupported feature used in schema: {0}")]
     UnsupportedSchemaFeature(UnsupportedFeature),
     /// Undeclared entity type(s) used in an entity type's memberOf field, an
     /// action's appliesTo fields, or an attribute type in a context or entity
     /// attributes record. Entity types are reported fully qualified, including
     /// any implicit or explicit namespaces.
+    #[error("Undeclared entity types: {0:?}")]
     UndeclaredEntityTypes(HashSet<String>),
     /// Undeclared action(s) used in an action's memberOf field.
+    #[error("Undeclared actions: {0:?}")]
     UndeclaredActions(HashSet<String>),
     /// Undeclared type used in entity or context attributes.
+    #[error("Undeclared common types: {0:?}")]
     UndeclaredCommonType(HashSet<String>),
     /// Duplicate specifications for an entity type. Argument is the name of
     /// the duplicate entity type.
+    #[error("Duplicate entity type {0}")]
     DuplicateEntityType(String),
     /// Duplicate specifications for an action. Argument is the name of the
     /// duplicate action.
+    #[error("Duplicate action {0}")]
     DuplicateAction(String),
     /// Duplicate specification for a reusable type declaration.
+    #[error("Duplicate common type {0}")]
     DuplicateCommonType(String),
     /// Cycle in the schema's action hierarchy.
+    #[error("Cycle in action hierarchy")]
     CycleInActionHierarchy,
     /// Parse errors occurring while parsing an entity type.
+    #[error("Parse error in entity type: {}", Self::format_parse_errs(.0))]
     EntityTypeParseError(Vec<ParseError>),
     /// Parse errors occurring while parsing a namespace identifier.
+    #[error("Parse error in namespace identifier: {}", Self::format_parse_errs(.0))]
     NamespaceParseError(Vec<ParseError>),
     /// Parse errors occurring while parsing an extension type.
+    #[error("Parse error in extension type: {}", Self::format_parse_errs(.0))]
     ExtensionTypeParseError(Vec<ParseError>),
     /// Parse errors occurring while parsing the name of one of reusable
     /// declared types.
+    #[error("Parse error in common type identifier: {}", Self::format_parse_errs(.0))]
     CommonTypeParseError(Vec<ParseError>),
     /// The schema file included an entity type `Action` in the entity type
     /// list. The `Action` entity type is always implicitly declared, and it
     /// cannot currently have attributes or be in any groups, so there is no
     /// purposes in adding an explicit entry.
+    #[error("Entity type `Action` declared in `entityTypes` list")]
     ActionEntityTypeDeclared,
     /// One or more action entities are declared with `attributes`, but this is
     /// not currently supported.
+    #[error("Actions declared with `attributes`: [{}]", .0.iter().join(", "))]
     ActionEntityAttributes(Vec<String>),
+    #[error("An entity shape or action context is declared with a type other than `Record`")]
     ContextOrShapeNotRecord,
     /// An Action Entity (transitively) has an attribute that is an empty set
+    #[error("An action entity has an attribute that is an empty set")]
     ActionEntityAttributeEmptySet,
     /// An Action Entity (transitively) has an attribute of unsupported type (ExprEscape, EntityEscape or ExtnEscape)
+    #[error("An action entity has attribute with unsupported type: (escaped expression, entity or extension)")]
     ActionEntityAttributeUnsupportedType,
 }
-
-impl std::error::Error for SchemaError {}
 
 impl From<transitive_closure::Err<EntityUID>> for SchemaError {
     fn from(e: transitive_closure::Err<EntityUID>) -> Self {
@@ -113,101 +132,7 @@ impl SchemaError {
     fn format_parse_errs(errs: &[ParseError]) -> String {
         errs.iter()
             .map(|e| e.to_string())
-            .collect::<Vec<_>>()
             .join(", ")
-    }
-}
-
-impl std::fmt::Display for SchemaError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            SchemaError::ParseFileFormat(e) => {
-                write!(f, "JSON Schema file could not be parsed: {e}")
-            }
-            SchemaError::ActionTransitiveClosureError(e) => {
-                write!(f, "Transitive closure error on action hierarchy: {}", e)
-            }
-            SchemaError::EntityTransitiveClosureError(e) => {
-                write!(f, "Transitive closure error on entity hierarchy: {}", e)
-            }
-            SchemaError::UnsupportedSchemaFeature(feat) => {
-                write!(f, "Unsupported feature used in schema: {feat}")
-            }
-            SchemaError::UndeclaredEntityTypes(e) => {
-                write!(f, "Undeclared entity types: {:?}", e)
-            }
-            SchemaError::UndeclaredActions(a) => {
-                write!(f, "Undeclared actions {:?}", a)
-            }
-            SchemaError::UndeclaredCommonType(t) => {
-                write!(f, "Undeclared common types {:?}", t)
-            }
-            SchemaError::DuplicateEntityType(e) => {
-                write!(f, "Duplicate entity type {e}")
-            }
-            SchemaError::DuplicateAction(a) => {
-                write!(f, "Duplicate action {}", a)
-            }
-            SchemaError::DuplicateCommonType(t) => {
-                write!(f, "Duplicate common type {t}")
-            }
-            SchemaError::CycleInActionHierarchy => {
-                write!(f, "Cycle in action hierarchy")
-            }
-            SchemaError::EntityTypeParseError(parse_errs) => {
-                write!(
-                    f,
-                    "Parse error in entity type: {}",
-                    Self::format_parse_errs(parse_errs),
-                )
-            }
-            SchemaError::NamespaceParseError(parse_errs) => {
-                write!(
-                    f,
-                    "Parse error in namespace identifier: {}",
-                    Self::format_parse_errs(parse_errs),
-                )
-            }
-            SchemaError::CommonTypeParseError(parse_errs) => {
-                write!(
-                    f,
-                    "Parse error in common type identifier: {}",
-                    Self::format_parse_errs(parse_errs),
-                )
-            }
-            SchemaError::ExtensionTypeParseError(parse_errs) => {
-                write!(
-                    f,
-                    "Parse error in extension type: {}",
-                    Self::format_parse_errs(parse_errs),
-                )
-            }
-            SchemaError::ActionEntityTypeDeclared => {
-                write!(f, "Entity type `Action` declared in `entityTypes` list.")
-            }
-            SchemaError::ActionEntityAttributes(actions) => {
-                write!(
-                    f,
-                    "Actions declared with `attributes`: [{}]",
-                    actions.iter().join(", ")
-                )
-            }
-            SchemaError::ContextOrShapeNotRecord => {
-                write!(
-                    f,
-                    "An entity shape or action context is declared with a type other than `Record`"
-                )
-            }
-            SchemaError::ActionEntityAttributeEmptySet => {
-                write!(f, "An action entity has an attribute that is an empty set")
-            }
-            SchemaError::ActionEntityAttributeUnsupportedType => {
-                write!(
-                    f,
-                    "An action entity has attribute with unsupported type: (escaped expression, entity or extension)"
-                )
-            }
-        }
     }
 }
 


### PR DESCRIPTION
This change is invisible to consumers of `SchemaError` (except that I also tweaked the punctuation in a couple error messages)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
