### PR TITLE
Provide errors for undeclared entity types and inconsistent action declarations

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -34,6 +34,16 @@ pub enum EntityType {
     Unspecified,
 }
 
+impl EntityType {
+    /// Is this an Action entity type
+    pub fn is_action(&self) -> bool {
+        match self {
+            Self::Concrete(name) => name.basename() == &Id::new_unchecked("Action"),
+            Self::Unspecified => false,
+        }
+    }
+}
+
 // Note: the characters '<' and '>' are not allowed in `Name`s, so the display for
 // `Unspecified` never conflicts with `Concrete(name)`.
 impl std::fmt::Display for EntityType {
@@ -130,6 +140,11 @@ impl EntityUID {
     /// Get the Eid component.
     pub fn eid(&self) -> &Eid {
         &self.eid
+    }
+
+    /// Does this EntityUID refer to an action entity?
+    pub fn is_action(&self) -> bool {
+        self.entity_type().is_action()
     }
 }
 
@@ -249,6 +264,12 @@ impl Entity {
     /// This function is available only inside Core.
     pub(crate) fn attrs(&self) -> &HashMap<SmolStr, RestrictedExpr> {
         &self.attrs
+    }
+
+    /// Read-only access the internal `ancestors` hashset.
+    /// This function is available only inside Core.
+    pub(crate) fn ancestors_set(&self) -> &HashSet<EntityUID> {
+        &self.ancestors
     }
 
     /// Set the given attribute to the given value.

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -740,7 +740,9 @@ mod json_parsing_tests {
         );
         let eparser: EntityJsonParser<'_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let err = eparser.from_json_value(json).expect_err("should fail due to invalid action parent");
+        let err = eparser
+            .from_json_value(json)
+            .expect_err("should fail due to invalid action parent");
         assert!(
             err.to_string().contains(r#"XYZ::Action::"view" is an action, so it should not have a parent User::"alice", which is not an action"#),
             "actual error message was {}",

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -157,9 +157,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
                 // action do exist in `ejson.attrs`. Later when consuming `ejson.attrs`,
                 // we'll do the rest of the checks for attribute agreement.
                 for (schema_attr, _) in action.attrs() {
-                    if ejson.attrs.contains_key(schema_attr) {
-                        // all good
-                    } else {
+                    if !ejson.attrs.contains_key(schema_attr) {
                         return Err(JsonDeserializationError::ActionDeclarationMismatch { uid });
                     }
                 }

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -284,7 +284,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
                         if parent_euid.is_action() {
                             Ok(())
                         } else {
-                            Err(JsonDeserializationError::ActionParentIsNotAnAction {
+                            Err(JsonDeserializationError::ActionParentIsNonAction {
                                 uid: uid.clone(),
                                 parent: parent_euid.clone(),
                             })

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -68,14 +68,45 @@ pub enum JsonDeserializationError {
         /// Expression we got instead
         got: Box<RestrictedExpr>,
     },
+    /// Parents of actions should be actions, but this action has a non-action parent
+    #[error("{uid} is an action, so it should not have a parent {parent}, which is not an action")]
+    ActionParentIsNotAnAction {
+        /// Action entity that had the invalid parent
+        uid: EntityUID,
+        /// Parent that is invalid
+        parent: EntityUID,
+    },
     /// Schema-based parsing needed an implicit extension constructor, but no suitable
     /// constructor was found
-    #[error("Extension constructor for {arg_type} -> {return_type} not found")]
+    #[error("{ctx}, extension constructor for {arg_type} -> {return_type} not found")]
     ImpliedConstructorNotFound {
+        /// Context of this error
+        ctx: JsonDeserializationErrorContext,
         /// return type of the constructor we were looking for
         return_type: Box<SchemaType>,
         /// argument type of the constructor we were looking for
         arg_type: Box<SchemaType>,
+    },
+    /// During schema-based parsing, encountered an entity of a type which is
+    /// not declared in the schema. (This error is only used for non-Action entity types.)
+    #[error("{uid} has type {} which is not declared in the schema", &.uid.entity_type())]
+    UnexpectedEntityType {
+        /// Entity that had the unexpected type
+        uid: EntityUID,
+    },
+    /// During schema-based parsing, encountered an action which was not
+    /// declared in the schema
+    #[error("Found entity data for {uid}, but it was not declared as an action in the schema")]
+    UndeclaredAction {
+        /// Action which was not declared in the schema
+        uid: EntityUID,
+    },
+    /// During schema-based parsing, encountered an action whose definition
+    /// doesn't precisely match the schema's declaration of that action
+    #[error("Definition of {uid} does not match the schema's declaration of that action")]
+    ActionDeclarationMismatch {
+        /// Action whose definition mismatched between entity data and schema
+        uid: EntityUID,
     },
     /// During schema-based parsing, encountered this attribute on this entity, but that
     /// attribute shouldn't exist on entities of this type

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -70,7 +70,7 @@ pub enum JsonDeserializationError {
     },
     /// Parents of actions should be actions, but this action has a non-action parent
     #[error("{uid} is an action, so it should not have a parent {parent}, which is not an action")]
-    ActionParentIsNotAnAction {
+    ActionParentIsNonAction {
         /// Action entity that had the invalid parent
         uid: EntityUID,
         /// Parent that is invalid

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -461,7 +461,7 @@ impl<'e> ValueParser<'e> {
             }
             ExtnValueJSON::ImplicitConstructor(val) => {
                 let arg = val.into_expr()?;
-                let argty = self.type_of_rexpr(arg.as_borrowed(), ctx)?;
+                let argty = self.type_of_rexpr(arg.as_borrowed(), ctx.clone())?;
                 let func = self
                     .extensions
                     .lookup_single_arg_constructor(
@@ -471,6 +471,7 @@ impl<'e> ValueParser<'e> {
                         &argty,
                     )?
                     .ok_or_else(|| JsonDeserializationError::ImpliedConstructorNotFound {
+                        ctx: ctx(),
                         return_type: Box::new(SchemaType::Extension {
                             name: expected_typename,
                         }),

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -1,36 +1,94 @@
 use super::SchemaType;
-use crate::ast::EntityType;
+use crate::ast::{Entity, EntityType, EntityUID};
 use smol_str::SmolStr;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 /// Trait for `Schema`s that can inform the parsing of Entity JSON data
 pub trait Schema {
-    /// Do entities of the given type have the given attribute, and if so, what type?
-    ///
-    /// Returning `None` indicates that attribute should not exist.
-    fn attr_type(&self, entity_type: &EntityType, attr: &str) -> Option<SchemaType>;
+    /// Type returned by `entity_type()`. Must implement the `EntityTypeDescription` trait
+    type EntityTypeDescription: EntityTypeDescription;
 
-    /// Get the names of all the required attributes for the given entity type.
-    fn required_attrs<'s>(
-        &'s self,
-        entity_type: &EntityType,
-    ) -> Box<dyn Iterator<Item = SmolStr> + 's>;
+    /// Get an `EntityTypeDescription` for the given entity type, or `None` if that
+    /// entity type is not declared in the schema (in which case entities of that
+    /// type should not appear in the JSON data).
+    fn entity_type(&self, entity_type: &EntityType) -> Option<Self::EntityTypeDescription>;
 
-    /// Get the entity types which are allowed to be parents of the given entity type.
-    fn allowed_parent_types<'s>(&'s self, entity_type: &EntityType) -> HashSet<EntityType>;
+    /// Get the entity information for the given action, or `None` if that
+    /// action is not declared in the schema (in which case this action should
+    /// not appear in the JSON data).
+    fn action(&self, action: &EntityUID) -> Option<Arc<Entity>>;
 }
 
-/// Simple type that implements `Schema` by expecting no attributes or parents to exist
+/// Simple type that implements `Schema` by expecting no entities to exist at all
 #[derive(Debug, Clone)]
-pub struct NullSchema;
-impl Schema for NullSchema {
-    fn attr_type(&self, _entity_type: &EntityType, _attr: &str) -> Option<SchemaType> {
+pub struct NoEntitiesSchema;
+impl Schema for NoEntitiesSchema {
+    type EntityTypeDescription = NullEntityTypeDescription;
+    fn entity_type(&self, _entity_type: &EntityType) -> Option<NullEntityTypeDescription> {
         None
     }
-    fn required_attrs(&self, _entity_type: &EntityType) -> Box<dyn Iterator<Item = SmolStr>> {
+    fn action(&self, _action: &EntityUID) -> Option<Arc<Entity>> {
+        None
+    }
+}
+
+/// Simple type that implements `Schema` by allowing entities of all types to
+/// exist, and allowing all actions to exist, but expecting no attributes or
+/// parents on any entity (action or otherwise)
+#[derive(Debug, Clone)]
+pub struct AllEntitiesNoAttrsSchema;
+impl Schema for AllEntitiesNoAttrsSchema {
+    type EntityTypeDescription = NullEntityTypeDescription;
+    fn entity_type(&self, entity_type: &EntityType) -> Option<NullEntityTypeDescription> {
+        Some(NullEntityTypeDescription {
+            ty: entity_type.clone(),
+        })
+    }
+    fn action(&self, action: &EntityUID) -> Option<Arc<Entity>> {
+        Some(Arc::new(Entity::new(
+            action.clone(),
+            HashMap::new(),
+            HashSet::new(),
+        )))
+    }
+}
+
+/// Trait for a schema's description of an individual entity type
+pub trait EntityTypeDescription {
+    /// Get the `EntityType` this `EntityTypeDescription` is describing
+    fn entity_type(&self) -> EntityType;
+
+    /// Do entities of this type have the given attribute, and if so, what type?
+    ///
+    /// Returning `None` indicates that attribute should not exist.
+    fn attr_type(&self, attr: &str) -> Option<SchemaType>;
+
+    /// Get the names of all the required attributes for this entity type.
+    fn required_attrs<'s>(&'s self) -> Box<dyn Iterator<Item = SmolStr> + 's>;
+
+    /// Get the entity types which are allowed to be parents of this entity type.
+    fn allowed_parent_types(&self) -> Arc<HashSet<EntityType>>;
+}
+
+/// Simple type that implements `EntityTypeDescription` by expecting no
+/// attributes to exist
+#[derive(Debug, Clone)]
+pub struct NullEntityTypeDescription {
+    /// null description for this type
+    ty: EntityType,
+}
+impl EntityTypeDescription for NullEntityTypeDescription {
+    fn entity_type(&self) -> EntityType {
+        self.ty.clone()
+    }
+    fn attr_type(&self, _attr: &str) -> Option<SchemaType> {
+        None
+    }
+    fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
         Box::new(std::iter::empty())
     }
-    fn allowed_parent_types(&self, _entity_type: &EntityType) -> HashSet<EntityType> {
-        HashSet::new()
+    fn allowed_parent_types(&self) -> Arc<HashSet<EntityType>> {
+        Arc::new(HashSet::new())
     }
 }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -134,7 +134,7 @@ impl<'e> RestrictedEvaluator<'e> {
                     Either::Right(residuals) => Ok(Expr::call_extension_fn(fn_name.clone(), residuals.collect()).into()),
                 }
             },
-            // PANIC SAFETY Unreachable via invariant on restricted expressions 
+            // PANIC SAFETY Unreachable via invariant on restricted expressions
             #[allow(clippy::unreachable)]
             expr =>unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
         }
@@ -3611,7 +3611,7 @@ pub mod test {
     fn eval_and_or() -> Result<()> {
         use crate::parser;
         let request = basic_request();
-        let eparser: EntityJsonParser<'_, '_> =
+        let eparser: EntityJsonParser<'_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
@@ -3724,7 +3724,7 @@ pub mod test {
     #[test]
     fn template_env_tests() {
         let request = basic_request();
-        let eparser: EntityJsonParser<'_, '_> =
+        let eparser: EntityJsonParser<'_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
@@ -3779,7 +3779,7 @@ pub mod test {
             EntityUID::with_eid("r"),
             Context::empty(),
         );
-        let eparser: EntityJsonParser<'_, '_> =
+        let eparser: EntityJsonParser<'_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1172,10 +1172,10 @@ impl ValidatorSchema {
         &'s self,
     ) -> impl Iterator<Item = cedar_policy_core::ast::Entity> + 's {
         // We could store the un-inverted `memberOf` relation for each action,
-        // but I [John] judge that the current implementation is actually less error
-        // prone, as it minimizes the threading of data structures through some
-        // complicated bits of schema construction code, and avoids computing
-        // the TC twice.
+        // but I [john-h-kastner-aws] judge that the current implementation is
+        // actually less error prone, as it minimizes the threading of data
+        // structures through some complicated bits of schema construction code,
+        // and avoids computing the TC twice.
         let mut action_ancestors: HashMap<&EntityUID, HashSet<EntityUID>> = HashMap::new();
         for (action_euid, action_def) in &self.action_ids {
             for descendant in &action_def.descendants {

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -21,6 +21,7 @@
 //! computed to obtain a `descendants` relation.
 
 use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::sync::Arc;
 
 use cedar_policy_core::{
     ast::{Eid, Entity, EntityType, EntityUID, Id, Name, RestrictedExpr},
@@ -1166,11 +1167,12 @@ impl ValidatorSchema {
         })
     }
 
-    pub fn action_entities(&self) -> cedar_policy_core::entities::Result<Entities> {
-        // Invert the action hierarchy to get the ancestor relation expected for
-        // the `Entity` datatype instead of descendant as stored by the schema.
+    /// Construct an `Entity` object for each action in the schema
+    fn action_entities_iter<'s>(
+        &'s self,
+    ) -> impl Iterator<Item = cedar_policy_core::ast::Entity> + 's {
         // We could store the un-inverted `memberOf` relation for each action,
-        // but I judge that the current implementation is actually less error
+        // but I [John] judge that the current implementation is actually less error
         // prone, as it minimizes the threading of data structures through some
         // complicated bits of schema construction code, and avoids computing
         // the TC twice.
@@ -1183,85 +1185,129 @@ impl ValidatorSchema {
                     .insert(action_euid.clone());
             }
         }
+        self.action_ids.iter().map(move |(action_id, action)| {
+            Entity::new(
+                action_id.clone(),
+                action.attributes.clone(),
+                action_ancestors.remove(action_id).unwrap_or_default(),
+            )
+        })
+    }
 
+    /// Invert the action hierarchy to get the ancestor relation expected for
+    /// the `Entity` datatype instead of descendant as stored by the schema.
+    pub fn action_entities(&self) -> cedar_policy_core::entities::Result<Entities> {
         Entities::from_entities(
-            self.action_ids.iter().map(|(action_id, action)| {
-                Entity::new(
-                    action_id.clone(),
-                    action.attributes.clone(),
-                    action_ancestors.remove(action_id).unwrap_or_default(),
-                )
-            }),
+            self.action_entities_iter(),
             TCComputation::AssumeAlreadyComputed,
         )
     }
 }
 
-impl cedar_policy_core::entities::Schema for ValidatorSchema {
-    fn attr_type(
+/// Struct which carries enough information that it can (efficiently) impl Core's `Schema`
+pub struct CoreSchema<'a> {
+    /// Contains all the information
+    schema: &'a ValidatorSchema,
+    /// For easy lookup, this is a map from action name to `Entity` object
+    /// for each action in the schema. This information is contained in the
+    /// `ValidatorSchema`, but not efficient to extract -- getting the `Entity`
+    /// from the `ValidatorSchema` is O(N) as of this writing, but with this
+    /// cache it's O(1).
+    actions: HashMap<EntityUID, Arc<Entity>>,
+}
+
+impl<'a> CoreSchema<'a> {
+    pub fn new(schema: &'a ValidatorSchema) -> Self {
+        Self {
+            actions: schema
+                .action_entities_iter()
+                .map(|e| (e.uid(), Arc::new(e)))
+                .collect(),
+            schema,
+        }
+    }
+}
+
+impl<'a> cedar_policy_core::entities::Schema for CoreSchema<'a> {
+    type EntityTypeDescription = EntityTypeDescription;
+
+    fn entity_type(
         &self,
         entity_type: &cedar_policy_core::ast::EntityType,
-        attr: &str,
-    ) -> Option<cedar_policy_core::entities::SchemaType> {
+    ) -> Option<EntityTypeDescription> {
         match entity_type {
-            cedar_policy_core::ast::EntityType::Unspecified => None, // Unspecified entity does not have attributes
+            cedar_policy_core::ast::EntityType::Unspecified => None, // Unspecified entities cannot be declared in the schema and should not appear in JSON data
             cedar_policy_core::ast::EntityType::Concrete(name) => {
-                let entity_type: &ValidatorEntityType = self.get_entity_type(name)?;
-                let validator_type: &crate::types::Type = &entity_type.attr(attr)?.attr_type;
-                let core_schema_type: cedar_policy_core::entities::SchemaType = validator_type
-                    .clone()
-                    .try_into()
-                    .expect("failed to convert validator type into Core SchemaType");
-                debug_assert!(validator_type.is_consistent_with(&core_schema_type));
-                Some(core_schema_type)
+                EntityTypeDescription::new(&self.schema, name)
             }
         }
     }
 
-    fn required_attrs<'s>(
-        &'s self,
-        entity_type: &cedar_policy_core::ast::EntityType,
-    ) -> Box<dyn Iterator<Item = SmolStr> + 's> {
-        match entity_type {
-            cedar_policy_core::ast::EntityType::Unspecified => Box::new(std::iter::empty()), // Unspecified entity does not have attributes
-            cedar_policy_core::ast::EntityType::Concrete(name) => {
-                match self.get_entity_type(name) {
-                    None => Box::new(std::iter::empty()),
-                    Some(entity_type) => Box::new(
-                        entity_type
-                            .attributes
-                            .iter()
-                            .filter(|(_, ty)| ty.is_required)
-                            .map(|(attr, _)| attr.clone()),
-                    ),
-                }
-            }
-        }
+    fn action(&self, action: &EntityUID) -> Option<Arc<cedar_policy_core::ast::Entity>> {
+        self.actions.get(action).map(Arc::clone)
     }
+}
 
-    fn allowed_parent_types<'s>(
-        &'s self,
-        entity_type: &cedar_policy_core::ast::EntityType,
-    ) -> HashSet<cedar_policy_core::ast::EntityType> {
-        match entity_type {
-            cedar_policy_core::ast::EntityType::Unspecified => HashSet::new(), // Unspecified entity cannot have any parents
-            cedar_policy_core::ast::EntityType::Concrete(child_type) => {
-                match self.get_entity_type(child_type) {
-                    None => HashSet::new(),
-                    Some(_) => {
-                        let mut set = HashSet::new();
-                        for (possible_parent_typename, possible_parent_et) in &self.entity_types {
-                            if possible_parent_et.descendants.contains(child_type) {
-                                set.insert(cedar_policy_core::ast::EntityType::Concrete(
-                                    possible_parent_typename.clone(),
-                                ));
-                            }
-                        }
-                        set
+/// Struct which carries enough information that it can impl Core's `EntityTypeDescription`
+pub struct EntityTypeDescription {
+    /// Core `EntityType` this is describing
+    core_type: cedar_policy_core::ast::EntityType,
+    /// Contains most of the schema information for this entity type
+    validator_type: ValidatorEntityType,
+    /// Allowed parent types for this entity type. (As of this writing, this
+    /// information is not contained in the `validator_type` by itself.)
+    allowed_parent_types: Arc<HashSet<cedar_policy_core::ast::EntityType>>,
+}
+
+impl EntityTypeDescription {
+    /// Create a description of the given type in the given schema.
+    /// Returns `None` if the given type is not in the given schema.
+    pub fn new(schema: &ValidatorSchema, type_name: &Name) -> Option<Self> {
+        Some(Self {
+            core_type: cedar_policy_core::ast::EntityType::Concrete(type_name.clone()),
+            validator_type: schema.get_entity_type(type_name).cloned()?,
+            allowed_parent_types: {
+                let mut set = HashSet::new();
+                for (possible_parent_typename, possible_parent_et) in &schema.entity_types {
+                    if possible_parent_et.descendants.contains(type_name) {
+                        set.insert(cedar_policy_core::ast::EntityType::Concrete(
+                            possible_parent_typename.clone(),
+                        ));
                     }
                 }
-            }
-        }
+                Arc::new(set)
+            },
+        })
+    }
+}
+
+impl cedar_policy_core::entities::EntityTypeDescription for EntityTypeDescription {
+    fn entity_type(&self) -> cedar_policy_core::ast::EntityType {
+        self.core_type.clone()
+    }
+
+    fn attr_type(&self, attr: &str) -> Option<cedar_policy_core::entities::SchemaType> {
+        let attr_type: &crate::types::Type = &self.validator_type.attr(attr)?.attr_type;
+        let core_schema_type: cedar_policy_core::entities::SchemaType = attr_type
+            .clone()
+            .try_into()
+            .expect("failed to convert validator type into Core SchemaType");
+        debug_assert!(attr_type.is_consistent_with(&core_schema_type));
+        Some(core_schema_type)
+    }
+
+    fn required_attrs<'s>(&'s self) -> Box<dyn Iterator<Item = SmolStr> + 's> {
+        Box::new(
+            self.validator_type
+                .attributes
+                .iter()
+                .filter(|(_, ty)| ty.is_required)
+                .map(|(attr, _)| attr.clone()),
+        )
+    }
+
+    fn allowed_parent_types(&self) -> Arc<HashSet<cedar_policy_core::ast::EntityType>> {
+        Arc::clone(&self.allowed_parent_types)
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -194,7 +194,7 @@ impl Entities {
         schema: Option<&Schema>,
     ) -> Result<Self, entities::EntitiesError> {
         let eparser = entities::EntityJsonParser::new(
-            schema.map(|s| &s.0),
+            schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0)),
             Extensions::all_available(),
             entities::TCComputation::ComputeNow,
         );
@@ -212,7 +212,7 @@ impl Entities {
         schema: Option<&Schema>,
     ) -> Result<Self, entities::EntitiesError> {
         let eparser = entities::EntityJsonParser::new(
-            schema.map(|s| &s.0),
+            schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0)),
             Extensions::all_available(),
             entities::TCComputation::ComputeNow,
         );
@@ -230,7 +230,7 @@ impl Entities {
         schema: Option<&Schema>,
     ) -> Result<Self, entities::EntitiesError> {
         let eparser = entities::EntityJsonParser::new(
-            schema.map(|s| &s.0),
+            schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0)),
             Extensions::all_available(),
             entities::TCComputation::ComputeNow,
         );


### PR DESCRIPTION
Addresses many of the issues discussed in comments on #73, but not the namespace part (which will come in a separate PR later).

This PR adds the following to the parsing of entity data:
* During schema-based parsing, error if an entity in the entity data has a type which wasn't declared in the schema.
* During parsing with or without a schema, error if an action entity has a parent which is not an action entity.
* During schema-based parsing, error if an action is provided in the entity data which was not declared in the schema.
* During schema-based parsing, error if an action is provided in both the entity data and the schema, but with conflicting definitions (different attribute values, different parents, missing or extra attributes).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
