### PR TITLE
Improve error for undeclared entity type

### DIFF
--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -148,6 +148,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
                             let basename = match etype {
                                 EntityType::Concrete(name) => name.basename(),
                                 // PANIC SAFETY: impossible to have the unspecified EntityType in JSON
+                                #[allow(clippy::unreachable)]
                                 EntityType::Unspecified => {
                                     unreachable!("unspecified EntityType in JSON")
                                 }
@@ -168,7 +169,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
                 // here, we ensure that all the attributes on the schema's copy of the
                 // action do exist in `ejson.attrs`. Later when consuming `ejson.attrs`,
                 // we'll do the rest of the checks for attribute agreement.
-                for (schema_attr, _) in action.attrs() {
+                for schema_attr in action.attrs().keys() {
                     if !ejson.attrs.contains_key(schema_attr) {
                         return Err(JsonDeserializationError::ActionDeclarationMismatch { uid });
                     }
@@ -242,10 +243,10 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
                         Ok((k, rexpr))
                     } else {
                         Err(JsonDeserializationError::TypeMismatch {
-                            ctx: JsonDeserializationErrorContext::EntityAttribute {
+                            ctx: Box::new(JsonDeserializationErrorContext::EntityAttribute {
                                 uid: uid.clone(),
                                 attr: k,
-                            },
+                            }),
                             expected: Box::new(expected_ty),
                             actual: Box::new(actual_ty),
                         })
@@ -321,11 +322,11 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
                         Ok(())
                     } else {
                         Err(JsonDeserializationError::InvalidParentType {
-                            ctx: JsonDeserializationErrorContext::EntityParents {
+                            ctx: Box::new(JsonDeserializationErrorContext::EntityParents {
                                 uid: uid.clone(),
-                            },
+                            }),
                             uid: uid.clone(),
-                            parent_ty: parent_type.clone(),
+                            parent_ty: Box::new(parent_type.clone()),
                         })
                     }
                 }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -50,7 +50,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, expected a literal entity reference, but got {got}")]
     ExpectedLiteralEntityRef {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// the expression we got instead
         got: Box<Expr>,
     },
@@ -58,7 +58,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, expected an extension value, but got {got}")]
     ExpectedExtnValue {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// the expression we got instead
         got: Box<Expr>,
     },
@@ -81,7 +81,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, extension constructor for {arg_type} -> {return_type} not found")]
     ImpliedConstructorNotFound {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// return type of the constructor we were looking for
         return_type: Box<SchemaType>,
         /// argument type of the constructor we were looking for
@@ -131,7 +131,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, record attribute {record_attr:?} shouldn't exist according to the schema")]
     UnexpectedRecordAttr {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// Name of the (Record) attribute which was unexpected
         record_attr: SmolStr,
     },
@@ -149,7 +149,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, expected the record to have an attribute {record_attr:?}, but it didn't")]
     MissingRequiredRecordAttr {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// Name of the (Record) attribute which was expected
         record_attr: SmolStr,
     },
@@ -158,7 +158,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, type mismatch: attribute was expected to have type {expected}, but actually has type {actual}")]
     TypeMismatch {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// Type which was expected
         expected: Box<SchemaType>,
         /// Type which was encountered instead
@@ -169,7 +169,7 @@ pub enum JsonDeserializationError {
     #[error("{ctx}, set elements have different types: {ty1} and {ty2}")]
     HeterogeneousSet {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// First element type which was found
         ty1: Box<SchemaType>,
         /// Second element type which was found
@@ -182,11 +182,11 @@ pub enum JsonDeserializationError {
     )]
     InvalidParentType {
         /// Context of this error
-        ctx: JsonDeserializationErrorContext,
+        ctx: Box<JsonDeserializationErrorContext>,
         /// Entity that has an invalid parent type
         uid: EntityUID,
         /// Parent type which was invalid
-        parent_ty: EntityType,
+        parent_ty: Box<EntityType>, // boxed to avoid this variant being very large (and thus all JsonDeserializationErrors being large)
     },
 }
 

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -89,10 +89,19 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, encountered an entity of a type which is
     /// not declared in the schema. (This error is only used for non-Action entity types.)
-    #[error("{uid} has type {} which is not declared in the schema", &.uid.entity_type())]
+    #[error("{uid} has type {} which is not declared in the schema{}",
+        &.uid.entity_type(),
+        match .suggested_types.as_slice() {
+            [] => String::new(),
+            [ty] => format!("; did you mean {ty}?"),
+            tys => format!("; did you mean one of {:?}?", tys.iter().map(ToString::to_string).collect::<Vec<String>>())
+        }
+    )]
     UnexpectedEntityType {
         /// Entity that had the unexpected type
         uid: EntityUID,
+        /// Suggested similar entity types that actually are declared in the schema (if any)
+        suggested_types: Vec<EntityType>,
     },
     /// During schema-based parsing, encountered an action which was not
     /// declared in the schema

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -358,7 +358,7 @@ impl<'e> ValueParser<'e> {
                         .collect::<Result<Vec<RestrictedExpr>, JsonDeserializationError>>()?,
                 )),
                 _ => Err(JsonDeserializationError::TypeMismatch {
-                    ctx: ctx(),
+                    ctx: Box::new(ctx()),
                     expected: Box::new(expected_ty.clone()),
                     actual: {
                         let jvalue: JSONValue = serde_json::from_value(val)?;
@@ -388,7 +388,7 @@ impl<'e> ValueParser<'e> {
                                     }
                                 }
                                 None if expected_attr_ty.is_required() => Some(Err(JsonDeserializationError::MissingRequiredRecordAttr {
-                                    ctx: ctx(),
+                                    ctx: Box::new(ctx()),
                                     record_attr: k.clone(),
                                 })),
                                 None => None,
@@ -399,14 +399,14 @@ impl<'e> ValueParser<'e> {
                     // we still need to verify that we didn't have any unexpected attrs.
                     if let Some((record_attr, _)) = actual_attrs.into_iter().next() {
                         return Err(JsonDeserializationError::UnexpectedRecordAttr {
-                            ctx: ctx2(),
+                            ctx: Box::new(ctx2()),
                             record_attr: record_attr.into(),
                         });
                     }
                     Ok(RestrictedExpr::record(rexpr_pairs))
                 }
                 _ => Err(JsonDeserializationError::TypeMismatch {
-                    ctx: ctx(),
+                    ctx: Box::new(ctx()),
                     expected: Box::new(expected_ty.clone()),
                     actual: {
                         let jvalue: JSONValue = serde_json::from_value(val)?;
@@ -441,7 +441,7 @@ impl<'e> ValueParser<'e> {
                 match expr.expr_kind() {
                     ExprKind::ExtensionFunctionApp { .. } => Ok(expr),
                     _ => Err(JsonDeserializationError::ExpectedExtnValue {
-                        ctx: ctx(),
+                        ctx: Box::new(ctx()),
                         got: Box::new(expr.clone().into()),
                     }),
                 }
@@ -454,7 +454,7 @@ impl<'e> ValueParser<'e> {
                 match expr.expr_kind() {
                     ExprKind::ExtensionFunctionApp { .. } => Ok(expr),
                     _ => Err(JsonDeserializationError::ExpectedExtnValue {
-                        ctx: ctx(),
+                        ctx: Box::new(ctx()),
                         got: Box::new(expr.clone().into()),
                     }),
                 }
@@ -471,7 +471,7 @@ impl<'e> ValueParser<'e> {
                         &argty,
                     )?
                     .ok_or_else(|| JsonDeserializationError::ImpliedConstructorNotFound {
-                        ctx: ctx(),
+                        ctx: Box::new(ctx()),
                         return_type: Box::new(SchemaType::Extension {
                             name: expected_typename,
                         }),
@@ -514,7 +514,7 @@ impl<'e> ValueParser<'e> {
                             None => Ok(SchemaType::Set { element_ty: Box::new(element_ty) }),
                             Some(Ok(conflicting_ty)) =>
                                 Err(JsonDeserializationError::HeterogeneousSet {
-                                    ctx: ctx(),
+                                    ctx: Box::new(ctx()),
                                     ty1: Box::new(element_ty),
                                     ty2: Box::new(conflicting_ty),
                                 }),
@@ -645,7 +645,7 @@ impl EntityUidJSON {
                         // PANIC SAFETY: Every `String` can be turned into a restricted expression
                         #[allow(clippy::unwrap_used)]
                         JsonDeserializationError::ExpectedLiteralEntityRef {
-                            ctx: ctx(),
+                            ctx: Box::new(ctx()),
                             got: Box::new(JSONValue::String(__expr).into_expr().unwrap().into()),
                         }
                     } else {
@@ -655,7 +655,7 @@ impl EntityUidJSON {
                 match expr.expr_kind() {
                     ExprKind::Lit(Literal::EntityUID(euid)) => Ok((**euid).clone()),
                     _ => Err(JsonDeserializationError::ExpectedLiteralEntityRef {
-                        ctx: ctx(),
+                        ctx: Box::new(ctx()),
                         got: Box::new(expr.clone().into()),
                     }),
                 }
@@ -667,7 +667,7 @@ impl EntityUidJSON {
                 match expr.expr_kind() {
                     ExprKind::Lit(Literal::EntityUID(euid)) => Ok((**euid).clone()),
                     _ => Err(JsonDeserializationError::ExpectedLiteralEntityRef {
-                        ctx: ctx(),
+                        ctx: Box::new(ctx()),
                         got: Box::new(expr.clone().into()),
                     }),
                 }

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -1,5 +1,5 @@
 use super::SchemaType;
-use crate::ast::{Entity, EntityType, EntityUID};
+use crate::ast::{Entity, EntityType, EntityUID, Id, Name};
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -18,6 +18,13 @@ pub trait Schema {
     /// action is not declared in the schema (in which case this action should
     /// not appear in the JSON data).
     fn action(&self, action: &EntityUID) -> Option<Arc<Entity>>;
+
+    /// Get the names of all entity types declared in the schema that have the
+    /// given basename (in the sense of `Name::basename()`).
+    fn entity_types_with_basename<'a>(
+        &'a self,
+        basename: &'a Id,
+    ) -> Box<dyn Iterator<Item = EntityType> + 'a>;
 }
 
 /// Simple type that implements `Schema` by expecting no entities to exist at all
@@ -30,6 +37,12 @@ impl Schema for NoEntitiesSchema {
     }
     fn action(&self, _action: &EntityUID) -> Option<Arc<Entity>> {
         None
+    }
+    fn entity_types_with_basename<'a>(
+        &'a self,
+        _basename: &'a Id,
+    ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
+        Box::new(std::iter::empty())
     }
 }
 
@@ -50,6 +63,14 @@ impl Schema for AllEntitiesNoAttrsSchema {
             action.clone(),
             HashMap::new(),
             HashSet::new(),
+        )))
+    }
+    fn entity_types_with_basename<'a>(
+        &'a self,
+        basename: &'a Id,
+    ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
+        Box::new(std::iter::once(EntityType::Concrete(
+            Name::unqualified_name(basename.clone()),
         )))
     }
 }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -999,7 +999,7 @@ impl ValidatorSchema {
             for p_entity in action.applies_to.applicable_principal_types() {
                 match p_entity {
                     EntityType::Concrete(p_entity) => {
-                        if !entity_types.contains_key(&p_entity) {
+                        if !entity_types.contains_key(p_entity) {
                             undeclared_e.insert(p_entity.to_string());
                         }
                     }
@@ -1010,7 +1010,7 @@ impl ValidatorSchema {
             for r_entity in action.applies_to.applicable_resource_types() {
                 match r_entity {
                     EntityType::Concrete(r_entity) => {
-                        if !entity_types.contains_key(&r_entity) {
+                        if !entity_types.contains_key(r_entity) {
                             undeclared_e.insert(r_entity.to_string());
                         }
                     }
@@ -1168,9 +1168,7 @@ impl ValidatorSchema {
     }
 
     /// Construct an `Entity` object for each action in the schema
-    fn action_entities_iter<'s>(
-        &'s self,
-    ) -> impl Iterator<Item = cedar_policy_core::ast::Entity> + 's {
+    fn action_entities_iter(&self) -> impl Iterator<Item = cedar_policy_core::ast::Entity> + '_ {
         // We could store the un-inverted `memberOf` relation for each action,
         // but I [john-h-kastner-aws] judge that the current implementation is
         // actually less error prone, as it minimizes the threading of data
@@ -1238,7 +1236,7 @@ impl<'a> cedar_policy_core::entities::Schema for CoreSchema<'a> {
         match entity_type {
             cedar_policy_core::ast::EntityType::Unspecified => None, // Unspecified entities cannot be declared in the schema and should not appear in JSON data
             cedar_policy_core::ast::EntityType::Concrete(name) => {
-                EntityTypeDescription::new(&self.schema, name)
+                EntityTypeDescription::new(self.schema, name)
             }
         }
     }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1246,6 +1246,19 @@ impl<'a> cedar_policy_core::entities::Schema for CoreSchema<'a> {
     fn action(&self, action: &EntityUID) -> Option<Arc<cedar_policy_core::ast::Entity>> {
         self.actions.get(action).map(Arc::clone)
     }
+
+    fn entity_types_with_basename<'b>(
+        &'b self,
+        basename: &'b Id,
+    ) -> Box<dyn Iterator<Item = EntityType> + 'b> {
+        Box::new(self.schema.entity_types().filter_map(move |(name, _)| {
+            if name.basename() == basename {
+                Some(EntityType::Concrete(name.clone()))
+            } else {
+                None
+            }
+        }))
+    }
 }
 
 /// Struct which carries enough information that it can impl Core's `EntityTypeDescription`


### PR DESCRIPTION
Finishes the work for #73.  When encountering an undeclared entity type, suggests declared entity types in other namespaces if there are any.

Resolves #73.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
