### PR TITLE
Update record types to allow for open and closed record

### DIFF
--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -108,7 +108,7 @@ impl TypeError {
 
     pub(crate) fn unsafe_attribute_access(
         on_expr: Expr,
-        missing: String,
+        attribute: String,
         suggestion: Option<String>,
         may_exist: bool,
     ) -> Self {
@@ -116,7 +116,7 @@ impl TypeError {
             on_expr: Some(on_expr),
             source_location: None,
             kind: TypeErrorKind::UnsafeAttributeAccess(UnsafeAttributeAccess {
-                missing,
+                attribute,
                 suggestion,
                 may_exist,
             }),
@@ -216,7 +216,7 @@ pub enum TypeErrorKind {
     /// that it could not statically guarantee would be present.
     #[error(
         "Attribute not found in record or entity: {}{}",
-        .0.missing,
+        .0.attribute,
         if .0.may_exist {
             ". There may be additional attributes that the validator is not able to reason about."
         } else {
@@ -278,8 +278,10 @@ pub struct TypesMustMatch {
 /// Structure containing details about a missing attribute error.
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct UnsafeAttributeAccess {
-    missing: String,
+    attribute: String,
     suggestion: Option<String>,
+    /// When this is true, the attribute might still exist, but the validator
+    /// cannot guarantee that it will.
     may_exist: bool,
 }
 

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -347,10 +347,11 @@ fn multiple_namespaces_attributes() {
         schema,
         parse_expr("B::Foo::\"foo\".x").unwrap(),
         None,
-        vec![TypeError::missing_attribute(
+        vec![TypeError::unsafe_attribute_access(
             parse_expr("B::Foo::\"foo\".x").unwrap(),
             "x".to_string(),
             None,
+            false,
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test_optional_attributes.rs
@@ -538,7 +538,8 @@ fn record_optional_attrs() {
                     "record": {
                         "type": "Record",
                         "attributes": {
-                            "name": { "type": "String", "required": false}
+                            "name": { "type": "String", "required": false},
+                            "other": { "type": "String", "required": true}
                         }
                     }
                 }
@@ -750,10 +751,11 @@ fn action_attrs_failing() {
     assert_policy_typecheck_fails(
         schema.clone(),
         failing_policy,
-        vec![TypeError::missing_attribute(
+        vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Action), "canUndo".into()),
             "canUndo".to_string(),
             Some("isReadOnly".to_string()),
+            false,
         )],
     );
 

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -370,8 +370,8 @@ fn ext_struct_non_lit() {
         assert_strict_type_error(
             s,
             &q,
-            parser::parse_expr(r#"ip(if context has foo then "a" else "b")"#).unwrap(),
-            parser::parse_expr(r#"ip(if context has foo then "a" else "b")"#).unwrap(),
+            parser::parse_expr(r#"ip(if 1 > 0 then "a" else "b")"#).unwrap(),
+            parser::parse_expr(r#"ip(if 1 > 0 then "a" else "b")"#).unwrap(),
             Type::extension("ipaddr".parse().unwrap()),
             TypeErrorKind::NonLitExtConstructor,
         )
@@ -381,8 +381,8 @@ fn ext_struct_non_lit() {
         assert_strict_type_error(
             s,
             &q,
-            parser::parse_expr(r#"decimal(if context has bar then "0.1" else "1.0")"#).unwrap(),
-            parser::parse_expr(r#"decimal(if context has bar then "0.1" else "1.0")"#).unwrap(),
+            parser::parse_expr(r#"decimal(if 1 > 0 then "0.1" else "1.0")"#).unwrap(),
+            parser::parse_expr(r#"decimal(if 1 > 0 then "0.1" else "1.0")"#).unwrap(),
             Type::extension("decimal".parse().unwrap()),
             TypeErrorKind::NonLitExtConstructor,
         )
@@ -568,16 +568,32 @@ fn test_has_attr() {
             s.clone(),
             &q,
             parser::parse_expr(r#"{name: "foo"} has bar"#).unwrap(),
-            parser::parse_expr(r#"{name: "foo"} has bar"#).unwrap(),
+            parser::parse_expr(r#"false"#).unwrap(),
+            Type::primitive_boolean(),
+        );
+        assert_typechecks_strict(
+            s.clone(),
+            &q,
+            parser::parse_expr(r#"{name: "foo"} has name"#).unwrap(),
+            parser::parse_expr(r#"true"#).unwrap(),
             Type::primitive_boolean(),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"{name: 1 == "foo"} has bar"#).unwrap(),
-            parser::parse_expr(r#"{name: 1 == "foo"} has bar"#).unwrap(),
+            parser::parse_expr(r#"(if 1 == 2 then {name: 1} else {bar: 2}) has bar"#).unwrap(),
+            parser::parse_expr(r#"(if 1 == 2 then {name: 1} else {bar: 2}) has bar"#).unwrap(),
             Type::primitive_boolean(),
-            [Type::primitive_long(), Type::primitive_string()],
+            [
+                Type::closed_record_with_required_attributes([(
+                    "name".into(),
+                    Type::primitive_long(),
+                )]),
+                Type::closed_record_with_required_attributes([(
+                    "bar".into(),
+                    Type::primitive_long(),
+                )]),
+            ],
         );
     })
 }

--- a/cedar-policy-validator/src/typecheck/test_type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test_type_annotation.rs
@@ -119,7 +119,7 @@ fn expr_typechecks_with_correct_annotation() {
             ("foo".into(), Expr::val(1)),
             ("bar".into(), Expr::val(false)),
         ]),
-        &ExprBuilder::with_data(Some(Type::record_with_required_attributes([
+        &ExprBuilder::with_data(Some(Type::closed_record_with_required_attributes([
             ("foo".into(), Type::primitive_long()),
             ("bar".into(), Type::singleton_boolean(false)),
         ])))

--- a/cedar-policy-validator/src/typecheck/test_unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test_unspecified_entity.rs
@@ -87,10 +87,11 @@ fn spec_principal_unspec_resource() {
     .expect("Policy should parse.");
     assert_policy_typecheck_fails(
         policy,
-        vec![TypeError::missing_attribute(
+        vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Resource), "name".into()),
             "name".to_string(),
             None,
+            true,
         )],
     );
 }
@@ -104,10 +105,11 @@ fn spec_resource_unspec_principal() {
     .expect("Policy should parse.");
     assert_policy_typecheck_fails(
         policy,
-        vec![TypeError::missing_attribute(
+        vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Principal), "name".into()),
             "name".to_string(),
             None,
+            true,
         )],
     );
 
@@ -128,10 +130,11 @@ fn unspec_resource_unspec_principal() {
     .expect("Policy should parse.");
     assert_policy_typecheck_fails(
         policy,
-        vec![TypeError::missing_attribute(
+        vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Principal), "name".into()),
             "name".to_string(),
             None,
+            true,
         )],
     );
 
@@ -142,10 +145,11 @@ fn unspec_resource_unspec_principal() {
     .expect("Policy should parse.");
     assert_policy_typecheck_fails(
         policy,
-        vec![TypeError::missing_attribute(
+        vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Resource), "name".into()),
             "name".to_string(),
             None,
+            true,
         )],
     );
 }

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -134,22 +134,31 @@ impl Type {
     }
 
     pub(crate) fn any_record() -> Type {
-        Type::record_with_required_attributes(None)
+        Type::EntityOrRecord(EntityRecordKind::Record {
+            attrs: Attributes::with_required_attributes(None),
+            // (open_attributes = false) <: (open_attributes = true),
+            // so this makes `any_record` a super type of all records.
+            open_attributes: OpenTag::OpenAttributes,
+        })
     }
 
     pub(crate) fn record_with_required_attributes(
         required_attrs: impl IntoIterator<Item = (SmolStr, Type)>,
+        open_attributes: OpenTag,
     ) -> Type {
         Type::EntityOrRecord(EntityRecordKind::Record {
             attrs: Attributes::with_required_attributes(required_attrs),
+            open_attributes,
         })
     }
 
     pub(crate) fn record_with_attributes(
         attrs: impl IntoIterator<Item = (SmolStr, AttributeType)>,
+        open_attributes: OpenTag,
     ) -> Type {
         Type::EntityOrRecord(EntityRecordKind::Record {
             attrs: Attributes::with_attributes(attrs),
+            open_attributes,
         })
     }
 
@@ -349,12 +358,19 @@ impl Type {
     /// attributes, so we return false.
     pub(crate) fn may_have_attr(schema: &ValidatorSchema, ty: &Type, attr: &str) -> bool {
         match ty {
-            // If the type of the expression is a entity reference type, and the
-            // attribute is not declared to exist in the schema, then we know
-            // the entity may not have the attribute. For an entity least upper
-            // bound resulting from multiple entity types, the type might have
-            // the attribute if any of the constituent entity types have the
-            // attribute in the schema.
+            // Never, being the bottom type, is a subtype of EntityOrRecord, so
+            // it could have any attributes.
+            Type::Never => true,
+            // An EntityOrRecord might have an open attributes record, in which
+            // case it could have any attribute.
+            Type::EntityOrRecord(k) if k.has_open_attributes_record() => true,
+            // In this case and all following `EntityOrRecord` cases, we know it
+            // does not have an open attributes record, so we know that an
+            // attribute may not exist if it is not explicitly listed in the
+            // type. For an entity, we look this up in the schema.  For an
+            // entity least upper bound resulting from multiple entity
+            // types, the type might have the attribute if any of the
+            // constituent entity types have the attribute in the schema.
             Type::EntityOrRecord(EntityRecordKind::Entity(entity_lub)) => {
                 entity_lub.lub_elements.iter().any(|entity| {
                     schema
@@ -366,10 +382,13 @@ impl Type {
             Type::EntityOrRecord(EntityRecordKind::ActionEntity { attrs, .. }) => {
                 attrs.iter().any(|(found_attr, _)| attr.eq(found_attr))
             }
-            // Other record or entity types always might have some attribute
-            // since the type may be the result of a least upper bound which
-            // could have dropped attributes from the type.
-            Type::EntityOrRecord(_) => true,
+            // A record will have an attribute if the attribute is in its
+            // attributes map. Records computed as a LUB may have an open
+            // attributes record, but that is handled by the first match case.
+            Type::EntityOrRecord(EntityRecordKind::Record { attrs, .. }) => {
+                attrs.get_attr(attr).is_some()
+            }
+            // No other types may have attributes.
             _ => false,
         }
     }
@@ -424,7 +443,10 @@ impl Type {
                     EntityRecordKind::ActionEntity { .. } => Type::json_type("ActionEntity"),
                 };
                 match rk {
-                    EntityRecordKind::Record { attrs } => {
+                    EntityRecordKind::Record {
+                        attrs,
+                        open_attributes,
+                    } => {
                         let attr_json = attrs
                             .iter()
                             .map(|(attr, attr_ty)| {
@@ -437,6 +459,12 @@ impl Type {
                             })
                             .collect::<serde_json::value::Map<_, _>>();
                         record_json.insert("attributes".to_string(), attr_json.into());
+                        if open_attributes.is_open() {
+                            record_json.insert(
+                                "additionalAttributes".to_string(),
+                                open_attributes.is_open().into(),
+                            );
+                        }
                     }
                     EntityRecordKind::ActionEntity { name, attrs } => {
                         let attr_json = attrs
@@ -505,7 +533,9 @@ impl Type {
             CoreSchemaType::EmptySet => matches!(self, Type::Set { .. }), // empty-set matches a set of any element type
             CoreSchemaType::Record { attrs } => match self {
                 Type::EntityOrRecord(kind) => match kind {
-                    EntityRecordKind::Record { attrs: self_attrs } => {
+                    EntityRecordKind::Record {
+                        attrs: self_attrs, ..
+                    } => {
                         attrs.iter().all(|(k, v)| {
                             match self_attrs.get_attr(k) {
                                 Some(ty) => {
@@ -620,7 +650,7 @@ impl TryFrom<Type> for cedar_policy_core::entities::SchemaType {
                     ty: EntityType::Concrete(name),
                 })
             }
-            Type::EntityOrRecord(EntityRecordKind::Record { attrs }) => {
+            Type::EntityOrRecord(EntityRecordKind::Record { attrs, .. }) => {
                 Ok(CoreSchemaType::Record {
                     attrs: {
                         attrs
@@ -843,6 +873,18 @@ impl Attributes {
         })
     }
 
+    // Determine if the attributes subtype while only allowing for depth
+    // subtyping. This forbids width subtyping, so there may not be attributes
+    // present in the subtype that do not exist in the super type.
+    pub(crate) fn is_subtype_depth_only(
+        &self,
+        schema: &ValidatorSchema,
+        other: &Attributes,
+    ) -> bool {
+        other.attrs.keys().collect::<HashSet<_>>() == self.attrs.keys().collect::<HashSet<_>>()
+            && self.is_subtype(schema, other)
+    }
+
     pub(crate) fn least_upper_bound(
         schema: &ValidatorSchema,
         attrs0: &Attributes,
@@ -868,6 +910,27 @@ impl IntoIterator for Attributes {
     }
 }
 
+/// Used to tag record types to indicate if their attributes record is open or
+/// closed.
+#[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone, Serialize)]
+pub enum OpenTag {
+    // The attributes are open. A value of this type may have attributes other
+    // than those listed.
+    OpenAttributes,
+    // The attributes are closed. The attributes for a value of this type must
+    // exactly match the attributes listed in the type.
+    ClosedAttributes,
+}
+
+impl OpenTag {
+    pub(crate) fn is_open(self) -> bool {
+        match self {
+            OpenTag::OpenAttributes => true,
+            OpenTag::ClosedAttributes => false,
+        }
+    }
+}
+
 /// Represents whether a type is an entity type, record type, or could be either
 ///
 /// The subtyping lattice for these types is that
@@ -875,7 +938,14 @@ impl IntoIterator for Attributes {
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
 pub enum EntityRecordKind {
     /// A record type, with these attributes
-    Record { attrs: Attributes },
+    Record {
+        /// The attributes that we know must exist (or may exist in the case of
+        /// optional attributes) for a record with this type along with the
+        /// types the attributes must have if they do exist.
+        attrs: Attributes,
+        /// Encodes whether the attributes for this record are open or closed.
+        open_attributes: OpenTag,
+    },
     /// Any entity type
     AnyEntity,
     /// An entity reference type. An entity reference might be a reference to one
@@ -904,9 +974,31 @@ impl EntityRecordKind {
         }
     }
 
+    /// Return `true` if this entity or record may have additional undeclared
+    /// attributes.
+    pub(crate) fn has_open_attributes_record(&self) -> bool {
+        match self {
+            // Records explicitly store this information.
+            EntityRecordKind::Record {
+                open_attributes, ..
+            } => open_attributes.is_open(),
+            // We know Actions never have additional attributes. This is true
+            // because the upper bound for any two action entities is
+            // `AnyEntity`, so if we have an ActionEntity here its attributes
+            // are known precisely.
+            EntityRecordKind::ActionEntity { .. } => false,
+            // The `AnyEntity` type has no declared attributes, but it is a
+            // super type of all other entity types which may have attributes,
+            // so it clearly may have additional attributes.
+            EntityRecordKind::AnyEntity => true,
+            // An entity LUB may not have additional attributes.
+            EntityRecordKind::Entity(_) => false,
+        }
+    }
+
     pub(crate) fn get_attr(&self, schema: &ValidatorSchema, attr: &str) -> Option<AttributeType> {
         match self {
-            EntityRecordKind::Record { attrs } => attrs.get_attr(attr).cloned(),
+            EntityRecordKind::Record { attrs, .. } => attrs.get_attr(attr).cloned(),
             EntityRecordKind::ActionEntity { attrs, .. } => attrs.get_attr(attr).cloned(),
             EntityRecordKind::AnyEntity => None,
             EntityRecordKind::Entity(lub) => {
@@ -918,7 +1010,7 @@ impl EntityRecordKind {
     pub fn all_attrs(&self, schema: &ValidatorSchema) -> Vec<SmolStr> {
         // Wish the clone here could be avoided, but `get_attribute_types` returns an owned `Attributes`.
         match self {
-            EntityRecordKind::Record { attrs } => attrs.attrs.keys().cloned().collect(),
+            EntityRecordKind::Record { attrs, .. } => attrs.attrs.keys().cloned().collect(),
             EntityRecordKind::ActionEntity { attrs, .. } => attrs.attrs.keys().cloned().collect(),
             EntityRecordKind::AnyEntity => vec![],
             EntityRecordKind::Entity(lub) => {
@@ -934,8 +1026,15 @@ impl EntityRecordKind {
     ) -> Option<EntityRecordKind> {
         use EntityRecordKind::*;
         match (rk0, rk1) {
-            (Record { attrs: attrs0 }, Record { attrs: attrs1 }) => Some(Record {
+            (Record { attrs: attrs0, .. }, Record { attrs: attrs1, .. }) => Some(Record {
                 attrs: Attributes::least_upper_bound(schema, attrs0, attrs1),
+                // If attrs0 <: attrs1 (or attrs1 <: attr0) without width
+                // subtyping, we could return the supertype for a LUB preserving
+                // `open_attributes: false`,  but this result is already
+                // achieved due to the subtype check done by
+                // `Type::least_upper_bound`.  This function will never be
+                // called when the records are in a subtype relation.
+                open_attributes: OpenTag::OpenAttributes,
             }),
             //We cannot take upper bounds of action entities because may_have_attr assumes the list of attrs it complete
             (ActionEntity { .. }, ActionEntity { .. }) => Some(AnyEntity),
@@ -968,8 +1067,28 @@ impl EntityRecordKind {
     ) -> bool {
         use EntityRecordKind::*;
         match (rk0, rk1) {
-            (Record { attrs: attrs0 }, Record { attrs: attrs1 }) => {
-                attrs0.is_subtype(schema, attrs1)
+            (
+                Record {
+                    attrs: attrs0,
+                    open_attributes: open0,
+                },
+                Record {
+                    attrs: attrs1,
+                    open_attributes: open1,
+                },
+            ) => {
+                // Closed attributes subtype open attributes. A record type with
+                // open attributes may contain a value that is not in a record
+                // type with closed attributes, so open attribute record types
+                // can never subtype closed attribute record types.
+                (!open0.is_open() || open1.is_open())
+                // When `rk1` has open attributes, width subtyping applies since
+                // there may be attributes in `rk0` that are not listed in
+                // `rk1`.  When `rk1` is closed, a subtype of `rk1` may not have
+                // any attributes that are not listed in `rk1`, so we apply
+                // depth subtyping only.
+                    && ((open1.is_open() && attrs0.is_subtype(schema, attrs1))
+                        || attrs0.is_subtype_depth_only(schema, attrs1))
             }
             (ActionEntity { .. }, ActionEntity { .. }) => false,
             (Entity(lub0), Entity(lub1)) => lub0.is_subtype(lub1),
@@ -1089,6 +1208,33 @@ mod test {
             };
             assert!(!lub.lub_elements.is_empty());
             Type::EntityOrRecord(EntityRecordKind::Entity(lub))
+        }
+
+        pub(crate) fn open_record_with_required_attributes(
+            required_attrs: impl IntoIterator<Item = (SmolStr, Type)>,
+        ) -> Type {
+            Type::EntityOrRecord(EntityRecordKind::Record {
+                attrs: Attributes::with_required_attributes(required_attrs),
+                open_attributes: OpenTag::OpenAttributes,
+            })
+        }
+
+        pub(crate) fn closed_record_with_required_attributes(
+            required_attrs: impl IntoIterator<Item = (SmolStr, Type)>,
+        ) -> Type {
+            Type::record_with_required_attributes(required_attrs, OpenTag::ClosedAttributes)
+        }
+
+        pub(crate) fn open_record_with_attributes(
+            attrs: impl IntoIterator<Item = (SmolStr, AttributeType)>,
+        ) -> Type {
+            Self::record_with_attributes(attrs, OpenTag::OpenAttributes)
+        }
+
+        pub(crate) fn closed_record_with_attributes(
+            attrs: impl IntoIterator<Item = (SmolStr, AttributeType)>,
+        ) -> Type {
+            Self::record_with_attributes(attrs, OpenTag::ClosedAttributes)
         }
     }
 
@@ -1273,60 +1419,93 @@ mod test {
     }
 
     #[test]
+    fn test_record_undef_lub() {
+        assert_least_upper_bound_empty_schema(
+            Type::open_record_with_attributes(None),
+            Type::primitive_string(),
+            None,
+        );
+
+        assert_least_upper_bound_empty_schema(
+            Type::closed_record_with_attributes(None),
+            Type::primitive_string(),
+            None,
+        );
+
+        assert_least_upper_bound_empty_schema(
+            Type::closed_record_with_attributes(None),
+            Type::set(Type::primitive_boolean()),
+            None,
+        );
+    }
+
+    #[test]
     fn test_record_lub() {
         assert_least_upper_bound_empty_schema(
-            Type::any_record(),
-            Type::any_record(),
-            Some(Type::record_with_attributes(None)),
+            Type::closed_record_with_attributes(None),
+            Type::closed_record_with_attributes(None),
+            Some(Type::closed_record_with_attributes(None)),
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::closed_record_with_attributes(None),
+            Type::open_record_with_attributes(None),
+            Some(Type::open_record_with_attributes(None)),
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::open_record_with_attributes(None),
+            Type::closed_record_with_attributes(None),
+            Some(Type::open_record_with_attributes(None)),
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::open_record_with_attributes(None),
+            Type::open_record_with_attributes(None),
+            Some(Type::open_record_with_attributes(None)),
         );
 
         assert_least_upper_bound_empty_schema(
-            Type::any_record(),
-            Type::any_entity_reference(),
-            None,
-        );
-
-        assert_least_upper_bound_empty_schema(
-            Type::record_with_required_attributes([
+            Type::closed_record_with_required_attributes([
                 ("foo".into(), Type::False),
                 ("bar".into(), Type::primitive_long()),
             ]),
-            Type::any_entity_reference(),
-            None,
-        );
-
-        assert_least_upper_bound_empty_schema(
-            Type::record_with_required_attributes([
-                ("foo".into(), Type::False),
-                ("bar".into(), Type::primitive_long()),
-            ]),
-            Type::record_with_required_attributes([
+            Type::closed_record_with_required_attributes([
                 ("foo".into(), Type::primitive_string()),
                 ("bar".into(), Type::primitive_long()),
             ]),
-            Some(Type::record_with_required_attributes([(
+            Some(Type::open_record_with_required_attributes([(
                 "bar".into(),
                 Type::primitive_long(),
             )])),
         );
 
         assert_least_upper_bound_empty_schema(
-            Type::record_with_required_attributes([
+            Type::closed_record_with_required_attributes([("bar".into(), Type::primitive_long())]),
+            Type::closed_record_with_required_attributes([
+                ("foo".into(), Type::primitive_string()),
+                ("bar".into(), Type::primitive_long()),
+            ]),
+            Some(Type::open_record_with_required_attributes([(
+                "bar".into(),
+                Type::primitive_long(),
+            )])),
+        );
+
+        assert_least_upper_bound_empty_schema(
+            Type::closed_record_with_required_attributes([
                 ("foo".into(), Type::False),
                 ("bar".into(), Type::primitive_long()),
             ]),
-            Type::record_with_required_attributes([
+            Type::closed_record_with_required_attributes([
                 ("foo".into(), Type::True),
                 ("baz".into(), Type::primitive_long()),
             ]),
-            Some(Type::record_with_required_attributes([(
+            Some(Type::open_record_with_required_attributes([(
                 "foo".into(),
                 Type::primitive_boolean(),
             )])),
         );
 
         assert_least_upper_bound_empty_schema(
-            Type::record_with_attributes([
+            Type::closed_record_with_attributes([
                 (
                     "foo".into(),
                     AttributeType::new(Type::primitive_long(), false),
@@ -1336,7 +1515,7 @@ mod test {
                     AttributeType::new(Type::primitive_long(), false),
                 ),
             ]),
-            Type::record_with_attributes([
+            Type::closed_record_with_attributes([
                 (
                     "foo".into(),
                     AttributeType::new(Type::primitive_long(), true),
@@ -1346,7 +1525,7 @@ mod test {
                     AttributeType::new(Type::primitive_long(), false),
                 ),
             ]),
-            Some(Type::record_with_attributes([
+            Some(Type::closed_record_with_attributes([
                 (
                     "foo".into(),
                     AttributeType::new(Type::primitive_long(), false),
@@ -1358,12 +1537,10 @@ mod test {
             ])),
         );
 
-        assert_least_upper_bound_empty_schema(Type::any_record(), Type::primitive_string(), None);
-
         assert_least_upper_bound_empty_schema(
-            Type::record_with_attributes(None),
-            Type::primitive_string(),
-            None,
+            Type::closed_record_with_required_attributes([("a".into(), Type::primitive_long())]),
+            Type::closed_record_with_attributes([]),
+            Some(Type::open_record_with_attributes([])),
         );
     }
 
@@ -1543,9 +1720,22 @@ mod test {
 
     #[test]
     fn test_record_entity_lub() {
-        assert_least_upper_bound_attr_schema(
+        assert_least_upper_bound_empty_schema(
             Type::any_entity_reference(),
             Type::any_record(),
+            None,
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::closed_record_with_attributes(None),
+            Type::any_entity_reference(),
+            None,
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::closed_record_with_required_attributes([
+                ("foo".into(), Type::False),
+                ("bar".into(), Type::primitive_long()),
+            ]),
+            Type::any_entity_reference(),
             None,
         );
         assert_least_upper_bound_attr_schema(
@@ -1560,7 +1750,7 @@ mod test {
         );
         assert_least_upper_bound_attr_schema(
             Type::named_entity_reference_from_str("buz"),
-            Type::record_with_required_attributes(vec![
+            Type::closed_record_with_required_attributes(vec![
                 ("a".into(), Type::primitive_long()),
                 ("b".into(), Type::primitive_long()),
                 ("c".into(), Type::named_entity_reference_from_str("bar")),
@@ -1603,7 +1793,7 @@ mod test {
         assert_least_upper_bound(
             schema,
             Type::named_entity_reference_from_str("U"),
-            Type::record_with_required_attributes([(
+            Type::closed_record_with_required_attributes([(
                 "foo".into(),
                 Type::named_entity_reference_from_str("U"),
             )]),
@@ -1699,12 +1889,12 @@ mod test {
         assert_json_parses_to_schema_type(Type::named_entity_reference_from_str("Foo"));
         assert_json_parses_to_schema_type(Type::named_entity_reference_from_str("Foo::Bar"));
         assert_json_parses_to_schema_type(Type::named_entity_reference_from_str("Foo::Bar::Baz"));
-        assert_json_parses_to_schema_type(Type::record_with_attributes(None));
-        assert_json_parses_to_schema_type(Type::record_with_attributes([(
+        assert_json_parses_to_schema_type(Type::closed_record_with_attributes(None));
+        assert_json_parses_to_schema_type(Type::closed_record_with_attributes([(
             "a".into(),
             AttributeType::required_attribute(Type::primitive_boolean()),
         )]));
-        assert_json_parses_to_schema_type(Type::record_with_attributes([
+        assert_json_parses_to_schema_type(Type::closed_record_with_attributes([
             (
                 "a".into(),
                 AttributeType::required_attribute(Type::primitive_boolean()),

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -134,12 +134,9 @@ impl Type {
     }
 
     pub(crate) fn any_record() -> Type {
-        Type::EntityOrRecord(EntityRecordKind::Record {
-            attrs: Attributes::with_required_attributes(None),
-            // (open_attributes = false) <: (open_attributes = true),
-            // so this makes `any_record` a super type of all records.
-            open_attributes: OpenTag::OpenAttributes,
-        })
+        // OpenAttributes <: ClosedAttributes, so this makes `any_record` a
+        // super type of all records.
+        Type::record_with_attributes(None, OpenTag::OpenAttributes)
     }
 
     pub(crate) fn record_with_required_attributes(

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -988,7 +988,10 @@ impl EntityRecordKind {
             // super type of all other entity types which may have attributes,
             // so it clearly may have additional attributes.
             EntityRecordKind::AnyEntity => true,
-            // An entity LUB may not have additional attributes.
+            // An entity LUB may not have an open attributes record. The record
+            // type returned by `get_attributes_type` _may_ be open, but even in
+            // that case we can account for all attributes that might exist by
+            // examining the elements of the LUB.
             EntityRecordKind::Entity(_) => false,
         }
     }
@@ -1027,8 +1030,8 @@ impl EntityRecordKind {
                 attrs: Attributes::least_upper_bound(schema, attrs0, attrs1),
                 // If attrs0 <: attrs1 (or attrs1 <: attr0) without width
                 // subtyping, we could return the supertype for a LUB preserving
-                // `open_attributes: false`,  but this result is already
-                // achieved due to the subtype check done by
+                // `open_attributes: OpenTag::OpenAttributes`,  but this result
+                // is already achieved due to the subtype check done by
                 // `Type::least_upper_bound`.  This function will never be
                 // called when the records are in a subtype relation.
                 open_attributes: OpenTag::OpenAttributes,


### PR DESCRIPTION
This splits off a change to record types made as part of partial schema validation

* Adds `open_attributes` to the record type struct. When true, we assume a record with that type may have other attributes. When false it will have exactly the attributes specified in the type.
* Record literals and records in schema are now closed.
* Update `has` to match use this new field. A `has` on a closed record will have type `False` if the attribute is not present.
* Update subtyping and LUB computation

I've update the Dafny Spec (https://github.com/cedar-policy/cedar-spec/pull/44) ~~, but don't have the working proofs~~ (Kesha finished them off for me). Diff testing and PBT passed an overnight run. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.