### PR TITLE
Resolve: Issue 114 Expose-EvaluationError

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -315,7 +315,7 @@ impl<'a> Hash for RestrictedExprShapeOnly<'a> {
 }
 
 /// Errors generated in the restricted_expr module
-#[derive(Debug, Clone, PartialEq, Hash, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Error)]
 pub enum RestrictedExpressionError {
     /// A "restricted" expression contained a feature that is not allowed
     /// in "restricted" expressions. The `feature` is just a string description

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -17,9 +17,10 @@
 use crate::ast::{EntityType, Name, Type};
 use smol_str::SmolStr;
 use std::collections::HashMap;
+use serde::{Serialize, Deserialize};
 
 /// Possible types that schema-based parsing can expect for Cedar values.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum SchemaType {
     /// Boolean
     Bool,
@@ -55,7 +56,7 @@ pub enum SchemaType {
 }
 
 /// Attribute type structure used in [`SchemaType`]
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub struct AttributeType {
     /// Type of the attribute
     attr_type: SchemaType,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -18,9 +18,10 @@ use crate::ast::*;
 use smol_str::SmolStr;
 use std::sync::Arc;
 use thiserror::Error;
+use serde::{Serialize, Deserialize};
 
 /// Errors that can occur during evaluation
-#[derive(Debug, PartialEq, Clone, Error)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Error)]
 pub enum EvaluationError {
     /// Tried to lookup this entity UID, but it didn't exist in the provided
     /// entities
@@ -125,7 +126,7 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Error)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Error)]
 pub enum IntegerOverflowError {
     #[error("integer overflow while attempting to {} the values {arg1} and {arg2}", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", _ => "perform an operation on" })]
     BinaryOp {

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -25,6 +25,7 @@ pub mod partial_evaluation;
 
 use crate::ast::{Extension, ExtensionFunction, Name};
 use crate::entities::SchemaType;
+use serde::{Serialize, Deserialize};
 use thiserror::Error;
 
 lazy_static::lazy_static! {
@@ -133,7 +134,7 @@ impl<'a> Extensions<'a> {
 }
 
 /// Errors thrown when looking up an extension function in [`Extensions`].
-#[derive(Debug, PartialEq, Clone, Error)]
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, Error)]
 pub enum ExtensionFunctionLookupError {
     /// Tried to call a function that doesn't exist
     #[error("extension function does not exist: {name}")]


### PR DESCRIPTION
closes #114 

## Reviewed by Kesha Hietala (khieta)

So, after some digging, I found the EvaluationError enum in `cedar-policy-core/src/evaluator/err.rs`‎ which is imported by the `cedar/cedar-policy-core/src/evaluator.rs` on lines 25-27.

I haven't tested this Idea but using that information and the TODO I arrived at a solution.
> /// TODO in the future this can/should be the actual Core `EvaluationError

[!] There's an unfinished comment on line 447 of api.rs I meant to say something like `[+] Modified to Resolve TODO `

### Solution
`cedar/cedar-policy/src/api.rs`
Import the EvaluationError enum from `cedar-policy-core` and include it as a variant called CoreError in the ApiEvaluationError enum.

The #[from] attribute allows for automatic conversion from EvaluationError to ApiEvaluationError::CoreError.

Consistent error handling experience leverages the error types and patterns defined in cedar-policy-core. 
This ensures that any changes made to cedar-policy-core's EvaluationError are reflected in the ceder-policy/src API module without any need for manual synchronization.


```rust
use cedar_policy_core::evaluator::err::EvaluationError;

#[derive(Debug, Clone, PartialEq, Eq, Error)]
pub enum ApiEvaluationError {
    #[error("{0}")]
    CoreError(#[from] EvaluationError),
}
````

### Additional changes

There are 8 references to EvaluationError that would need to be changed.
Here's an example using line 121-132 from cedar-policy/src/api.rs.

```rust
pub fn attr(&self, attr: &str) -> Option<Result<EvalResult, ApiEvaluationError>> {
    let expr = self.0.get(attr)?;
    let all_ext = Extensions::all_available();
    let evaluator = RestrictedEvaluator::new(&all_ext);
    Some(
        evaluator
            .interpret(expr.as_borrowed())
            .map(EvalResult::from)
            .map_err(ApiEvaluationError::from),
    )
}
```
## Further changes
`cedar-policy-core/src/authorizer.rs`
There are a few `Vec<string>` calls that need to be updated.
For example, in the Diagnostics struct.
- We need to update the Diagnostics struct to use `Vec<EvaluationError>` for the errors field instead of `Vec<String>`
```rust
#[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
pub struct Diagnostics {
    pub reason: HashSet<PolicyID>,
    pub errors: Vec<EvaluationError>,
}
```
- Modify the Response struct's 'new' function to accept a `Vec<EvaluationError>` for the errors parameter and update the construction of diagnostics. 
```rust
impl Response {
    pub fn new(decision: Decision, reason: HashSet<PolicyID>, errors: Vec<EvaluationError>) -> Self {
        Response {
            decision,
            diagnostics: Diagnostics { reason, errors },
        }
    }
}

```
The Response struct will now use a `Vec<EvaluationError>` for the errors field within the Diagnostics struct. It's important to 
update any code that creates a new Response instance to pass a `Vec<EvaluationError>` for the errors parameter.