### PR TITLE
hide `Arbitrary` implementations behind crate features, not `cfg(fuzzing)`

### DIFF
--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -23,6 +23,7 @@ rustc_lexer = "0.1"
 thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
+arbitrary = { version = "1", features = ["derive"], optional = true }
 
 # ipaddr extension requires ipnet
 ipnet = { version = "2.5.0", optional = true }
@@ -30,14 +31,14 @@ ipnet = { version = "2.5.0", optional = true }
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }
 
-# Enables `Arbitrary` implementations for several types in this crate
-arbitrary = { version = "1", features = ["derive"] }
-
 [features]
 # by default, enable all Cedar extensions
 default = ["ipaddr", "decimal"]
 ipaddr = ["dep:ipnet"]
 decimal = ["dep:regex"]
+
+# Enables `Arbitrary` implementations for several types in this crate
+arbitrary = ["dep:arbitrary"]
 
 [build-dependencies]
 lalrpop = "0.19.12"

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -26,7 +26,7 @@ use std::collections::{HashMap, HashSet};
 /// and the second is an unspecified type, which is used (internally) to represent cases
 /// where the input request does not provide a principal, action, and/or resource.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum EntityType {
     /// Concrete nominal type
     Concrete(Name),
@@ -57,7 +57,7 @@ impl std::fmt::Display for EntityType {
 
 /// Unique ID for an entity. These represent entities in the AST.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct EntityUID {
     /// Typename of the entity
     ty: EntityType,
@@ -186,7 +186,7 @@ impl AsRef<str> for Eid {
     }
 }
 
-#[cfg(fuzzing)]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for Eid {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let x: String = u.arbitrary()?;

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1367,7 +1367,7 @@ impl<T> Expr<T> {
 
 /// AST variables
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Var {
     /// the Principal of the given request
     #[serde(rename = "principal")]

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -89,7 +89,7 @@ where
 
 /// Which "style" is a function call
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum CallStyle {
     /// Function-style, eg foo(a, b)
     FunctionStyle,

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -27,7 +27,7 @@ use crate::parser::err::ParseError;
 /// The name can include namespaces.
 /// Clone is O(1).
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Name {
     /// Basename
     pub(crate) id: Id,
@@ -233,7 +233,7 @@ impl std::str::FromStr for Id {
     }
 }
 
-#[cfg(fuzzing)]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for Id {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         // identifier syntax:

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 /// Built-in operators with exactly one argument
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UnaryOp {
     /// Logical negation
     ///
@@ -33,7 +33,7 @@ pub enum UnaryOp {
 
 /// Built-in operators with exactly two arguments
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum BinaryOp {
     /// Equality
     ///

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -25,8 +25,8 @@ use serde::{Deserialize, Serialize};
 // and it's difficult to parse them into Dafny characters.
 // Instead we serialize the unicode values of Rust characters and leverage
 // Dafny's type conversion to retrieve the characters.
-#[cfg_attr(not(fuzzing), derive(Serialize))]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(not(feature = "arbitrary"), derive(Serialize))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
     /// A character literal
     Char(char),
@@ -34,7 +34,7 @@ pub enum PatternElem {
     Wildcard,
 }
 
-#[cfg(fuzzing)]
+#[cfg(feature = "arbitrary")]
 impl Serialize for PatternElem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1174,7 +1174,7 @@ impl EntityReference {
 
 /// Subset of AST variables that have the same constraint form
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PrincipalOrResource {
     /// The principal of a request
     Principal,
@@ -1397,7 +1397,7 @@ impl std::fmt::Display for PolicyID {
     }
 }
 
-#[cfg(fuzzing)]
+#[cfg(feature = "arbitrary")]
 impl<'u> arbitrary::Arbitrary<'u> for PolicyID {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<PolicyID> {
         let s: String = u.arbitrary()?;
@@ -1410,7 +1410,7 @@ impl<'u> arbitrary::Arbitrary<'u> for PolicyID {
 
 /// the Effect of a policy
 #[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, Clone, Copy)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Effect {
     /// this is a Permit policy
     #[serde(rename = "permit")]

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -15,12 +15,12 @@ cedar-policy-core = { version = "2.2.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
-arbitrary = { version = "1", features = ["derive"] }
 thiserror = "1.0"
 itertools = "0.10"
 unicode-security = "0.1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
+arbitrary = { version = "1", features = ["derive"], optional = true }
 
 [features]
 # by default, enable all Cedar extensions
@@ -28,3 +28,6 @@ default = ["ipaddr", "decimal"]
 # when enabling a feature, make sure that the Core feature is also enabled
 ipaddr = ["cedar-policy-core/ipaddr"]
 decimal = ["cedar-policy-core/decimal"]
+
+# Enables `Arbitrary` implementations for several types in this crate
+arbitrary = ["dep:arbitrary"]

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -275,7 +275,7 @@ impl SchemaType {
     }
 }
 
-#[cfg(fuzzing)]
+#[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType> {
         use cedar_policy_core::ast::Name;
@@ -336,7 +336,7 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
 /// unknown fields for TypeOfAttribute should be passed to SchemaType where
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
-#[cfg_attr(fuzzing, derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct TypeOfAttribute {
     #[serde(flatten)]
     pub ty: SchemaType,


### PR DESCRIPTION
In support of https://github.com/cedar-policy/cedar-spec/issues/46, this lets downstream crates use these `Arbitrary` implementations even when not `cfg(fuzzing)`, just by enabling the new `arbitrary` feature.  As a bonus, `arbitrary` itself becomes an optional dependency, rather than required.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
