### PR TITLE
add additional methods on `EntityTypeName`

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -937,6 +937,28 @@ impl std::fmt::Display for EntityId {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
 pub struct EntityTypeName(ast::Name);
 
+impl EntityTypeName {
+    /// Get the basename of the `EntityTypeName` (ie, with namespaces stripped).
+    pub fn basename(&self) -> &str {
+        self.0.basename().as_ref()
+    }
+
+    /// Get the namespace of the `EntityTypeName`, as components
+    pub fn namespace_components(&self) -> impl Iterator<Item = &str> {
+        self.0.namespace_components().map(AsRef::as_ref)
+    }
+
+    /// Get the full namespace of the `EntityTypeName`, as a single string.
+    ///
+    /// Examples:
+    /// - `foo::bar` --> the namespace is `"foo"`
+    /// - `bar` --> the namespace is `""`
+    /// - `foo::bar::baz` --> the namespace is `"foo::bar"`
+    pub fn namespace(&self) -> String {
+        self.0.namespace()
+    }
+}
+
 impl FromStr for EntityTypeName {
     type Err = ParseErrors;
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2230,6 +2230,37 @@ mod entity_uid_tests {
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
         assert_eq!(euid.id().as_ref(), "bobby");
         assert_eq!(euid.type_name().to_string(), "Chess::Master");
+        assert_eq!(euid.type_name().basename(), "Master");
+        assert_eq!(euid.type_name().namespace(), "Chess");
+        assert_eq!(euid.type_name().namespace_components().count(), 1);
+    }
+
+    /// building an `EntityUid` from components, with no namespace
+    #[test]
+    fn entity_uid_no_namespace() {
+        let entity_id = EntityId::from_str("bobby").expect("failed at constructing EntityId");
+        let entity_type_name = EntityTypeName::from_str("User")
+            .expect("failed at constructing EntityTypeName");
+        let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
+        assert_eq!(euid.id().as_ref(), "bobby");
+        assert_eq!(euid.type_name().to_string(), "User");
+        assert_eq!(euid.type_name().basename(), "User");
+        assert_eq!(euid.type_name().namespace(), String::new());
+        assert_eq!(euid.type_name().namespace_components().count(), 0);
+    }
+
+    /// building an `EntityUid` from components, with many nested namespaces
+    #[test]
+    fn entity_uid_nested_namespaces() {
+        let entity_id = EntityId::from_str("bobby").expect("failed at constructing EntityId");
+        let entity_type_name = EntityTypeName::from_str("A::B::C::D::Z")
+            .expect("failed at constructing EntityTypeName");
+        let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
+        assert_eq!(euid.id().as_ref(), "bobby");
+        assert_eq!(euid.type_name().to_string(), "A::B::C::D::Z");
+        assert_eq!(euid.type_name().basename(), "Z");
+        assert_eq!(euid.type_name().namespace(), "A::B::C::D");
+        assert_eq!(euid.type_name().namespace_components().count(), 4);
     }
 
     /// building an `EntityUid` from components, including escapes
@@ -2245,6 +2276,9 @@ mod entity_uid_tests {
         //   the EntityId has the literal backslash characters in it
         assert_eq!(euid.id().as_ref(), r#"bobby\'s sister:\nVeronica"#);
         assert_eq!(euid.type_name().to_string(), "Hockey::Master");
+        assert_eq!(euid.type_name().basename(), "Master");
+        assert_eq!(euid.type_name().namespace(), "Hockey");
+        assert_eq!(euid.type_name().namespace_components().count(), 1);
     }
 
     /// building an `EntityUid` from components, including backslashes

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2239,8 +2239,8 @@ mod entity_uid_tests {
     #[test]
     fn entity_uid_no_namespace() {
         let entity_id = EntityId::from_str("bobby").expect("failed at constructing EntityId");
-        let entity_type_name = EntityTypeName::from_str("User")
-            .expect("failed at constructing EntityTypeName");
+        let entity_type_name =
+            EntityTypeName::from_str("User").expect("failed at constructing EntityTypeName");
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
         assert_eq!(euid.id().as_ref(), "bobby");
         assert_eq!(euid.type_name().to_string(), "User");

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2325,11 +2325,23 @@ mod entity_uid_tests {
             EntityTypeName::from_str(" A :: B\n::C \n  ::D\n").unwrap(),
             EntityId::from_str(" hi there are \n spaces and \n newlines ").unwrap(),
         );
-        assert_eq!(euid_spaces_and_newlines.id().as_ref(), " hi there are \n spaces and \n newlines ");
-        assert_eq!(euid_spaces_and_newlines.type_name().to_string(), "A::B::C::D"); // expect to have been normalized
+        assert_eq!(
+            euid_spaces_and_newlines.id().as_ref(),
+            " hi there are \n spaces and \n newlines "
+        );
+        assert_eq!(
+            euid_spaces_and_newlines.type_name().to_string(),
+            "A::B::C::D"
+        ); // expect to have been normalized
         assert_eq!(euid_spaces_and_newlines.type_name().basename(), "D");
         assert_eq!(euid_spaces_and_newlines.type_name().namespace(), "A::B::C");
-        assert_eq!(euid_spaces_and_newlines.type_name().namespace_components().count(), 3);
+        assert_eq!(
+            euid_spaces_and_newlines
+                .type_name()
+                .namespace_components()
+                .count(),
+            3
+        );
     }
 
     #[test]


### PR DESCRIPTION
Some consumers would like to get the basename or namespace components of the typename without having to resort to string operations or parsing themselves.  These methods give the canonical/correct definitions.

Somewhat related to https://github.com/cedar-policy/rfcs/pull/9


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
