### PR TITLE
Implement RFC 9

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -110,6 +110,28 @@ impl EntityUID {
         })
     }
 
+    /// Create an `EntityUID` by parsing a string, which is required to be normalized.
+    /// That is, this constructor will not accept strings with spurious whitespace
+    /// (e.g. `A :: B :: C::"foo"`), Cedar comments (e.g. `A::B::"bar" // comment`), etc. See
+    /// [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md)
+    /// for more details and justification.
+    ///
+    /// For the version that accepts whitespace, Cedar comments, and etc, use the
+    /// actual `FromStr` implementation for `EntityUID`.
+    pub fn parse_normalized_euid(s: &str) -> Result<Self, Vec<ParseError>> {
+        use std::str::FromStr;
+        let parsed = EntityUID::from_str(s)?;
+        let normalized = parsed.to_string();
+        if normalized == s {
+            // the normalized representation is indeed the one that was provided
+            Ok(parsed)
+        } else {
+            Err(vec![ParseError::ToAST(format!(
+                "Entity UID needs to be normalized (e.g., whitespace removed): {s} The normalized form is {normalized}"
+            ))])
+        }
+    }
+
     /// Split into the `EntityType` representing the entity type, and the `Eid`
     /// representing its name
     pub fn components(self) -> (EntityType, Eid) {

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -17,6 +17,7 @@
 use crate::ast::*;
 use crate::parser::err::ParseError;
 use crate::transitive_closure::TCNode;
+use crate::FromNormalizedStr;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
@@ -110,28 +111,6 @@ impl EntityUID {
         })
     }
 
-    /// Create an `EntityUID` by parsing a string, which is required to be normalized.
-    /// That is, this constructor will not accept strings with spurious whitespace
-    /// (e.g. `A :: B :: C::"foo"`), Cedar comments (e.g. `A::B::"bar" // comment`), etc. See
-    /// [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md)
-    /// for more details and justification.
-    ///
-    /// For the version that accepts whitespace, Cedar comments, and etc, use the
-    /// actual `FromStr` implementation for `EntityUID`.
-    pub fn parse_normalized_euid(s: &str) -> Result<Self, Vec<ParseError>> {
-        use std::str::FromStr;
-        let parsed = EntityUID::from_str(s)?;
-        let normalized = parsed.to_string();
-        if normalized == s {
-            // the normalized representation is indeed the one that was provided
-            Ok(parsed)
-        } else {
-            Err(vec![ParseError::ToAST(format!(
-                "Entity UID needs to be normalized (e.g., whitespace removed): {s} The normalized form is {normalized}"
-            ))])
-        }
-    }
-
     /// Split into the `EntityType` representing the entity type, and the `Eid`
     /// representing its name
     pub fn components(self) -> (EntityType, Eid) {
@@ -182,6 +161,12 @@ impl std::str::FromStr for EntityUID {
 
     fn from_str(s: &str) -> Result<Self, Vec<ParseError>> {
         crate::parser::parse_euid(s)
+    }
+}
+
+impl FromNormalizedStr for EntityUID {
+    fn describe_self() -> &'static str {
+        "Entity UID"
     }
 }
 

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-use crate::{ast::*, extensions::Extensions, parser::SourceInfo};
+use crate::{
+    ast::*,
+    extensions::Extensions,
+    parser::{err::ParseError, SourceInfo},
+};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
@@ -759,6 +763,14 @@ fn maybe_with_parens(expr: &Expr) -> String {
         ExprKind::Like { .. } => format!("({})", expr),
         ExprKind::Set { .. } => expr.to_string(),
         ExprKind::Record { .. } => expr.to_string(),
+    }
+}
+
+impl std::str::FromStr for Expr {
+    type Err = Vec<ParseError>;
+
+    fn from_str(s: &str) -> Result<Expr, Vec<ParseError>> {
+        crate::parser::parse_expr(s)
     }
 }
 

--- a/cedar-policy-core/src/ast/literal.rs
+++ b/cedar-policy-core/src/ast/literal.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast::{EntityUID, StaticallyTyped, Type};
+use crate::parser;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::sync::Arc;
@@ -66,6 +67,14 @@ impl std::fmt::Display for Literal {
             Self::String(s) => write!(f, "\"{}\"", s.escape_debug()),
             Self::EntityUID(uid) => write!(f, "{}", uid),
         }
+    }
+}
+
+impl std::str::FromStr for Literal {
+    type Err = Vec<parser::err::ParseError>;
+
+    fn from_str(s: &str) -> Result<Literal, Self::Err> {
+        parser::parse_literal(s)
     }
 }
 

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -24,6 +24,8 @@ use super::PrincipalOrResource;
 use crate::{parser::err::ParseError, FromNormalizedStr};
 
 /// Arc::unwrap_or_clone() isn't stabilized as of this writing, but this is its implementation
+//
+// TODO: use `Arc::unwrap_or_clone()` once stable
 pub fn unwrap_or_clone<T: Clone>(arc: Arc<T>) -> T {
     Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone())
 }

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -225,28 +225,6 @@ impl Id {
         Id(s.into())
     }
 
-    /// Create an `Id` by parsing a string, which is required to be normalized.
-    /// That is, this constructor will not accept strings with spurious whitespace
-    /// (e.g. ` ABC `), Cedar comments (e.g. `ABC// comment`), etc. See
-    /// [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md)
-    /// for more details and justification.
-    ///
-    /// For the version that accepts whitespace, Cedar comments, and etc, use the
-    /// actual `FromStr` implementation for `Id`.
-    pub fn parse_normalized_id(s: &str) -> Result<Id, Vec<ParseError>> {
-        use std::str::FromStr;
-        let parsed = Id::from_str(s)?;
-        let normalized = parsed.to_string();
-        if normalized == s {
-            // the normalized representation is indeed the one that was provided
-            Ok(parsed)
-        } else {
-            Err(vec![ParseError::ToAST(format!(
-                "Id needs to be normalized (e.g., whitespace removed): {s} The normalized form is {normalized}"
-            ))])
-        }
-    }
-
     /// Get the underlying string
     pub fn to_smolstr(self) -> SmolStr {
         self.0
@@ -328,13 +306,13 @@ mod test {
 
     #[test]
     fn normalized_id() {
-        Id::parse_normalized_id("foo").expect("should be OK");
-        Id::parse_normalized_id("foo::bar").expect_err("shouldn't be OK");
-        Id::parse_normalized_id(r#"foo::"bar""#).expect_err("shouldn't be OK");
-        Id::parse_normalized_id(" foo").expect_err("shouldn't be OK");
-        Id::parse_normalized_id("foo ").expect_err("shouldn't be OK");
-        Id::parse_normalized_id("foo\n").expect_err("shouldn't be OK");
-        Id::parse_normalized_id("foo//comment").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo").expect("should be OK");
+        Id::from_normalized_str("foo::bar").expect_err("shouldn't be OK");
+        Id::from_normalized_str(r#"foo::"bar""#).expect_err("shouldn't be OK");
+        Id::from_normalized_str(" foo").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo ").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo\n").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo//comment").expect_err("shouldn't be OK");
     }
 
     #[test]

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -16,6 +16,7 @@
 
 use super::{Expr, ExprKind, Literal, Name};
 use crate::entities::JsonSerializationError;
+use crate::parser;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::hash::{Hash, Hasher};
@@ -113,6 +114,14 @@ impl RestrictedExpr {
             function_name,
             args.into_iter().map(Into::into).collect(),
         ))
+    }
+}
+
+impl std::str::FromStr for RestrictedExpr {
+    type Err = Vec<parser::err::ParseError>;
+
+    fn from_str(s: &str) -> Result<RestrictedExpr, Self::Err> {
+        parser::parse_restrictedexpr(s)
     }
 }
 

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -22,6 +22,7 @@ use crate::ast::{
     BorrowedRestrictedExpr, Eid, EntityUID, Expr, ExprKind, Literal, Name, RestrictedExpr,
 };
 use crate::extensions::{Extensions, ExtensionsError};
+use crate::FromNormalizedStr;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
@@ -128,7 +129,7 @@ impl TryFrom<TypeAndId> for EntityUID {
 
     fn try_from(e: TypeAndId) -> Result<EntityUID, Self::Error> {
         Ok(EntityUID::from_components(
-            Name::parse_normalized_name(&e.entity_type)?,
+            Name::from_normalized_str(&e.entity_type)?,
             Eid::new(e.id),
         ))
     }
@@ -289,7 +290,7 @@ impl FnAndArg {
     pub fn into_expr(self) -> Result<RestrictedExpr, JsonDeserializationError> {
         use crate::parser;
         Ok(RestrictedExpr::call_extension_fn(
-            Name::parse_normalized_name(&self.ext_fn).map_err(|errs| {
+            Name::from_normalized_str(&self.ext_fn).map_err(|errs| {
                 JsonDeserializationError::ExtnParseError(parser::err::ParseError::WithContext {
                     context: format!(
                         "in __extn escape, {:?} is not a valid function name",

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -128,7 +128,7 @@ impl TryFrom<TypeAndId> for EntityUID {
 
     fn try_from(e: TypeAndId) -> Result<EntityUID, Self::Error> {
         Ok(EntityUID::from_components(
-            e.entity_type.parse()?,
+            Name::parse_normalized_name(&e.entity_type)?,
             Eid::new(e.id),
         ))
     }
@@ -289,7 +289,7 @@ impl FnAndArg {
     pub fn into_expr(self) -> Result<RestrictedExpr, JsonDeserializationError> {
         use crate::parser;
         Ok(RestrictedExpr::call_extension_fn(
-            self.ext_fn.parse().map_err(|errs| {
+            Name::parse_normalized_name(&self.ext_fn).map_err(|errs| {
                 JsonDeserializationError::ExtnParseError(parser::err::ParseError::WithContext {
                     context: format!(
                         "in __extn escape, {:?} is not a valid function name",

--- a/cedar-policy-core/src/est/utils.rs
+++ b/cedar-policy-core/src/est/utils.rs
@@ -17,6 +17,8 @@
 use std::sync::Arc;
 
 /// Arc::unwrap_or_clone() isn't stabilized as of this writing, but this is its implementation
+//
+// TODO: use `Arc::unwrap_or_clone()` once stable
 pub fn unwrap_or_clone<T: Clone>(arc: Arc<T>) -> T {
     Arc::try_unwrap(arc).unwrap_or_else(|arc| (*arc).clone())
 }

--- a/cedar-policy-core/src/from_normalized_str.rs
+++ b/cedar-policy-core/src/from_normalized_str.rs
@@ -1,0 +1,38 @@
+use crate::parser::err::ParseError;
+use std::fmt::Display;
+use std::str::FromStr;
+
+/// Trait for parsing "normalized" strings only, throwing an error if a
+/// non-normalized string is encountered. See docs on the
+/// [`from_normalized_str`] trait function.
+pub trait FromNormalizedStr: FromStr<Err = Vec<ParseError>> + Display {
+    /// Create a `Self` by parsing a string, which is required to be normalized.
+    /// That is, the input is required to roundtrip with the `Display` impl on `Self`:
+    /// `Self::from_normalized_str(x).to_string() == x` must hold.
+    ///
+    /// In Cedar's context, that means that `from_normalized_str()` will not
+    /// accept strings with spurious whitespace (e.g. `A :: B :: C::"foo"`),
+    /// Cedar comments (e.g. `A::B::"bar" // comment`), etc. See
+    /// [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md)
+    /// for more details and justification.
+    ///
+    /// For the version that accepts whitespace, Cedar comments, and etc, use the
+    /// actual `FromStr` implementations.
+    fn from_normalized_str(s: &str) -> Result<Self, Vec<ParseError>> {
+        let parsed = Self::from_str(s)?;
+        let normalized = parsed.to_string();
+        if normalized == s {
+            // the normalized representation is indeed the one that was provided
+            Ok(parsed)
+        } else {
+            Err(vec![ParseError::ToAST(format!(
+                "{} needs to be normalized (e.g., whitespace removed): {s} The normalized form is {normalized}",
+                Self::describe_self()
+            ))])
+        }
+    }
+
+    /// Short string description of the `Self` type, to be used in error messages.
+    /// What are we trying to parse?
+    fn describe_self() -> &'static str;
+}

--- a/cedar-policy-core/src/from_normalized_str.rs
+++ b/cedar-policy-core/src/from_normalized_str.rs
@@ -16,7 +16,7 @@ pub trait FromNormalizedStr: FromStr<Err = Vec<ParseError>> + Display {
     /// [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md)
     /// for more details and justification.
     ///
-    /// For the version that accepts whitespace, Cedar comments, and etc, use the
+    /// For the version that accepts whitespace and Cedar comments, use the
     /// actual `FromStr` implementations.
     fn from_normalized_str(s: &str) -> Result<Self, Vec<ParseError>> {
         let parsed = Self::from_str(s)?;

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -29,11 +29,11 @@ extern crate lalrpop_util;
 
 pub mod ast;
 pub mod authorizer;
+mod from_normalized_str;
+pub use from_normalized_str::*;
 pub mod entities;
 pub mod est;
 pub mod evaluator;
 pub mod extensions;
-
 pub mod parser;
-
 pub mod transitive_closure;

--- a/cedar-policy-validator/src/extensions/decimal.rs
+++ b/cedar-policy-validator/src/extensions/decimal.rs
@@ -16,10 +16,10 @@
 
 use crate::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
 use crate::types::{self, Type};
-use cedar_policy_core::ast::{Expr, ExprKind, Literal};
+use cedar_policy_core::ast::{Expr, ExprKind, Literal, RestrictedExpr};
 use cedar_policy_core::evaluator::RestrictedEvaluator;
 use cedar_policy_core::extensions::{decimal, Extensions};
-use cedar_policy_core::parser::parse_restrictedexpr;
+use std::str::FromStr;
 
 /// If any of the panics in this file are triggered, that means that this file has become
 /// out-of-date with the decimal extension definition in CedarCore.
@@ -85,7 +85,7 @@ fn validate_decimal_string(exprs: &[Expr]) -> Result<(), String> {
         Some(arg) if matches!(arg.expr_kind(), ExprKind::Lit(Literal::String(_))) => {
             let exts = Extensions::all_available();
             let evaluator = RestrictedEvaluator::new(&exts);
-            let expr = parse_restrictedexpr(&format!("decimal({arg})")).expect("parsing error");
+            let expr = RestrictedExpr::from_str(&format!("decimal({arg})")).expect("parsing error");
             match evaluator.interpret(expr.as_borrowed()) {
                 Ok(_) => Ok(()),
                 Err(_) => Err(format!("Failed to parse as a decimal value: {arg}")),

--- a/cedar-policy-validator/src/extensions/ipaddr.rs
+++ b/cedar-policy-validator/src/extensions/ipaddr.rs
@@ -16,10 +16,10 @@
 
 use crate::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
 use crate::types::{self, Type};
-use cedar_policy_core::ast::{Expr, ExprKind, Literal};
+use cedar_policy_core::ast::{Expr, ExprKind, Literal, RestrictedExpr};
 use cedar_policy_core::evaluator::RestrictedEvaluator;
 use cedar_policy_core::extensions::{ipaddr, Extensions};
-use cedar_policy_core::parser::parse_restrictedexpr;
+use std::str::FromStr;
 
 /// If any of the panics in this file are triggered, that means that this file has become
 /// out-of-date with the ipaddr extension definition in CedarCore.
@@ -84,7 +84,7 @@ fn validate_ip_string(exprs: &[Expr]) -> Result<(), String> {
         Some(arg) if matches!(arg.expr_kind(), ExprKind::Lit(Literal::String(_))) => {
             let exts = Extensions::all_available();
             let evaluator = RestrictedEvaluator::new(&exts);
-            let expr = parse_restrictedexpr(&format!("ip({arg})")).expect("parsing error");
+            let expr = RestrictedExpr::from_str(&format!("ip({arg})")).expect("parsing error");
             match evaluator.interpret(expr.as_borrowed()) {
                 Ok(_) => Ok(()),
                 Err(_) => Err(format!("Failed to parse as IP address: {arg}")),

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -28,6 +28,7 @@ use cedar_policy_core::{
     entities::{Entities, JSONValue, TCComputation},
     parser::err::ParseError,
     transitive_closure::{compute_tc, TCNode},
+    FromNormalizedStr,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -232,7 +233,7 @@ impl ValidatorNamespaceDef {
             None => None,
             Some("") => None, // we consider "" to be the same as the empty namespace for this purpose
             Some(ns) => {
-                Some(Name::parse_normalized_name(ns).map_err(SchemaError::NamespaceParseError)?)
+                Some(Name::from_normalized_str(ns).map_err(SchemaError::NamespaceParseError)?)
             }
         };
 
@@ -575,7 +576,7 @@ impl ValidatorNamespaceDef {
         name_str: &SmolStr,
         default_namespace: Option<&Name>,
     ) -> std::result::Result<Name, Vec<ParseError>> {
-        let name = Name::parse_normalized_name(name_str)?;
+        let name = Name::from_normalized_str(name_str)?;
 
         let qualified_name = if name.namespace_components().next().is_some() {
             // The name is already qualified. Don't touch it.
@@ -618,9 +619,9 @@ impl ValidatorNamespaceDef {
         namespace: Option<&Name>,
     ) -> Result<EntityUID> {
         let namespaced_action_type = if let Some(action_ty) = &action_id.ty {
-            Name::parse_normalized_name(action_ty).map_err(SchemaError::EntityTypeParseError)?
+            Name::from_normalized_str(action_ty).map_err(SchemaError::EntityTypeParseError)?
         } else {
-            let id = Id::parse_normalized_id(ACTION_ENTITY_TYPE).expect(
+            let id = Id::from_normalized_str(ACTION_ENTITY_TYPE).expect(
                 "Expected that the constant ACTION_ENTITY_TYPE would be a valid entity type.",
             );
             match namespace {
@@ -675,7 +676,7 @@ impl ValidatorNamespaceDef {
                 Ok(Type::named_entity_reference(entity_type_name).into())
             }
             SchemaType::Type(SchemaTypeVariant::Extension { name }) => {
-                let extension_type_name = Name::parse_normalized_name(&name)
+                let extension_type_name = Name::from_normalized_str(&name)
                     .map_err(SchemaError::ExtensionTypeParseError)?;
                 Ok(Type::extension(extension_type_name).into())
             }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -588,7 +588,7 @@ impl ValidatorNamespaceDef {
                 Some(namespace) => {
                     Name::type_in_namespace(name.basename().clone(), namespace.clone())
                 }
-                None => Name::unqualified_name(name.basename().clone()),
+                None => name,
             }
         };
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -602,7 +602,7 @@ impl ValidatorNamespaceDef {
         type_name: impl AsRef<str>,
         namespace: Option<Name>,
     ) -> std::result::Result<Name, Vec<ParseError>> {
-        let type_name = Id::parse_normalized_id(type_name.as_ref())?;
+        let type_name = Id::from_normalized_str(type_name.as_ref())?;
         match namespace {
             Some(namespace) => Ok(Name::type_in_namespace(type_name, namespace)),
             None => Ok(Name::unqualified_name(type_name)),

--- a/cedar-policy-validator/src/typecheck/test_extensions.rs
+++ b/cedar-policy-validator/src/typecheck/test_extensions.rs
@@ -18,12 +18,9 @@
 #![cfg(test)]
 // GRCOV_STOP_COVERAGE
 
-use cedar_policy_core::{
-    ast::{Expr, Name},
-    parser,
-};
-
 use crate::{type_error::TypeError, types::Type};
+use cedar_policy_core::ast::{Expr, Name};
+use std::str::FromStr;
 
 use super::test_utils::{assert_typecheck_fails_empty_schema, assert_typechecks_empty_schema};
 
@@ -31,11 +28,11 @@ use super::test_utils::{assert_typecheck_fails_empty_schema, assert_typechecks_e
 #[cfg(feature = "ipaddr")]
 fn ip_extension_typechecks() {
     let ipaddr_name = Name::parse_unqualified_name("ipaddr").expect("should be a valid identifier");
-    let expr = parser::parse_expr("ip(\"127.0.0.1\")").expect("parsing should succeed");
+    let expr = Expr::from_str("ip(\"127.0.0.1\")").expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::extension(ipaddr_name));
-    let expr = parser::parse_expr("ip(\"1:2:3:4::/48\").isIpv4()").expect("parsing should succeed");
+    let expr = Expr::from_str("ip(\"1:2:3:4::/48\").isIpv4()").expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::primitive_boolean());
-    let expr = parser::parse_expr("ip(\"127.0.0.1\").isInRange(ip(\"1:2:3:4::/48\"))")
+    let expr = Expr::from_str("ip(\"127.0.0.1\").isInRange(ip(\"1:2:3:4::/48\"))")
         .expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::primitive_boolean());
 }
@@ -44,7 +41,7 @@ fn ip_extension_typechecks() {
 #[cfg(feature = "ipaddr")]
 fn ip_extension_typecheck_fails() {
     let ipaddr_name = Name::parse_unqualified_name("ipaddr").expect("should be a valid identifier");
-    let expr = parser::parse_expr("ip(3)").expect("parsing should succeed");
+    let expr = Expr::from_str("ip(3)").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(ipaddr_name.clone()),
@@ -54,7 +51,7 @@ fn ip_extension_typecheck_fails() {
             Type::primitive_long(),
         )],
     );
-    let expr = parser::parse_expr("ip(\"foo\")").expect("parsing should succeed");
+    let expr = Expr::from_str("ip(\"foo\")").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::extension(ipaddr_name.clone()),
@@ -63,14 +60,13 @@ fn ip_extension_typecheck_fails() {
             "Failed to parse as IP address: \"foo\"".into(),
         )],
     );
-    let expr = parser::parse_expr("ip(\"127.0.0.1\").isIpv4(3)").expect("parsing should succeed");
+    let expr = Expr::from_str("ip(\"127.0.0.1\").isIpv4(3)").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::primitive_boolean(),
         vec![TypeError::wrong_number_args(expr, 1, 2)],
     );
-    let expr =
-        parser::parse_expr("ip(\"127.0.0.1\").isInRange(3)").expect("parsing should succeed");
+    let expr = Expr::from_str("ip(\"127.0.0.1\").isInRange(3)").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::primitive_boolean(),
@@ -87,18 +83,18 @@ fn ip_extension_typecheck_fails() {
 fn decimal_extension_typechecks() {
     let decimal_name =
         Name::parse_unqualified_name("decimal").expect("should be a valid identifier");
-    let expr = parser::parse_expr("decimal(\"1.23\")").expect("parsing should succeed");
+    let expr = Expr::from_str("decimal(\"1.23\")").expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::extension(decimal_name));
-    let expr = parser::parse_expr("decimal(\"1.23\").lessThan(decimal(\"1.24\"))")
+    let expr = Expr::from_str("decimal(\"1.23\").lessThan(decimal(\"1.24\"))")
         .expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::primitive_boolean());
-    let expr = parser::parse_expr("decimal(\"1.23\").lessThanOrEqual(decimal(\"1.24\"))")
+    let expr = Expr::from_str("decimal(\"1.23\").lessThanOrEqual(decimal(\"1.24\"))")
         .expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::primitive_boolean());
-    let expr = parser::parse_expr("decimal(\"1.23\").greaterThan(decimal(\"1.24\"))")
+    let expr = Expr::from_str("decimal(\"1.23\").greaterThan(decimal(\"1.24\"))")
         .expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::primitive_boolean());
-    let expr = parser::parse_expr("decimal(\"1.23\").greaterThanOrEqual(decimal(\"1.24\"))")
+    let expr = Expr::from_str("decimal(\"1.23\").greaterThanOrEqual(decimal(\"1.24\"))")
         .expect("parsing should succeed");
     assert_typechecks_empty_schema(expr, Type::primitive_boolean());
 }
@@ -108,7 +104,7 @@ fn decimal_extension_typechecks() {
 fn decimal_extension_typecheck_fails() {
     let decimal_name =
         Name::parse_unqualified_name("decimal").expect("should be a valid identifier");
-    let expr = parser::parse_expr("decimal(3)").expect("parsing should succeed");
+    let expr = Expr::from_str("decimal(3)").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(decimal_name.clone()),
@@ -118,7 +114,7 @@ fn decimal_extension_typecheck_fails() {
             Type::primitive_long(),
         )],
     );
-    let expr = parser::parse_expr("decimal(\"foo\")").expect("parsing should succeed");
+    let expr = Expr::from_str("decimal(\"foo\")").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::extension(decimal_name.clone()),
@@ -127,14 +123,13 @@ fn decimal_extension_typecheck_fails() {
             "Failed to parse as a decimal value: \"foo\"".into(),
         )],
     );
-    let expr =
-        parser::parse_expr("decimal(\"1.23\").lessThan(3, 4)").expect("parsing should succeed");
+    let expr = Expr::from_str("decimal(\"1.23\").lessThan(3, 4)").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::primitive_boolean(),
         vec![TypeError::wrong_number_args(expr, 2, 3)],
     );
-    let expr = parser::parse_expr("decimal(\"1.23\").lessThan(3)").expect("parsing should succeed");
+    let expr = Expr::from_str("decimal(\"1.23\").lessThan(3)").expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::primitive_boolean(),

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -20,11 +20,12 @@
 // GRCOV_STOP_COVERAGE
 
 use serde_json::json;
+use std::str::FromStr;
 use std::vec;
 
 use cedar_policy_core::{
     ast::{EntityUID, Expr, StaticPolicy},
-    parser::{parse_expr, parse_policy},
+    parser::parse_policy,
 };
 
 use super::test_utils::{
@@ -73,19 +74,20 @@ fn assert_expr_typecheck_fails_namespace_schema(e: Expr, t: Option<Type>, errs: 
 #[test]
 fn namespaced_entity_eq() {
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" == N::S::Foo::"alice""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" == N::S::Foo::"alice""#).expect("Expr should parse."),
         Type::True,
     );
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" == N::S::Foo::"bob""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" == N::S::Foo::"bob""#).expect("Expr should parse."),
         Type::False,
     );
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" == N::S::Bar::"bob""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" == N::S::Bar::"bob""#).expect("Expr should parse."),
         Type::False,
     );
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Action::"baz" == N::S::Action::"baz""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Action::"baz" == N::S::Action::"baz""#)
+            .expect("Expr should parse."),
         Type::True,
     );
 }
@@ -93,11 +95,11 @@ fn namespaced_entity_eq() {
 #[test]
 fn namespaced_entity_in() {
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" in N::S::Foo::"bob""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" in N::S::Foo::"bob""#).expect("Expr should parse."),
         Type::primitive_boolean(),
     );
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" in N::S::Bar::"bob""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" in N::S::Bar::"bob""#).expect("Expr should parse."),
         Type::False,
     );
 }
@@ -105,11 +107,11 @@ fn namespaced_entity_in() {
 #[test]
 fn namespaced_entity_has() {
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" has foo"#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" has foo"#).expect("Expr should parse."),
         Type::False,
     );
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" has name"#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" has name"#).expect("Expr should parse."),
         Type::primitive_boolean(),
     );
 }
@@ -117,7 +119,7 @@ fn namespaced_entity_has() {
 #[test]
 fn namespaced_entity_get_attr() {
     assert_expr_typechecks_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice".name"#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice".name"#).expect("Expr should parse."),
         Type::primitive_string(),
     );
 }
@@ -125,10 +127,10 @@ fn namespaced_entity_get_attr() {
 #[test]
 fn namespaced_entity_can_type_error() {
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"N::S::Foo::"alice" > 1"#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"alice" > 1"#).expect("Expr should parse."),
         Some(Type::primitive_boolean()),
         vec![TypeError::expected_type(
-            parse_expr(r#"N::S::Foo::"alice""#).expect("Expr should parse."),
+            Expr::from_str(r#"N::S::Foo::"alice""#).expect("Expr should parse."),
             Type::primitive_long(),
             Type::named_entity_reference_from_str("N::S::Foo"),
         )],
@@ -138,32 +140,32 @@ fn namespaced_entity_can_type_error() {
 #[test]
 fn namespaced_entity_wrong_namespace() {
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"N::S::T::Foo::"alice""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::T::Foo::"alice""#).expect("Expr should parse."),
         None,
         vec![],
     );
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"N::Foo::"alice""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::Foo::"alice""#).expect("Expr should parse."),
         None,
         vec![],
     );
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"Foo::"alice""#).expect("Expr should parse."),
+        Expr::from_str(r#"Foo::"alice""#).expect("Expr should parse."),
         None,
         vec![],
     );
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"N::Action::"baz""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::Action::"baz""#).expect("Expr should parse."),
         None,
         vec![],
     );
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"Action::N::S::"baz""#).expect("Expr should parse."),
+        Expr::from_str(r#"Action::N::S::"baz""#).expect("Expr should parse."),
         None,
         vec![],
     );
     assert_expr_typecheck_fails_namespace_schema(
-        parse_expr(r#"Action::"baz""#).expect("Expr should parse."),
+        Expr::from_str(r#"Action::"baz""#).expect("Expr should parse."),
         None,
         vec![],
     );
@@ -195,24 +197,24 @@ fn namespaced_entity_type_in_attribute() {
     // comparison.
     assert_typechecks(
         schema.clone(),
-        parse_expr(r#"N::S::Foo::"foo".bar == N::S::Bar::"bar""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"foo".bar == N::S::Bar::"bar""#).expect("Expr should parse."),
         Type::primitive_boolean(),
     );
     assert_typechecks(
         schema.clone(),
-        parse_expr(r#"N::S::Foo::"foo".bar == N::S::Foo::"foo""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"foo".bar == N::S::Foo::"foo""#).expect("Expr should parse."),
         Type::singleton_boolean(false),
     );
     // Implicit namespace is applied to the attribute type and correctly used in
     // comparison.
     assert_typechecks(
         schema.clone(),
-        parse_expr(r#"N::S::Foo::"foo".baz == N::S::Bar::"bar""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"foo".baz == N::S::Bar::"bar""#).expect("Expr should parse."),
         Type::primitive_boolean(),
     );
     assert_typechecks(
         schema,
-        parse_expr(r#"N::S::Foo::"foo".baz == N::S::Foo::"foo""#).expect("Expr should parse."),
+        Expr::from_str(r#"N::S::Foo::"foo".baz == N::S::Foo::"foo""#).expect("Expr should parse."),
         Type::singleton_boolean(false),
     );
 }
@@ -297,17 +299,17 @@ fn multiple_namespaces_literals() {
 
     assert_typechecks(
         schema.clone(),
-        parse_expr("A::Foo::\"foo\"").unwrap(),
+        Expr::from_str("A::Foo::\"foo\"").unwrap(),
         Type::named_entity_reference_from_str("A::Foo"),
     );
     assert_typechecks(
         schema.clone(),
-        parse_expr("B::Foo::\"foo\"").unwrap(),
+        Expr::from_str("B::Foo::\"foo\"").unwrap(),
         Type::named_entity_reference_from_str("B::Foo"),
     );
     assert_typechecks(
         schema,
-        parse_expr("C::Foo::\"foo\"").unwrap(),
+        Expr::from_str("C::Foo::\"foo\"").unwrap(),
         Type::named_entity_reference_from_str("C::Foo"),
     );
 }
@@ -340,15 +342,15 @@ fn multiple_namespaces_attributes() {
 
     assert_typechecks(
         schema.clone(),
-        parse_expr("A::Foo::\"foo\".x").unwrap(),
+        Expr::from_str("A::Foo::\"foo\".x").unwrap(),
         Type::named_entity_reference_from_str("B::Foo"),
     );
     assert_typecheck_fails(
         schema,
-        parse_expr("B::Foo::\"foo\".x").unwrap(),
+        Expr::from_str("B::Foo::\"foo\".x").unwrap(),
         None,
         vec![TypeError::missing_attribute(
-            parse_expr("B::Foo::\"foo\".x").unwrap(),
+            Expr::from_str("B::Foo::\"foo\".x").unwrap(),
             "x".to_string(),
             None,
         )],

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -19,11 +19,12 @@
 #![cfg(test)]
 // GRCOV_STOP_COVERAGE
 
+use std::str::FromStr;
 use std::sync::Arc;
 
 use cedar_policy_core::{
     ast::{EntityUID, Expr, StaticPolicy, Template, Var},
-    parser::{parse_expr, parse_policy, parse_policy_template},
+    parser::{parse_policy, parse_policy_template},
 };
 
 use super::test_utils::{
@@ -420,13 +421,14 @@ fn entity_lub_cant_access_attribute_not_shared() {
         p,
         vec![
             TypeError::missing_attribute(
-                parse_expr(r#"(if 1 > 0 then User::"alice" else Photo::"vacation.jpg").name"#)
+                Expr::from_str(r#"(if 1 > 0 then User::"alice" else Photo::"vacation.jpg").name"#)
                     .unwrap(),
                 "name".into(),
                 None,
             ),
             TypeError::types_must_match(
-                parse_expr(r#"if 1 > 0 then User::"alice" else Photo::"vacation.jpg""#).unwrap(),
+                Expr::from_str(r#"if 1 > 0 then User::"alice" else Photo::"vacation.jpg""#)
+                    .unwrap(),
                 [
                     Type::named_entity_reference_from_str("User"),
                     Type::named_entity_reference_from_str("Photo"),
@@ -479,7 +481,7 @@ fn entity_record_lub_is_none() {
         ).expect("Policy should parse."),
         vec![
             TypeError::incompatible_types(
-                parse_expr(r#"if 1 > 0 then User::"alice" else {name: "bob"}"#).unwrap(),
+                Expr::from_str(r#"if 1 > 0 then User::"alice" else {name: "bob"}"#).unwrap(),
                 [
                     Type::record_with_required_attributes([("name".into(), Type::primitive_string())]),
                     Type::named_entity_reference_from_str("User"),
@@ -692,7 +694,7 @@ fn record_entity_lub_non_term() {
         schema,
         policy,
         vec![TypeError::incompatible_types(
-            parse_expr(r#"if principal.bar then principal.foo else U::"b""#).unwrap(),
+            Expr::from_str(r#"if principal.bar then principal.foo else U::"b""#).unwrap(),
             [
                 Type::record_with_required_attributes([(
                     "foo".into(),

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -19,11 +19,9 @@
 // GRCOV_STOP_COVERAGE
 
 use serde_json::json;
+use std::str::FromStr;
 
-use cedar_policy_core::{
-    ast::{EntityType, EntityUID, Expr},
-    parser::{self, parse_expr},
-};
+use cedar_policy_core::ast::{EntityType, EntityUID, Expr};
 
 use crate::{
     types::{Attributes, RequestEnv, Type},
@@ -156,7 +154,7 @@ fn strict_typecheck_catches_regular_type_error() {
             let mut errs = Vec::new();
             typechecker.typecheck_strict(
                 &q,
-                &parse_expr("1 + false").unwrap(),
+                &Expr::from_str("1 + false").unwrap(),
                 Type::primitive_long(),
                 &mut errs,
             );
@@ -176,8 +174,8 @@ fn false_eq_rewrites_to_false() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"principal == Photo::"image.jpg""#).unwrap(),
-            parser::parse_expr(r#"false"#).unwrap(),
+            Expr::from_str(r#"principal == Photo::"image.jpg""#).unwrap(),
+            Expr::from_str(r#"false"#).unwrap(),
             Type::primitive_boolean(),
         )
     })
@@ -189,8 +187,8 @@ fn true_eq_rewrites_to_true() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"action == Action::"view_photo""#).unwrap(),
-            parser::parse_expr(r#"true"#).unwrap(),
+            Expr::from_str(r#"action == Action::"view_photo""#).unwrap(),
+            Expr::from_str(r#"true"#).unwrap(),
             Type::primitive_boolean(),
         )
     })
@@ -202,8 +200,8 @@ fn bool_eq_types_match() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"1 == 1"#).unwrap(),
-            parser::parse_expr(r#"1 == 1"#).unwrap(),
+            Expr::from_str(r#"1 == 1"#).unwrap(),
+            Expr::from_str(r#"1 == 1"#).unwrap(),
             Type::primitive_boolean(),
         )
     })
@@ -215,8 +213,8 @@ fn eq_strict_types_mismatch() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"1 == "foo""#).unwrap(),
-            parser::parse_expr(r#"1 == "foo""#).unwrap(),
+            Expr::from_str(r#"1 == "foo""#).unwrap(),
+            Expr::from_str(r#"1 == "foo""#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_string(), Type::primitive_long()],
         )
@@ -229,8 +227,8 @@ fn contains_strict_types_mismatch() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"[1].contains("test")"#).unwrap(),
-            parser::parse_expr(r#"[1].contains("test")"#).unwrap(),
+            Expr::from_str(r#"[1].contains("test")"#).unwrap(),
+            Expr::from_str(r#"[1].contains("test")"#).unwrap(),
             Type::primitive_boolean(),
             [Type::set(Type::primitive_long()), Type::primitive_string()],
         )
@@ -243,8 +241,8 @@ fn contains_any_strict_types_mismatch() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"[principal].containsAny([1])"#).unwrap(),
-            parser::parse_expr(r#"[principal].containsAny([1])"#).unwrap(),
+            Expr::from_str(r#"[principal].containsAny([1])"#).unwrap(),
+            Expr::from_str(r#"[principal].containsAny([1])"#).unwrap(),
             Type::primitive_boolean(),
             [
                 Type::set(Type::named_entity_reference_from_str("User")),
@@ -260,8 +258,8 @@ fn contains_all_strict_types_mismatch() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"[principal].containsAll([1])"#).unwrap(),
-            parser::parse_expr(r#"[principal].containsAll([1])"#).unwrap(),
+            Expr::from_str(r#"[principal].containsAll([1])"#).unwrap(),
+            Expr::from_str(r#"[principal].containsAll([1])"#).unwrap(),
             Type::primitive_boolean(),
             [
                 Type::set(Type::named_entity_reference_from_str("User")),
@@ -277,8 +275,8 @@ fn if_false_else_only() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"if resource == User::"alice" then 1 else "foo""#).unwrap(),
-            parser::parse_expr(r#""foo""#).unwrap(),
+            Expr::from_str(r#"if resource == User::"alice" then 1 else "foo""#).unwrap(),
+            Expr::from_str(r#""foo""#).unwrap(),
             Type::primitive_string(),
         )
     })
@@ -290,8 +288,8 @@ fn if_true_then_only() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"if action == Action::"view_photo" then 1 else "foo""#).unwrap(),
-            parser::parse_expr(r#"1"#).unwrap(),
+            Expr::from_str(r#"if action == Action::"view_photo" then 1 else "foo""#).unwrap(),
+            Expr::from_str(r#"1"#).unwrap(),
             Type::primitive_long(),
         )
     })
@@ -303,8 +301,8 @@ fn if_bool_keeps_both() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"if principal == User::"alice" then 1 else 2"#).unwrap(),
-            parser::parse_expr(r#"if principal == User::"alice" then 1 else 2"#).unwrap(),
+            Expr::from_str(r#"if principal == User::"alice" then 1 else 2"#).unwrap(),
+            Expr::from_str(r#"if principal == User::"alice" then 1 else 2"#).unwrap(),
             Type::primitive_long(),
         )
     })
@@ -316,11 +314,11 @@ fn if_bool_strict_type_mismatch() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(
+            Expr::from_str(
                 r#"if principal == User::"alice" then User::"alice" else Photo::"pie.jpg""#,
             )
             .unwrap(),
-            parser::parse_expr(
+            Expr::from_str(
                 r#"if principal == User::"alice" then User::"alice" else Photo::"pie.jpg""#,
             )
             .unwrap(),
@@ -339,8 +337,8 @@ fn set_strict_types_mismatch() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"[User::"alice", Photo::"foo.jpg"]"#).unwrap(),
-            parser::parse_expr(r#"[User::"alice", Photo::"foo.jpg"]"#).unwrap(),
+            Expr::from_str(r#"[User::"alice", Photo::"foo.jpg"]"#).unwrap(),
+            Expr::from_str(r#"[User::"alice", Photo::"foo.jpg"]"#).unwrap(),
             Type::set(Type::entity_lub(["User", "Photo"])),
             [
                 Type::named_entity_reference_from_str("User"),
@@ -356,8 +354,8 @@ fn empty_set_literal() {
         assert_strict_type_error(
             s,
             &q,
-            parser::parse_expr(r#"[]"#).unwrap(),
-            parser::parse_expr(r#"[]"#).unwrap(),
+            Expr::from_str(r#"[]"#).unwrap(),
+            Expr::from_str(r#"[]"#).unwrap(),
             Type::any_set(),
             TypeErrorKind::EmptySetForbidden,
         )
@@ -370,8 +368,8 @@ fn ext_struct_non_lit() {
         assert_strict_type_error(
             s,
             &q,
-            parser::parse_expr(r#"ip(if context has foo then "a" else "b")"#).unwrap(),
-            parser::parse_expr(r#"ip(if context has foo then "a" else "b")"#).unwrap(),
+            Expr::from_str(r#"ip(if context has foo then "a" else "b")"#).unwrap(),
+            Expr::from_str(r#"ip(if context has foo then "a" else "b")"#).unwrap(),
             Type::extension("ipaddr".parse().unwrap()),
             TypeErrorKind::NonLitExtConstructor,
         )
@@ -381,8 +379,8 @@ fn ext_struct_non_lit() {
         assert_strict_type_error(
             s,
             &q,
-            parser::parse_expr(r#"decimal(if context has bar then "0.1" else "1.0")"#).unwrap(),
-            parser::parse_expr(r#"decimal(if context has bar then "0.1" else "1.0")"#).unwrap(),
+            Expr::from_str(r#"decimal(if context has bar then "0.1" else "1.0")"#).unwrap(),
+            Expr::from_str(r#"decimal(if context has bar then "0.1" else "1.0")"#).unwrap(),
             Type::extension("decimal".parse().unwrap()),
             TypeErrorKind::NonLitExtConstructor,
         )
@@ -398,11 +396,11 @@ fn entity_in_lub() {
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(
+            Expr::from_str(
                 r#"User::"alice" in (if 1 > 0 then User::"alice" else Photo::"pie.jpg")"#,
             )
             .unwrap(),
-            parser::parse_expr(
+            Expr::from_str(
                 r#"User::"alice" in (if 1 > 0 then User::"alice" else Photo::"pie.jpg")"#,
             )
             .unwrap(),
@@ -425,23 +423,23 @@ fn test_and() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"1 == 2 && 2 == 3"#).unwrap(),
-            parser::parse_expr(r#"1 == 2 && 2 == 3"#).unwrap(),
+            Expr::from_str(r#"1 == 2 && 2 == 3"#).unwrap(),
+            Expr::from_str(r#"1 == 2 && 2 == 3"#).unwrap(),
             Type::primitive_boolean(),
         );
         assert_types_must_match(
             s.clone(),
             &q,
-            parser::parse_expr(r#"(1 == (2 > 0)) && true"#).unwrap(),
-            parser::parse_expr(r#"(1 == (2 > 0)) && true"#).unwrap(),
+            Expr::from_str(r#"(1 == (2 > 0)) && true"#).unwrap(),
+            Expr::from_str(r#"(1 == (2 > 0)) && true"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"true && (1 == (2 > 0))"#).unwrap(),
-            parser::parse_expr(r#"true && (1 == (2 > 0))"#).unwrap(),
+            Expr::from_str(r#"true && (1 == (2 > 0))"#).unwrap(),
+            Expr::from_str(r#"true && (1 == (2 > 0))"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
         );
@@ -454,23 +452,23 @@ fn test_or() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"1 == 2 || 2 == 3"#).unwrap(),
-            parser::parse_expr(r#"1 == 2 || 2 == 3"#).unwrap(),
+            Expr::from_str(r#"1 == 2 || 2 == 3"#).unwrap(),
+            Expr::from_str(r#"1 == 2 || 2 == 3"#).unwrap(),
             Type::primitive_boolean(),
         );
         assert_types_must_match(
             s.clone(),
             &q,
-            parser::parse_expr(r#"(1 == (2 > 0)) || false"#).unwrap(),
-            parser::parse_expr(r#"(1 == (2 > 0)) || false"#).unwrap(),
+            Expr::from_str(r#"(1 == (2 > 0)) || false"#).unwrap(),
+            Expr::from_str(r#"(1 == (2 > 0)) || false"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_boolean(), Type::primitive_long()],
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"false || (1 == (2 > 0))"#).unwrap(),
-            parser::parse_expr(r#"false || (1 == (2 > 0))"#).unwrap(),
+            Expr::from_str(r#"false || (1 == (2 > 0))"#).unwrap(),
+            Expr::from_str(r#"false || (1 == (2 > 0))"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_boolean(), Type::primitive_long()],
         );
@@ -483,15 +481,15 @@ fn test_unary() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"!(1 == 2)"#).unwrap(),
-            parser::parse_expr(r#"!(1 == 2)"#).unwrap(),
+            Expr::from_str(r#"!(1 == 2)"#).unwrap(),
+            Expr::from_str(r#"!(1 == 2)"#).unwrap(),
             Type::primitive_boolean(),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"!(1 == "foo")"#).unwrap(),
-            parser::parse_expr(r#"!(1 == "foo")"#).unwrap(),
+            Expr::from_str(r#"!(1 == "foo")"#).unwrap(),
+            Expr::from_str(r#"!(1 == "foo")"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
         );
@@ -504,15 +502,15 @@ fn test_mul() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"2*(if 1 == 2 then 3 else 4)"#).unwrap(),
-            parser::parse_expr(r#"2*(if 1 == 2 then 3 else 4)"#).unwrap(),
+            Expr::from_str(r#"2*(if 1 == 2 then 3 else 4)"#).unwrap(),
+            Expr::from_str(r#"2*(if 1 == 2 then 3 else 4)"#).unwrap(),
             Type::primitive_long(),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"2*(if 1 == false then 3 else 4)"#).unwrap(),
-            parser::parse_expr(r#"2*(if 1 == false then 3 else 4)"#).unwrap(),
+            Expr::from_str(r#"2*(if 1 == false then 3 else 4)"#).unwrap(),
+            Expr::from_str(r#"2*(if 1 == false then 3 else 4)"#).unwrap(),
             Type::primitive_long(),
             [Type::primitive_long(), Type::primitive_boolean()],
         );
@@ -525,15 +523,15 @@ fn test_like() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#""a" like "a""#).unwrap(),
-            parser::parse_expr(r#""a" like "a""#).unwrap(),
+            Expr::from_str(r#""a" like "a""#).unwrap(),
+            Expr::from_str(r#""a" like "a""#).unwrap(),
             Type::primitive_boolean(),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"(if 1 == false then "foo" else "bar") like "bar""#).unwrap(),
-            parser::parse_expr(r#"(if 1 == false then "foo" else "bar") like "bar""#).unwrap(),
+            Expr::from_str(r#"(if 1 == false then "foo" else "bar") like "bar""#).unwrap(),
+            Expr::from_str(r#"(if 1 == false then "foo" else "bar") like "bar""#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
         );
@@ -546,15 +544,15 @@ fn test_get_attr() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"{name: "foo"}.name"#).unwrap(),
-            parser::parse_expr(r#"{name: "foo"}.name"#).unwrap(),
+            Expr::from_str(r#"{name: "foo"}.name"#).unwrap(),
+            Expr::from_str(r#"{name: "foo"}.name"#).unwrap(),
             Type::primitive_string(),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"{name: 1 == "foo"}.name"#).unwrap(),
-            parser::parse_expr(r#"{name: 1 == "foo"}.name"#).unwrap(),
+            Expr::from_str(r#"{name: 1 == "foo"}.name"#).unwrap(),
+            Expr::from_str(r#"{name: 1 == "foo"}.name"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
         );
@@ -567,15 +565,15 @@ fn test_has_attr() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"{name: "foo"} has bar"#).unwrap(),
-            parser::parse_expr(r#"{name: "foo"} has bar"#).unwrap(),
+            Expr::from_str(r#"{name: "foo"} has bar"#).unwrap(),
+            Expr::from_str(r#"{name: "foo"} has bar"#).unwrap(),
             Type::primitive_boolean(),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"{name: 1 == "foo"} has bar"#).unwrap(),
-            parser::parse_expr(r#"{name: 1 == "foo"} has bar"#).unwrap(),
+            Expr::from_str(r#"{name: 1 == "foo"} has bar"#).unwrap(),
+            Expr::from_str(r#"{name: 1 == "foo"} has bar"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
         );
@@ -589,15 +587,15 @@ fn test_extension() {
         assert_typechecks_strict(
             s.clone(),
             &q,
-            parser::parse_expr(r#"ip("127.0.0.1")"#).unwrap(),
-            parser::parse_expr(r#"ip("127.0.0.1")"#).unwrap(),
+            Expr::from_str(r#"ip("127.0.0.1")"#).unwrap(),
+            Expr::from_str(r#"ip("127.0.0.1")"#).unwrap(),
             Type::extension("ipaddr".parse().unwrap()),
         );
         assert_types_must_match(
             s,
             &q,
-            parser::parse_expr(r#"ip("192.168.1.0/8").isInRange(if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
-            parser::parse_expr(r#"ip("192.168.1.0/8").isInRange(if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
+            Expr::from_str(r#"ip("192.168.1.0/8").isInRange(if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
+            Expr::from_str(r#"ip("192.168.1.0/8").isInRange(if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()]
         );
@@ -610,8 +608,8 @@ fn true_false_equality() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"[false] == [true, true]"#).unwrap(),
-            parser::parse_expr(r#"[false] == [true, true]"#).unwrap(),
+            Expr::from_str(r#"[false] == [true, true]"#).unwrap(),
+            Expr::from_str(r#"[false] == [true, true]"#).unwrap(),
             Type::primitive_boolean(),
         )
     });
@@ -619,8 +617,8 @@ fn true_false_equality() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"[true].contains(false)"#).unwrap(),
-            parser::parse_expr(r#"[true].contains(false)"#).unwrap(),
+            Expr::from_str(r#"[true].contains(false)"#).unwrap(),
+            Expr::from_str(r#"[true].contains(false)"#).unwrap(),
             Type::primitive_boolean(),
         )
     })
@@ -632,8 +630,8 @@ fn true_false_set() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"[true, false]"#).unwrap(),
-            parser::parse_expr(r#"[true, false]"#).unwrap(),
+            Expr::from_str(r#"[true, false]"#).unwrap(),
+            Expr::from_str(r#"[true, false]"#).unwrap(),
             Type::set(Type::primitive_boolean()),
         )
     });
@@ -641,8 +639,8 @@ fn true_false_set() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"[[true], [false]]"#).unwrap(),
-            parser::parse_expr(r#"[[true], [false]]"#).unwrap(),
+            Expr::from_str(r#"[[true], [false]]"#).unwrap(),
+            Expr::from_str(r#"[[true], [false]]"#).unwrap(),
             Type::set(Type::set(Type::primitive_boolean())),
         )
     });
@@ -650,8 +648,8 @@ fn true_false_set() {
         assert_typechecks_strict(
             s,
             &q,
-            parser::parse_expr(r#"[[[true, false], [true, true]], [[false, false]]]"#).unwrap(),
-            parser::parse_expr(r#"[[[true, false], [true, true]], [[false, false]]]"#).unwrap(),
+            Expr::from_str(r#"[[[true, false], [true, true]], [[false, false]]]"#).unwrap(),
+            Expr::from_str(r#"[[[true, false], [true, true]], [[false, false]]]"#).unwrap(),
             Type::set(Type::set(Type::set(Type::primitive_boolean()))),
         )
     })

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1681,7 +1681,7 @@ mod test {
         let parsed_schema_type: SchemaType = serde_json::from_str(&json_str)
             .expect("JSON representation should have parsed into a schema type");
         let type_from_schema_type =
-            ValidatorNamespaceDef::try_schema_type_into_validator_type(&[], parsed_schema_type)
+            ValidatorNamespaceDef::try_schema_type_into_validator_type(None, parsed_schema_type)
                 .expect("Schema type should have converted to type.")
                 .resolve_type_defs(&HashMap::new())
                 .unwrap();

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2437,7 +2437,10 @@ mod entity_uid_tests {
         EntityTypeName::from_str(" A :: B\n::C \n  ::D\n").expect_err("should fail due to RFC 9");
 
         // but embedded whitespace should be OK when parsing an actual policy
-        let policy = Policy::from_str(r#"permit(principal == A ::   B::C :: " hi there are spaces ", action, resource);"#).expect("should succeed, see RFC 9");
+        let policy = Policy::from_str(
+            r#"permit(principal == A ::   B::C :: " hi there are spaces ", action, resource);"#,
+        )
+        .expect("should succeed, see RFC 9");
         let euid = match policy.principal_constraint() {
             PrincipalConstraint::Eq(euid) => euid,
             _ => panic!("expected Eq constraint"),
@@ -2448,13 +2451,16 @@ mod entity_uid_tests {
         assert_eq!(euid.type_name().namespace(), "A::B");
         assert_eq!(euid.type_name().namespace_components().count(), 2);
 
-        let policy = Policy::from_str(r#"
+        let policy = Policy::from_str(
+            r#"
 permit(principal ==  A :: B
     ::C
     :: D
     ::  " hi there are
     spaces and
-    newlines ", action, resource);"#).expect("should succeed, see RFC 9");
+    newlines ", action, resource);"#,
+        )
+        .expect("should succeed, see RFC 9");
         let euid = match policy.principal_constraint() {
             PrincipalConstraint::Eq(euid) => euid,
             _ => panic!("expected Eq constraint"),
@@ -2463,19 +2469,10 @@ permit(principal ==  A :: B
             euid.id().as_ref(),
             " hi there are\n    spaces and\n    newlines "
         );
-        assert_eq!(
-            euid.type_name().to_string(),
-            "A::B::C::D"
-        ); // expect to have been normalized
+        assert_eq!(euid.type_name().to_string(), "A::B::C::D"); // expect to have been normalized
         assert_eq!(euid.type_name().basename(), "D");
         assert_eq!(euid.type_name().namespace(), "A::B::C");
-        assert_eq!(
-            euid
-                .type_name()
-                .namespace_components()
-                .count(),
-            3
-        );
+        assert_eq!(euid.type_name().namespace_components().count(), 3);
     }
 
     #[test]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1906,7 +1906,7 @@ impl FromStr for Expression {
 
     /// create an Expression using Cedar syntax
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        parser::parse_expr(expression)
+        ast::Expr::from_str(expression)
             .map_err(ParseErrors)
             .map(Expression)
     }
@@ -1965,7 +1965,7 @@ impl FromStr for RestrictedExpression {
 
     /// create a `RestrictedExpression` using Cedar syntax
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        parser::parse_restrictedexpr(expression)
+        ast::RestrictedExpr::from_str(expression)
             .map_err(ParseErrors)
             .map(RestrictedExpression)
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -32,7 +32,6 @@ use cedar_policy_core::evaluator::{Evaluator, RestrictedEvaluator};
 pub use cedar_policy_core::extensions;
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::parser;
-use cedar_policy_core::parser::err::ParseError;
 pub use cedar_policy_core::parser::err::ParseErrors;
 use cedar_policy_core::parser::SourceInfo;
 pub use cedar_policy_validator::{TypeErrorKind, ValidationErrorKind, ValidationWarningKind};
@@ -966,13 +965,9 @@ impl FromStr for EntityTypeName {
     type Err = ParseErrors;
 
     fn from_str(namespace_type_str: &str) -> Result<Self, Self::Err> {
-        match ast::Name::from_str(namespace_type_str).map(EntityTypeName) {
-            Err(errs) => Err(ParseErrors(errs).into()),
-            Ok(name) if name.to_string() == namespace_type_str => Ok(name), // check that the normalized representation is indeed the one that was provided
-            Ok(name) => Err(ParseErrors(vec![ParseError::ToAST(format!(
-                "Entity typename needs to be normalized (e.g., whitespace removed): {namespace_type_str} The normalized form is {name}"
-            ))])),
-        }
+        ast::Name::parse_normalized_name(namespace_type_str)
+            .map(EntityTypeName)
+            .map_err(ParseErrors)
     }
 }
 
@@ -992,13 +987,9 @@ impl FromStr for EntityNamespace {
     type Err = ParseErrors;
 
     fn from_str(namespace_str: &str) -> Result<Self, Self::Err> {
-        match ast::Name::from_str(namespace_str).map(EntityNamespace) {
-            Err(errs) => Err(ParseErrors(errs).into()),
-            Ok(name) if name.to_string() == namespace_str => Ok(name), // check that the normalized representation is indeed the one that was provided
-            Ok(name) => Err(ParseErrors(vec![ParseError::ToAST(format!(
-                "Entity namespace needs to be normalized (e.g., whitespace removed): {namespace_str} The normalized form is {name}"
-            ))]))
-        }
+        ast::Name::parse_normalized_name(namespace_str)
+            .map(EntityNamespace)
+            .map_err(ParseErrors)
     }
 }
 
@@ -1067,13 +1058,9 @@ impl FromStr for EntityUid {
     // You can't actually `#[deprecated]` a trait implementation or trait
     // method.
     fn from_str(uid_str: &str) -> Result<Self, Self::Err> {
-        match parser::parse_euid(uid_str).map(EntityUid) {
-            Err(errs) => Err(ParseErrors(errs).into()),
-            Ok(euid) if euid.to_string() == uid_str => Ok(euid), // check that the normalized representation is indeed the one that was provided
-            Ok(euid) => Err(ParseErrors(vec![ParseError::ToAST(format!(
-                "EntityUid needs to be normalized (e.g., whitespace removed): {uid_str} The normalized form is {euid}"
-            ))])),
-        }
+        ast::EntityUID::parse_normalized_euid(uid_str)
+            .map(EntityUid)
+            .map_err(ParseErrors)
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -34,6 +34,7 @@ use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::parser;
 pub use cedar_policy_core::parser::err::ParseErrors;
 use cedar_policy_core::parser::SourceInfo;
+use cedar_policy_core::FromNormalizedStr;
 pub use cedar_policy_validator::{TypeErrorKind, ValidationErrorKind, ValidationWarningKind};
 use itertools::Itertools;
 use ref_cast::RefCast;
@@ -965,7 +966,7 @@ impl FromStr for EntityTypeName {
     type Err = ParseErrors;
 
     fn from_str(namespace_type_str: &str) -> Result<Self, Self::Err> {
-        ast::Name::parse_normalized_name(namespace_type_str)
+        ast::Name::from_normalized_str(namespace_type_str)
             .map(EntityTypeName)
             .map_err(ParseErrors)
     }
@@ -987,7 +988,7 @@ impl FromStr for EntityNamespace {
     type Err = ParseErrors;
 
     fn from_str(namespace_str: &str) -> Result<Self, Self::Err> {
-        ast::Name::parse_normalized_name(namespace_str)
+        ast::Name::from_normalized_str(namespace_str)
             .map(EntityNamespace)
             .map_err(ParseErrors)
     }
@@ -1058,7 +1059,7 @@ impl FromStr for EntityUid {
     // You can't actually `#[deprecated]` a trait implementation or trait
     // method.
     fn from_str(uid_str: &str) -> Result<Self, Self::Err> {
-        ast::EntityUID::parse_normalized_euid(uid_str)
+        ast::EntityUID::from_normalized_str(uid_str)
             .map(EntityUid)
             .map_err(ParseErrors)
     }


### PR DESCRIPTION
Fixes #133 and implements [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md); see comments there.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
