### PR TITLE
Revamp parse errors

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 miette = { version = "5.9.0", features = ["fancy"] }
+thiserror = "1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -18,9 +18,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 miette = { version = "5.9.0", features = ["fancy"] }
 
-[features]
-default = []
-
 [dev-dependencies]
 assert_cmd = "2.0"
 tempfile = "3"

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -16,7 +16,7 @@ cedar-policy-formatter = { version = "=2.3.0", path = "../cedar-policy-formatter
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-anyhow = "1.0"
+miette = { version = "5.9.0", features = ["fancy"] }
 
 [features]
 default = []

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/cedar-policy/cedar"
 [dependencies]
 cedar-policy = { version = "=2.3.0", path = "../cedar-policy" }
 cedar-policy-formatter = { version = "=2.3.0", path = "../cedar-policy-formatter" }
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 miette = { version = "5.9.0", features = ["fancy"] }

--- a/cedar-policy-cli/src/err.rs
+++ b/cedar-policy-cli/src/err.rs
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::error::Error;
+
+use miette::{Diagnostic, Report};
+use thiserror::Error;
+
+/// Internal adapter from Rust's standard [`Error`] to [`miette`]'s
+/// [`Diagnostic`], with an attached diagnostic code.
+#[derive(Debug, Diagnostic, Error)]
+#[error(transparent)]
+#[diagnostic(code(cedar_policy_cli::other_err))]
+struct DiagnosticError(Box<dyn Error + Send + Sync + 'static>);
+
+/// Alternative to [`miette::IntoDiagnostic`] which attaches diagnostic codes
+/// to adapted [`Error`]s for better-formatted output.
+pub trait IntoDiagnostic<T, E> {
+    fn into_diagnostic(self) -> Result<T, Report>;
+}
+
+impl<T, E: Error + Send + Sync + 'static> IntoDiagnostic<T, E> for Result<T, E> {
+    fn into_diagnostic(self) -> Result<T, Report> {
+        self.map_err(|err| DiagnosticError(Box::new(err)).into())
+    }
+}

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -59,6 +59,9 @@ pub enum ErrorFormat {
     /// snippets.
     #[default]
     Human,
+    /// Plain-text error messages without fancy graphics or colors, suitable for
+    /// screen readers.
+    Plain,
     /// Machine-readable JSON output.
     Json,
 }
@@ -70,6 +73,7 @@ impl Display for ErrorFormat {
             "{}",
             match self {
                 ErrorFormat::Human => "human",
+                ErrorFormat::Plain => "plain",
                 ErrorFormat::Json => "json",
             }
         )

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -19,11 +19,12 @@
 // omitted.
 #![allow(clippy::needless_return)]
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 use miette::{miette, IntoDiagnostic, NamedSource, Report, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
+    fmt::{self, Display},
     fs::OpenOptions,
     path::Path,
     process::{ExitCode, Termination},
@@ -40,6 +41,39 @@ use cedar_policy_formatter::{policies_str_to_pretty, Config};
 pub struct Cli {
     #[command(subcommand)]
     pub command: Commands,
+    /// The output format to use for error reporting.
+    #[arg(
+        global = true,
+        short = 'f',
+        long = "error-format",
+        env = "CEDAR_ERROR_FORMAT",
+        default_value_t,
+        value_enum
+    )]
+    pub err_fmt: ErrorFormat,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum ErrorFormat {
+    /// Human-readable error messages with terminal graphics and inline code
+    /// snippets.
+    #[default]
+    Human,
+    /// Machine-readable JSON output.
+    Json,
+}
+
+impl Display for ErrorFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                ErrorFormat::Human => "human",
+                ErrorFormat::Json => "json",
+            }
+        )
+    }
 }
 
 #[derive(Subcommand, Debug)]

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -638,7 +638,7 @@ fn write_template_linked_file(linked: &[TemplateLinked], path: impl AsRef<Path>)
         .create(true)
         .open(path)
         .into_diagnostic()?;
-    Ok(serde_json::to_writer(f, linked).into_diagnostic()?)
+    serde_json::to_writer(f, linked).into_diagnostic()
 }
 
 pub fn authorize(args: &AuthorizeArgs) -> CedarExitCode {

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -19,8 +19,10 @@
 // omitted.
 #![allow(clippy::needless_return)]
 
+mod err;
+
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use miette::{miette, IntoDiagnostic, NamedSource, Report, Result, WrapErr};
+use miette::{miette, NamedSource, Report, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -34,6 +36,8 @@ use std::{
 
 use cedar_policy::*;
 use cedar_policy_formatter::{policies_str_to_pretty, Config};
+
+use crate::err::IntoDiagnostic;
 
 /// Basic Cedar CLI for evaluating authorization queries
 #[derive(Parser)]

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -147,29 +147,29 @@ impl RequestArgs {
                     .wrap_err_with(|| format!("failed to open request-json file {jsonfile}"))?;
                 let qjson: RequestJSON = serde_json::from_str(&jsonstring)
                     .into_diagnostic()
-                    .context(format!("failed to parse request-json file {jsonfile}"))?;
+                    .wrap_err_with(|| format!("failed to parse request-json file {jsonfile}"))?;
                 let principal = qjson
                     .principal
                     .map(|s| {
-                        s.parse().context(format!(
-                            "failed to parse principal in {jsonfile} as entity Uid"
-                        ))
+                        s.parse().wrap_err_with(|| {
+                            format!("failed to parse principal in {jsonfile} as entity Uid")
+                        })
                     })
                     .transpose()?;
                 let action = qjson
                     .action
                     .map(|s| {
-                        s.parse().context(format!(
-                            "failed to parse action in {jsonfile} as entity Uid"
-                        ))
+                        s.parse().wrap_err_with(|| {
+                            format!("failed to parse action in {jsonfile} as entity Uid")
+                        })
                     })
                     .transpose()?;
                 let resource = qjson
                     .resource
                     .map(|s| {
-                        s.parse().context(format!(
-                            "failed to parse resource in {jsonfile} as entity Uid"
-                        ))
+                        s.parse().wrap_err_with(|| {
+                            format!("failed to parse resource in {jsonfile} as entity Uid")
+                        })
                     })
                     .transpose()?;
                 let context = Context::from_json_value(
@@ -185,8 +185,9 @@ impl RequestArgs {
                     .principal
                     .as_ref()
                     .map(|s| {
-                        s.parse()
-                            .context(format!("failed to parse principal {s} as entity Uid"))
+                        s.parse().wrap_err_with(|| {
+                            format!("failed to parse principal {s} as entity Uid")
+                        })
                     })
                     .transpose()?;
                 let action = self
@@ -194,7 +195,7 @@ impl RequestArgs {
                     .as_ref()
                     .map(|s| {
                         s.parse()
-                            .context(format!("failed to parse action {s} as entity Uid"))
+                            .wrap_err_with(|| format!("failed to parse action {s} as entity Uid"))
                     })
                     .transpose()?;
                 let resource = self
@@ -202,7 +203,7 @@ impl RequestArgs {
                     .as_ref()
                     .map(|s| {
                         s.parse()
-                            .context(format!("failed to parse resource {s} as entity Uid"))
+                            .wrap_err_with(|| format!("failed to parse resource {s} as entity Uid"))
                     })
                     .transpose()?;
                 let context: Context = match &self.context_json_file {
@@ -870,7 +871,7 @@ fn execute_request(
     let request = match request.get_request(schema.as_ref()) {
         Ok(q) => Some(q),
         Err(e) => {
-            errs.push(e.context("failed to parse request"));
+            errs.push(e.wrap_err("failed to parse request"));
             None
         }
     };

--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -17,13 +17,23 @@
 #![forbid(unsafe_code)]
 
 use cedar_policy_cli::{
-    authorize, check_parse, evaluate, format_policies, link, validate, CedarExitCode, Cli, Commands,
+    authorize, check_parse, evaluate, format_policies, link, validate, CedarExitCode, Cli,
+    Commands, ErrorFormat,
 };
 
 use clap::Parser;
 
 fn main() -> CedarExitCode {
-    match Cli::parse().command {
+    let cli = Cli::parse();
+    match cli.err_fmt {
+        ErrorFormat::Human => (), // This is the default.
+        ErrorFormat::Json => {
+            miette::set_hook(Box::new(|_| Box::new(miette::JSONReportHandler::new())))
+                .expect("failed to install JSON error-reporting hook");
+        }
+    }
+
+    match cli.command {
         Commands::Authorize(args) => authorize(&args),
         Commands::Evaluate(args) => evaluate(&args).0,
         Commands::CheckParse(args) => check_parse(&args),

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -30,6 +30,8 @@ ipnet = { version = "2.5.0", optional = true }
 
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }
+phf = { version = "0.11.2", features = ["macros"] }
+miette = "5.9.0"
 
 [features]
 # by default, enable all Cedar extensions

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }
+miette = "5.9.0"
 
 # ipaddr extension requires ipnet
 ipnet = { version = "2.5.0", optional = true }
@@ -31,7 +32,6 @@ ipnet = { version = "2.5.0", optional = true }
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }
 phf = { version = "0.11.2", features = ["macros"] }
-miette = "5.9.0"
 
 [features]
 # by default, enable all Cedar extensions

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -25,7 +25,6 @@ smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 miette = "5.9.0"
-phf = { version = "0.11.2", features = ["macros"] }
 
 # ipaddr extension requires ipnet
 ipnet = { version = "2.5.0", optional = true }

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -25,13 +25,13 @@ smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 miette = "5.9.0"
+phf = { version = "0.11.2", features = ["macros"] }
 
 # ipaddr extension requires ipnet
 ipnet = { version = "2.5.0", optional = true }
 
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }
-phf = { version = "0.11.2", features = ["macros"] }
 
 [features]
 # by default, enable all Cedar extensions

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -15,7 +15,7 @@
  */
 
 use crate::ast::*;
-use crate::parser::err::ParseError;
+use crate::parser::err::ParseErrors;
 use crate::transitive_closure::TCNode;
 use crate::FromNormalizedStr;
 use itertools::Itertools;
@@ -104,7 +104,7 @@ impl EntityUID {
     // GRCOV_BEGIN_COVERAGE
 
     /// Create an `EntityUID` with the given (unqualified) typename, and the given string as its EID.
-    pub fn with_eid_and_type(typename: &str, eid: &str) -> Result<Self, Vec<ParseError>> {
+    pub fn with_eid_and_type(typename: &str, eid: &str) -> Result<Self, ParseErrors> {
         Ok(Self {
             ty: EntityType::Concrete(Name::parse_unqualified_name(typename)?),
             eid: Eid(eid.into()),
@@ -157,9 +157,9 @@ impl std::fmt::Display for EntityUID {
 
 // allow `.parse()` on a string to make an `EntityUID`
 impl std::str::FromStr for EntityUID {
-    type Err = Vec<ParseError>;
+    type Err = ParseErrors;
 
-    fn from_str(s: &str) -> Result<Self, Vec<ParseError>> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         crate::parser::parse_euid(s)
     }
 }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -17,7 +17,7 @@
 use crate::{
     ast::*,
     extensions::Extensions,
-    parser::{err::ParseError, SourceInfo},
+    parser::{err::ParseErrors, SourceInfo},
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -767,9 +767,9 @@ fn maybe_with_parens(expr: &Expr) -> String {
 }
 
 impl std::str::FromStr for Expr {
-    type Err = Vec<ParseError>;
+    type Err = ParseErrors;
 
-    fn from_str(s: &str) -> Result<Expr, Vec<ParseError>> {
+    fn from_str(s: &str) -> Result<Expr, Self::Err> {
         crate::parser::parse_expr(s)
     }
 }

--- a/cedar-policy-core/src/ast/literal.rs
+++ b/cedar-policy-core/src/ast/literal.rs
@@ -71,7 +71,7 @@ impl std::fmt::Display for Literal {
 }
 
 impl std::str::FromStr for Literal {
-    type Err = Vec<parser::err::ParseError>;
+    type Err = crate::parser::err::ParseErrors;
 
     fn from_str(s: &str) -> Result<Literal, Self::Err> {
         parser::parse_literal(s)

--- a/cedar-policy-core/src/ast/literal.rs
+++ b/cedar-policy-core/src/ast/literal.rs
@@ -71,7 +71,7 @@ impl std::fmt::Display for Literal {
 }
 
 impl std::str::FromStr for Literal {
-    type Err = crate::parser::err::ParseErrors;
+    type Err = parser::err::ParseErrors;
 
     fn from_str(s: &str) -> Result<Literal, Self::Err> {
         parser::parse_literal(s)

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -20,8 +20,10 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 
+use crate::parser::err::ParseErrors;
+use crate::FromNormalizedStr;
+
 use super::PrincipalOrResource;
-use crate::{parser::err::ParseError, FromNormalizedStr};
 
 /// Arc::unwrap_or_clone() isn't stabilized as of this writing, but this is its implementation
 //
@@ -61,7 +63,7 @@ impl Name {
 
     /// Create a `Name` with no path (no namespaces).
     /// Returns an error if `s` is not a valid identifier.
-    pub fn parse_unqualified_name(s: &str) -> Result<Self, Vec<ParseError>> {
+    pub fn parse_unqualified_name(s: &str) -> Result<Self, ParseErrors> {
         Ok(Self {
             id: s.parse()?,
             path: Arc::new(vec![]),
@@ -109,9 +111,9 @@ impl std::fmt::Display for Name {
 
 // allow `.parse()` on a string to make a `Name`
 impl std::str::FromStr for Name {
-    type Err = Vec<ParseError>;
+    type Err = ParseErrors;
 
-    fn from_str(s: &str) -> Result<Self, Vec<ParseError>> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         crate::parser::parse_name(s)
     }
 }
@@ -247,9 +249,9 @@ impl std::fmt::Display for Id {
 
 // allow `.parse()` on a string to make an `Id`
 impl std::str::FromStr for Id {
-    type Err = Vec<ParseError>;
+    type Err = ParseErrors;
 
-    fn from_str(s: &str) -> Result<Self, Vec<ParseError>> {
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         crate::parser::parse_ident(s)
     }
 }

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -118,7 +118,7 @@ impl RestrictedExpr {
 }
 
 impl std::str::FromStr for RestrictedExpr {
-    type Err = Vec<parser::err::ParseError>;
+    type Err = parser::err::ParseErrors;
 
     fn from_str(s: &str) -> Result<RestrictedExpr, Self::Err> {
         parser::parse_restrictedexpr(s)

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -177,7 +177,7 @@ impl JSONValue {
                             "contents of __expr escape {} are not a valid Cedar expression",
                             expr
                         ),
-                        errs,
+                        errs: errs.into(),
                     })
                 })?;
                 Ok(RestrictedExpr::new(expr)?)
@@ -192,7 +192,7 @@ impl JSONValue {
                                     "contents of __entity escape {} do not make a valid entity reference",
                                     serde_json::to_string_pretty(&entity).unwrap_or_else(|_| format!("{:?}", &entity))
                                 ),
-                                errs,
+                                errs: errs.into(),
                             },
                         )
                     })?,
@@ -296,7 +296,7 @@ impl FnAndArg {
                         "in __extn escape, {:?} is not a valid function name",
                         &self.ext_fn,
                     ),
-                    errs,
+                    errs: parser::err::ParseErrors(errs),
                 })
             })?,
             vec![JSONValue::into_expr(*self.arg)?],

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -125,7 +125,7 @@ impl From<&EntityUID> for TypeAndId {
 }
 
 impl TryFrom<TypeAndId> for EntityUID {
-    type Error = Vec<crate::parser::err::ParseError>;
+    type Error = crate::parser::err::ParseErrors;
 
     fn try_from(e: TypeAndId) -> Result<EntityUID, Self::Error> {
         Ok(EntityUID::from_components(
@@ -296,7 +296,7 @@ impl FnAndArg {
                         "in __extn escape, {:?} is not a valid function name",
                         &self.ext_fn,
                     ),
-                    errs: parser::err::ParseErrors(errs),
+                    errs: errs.into(),
                 })
             })?,
             vec![JSONValue::into_expr(*self.arg)?],

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -172,13 +172,16 @@ impl JSONValue {
             Self::ExprEscape { __expr: expr } => {
                 use crate::parser;
                 let expr: Expr = parser::parse_expr(&expr).map_err(|errs| {
-                    JsonDeserializationError::ExprParseError(parser::err::ParseError::WithContext {
-                        context: format!(
-                            "contents of __expr escape {} are not a valid Cedar expression",
-                            expr
-                        ),
-                        errs,
-                    })
+                    JsonDeserializationError::ExprParseError(
+                        parser::err::WithContext {
+                            context: format!(
+                                "contents of __expr escape {} are not a valid Cedar expression",
+                                expr
+                            ),
+                            errs,
+                        }
+                        .into(),
+                    )
                 })?;
                 Ok(RestrictedExpr::new(expr)?)
             }
@@ -187,13 +190,13 @@ impl JSONValue {
                 Ok(RestrictedExpr::val(
                     EntityUID::try_from(entity.clone()).map_err(|errs| {
                         JsonDeserializationError::EntityParseError(
-                            parser::err::ParseError::WithContext {
+                            parser::err::WithContext {
                                 context: format!(
                                     "contents of __entity escape {} do not make a valid entity reference",
                                     serde_json::to_string_pretty(&entity).unwrap_or_else(|_| format!("{:?}", &entity))
                                 ),
                                 errs,
-                            },
+                            }.into(),
                         )
                     })?,
                 ))
@@ -291,13 +294,16 @@ impl FnAndArg {
         use crate::parser;
         Ok(RestrictedExpr::call_extension_fn(
             Name::from_normalized_str(&self.ext_fn).map_err(|errs| {
-                JsonDeserializationError::ExtnParseError(parser::err::ParseError::WithContext {
-                    context: format!(
-                        "in __extn escape, {:?} is not a valid function name",
-                        &self.ext_fn,
-                    ),
-                    errs,
-                })
+                JsonDeserializationError::ExtnParseError(
+                    parser::err::WithContext {
+                        context: format!(
+                            "in __extn escape, {:?} is not a valid function name",
+                            &self.ext_fn,
+                        ),
+                        errs,
+                    }
+                    .into(),
+                )
             })?,
             vec![JSONValue::into_expr(*self.arg)?],
         ))

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -177,7 +177,7 @@ impl JSONValue {
                             "contents of __expr escape {} are not a valid Cedar expression",
                             expr
                         ),
-                        errs: errs.into(),
+                        errs,
                     })
                 })?;
                 Ok(RestrictedExpr::new(expr)?)
@@ -192,7 +192,7 @@ impl JSONValue {
                                     "contents of __entity escape {} do not make a valid entity reference",
                                     serde_json::to_string_pretty(&entity).unwrap_or_else(|_| format!("{:?}", &entity))
                                 ),
-                                errs: errs.into(),
+                                errs,
                             },
                         )
                     })?,
@@ -296,7 +296,7 @@ impl FnAndArg {
                         "in __extn escape, {:?} is not a valid function name",
                         &self.ext_fn,
                     ),
-                    errs: errs.into(),
+                    errs,
                 })
             })?,
             vec![JSONValue::into_expr(*self.arg)?],

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -599,7 +599,7 @@ impl TryFrom<Expr> for ast::Expr {
                         let fn_name = fn_name.parse().map_err(|errs|
                             JsonDeserializationError::ExtnParseError(ParseError::WithContext {
                                 context: format!("expected valid operator or extension function name; got {fn_name}"),
-                                errs,
+                                errs: ParseErrors(errs),
                             })
                         )?;
                         Ok(ast::Expr::call_extension_fn(

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -19,7 +19,7 @@ use super::EstToAstError;
 use crate::ast;
 use crate::entities::{JSONValue, JsonDeserializationError, TypeAndId};
 use crate::parser::cst;
-use crate::parser::err::{ParseError, ParseErrors};
+use crate::parser::err::{ParseError, ParseErrors, WithContext};
 use crate::parser::unescape;
 use crate::parser::ASTNode;
 use either::Either;
@@ -597,10 +597,10 @@ impl TryFrom<Expr> for ast::Expr {
                             .next()
                             .expect("already checked that len was 1");
                         let fn_name = fn_name.parse().map_err(|errs|
-                            JsonDeserializationError::ExtnParseError(ParseError::WithContext {
+                            JsonDeserializationError::ExtnParseError(WithContext {
                                 context: format!("expected valid operator or extension function name; got {fn_name}"),
                                 errs,
-                            })
+                            }.into())
                         )?;
                         Ok(ast::Expr::call_extension_fn(
                             fn_name,

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -599,7 +599,7 @@ impl TryFrom<Expr> for ast::Expr {
                         let fn_name = fn_name.parse().map_err(|errs|
                             JsonDeserializationError::ExtnParseError(ParseError::WithContext {
                                 context: format!("expected valid operator or extension function name; got {fn_name}"),
-                                errs: ParseErrors(errs),
+                                errs,
                             })
                         )?;
                         Ok(ast::Expr::call_extension_fn(
@@ -1058,7 +1058,7 @@ fn interpret_primary(p: cst::Primary) -> Result<Either<ast::Name, Expr>, ParseEr
         },
         cst::Primary::Ref(ASTNode { node, .. }) => match node {
             Some(cst::Ref::Uid { path, eid }) => {
-                let mut errs = vec![];
+                let mut errs = ParseErrors::new();
                 let maybe_name = path.to_name(&mut errs);
                 let maybe_eid = eid.as_valid_string(&mut errs);
 
@@ -1071,7 +1071,7 @@ fn interpret_primary(p: cst::Primary) -> Result<Either<ast::Name, Expr>, ParseEr
                             )),
                         })))
                     }
-                    _ => Err(ParseErrors(errs)),
+                    _ => Err(errs),
                 }
             }
             Some(cst::Ref::Ref { .. }) => {
@@ -1090,7 +1090,7 @@ fn interpret_primary(p: cst::Primary) -> Result<Either<ast::Name, Expr>, ParseEr
                 }
                 (&[], Some(cst::Ident::Context)) => Ok(Either::Right(Expr::var(ast::Var::Context))),
                 (path, Some(cst::Ident::Ident(id))) => Ok(Either::Left(ast::Name::new(
-                    id.parse().map_err(ParseErrors)?,
+                    id.parse()?,
                     path.iter()
                         .map(|ASTNode { node, .. }| {
                             node.as_ref()
@@ -1099,7 +1099,7 @@ fn interpret_primary(p: cst::Primary) -> Result<Either<ast::Name, Expr>, ParseEr
                                         "node should not be empty".to_string(),
                                     )])
                                 })
-                                .and_then(|id| id.to_string().parse().map_err(ParseErrors))
+                                .and_then(|id| id.to_string().parse().map_err(Into::into))
                         })
                         .collect::<Result<Vec<ast::Id>, _>>()?,
                 ))),
@@ -1137,12 +1137,12 @@ fn interpret_primary(p: cst::Primary) -> Result<Either<ast::Name, Expr>, ParseEr
             .into_iter()
             .map(|node| match node.node {
                 Some(cst::RecInit(k, v)) => {
-                    let mut errs = vec![];
+                    let mut errs = ParseErrors::new();
                     let s = k
                         .to_expr_or_special(&mut errs)
                         .and_then(|es| es.into_valid_attr(&mut errs));
                     if !errs.is_empty() {
-                        Err(ParseErrors(errs))
+                        Err(errs)
                     } else {
                         match (s, v.node) {
                             (Some(s), Some(e)) => Ok((s, e.try_into()?)),

--- a/cedar-policy-core/src/from_normalized_str.rs
+++ b/cedar-policy-core/src/from_normalized_str.rs
@@ -1,11 +1,11 @@
-use crate::parser::err::ParseError;
+use crate::parser::err::{ParseError, ParseErrors};
 use std::fmt::Display;
 use std::str::FromStr;
 
 /// Trait for parsing "normalized" strings only, throwing an error if a
 /// non-normalized string is encountered. See docs on the
 /// [`from_normalized_str`] trait function.
-pub trait FromNormalizedStr: FromStr<Err = Vec<ParseError>> + Display {
+pub trait FromNormalizedStr: FromStr<Err = ParseErrors> + Display {
     /// Create a `Self` by parsing a string, which is required to be normalized.
     /// That is, the input is required to roundtrip with the `Display` impl on `Self`:
     /// `Self::from_normalized_str(x).to_string() == x` must hold.
@@ -18,17 +18,17 @@ pub trait FromNormalizedStr: FromStr<Err = Vec<ParseError>> + Display {
     ///
     /// For the version that accepts whitespace and Cedar comments, use the
     /// actual `FromStr` implementations.
-    fn from_normalized_str(s: &str) -> Result<Self, Vec<ParseError>> {
+    fn from_normalized_str(s: &str) -> Result<Self, ParseErrors> {
         let parsed = Self::from_str(s)?;
         let normalized = parsed.to_string();
         if normalized == s {
             // the normalized representation is indeed the one that was provided
             Ok(parsed)
         } else {
-            Err(vec![ParseError::ToAST(format!(
+            Err(ParseError::ToAST(format!(
                 "{} needs to be normalized (e.g., whitespace removed): {s} The normalized form is {normalized}",
                 Self::describe_self()
-            ))])
+            )).into())
         }
     }
 

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -187,6 +187,8 @@ pub fn parse_policy_to_est_and_ast(
 /// Parse a policy or template (either one works) to its EST representation
 pub fn parse_policy_or_template_to_est(text: &str) -> Result<est::Policy, err::ParseErrors> {
     let cst = text_to_cst::parse_policy(text)?;
+    // PANIC SAFETY Shouldn't be `none` since `parse_policy()` didn't return `Err`
+    #[allow(clippy::expect_used)]
     let cst_node = cst.node.expect("missing policy or template node");
     cst_node.try_into()
 }
@@ -314,7 +316,7 @@ pub fn parse_request(
             .map_err(|e| {
                 errs.push(err::ParseError::WithContext {
                     context: format!("trying to parse {}", name),
-                    errs: e.into(),
+                    errs: e,
                 })
             })
             .ok()

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -290,7 +290,7 @@ pub fn parse_internal_string(val: &str) -> Result<SmolStr, err::ParseErrors> {
 /// parse an identifier
 ///
 /// Private to this crate. Users outside Core should use `Id`'s `FromStr` impl
-/// or its constructorsVec<err::Error>Vec<err::Error>Vec<err::Error>
+/// or its constructors
 pub(crate) fn parse_ident(id: &str) -> Result<ast::Id, err::ParseErrors> {
     let mut errs = err::ParseErrors::new();
     let cst = text_to_cst::parse_ident(id)?;
@@ -299,53 +299,6 @@ pub(crate) fn parse_ident(id: &str) -> Result<ast::Id, err::ParseErrors> {
         Ok(ast)
     } else {
         Err(errs)
-    }
-}
-
-/// parse into a `Request`
-pub fn parse_request(
-    principal: impl AsRef<str>,      // should be a "Type::EID" string
-    action: impl AsRef<str>,         // should be a "Type::EID" string
-    resource: impl AsRef<str>,       // should be a "Type::EID" string
-    context_json: serde_json::Value, // JSON object mapping Strings to ast::RestrictedExpr
-) -> Result<ast::Request, err::ParseErrors> {
-    let mut errs = err::ParseErrors::new();
-    // Parse principal, action, resource
-    let mut parse_par = |s, name| {
-        parse_euid(s)
-            .map_err(|e| {
-                errs.push(err::ParseError::WithContext {
-                    context: format!("trying to parse {}", name),
-                    errs: e,
-                })
-            })
-            .ok()
-    };
-
-    let (principal, action, resource) = (
-        parse_par(principal.as_ref(), "principal"),
-        parse_par(action.as_ref(), "action"),
-        parse_par(resource.as_ref(), "resource"),
-    );
-
-    let context = match ast::Context::from_json_value(context_json) {
-        Ok(ctx) => Some(ctx),
-        Err(e) => {
-            errs.push(err::ParseError::ToAST(format!(
-                "failed to parse context JSON: {}",
-                err::ParseErrors(vec![err::ParseError::ToAST(e.to_string())])
-            )));
-            None
-        }
-    };
-    match (principal, action, resource, errs.as_slice()) {
-        (Some(p), Some(a), Some(r), &[]) => Ok(ast::Request {
-            principal: ast::EntityUIDEntry::concrete(p),
-            action: ast::EntityUIDEntry::concrete(a),
-            resource: ast::EntityUIDEntry::concrete(r),
-            context,
-        }),
-        _ => Err(errs),
     }
 }
 

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -40,11 +40,15 @@ use crate::est;
 
 /// simple main function for parsing policies
 /// generates numbered ids
-pub fn parse_policyset(text: &str) -> Result<ast::PolicySet, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
-    text_to_cst::parse_policies(text)?
-        .to_policyset(&mut errs)
-        .ok_or(errs)
+pub fn parse_policyset(text: &str) -> Result<ast::PolicySet, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_policies(text)?;
+    let Some(ast) = cst.to_policyset(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
 }
 
 /// Like `parse_policyset()`, but also returns the (lossless) original text of
@@ -52,24 +56,22 @@ pub fn parse_policyset(text: &str) -> Result<ast::PolicySet, Vec<err::ParseError
 pub fn parse_policyset_and_also_return_policy_text(
     text: &str,
 ) -> Result<(HashMap<ast::PolicyID, &str>, ast::PolicySet), err::ParseErrors> {
-    let mut errs = Vec::new();
-    let cst = text_to_cst::parse_policies(text).map_err(err::ParseErrors)?;
-    let pset = cst
-        .to_policyset(&mut errs)
-        .ok_or_else(|| err::ParseErrors(errs.clone()))?;
-    // PANIC SAFETY Shouldn't be `none` since `parse_policies()` and `to_policyset()` didn't return `Err`
-    #[allow(clippy::expect_used)]
-    // PANIC SAFETY Indexing is safe because of how `SourceInfo` is constructed
-    #[allow(clippy::indexing_slicing)]
-    let texts = cst
-        .with_generated_policyids()
-        .expect("shouldn't be None since parse_policies() and to_policyset() didn't return Err")
-        .map(|(id, policy)| (id, &text[policy.info.0.clone()]))
-        .collect::<HashMap<ast::PolicyID, &str>>();
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_policies(text)?;
+    let Some(pset) = cst.to_policyset(&mut errs) else { return Err(errs); };
     if errs.is_empty() {
+        // PANIC SAFETY Shouldn't be `none` since `parse_policies()` and `to_policyset()` didn't return `Err`
+        #[allow(clippy::expect_used)]
+        // PANIC SAFETY Indexing is safe because of how `SourceInfo` is constructed
+        #[allow(clippy::indexing_slicing)]
+        let texts = cst
+            .with_generated_policyids()
+            .expect("shouldn't be None since parse_policies() and to_policyset() didn't return Err")
+            .map(|(id, policy)| (id, &text[policy.info.0.clone()]))
+            .collect::<HashMap<ast::PolicyID, &str>>();
         Ok((texts, pset))
     } else {
-        Err(err::ParseErrors(errs))
+        Err(errs)
     }
 }
 
@@ -79,24 +81,23 @@ pub fn parse_policyset_and_also_return_policy_text(
 pub fn parse_policyset_to_ests_and_pset(
     text: &str,
 ) -> Result<(HashMap<ast::PolicyID, est::Policy>, ast::PolicySet), err::ParseErrors> {
-    let mut errs = Vec::new();
-    let cst = text_to_cst::parse_policies(text).map_err(err::ParseErrors)?;
-    let pset = cst
-        .to_policyset(&mut errs)
-        .ok_or_else(|| err::ParseErrors(errs.clone()))?;
-    // PANIC SAFETY Shouldn't be `none` since `parse_policies()` and `to_policyset()` didn't return `Err`
-    #[allow(clippy::expect_used)]
-    let ests = cst
-        .with_generated_policyids()
-        .expect("shouldn't be None since parse_policies() and to_policyset() didn't return Err")
-        .map(|(id, policy)| match &policy.node {
-            Some(p) => Ok(Some((id, p.clone().try_into()?))),
-            None => Ok(None),
-        })
-        .collect::<Result<Option<HashMap<ast::PolicyID, est::Policy>>, err::ParseErrors>>()?;
-    match (errs.is_empty(), ests) {
-        (true, Some(ests)) => Ok((ests, pset)),
-        (_, _) => Err(err::ParseErrors(errs)),
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_policies(text)?;
+    let Some(pset) = cst.to_policyset(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        // PANIC SAFETY Shouldn't be `None` since `parse_policies()` and `to_policyset()` didn't return `Err`
+        #[allow(clippy::expect_used)]
+        let ests = cst
+            .with_generated_policyids()
+            .expect("missing policy set node")
+            .map(|(id, policy)| {
+                let p = policy.node.as_ref().expect("missing policy node").clone();
+                Ok((id, p.try_into()?))
+            })
+            .collect::<Result<HashMap<ast::PolicyID, est::Policy>, err::ParseErrors>>()?;
+        Ok((ests, pset))
+    } else {
+        Err(errs)
     }
 }
 
@@ -106,15 +107,16 @@ pub fn parse_policyset_to_ests_and_pset(
 pub fn parse_policy_template(
     id: Option<String>,
     text: &str,
-) -> Result<ast::Template, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
+) -> Result<ast::Template, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
     let id = match id {
         Some(id) => ast::PolicyID::from_string(id),
         None => ast::PolicyID::from_string("policy0"),
     };
-    let r = text_to_cst::parse_policy(text)?.to_policy_template(id, &mut errs);
+    let cst = text_to_cst::parse_policy(text)?;
+    let Some(ast) = cst.to_policy_template(id, &mut errs) else { return Err(errs); };
     if errs.is_empty() {
-        r.ok_or(errs).map(ast::Template::from)
+        Ok(ast)
     } else {
         Err(errs)
     }
@@ -127,38 +129,34 @@ pub fn parse_policy_template_to_est_and_ast(
     id: Option<String>,
     text: &str,
 ) -> Result<(est::Policy, ast::Template), err::ParseErrors> {
-    let mut errs = Vec::new();
+    let mut errs = err::ParseErrors::new();
     let id = match id {
         Some(id) => ast::PolicyID::from_string(id),
         None => ast::PolicyID::from_string("policy0"),
     };
-    let cst = text_to_cst::parse_policy(text).map_err(err::ParseErrors)?;
-    let ast = cst
-        .to_policy_template(id, &mut errs)
-        .ok_or_else(|| err::ParseErrors(errs.clone()))?;
-    let est = cst.node.map(TryInto::try_into).transpose()?;
-    match (errs.is_empty(), est) {
-        (true, Some(est)) => Ok((est, ast)),
-        (_, _) => Err(err::ParseErrors(errs)),
+    let cst = text_to_cst::parse_policy(text)?;
+    let (Some(ast), Some(cst_node)) = (cst.to_policy_template(id, &mut errs), cst.node) else { return Err(errs); };
+    if errs.is_empty() {
+        let est = cst_node.try_into()?;
+        Ok((est, ast))
+    } else {
+        Err(errs)
     }
 }
 
 /// simple main function for parsing a policy.
 /// If `id` is Some, then the resulting policy will have that `id`.
 /// If the `id` is None, the parser will use "policy0".
-pub fn parse_policy(
-    id: Option<String>,
-    text: &str,
-) -> Result<ast::StaticPolicy, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
+pub fn parse_policy(id: Option<String>, text: &str) -> Result<ast::StaticPolicy, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
     let id = match id {
         Some(id) => ast::PolicyID::from_string(id),
         None => ast::PolicyID::from_string("policy0"),
     };
-    let r = text_to_cst::parse_policy(text)?.to_policy(id, &mut errs);
-
+    let cst = text_to_cst::parse_policy(text)?;
+    let Some(ast) = cst.to_policy(id, &mut errs) else { return Err(errs); };
     if errs.is_empty() {
-        r.ok_or(errs)
+        Ok(ast)
     } else {
         Err(errs)
     }
@@ -171,90 +169,97 @@ pub fn parse_policy_to_est_and_ast(
     id: Option<String>,
     text: &str,
 ) -> Result<(est::Policy, ast::StaticPolicy), err::ParseErrors> {
-    let mut errs = Vec::new();
+    let mut errs = err::ParseErrors::new();
     let id = match id {
         Some(id) => ast::PolicyID::from_string(id),
         None => ast::PolicyID::from_string("policy0"),
     };
-    let cst = text_to_cst::parse_policy(text).map_err(err::ParseErrors)?;
-    let ast = cst
-        .to_policy(id, &mut errs)
-        .ok_or_else(|| err::ParseErrors(errs.clone()))?;
-
-    let est = cst.node.map(TryInto::try_into).transpose()?;
-    match (errs.is_empty(), est) {
-        (true, Some(est)) => Ok((est, ast)),
-        (_, _) => Err(err::ParseErrors(errs)),
+    let cst = text_to_cst::parse_policy(text)?;
+    let (Some(ast), Some(cst_node)) = (cst.to_policy(id, &mut errs), cst.node) else { return Err(errs); };
+    if errs.is_empty() {
+        let est = cst_node.try_into()?;
+        Ok((est, ast))
+    } else {
+        Err(errs)
     }
 }
 
 /// Parse a policy or template (either one works) to its EST representation
 pub fn parse_policy_or_template_to_est(text: &str) -> Result<est::Policy, err::ParseErrors> {
-    let cst = text_to_cst::parse_policy(text).map_err(err::ParseErrors)?;
-    let est = cst.node.map(TryInto::try_into).transpose()?;
-    match est {
-        Some(est) => Ok(est),
-        None => Err(err::ParseErrors(vec![])), // theoretically this shouldn't happen if the `?`s above didn't already fail us out
-    }
+    let cst = text_to_cst::parse_policy(text)?;
+    let cst_node = cst.node.expect("missing policy or template node");
+    cst_node.try_into()
 }
 
 /// parse an Expr
 ///
 /// Private to this crate. Users outside Core should use `Expr`'s `FromStr` impl
 /// or its constructors
-pub(crate) fn parse_expr(ptext: &str) -> Result<ast::Expr, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
-    text_to_cst::parse_expr(ptext)?
-        .to_expr(&mut errs)
-        .ok_or(errs)
+pub(crate) fn parse_expr(ptext: &str) -> Result<ast::Expr, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_expr(ptext)?;
+    let Some(ast) = cst.to_expr(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
 }
 
 /// parse a RestrictedExpr
 ///
 /// Private to this crate. Users outside Core should use `RestrictedExpr`'s
 /// `FromStr` impl or its constructors
-pub(crate) fn parse_restrictedexpr(
-    ptext: &str,
-) -> Result<ast::RestrictedExpr, Vec<err::ParseError>> {
+pub(crate) fn parse_restrictedexpr(ptext: &str) -> Result<ast::RestrictedExpr, err::ParseErrors> {
     parse_expr(ptext)
-        .and_then(|expr| ast::RestrictedExpr::new(expr).map_err(|err| vec![err.into()]))
+        .and_then(|expr| ast::RestrictedExpr::new(expr).map_err(err::ParseErrors::from))
 }
 
 /// parse an EntityUID
 ///
 /// Private to this crate. Users outside Core should use `EntityUID`'s `FromStr`
 /// impl or its constructors
-pub(crate) fn parse_euid(euid: &str) -> Result<ast::EntityUID, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
-    text_to_cst::parse_ref(euid)?.to_ref(&mut errs).ok_or(errs)
+pub(crate) fn parse_euid(euid: &str) -> Result<ast::EntityUID, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_ref(euid)?;
+    let Some(ast) = cst.to_ref(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
 }
 
 /// parse a Name
 ///
 /// Private to this crate. Users outside Core should use `Name`'s `FromStr` impl
 /// or its constructors
-pub(crate) fn parse_name(name: &str) -> Result<ast::Name, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
-    text_to_cst::parse_name(name)?
-        .to_name(&mut errs)
-        .ok_or(errs)
+pub(crate) fn parse_name(name: &str) -> Result<ast::Name, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_name(name)?;
+    let Some(ast) = cst.to_name(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
 }
 
 /// parse a string into an ast::Literal (does not support expressions)
 ///
 /// Private to this crate. Users outside Core should use `Literal`'s `FromStr` impl
 /// or its constructors
-pub(crate) fn parse_literal(val: &str) -> Result<ast::Literal, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
-    match text_to_cst::parse_primary(val)?
-        .to_expr(&mut errs)
-        .ok_or(errs)?
-        .into_expr_kind()
-    {
-        ast::ExprKind::Lit(v) => Ok(v),
-        _ => Err(vec![err::ParseError::ToAST(
-            "text is not a literal".to_string(),
-        )]),
+pub(crate) fn parse_literal(val: &str) -> Result<ast::Literal, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_primary(val)?;
+    let Some(ast) = cst.to_expr(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        match ast.into_expr_kind() {
+            ast::ExprKind::Lit(v) => Ok(v),
+            _ => Err(err::ParseError::ToAST("text is not a literal".to_string()).into()),
+        }
+    } else {
+        Err(errs)
     }
 }
 
@@ -268,23 +273,31 @@ pub(crate) fn parse_literal(val: &str) -> Result<ast::Literal, Vec<err::ParseErr
 ///
 /// It does not return a string suitable for a pattern. Use the
 /// full expression parser for those.
-pub fn parse_internal_string(val: &str) -> Result<SmolStr, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
+pub fn parse_internal_string(val: &str) -> Result<SmolStr, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
     // we need to add quotes for this to be a valid string literal
-    text_to_cst::parse_primary(&format!(r#""{val}""#))?
-        .to_string_literal(&mut errs)
-        .ok_or(errs)
+    let cst = text_to_cst::parse_primary(&format!(r#""{val}""#))?;
+    let Some(ast) = cst.to_string_literal(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
 }
 
 /// parse an identifier
 ///
 /// Private to this crate. Users outside Core should use `Id`'s `FromStr` impl
-/// or its constructors
-pub(crate) fn parse_ident(id: &str) -> Result<ast::Id, Vec<err::ParseError>> {
-    let mut errs = Vec::new();
-    text_to_cst::parse_ident(id)?
-        .to_valid_ident(&mut errs)
-        .ok_or(errs)
+/// or its constructorsVec<err::Error>Vec<err::Error>Vec<err::Error>
+pub(crate) fn parse_ident(id: &str) -> Result<ast::Id, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_ident(id)?;
+    let Some(ast) = cst.to_valid_ident(&mut errs) else { return Err(errs); };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
 }
 
 /// parse into a `Request`
@@ -293,8 +306,8 @@ pub fn parse_request(
     action: impl AsRef<str>,         // should be a "Type::EID" string
     resource: impl AsRef<str>,       // should be a "Type::EID" string
     context_json: serde_json::Value, // JSON object mapping Strings to ast::RestrictedExpr
-) -> Result<ast::Request, Vec<err::ParseError>> {
-    let mut errs = vec![];
+) -> Result<ast::Request, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
     // Parse principal, action, resource
     let mut parse_par = |s, name| {
         parse_euid(s)

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -577,7 +577,7 @@ impl ASTNode<Option<cst::VariableDef>> {
 
 fn action_type_error_msg(euid: &EntityUID) -> ParseError {
     let msg = format!("Expected an EntityUID with the type `Action`. Got: {euid}");
-    ParseError::ToCST(msg)
+    ParseError::ToAST(msg)
 }
 
 /// Check that all of the EUIDs in an action constraint have the type `Action`, under an arbitrary namespace
@@ -2139,7 +2139,7 @@ mod tests {
     use super::*;
     use crate::{
         ast::Expr,
-        parser::{err::MultipleParseErrors, *},
+        parser::{err::ParseErrors, *},
     };
     use std::str::FromStr;
 
@@ -3593,7 +3593,7 @@ mod tests {
                 .expect("should construct a CST")
                 .to_expr(&mut errs);
             assert!(e.is_none());
-            assert!(MultipleParseErrors(&errs).to_string().contains(em));
+            assert!(ParseErrors(errs).to_string().contains(em));
         }
     }
 }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -35,7 +35,7 @@
 // cases where there is a secondary conversion. This prevents any further
 // cloning.
 
-use super::err::ParseError;
+use super::err::{ParseError, ParseErrors};
 use super::node::{ASTNode, SourceInfo};
 use super::unescape::{to_pattern, to_unescaped_string};
 use super::{cst, err};
@@ -49,9 +49,6 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
 use std::mem;
 use std::sync::Arc;
-
-// shortcut for error parameter
-type Errs<'a> = &'a mut Vec<err::ParseError>;
 
 // for storing extension function names per callstyle
 struct ExtStyles<'a> {
@@ -95,7 +92,7 @@ impl ASTNode<Option<cst::Policies>> {
     }
 
     /// convert `cst::Policies` to `ast::PolicySet`
-    pub fn to_policyset(&self, errs: Errs<'_>) -> Option<ast::PolicySet> {
+    pub fn to_policyset(&self, errs: &mut ParseErrors) -> Option<ast::PolicySet> {
         let mut pset = ast::PolicySet::new();
         let mut complete_set = true;
         for (policy_id, policy) in self.with_generated_policyids()? {
@@ -143,7 +140,7 @@ impl ASTNode<Option<cst::Policy>> {
     pub fn to_policy_or_template(
         &self,
         id: ast::PolicyID,
-        errs: Errs<'_>,
+        errs: &mut ParseErrors,
     ) -> Option<Either<ast::StaticPolicy, ast::Template>> {
         let t = self.to_policy_template(id, errs)?;
         if t.slots().count() == 0 {
@@ -155,7 +152,11 @@ impl ASTNode<Option<cst::Policy>> {
     }
 
     /// Convert `cst::Policy` to an AST `InlinePolicy`. (Will fail if the CST is for a template)
-    pub fn to_policy(&self, id: ast::PolicyID, errs: Errs<'_>) -> Option<ast::StaticPolicy> {
+    pub fn to_policy(
+        &self,
+        id: ast::PolicyID,
+        errs: &mut ParseErrors,
+    ) -> Option<ast::StaticPolicy> {
         let tp = self.to_policy_template(id, errs)?;
         match ast::StaticPolicy::try_from(tp) {
             Ok(p) => Some(p),
@@ -168,7 +169,11 @@ impl ASTNode<Option<cst::Policy>> {
 
     /// Convert `cst::Policy` to `ast::Template`. Works for inline policies as
     /// well, which will become templates with 0 slots
-    pub fn to_policy_template(&self, id: ast::PolicyID, errs: Errs<'_>) -> Option<ast::Template> {
+    pub fn to_policy_template(
+        &self,
+        id: ast::PolicyID,
+        errs: &mut ParseErrors,
+    ) -> Option<ast::Template> {
         let (src, maybe_policy) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let policy = maybe_policy?;
@@ -237,7 +242,7 @@ impl cst::Policy {
     /// get the head constraints from the `cst::Policy`
     pub fn extract_head(
         &self,
-        errs: Errs<'_>,
+        errs: &mut ParseErrors,
     ) -> (
         Option<PrincipalConstraint>,
         Option<ActionConstraint>,
@@ -280,7 +285,7 @@ impl cst::Policy {
 impl ASTNode<Option<cst::Annotation>> {
     /// Get the (k, v) pair for the annotation. Critically, this checks validity
     /// for the strings and does unescaping
-    pub fn to_kv_pair(&self, errs: Errs<'_>) -> Option<(ast::Id, SmolStr)> {
+    pub fn to_kv_pair(&self, errs: &mut ParseErrors) -> Option<(ast::Id, SmolStr)> {
         let maybe_anno = self.as_inner();
         // return right away if there's no data, parse provided error
         let anno = maybe_anno?;
@@ -308,7 +313,7 @@ impl ASTNode<Option<cst::Annotation>> {
 
 impl ASTNode<Option<cst::Ident>> {
     /// Convert `cst::Ident` to `ast::Id`. Fails for reserved or invalid identifiers
-    pub fn to_valid_ident(&self, errs: Errs<'_>) -> Option<ast::Id> {
+    pub fn to_valid_ident(&self, errs: &mut ParseErrors) -> Option<ast::Id> {
         let maybe_ident = self.as_inner();
         // return right away if there's no data, parse provided error
         let ident = maybe_ident?;
@@ -338,7 +343,7 @@ impl ASTNode<Option<cst::Ident>> {
     }
 
     /// effect
-    pub(crate) fn to_effect(&self, errs: Errs<'_>) -> Option<ast::Effect> {
+    pub(crate) fn to_effect(&self, errs: &mut ParseErrors) -> Option<ast::Effect> {
         let maybe_effect = self.as_inner();
         // return right away if there's no data, parse provided error
         let effect = maybe_effect?;
@@ -354,7 +359,7 @@ impl ASTNode<Option<cst::Ident>> {
             }
         }
     }
-    pub(crate) fn to_cond_is_when(&self, errs: Errs<'_>) -> Option<bool> {
+    pub(crate) fn to_cond_is_when(&self, errs: &mut ParseErrors) -> Option<bool> {
         let maybe_cond = self.as_inner();
         // return right away if there's no data, parse provided error
         let cond = maybe_cond?;
@@ -371,7 +376,7 @@ impl ASTNode<Option<cst::Ident>> {
         }
     }
 
-    fn to_var(&self, errs: Errs<'_>) -> Option<ast::Var> {
+    fn to_var(&self, errs: &mut ParseErrors) -> Option<ast::Var> {
         let maybe_ident = self.as_inner();
         match maybe_ident {
             Some(cst::Ident::Principal) => Some(ast::Var::Principal),
@@ -396,7 +401,7 @@ impl ast::Id {
         &self,
         e: ast::Expr,
         mut args: Vec<ast::Expr>,
-        errs: Errs<'_>,
+        errs: &mut ParseErrors,
         l: SourceInfo,
     ) -> Option<ast::Expr> {
         let mut adj_args = args.iter_mut().peekable();
@@ -439,7 +444,7 @@ enum PrincipalOrResource {
 }
 
 impl ASTNode<Option<cst::VariableDef>> {
-    fn to_principal_constraint(&self, errs: Errs<'_>) -> Option<PrincipalConstraint> {
+    fn to_principal_constraint(&self, errs: &mut ParseErrors) -> Option<PrincipalConstraint> {
         match self.to_principal_or_resource_constraint(errs)? {
             PrincipalOrResource::Principal(p) => Some(p),
             PrincipalOrResource::Resource(_) => {
@@ -451,7 +456,7 @@ impl ASTNode<Option<cst::VariableDef>> {
         }
     }
 
-    fn to_resource_constraint(&self, errs: Errs<'_>) -> Option<ResourceConstraint> {
+    fn to_resource_constraint(&self, errs: &mut ParseErrors) -> Option<ResourceConstraint> {
         match self.to_principal_or_resource_constraint(errs)? {
             PrincipalOrResource::Principal(_) => {
                 errs.push(err::ParseError::ToAST(
@@ -463,7 +468,10 @@ impl ASTNode<Option<cst::VariableDef>> {
         }
     }
 
-    fn to_principal_or_resource_constraint(&self, errs: Errs<'_>) -> Option<PrincipalOrResource> {
+    fn to_principal_or_resource_constraint(
+        &self,
+        errs: &mut ParseErrors,
+    ) -> Option<PrincipalOrResource> {
         let maybe_vardef = self.as_inner();
         // return right away if there's no data, parse provided error
         let vardef = maybe_vardef?;
@@ -516,7 +524,7 @@ impl ASTNode<Option<cst::VariableDef>> {
         }
     }
 
-    fn to_action_constraint(&self, errs: Errs<'_>) -> Option<ast::ActionConstraint> {
+    fn to_action_constraint(&self, errs: &mut ParseErrors) -> Option<ast::ActionConstraint> {
         let maybe_vardef = self.as_inner();
         let vardef = maybe_vardef?;
 
@@ -583,7 +591,7 @@ fn action_type_error_msg(euid: &EntityUID) -> ParseError {
 /// Check that all of the EUIDs in an action constraint have the type `Action`, under an arbitrary namespace
 fn action_constraint_contains_only_action_types(
     a: ActionConstraint,
-) -> Result<ActionConstraint, Vec<ParseError>> {
+) -> Result<ActionConstraint, ParseErrors> {
     match a {
         ActionConstraint::Any => Ok(a),
         ActionConstraint::In(ref euids) => {
@@ -604,7 +612,7 @@ fn action_constraint_contains_only_action_types(
             if euid_has_action_type(euid) {
                 Ok(a)
             } else {
-                Err(vec![action_type_error_msg(euid)])
+                Err(action_type_error_msg(euid).into())
             }
         }
     }
@@ -621,7 +629,7 @@ fn euid_has_action_type(euid: &EntityUID) -> bool {
 
 impl ASTNode<Option<cst::Cond>> {
     /// to expr
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         let (src, maybe_cond) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let cond = maybe_cond?;
@@ -648,7 +656,7 @@ impl ASTNode<Option<cst::Cond>> {
 }
 
 impl ASTNode<Option<cst::Str>> {
-    pub(crate) fn as_valid_string(&self, errs: Errs<'_>) -> Option<&SmolStr> {
+    pub(crate) fn as_valid_string(&self, errs: &mut ParseErrors) -> Option<&SmolStr> {
         let id = self.as_inner();
         // return right away if there's no data, parse provided error
         let id = id?;
@@ -684,7 +692,7 @@ pub(crate) enum ExprOrSpecial<'a> {
 }
 
 impl ExprOrSpecial<'_> {
-    fn into_expr(self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn into_expr(self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         match self {
             Self::Expr(e) => Some(e),
             Self::Var(v, l) => Some(construct_expr_var(v, l)),
@@ -709,7 +717,7 @@ impl ExprOrSpecial<'_> {
     }
 
     /// Variables, names (with no prefixes), and string literals can all be used as record attributes
-    pub(crate) fn into_valid_attr(self, errs: Errs<'_>) -> Option<SmolStr> {
+    pub(crate) fn into_valid_attr(self, errs: &mut ParseErrors) -> Option<SmolStr> {
         match self {
             Self::Var(var, _) => Some(construct_string_from_var(var)),
             Self::Name(name) => name.into_valid_attr(errs),
@@ -731,7 +739,7 @@ impl ExprOrSpecial<'_> {
         }
     }
 
-    fn into_pattern(self, errs: Errs<'_>) -> Option<Vec<PatternElem>> {
+    fn into_pattern(self, errs: &mut ParseErrors) -> Option<Vec<PatternElem>> {
         match self {
             Self::StrLit(s, _) => match to_pattern(s) {
                 Ok(pat) => Some(pat),
@@ -763,7 +771,7 @@ impl ExprOrSpecial<'_> {
         }
     }
     /// to string literal
-    fn into_string_literal(self, errs: Errs<'_>) -> Option<SmolStr> {
+    fn into_string_literal(self, errs: &mut ParseErrors) -> Option<SmolStr> {
         match self {
             Self::StrLit(s, _) => match to_unescaped_string(s) {
                 Ok(s) => Some(s),
@@ -798,19 +806,19 @@ impl ExprOrSpecial<'_> {
 
 impl ASTNode<Option<cst::Expr>> {
     /// to ref
-    fn to_ref(&self, var: ast::Var, errs: Errs<'_>) -> Option<EntityUID> {
+    fn to_ref(&self, var: ast::Var, errs: &mut ParseErrors) -> Option<EntityUID> {
         self.to_ref_or_refs::<SingleEntity>(errs, var).map(|x| x.0)
     }
 
-    fn to_ref_or_slot(&self, errs: Errs<'_>, var: ast::Var) -> Option<EntityReference> {
+    fn to_ref_or_slot(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<EntityReference> {
         self.to_ref_or_refs::<EntityReference>(errs, var)
     }
 
-    fn to_refs(&self, errs: Errs<'_>, var: ast::Var) -> Option<OneOrMultipleRefs> {
+    fn to_refs(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<OneOrMultipleRefs> {
         self.to_ref_or_refs::<OneOrMultipleRefs>(errs, var)
     }
 
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_expr = self.as_inner();
         let expr = &*maybe_expr?.expr;
         match expr {
@@ -826,10 +834,10 @@ impl ASTNode<Option<cst::Expr>> {
     }
 
     /// convert `cst::Expr` to `ast::Expr`
-    pub fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    pub fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    pub(crate) fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    pub(crate) fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_expr) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let expr = &*maybe_expr?.expr;
@@ -857,9 +865,9 @@ impl ASTNode<Option<cst::Expr>> {
 /// or runtime data.
 trait RefKind: Sized {
     fn err_string() -> &'static str;
-    fn create_single_ref(e: EntityUID, errs: Errs<'_>) -> Option<Self>;
-    fn create_multiple_refs(es: Vec<EntityUID>, errs: Errs<'_>) -> Option<Self>;
-    fn create_slot(errs: Errs<'_>) -> Option<Self>;
+    fn create_single_ref(e: EntityUID, errs: &mut ParseErrors) -> Option<Self>;
+    fn create_multiple_refs(es: Vec<EntityUID>, errs: &mut ParseErrors) -> Option<Self>;
+    fn create_slot(errs: &mut ParseErrors) -> Option<Self>;
 }
 
 struct SingleEntity(pub EntityUID);
@@ -869,18 +877,18 @@ impl RefKind for SingleEntity {
         "entity uid"
     }
 
-    fn create_single_ref(e: EntityUID, _errs: Errs<'_>) -> Option<Self> {
+    fn create_single_ref(e: EntityUID, _errs: &mut ParseErrors) -> Option<Self> {
         Some(SingleEntity(e))
     }
 
-    fn create_multiple_refs(_es: Vec<EntityUID>, errs: Errs<'_>) -> Option<Self> {
+    fn create_multiple_refs(_es: Vec<EntityUID>, errs: &mut ParseErrors) -> Option<Self> {
         errs.push(err::ParseError::ToAST(
             "expected single entity uid, got a set of entity uids".to_string(),
         ));
         None
     }
 
-    fn create_slot(errs: Errs<'_>) -> Option<Self> {
+    fn create_slot(errs: &mut ParseErrors) -> Option<Self> {
         errs.push(err::ParseError::ToAST(
             "expected a single entity uid, got a template slot".to_string(),
         ));
@@ -893,15 +901,15 @@ impl RefKind for EntityReference {
         "entity uid or template slot"
     }
 
-    fn create_slot(_: Errs<'_>) -> Option<Self> {
+    fn create_slot(_: &mut ParseErrors) -> Option<Self> {
         Some(EntityReference::Slot)
     }
 
-    fn create_single_ref(e: EntityUID, _errs: Errs<'_>) -> Option<Self> {
+    fn create_single_ref(e: EntityUID, _errs: &mut ParseErrors) -> Option<Self> {
         Some(EntityReference::euid(e))
     }
 
-    fn create_multiple_refs(_es: Vec<EntityUID>, errs: Errs<'_>) -> Option<Self> {
+    fn create_multiple_refs(_es: Vec<EntityUID>, errs: &mut ParseErrors) -> Option<Self> {
         errs.push(err::ParseError::ToAST(
             "expected single entity uid or template slot, got a set of entity uids".to_string(),
         ));
@@ -921,22 +929,22 @@ impl RefKind for OneOrMultipleRefs {
         "entity uid, set of entity uids, or template slot"
     }
 
-    fn create_slot(errs: Errs<'_>) -> Option<Self> {
+    fn create_slot(errs: &mut ParseErrors) -> Option<Self> {
         errs.push(err::ParseError::ToAST("Unexpected slot".to_string()));
         None
     }
 
-    fn create_single_ref(e: EntityUID, _errs: Errs<'_>) -> Option<Self> {
+    fn create_single_ref(e: EntityUID, _errs: &mut ParseErrors) -> Option<Self> {
         Some(OneOrMultipleRefs::Single(e))
     }
 
-    fn create_multiple_refs(es: Vec<EntityUID>, _errs: Errs<'_>) -> Option<Self> {
+    fn create_multiple_refs(es: Vec<EntityUID>, _errs: &mut ParseErrors) -> Option<Self> {
         Some(OneOrMultipleRefs::Multiple(es))
     }
 }
 
 impl ASTNode<Option<cst::Or>> {
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_or) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let or = maybe_or?;
@@ -957,7 +965,7 @@ impl ASTNode<Option<cst::Or>> {
         }
     }
 
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_or = self.as_inner();
         let or = maybe_or?;
         match or.extended.len() {
@@ -974,7 +982,7 @@ impl ASTNode<Option<cst::Or>> {
 }
 
 impl ASTNode<Option<cst::And>> {
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_and = self.as_inner();
         let and = maybe_and?;
         match and.extended.len() {
@@ -989,10 +997,10 @@ impl ASTNode<Option<cst::And>> {
         }
     }
 
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_and) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let and = maybe_and?;
@@ -1015,7 +1023,7 @@ impl ASTNode<Option<cst::And>> {
 }
 
 impl ASTNode<Option<cst::Relation>> {
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_rel = self.as_inner();
         match maybe_rel? {
             cst::Relation::Common { initial, extended } => match extended.len() {
@@ -1045,10 +1053,10 @@ impl ASTNode<Option<cst::Relation>> {
         }
     }
 
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_rel) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let rel = maybe_rel?;
@@ -1108,7 +1116,7 @@ impl ASTNode<Option<cst::Relation>> {
 }
 
 impl ASTNode<Option<cst::Add>> {
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_add = self.as_inner();
         let add = maybe_add?;
         match add.extended.len() {
@@ -1123,10 +1131,10 @@ impl ASTNode<Option<cst::Add>> {
         }
     }
 
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_add) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let add = maybe_add?;
@@ -1151,7 +1159,7 @@ impl ASTNode<Option<cst::Add>> {
 }
 
 impl ASTNode<Option<cst::Mult>> {
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_mult = self.as_inner();
         let mult = maybe_mult?;
         match mult.extended.len() {
@@ -1166,10 +1174,10 @@ impl ASTNode<Option<cst::Mult>> {
         }
     }
 
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_mult) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let mult = maybe_mult?;
@@ -1254,7 +1262,7 @@ impl ASTNode<Option<cst::Mult>> {
 }
 
 impl ASTNode<Option<cst::Unary>> {
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_unary = self.as_inner();
         let unary = maybe_unary?;
         match &unary.op {
@@ -1268,10 +1276,10 @@ impl ASTNode<Option<cst::Unary>> {
         }
     }
 
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_unary) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let unary = maybe_unary?;
@@ -1365,7 +1373,7 @@ impl ASTNode<Option<cst::Member>> {
         }
     }
 
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_mem = self.as_inner();
         let mem = maybe_mem?;
         match mem.access.len() {
@@ -1379,7 +1387,7 @@ impl ASTNode<Option<cst::Member>> {
         }
     }
 
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_mem) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let mem = maybe_mem?;
@@ -1593,7 +1601,7 @@ impl ASTNode<Option<cst::Member>> {
 }
 
 impl ASTNode<Option<cst::MemAccess>> {
-    fn to_access(&self, errs: Errs<'_>) -> Option<AstAccessor> {
+    fn to_access(&self, errs: &mut ParseErrors) -> Option<AstAccessor> {
         let maybe_acc = self.as_inner();
         // return right away if there's no data, parse provided error
         let acc = maybe_acc?;
@@ -1620,7 +1628,7 @@ impl ASTNode<Option<cst::MemAccess>> {
 }
 
 impl ASTNode<Option<cst::Primary>> {
-    fn to_ref_or_refs<T: RefKind>(&self, errs: Errs<'_>, var: ast::Var) -> Option<T> {
+    fn to_ref_or_refs<T: RefKind>(&self, errs: &mut ParseErrors, var: ast::Var) -> Option<T> {
         let maybe_prim = self.as_inner();
         let prim = maybe_prim?;
         let r: Result<Option<T>, String> = match prim {
@@ -1661,10 +1669,10 @@ impl ASTNode<Option<cst::Primary>> {
         }
     }
 
-    pub(crate) fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    pub(crate) fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_expr_or_special(errs)?.into_expr(errs)
     }
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_prim) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let prim = maybe_prim?;
@@ -1676,7 +1684,7 @@ impl ASTNode<Option<cst::Primary>> {
             #[allow(clippy::manual_map)]
             cst::Primary::Name(n) => {
                 // if `n` isn't a var we don't want errors, we'll get them later
-                if let Some(v) = n.to_var(&mut Vec::new()) {
+                if let Some(v) = n.to_var(&mut ParseErrors::new()) {
                     Some(ExprOrSpecial::Var(v, src.clone()))
                 } else if let Some(n) = n.to_name(errs) {
                     Some(ExprOrSpecial::Name(n))
@@ -1709,7 +1717,7 @@ impl ASTNode<Option<cst::Primary>> {
 
     /// convert `cst::Primary` representing a string literal to a `SmolStr`.
     /// Fails (and adds to `errs`) if the `Primary` wasn't a string literal.
-    pub fn to_string_literal(&self, errs: Errs<'_>) -> Option<SmolStr> {
+    pub fn to_string_literal(&self, errs: &mut ParseErrors) -> Option<SmolStr> {
         let maybe_prim = self.as_inner();
         // return right away if there's no data, parse provided error
         let prim = maybe_prim?;
@@ -1727,7 +1735,7 @@ impl ASTNode<Option<cst::Primary>> {
 }
 
 impl ASTNode<Option<cst::Slot>> {
-    fn to_expr(&self, _errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, _errs: &mut ParseErrors) -> Option<ast::Expr> {
         let (src, s) = self.as_inner_pair();
         s.map(|s| {
             ast::ExprBuilder::new()
@@ -1742,7 +1750,7 @@ impl ASTNode<Option<cst::Slot>> {
 
 impl ASTNode<Option<cst::Name>> {
     /// Build type constraints
-    fn to_type_constraint(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_type_constraint(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         let (src, maybe_name) = self.as_inner_pair();
         match maybe_name {
             Some(_) => {
@@ -1755,7 +1763,7 @@ impl ASTNode<Option<cst::Name>> {
         }
     }
 
-    pub(crate) fn to_name(&self, errs: Errs<'_>) -> Option<ast::Name> {
+    pub(crate) fn to_name(&self, errs: &mut ParseErrors) -> Option<ast::Name> {
         let maybe_name = self.as_inner();
         // return right away if there's no data, parse provided error
         let name = maybe_name?;
@@ -1773,7 +1781,7 @@ impl ASTNode<Option<cst::Name>> {
             _ => None,
         }
     }
-    fn to_ident(&self, errs: Errs<'_>) -> Option<&cst::Ident> {
+    fn to_ident(&self, errs: &mut ParseErrors) -> Option<&cst::Ident> {
         let maybe_name = self.as_inner();
         // return right away if there's no data, parse provided error
         let name = maybe_name?;
@@ -1792,7 +1800,7 @@ impl ASTNode<Option<cst::Name>> {
 
         name.name.as_inner()
     }
-    fn to_var(&self, errs: Errs<'_>) -> Option<ast::Var> {
+    fn to_var(&self, errs: &mut ParseErrors) -> Option<ast::Var> {
         let name = self.to_ident(errs)?;
 
         match name {
@@ -1813,7 +1821,7 @@ impl ASTNode<Option<cst::Name>> {
 
 impl ast::Name {
     /// Convert the `Name` into a `String` attribute, which fails if it had any namespaces
-    fn into_valid_attr(self, errs: Errs<'_>) -> Option<SmolStr> {
+    fn into_valid_attr(self, errs: &mut ParseErrors) -> Option<SmolStr> {
         if !self.path.is_empty() {
             errs.push(err::ParseError::ToAST(
                 "A name with a path is not a valid attribute".to_string(),
@@ -1824,7 +1832,12 @@ impl ast::Name {
         }
     }
 
-    fn into_func(self, args: Vec<ast::Expr>, errs: Errs<'_>, l: SourceInfo) -> Option<ast::Expr> {
+    fn into_func(
+        self,
+        args: Vec<ast::Expr>,
+        errs: &mut ParseErrors,
+        l: SourceInfo,
+    ) -> Option<ast::Expr> {
         // error on standard methods
         if self.path.is_empty() {
             let id = self.id.as_ref();
@@ -1853,7 +1866,7 @@ impl ast::Name {
 
 impl ASTNode<Option<cst::Ref>> {
     /// convert `cst::Ref` to `ast::EntityUID`
-    pub fn to_ref(&self, errs: Errs<'_>) -> Option<ast::EntityUID> {
+    pub fn to_ref(&self, errs: &mut ParseErrors) -> Option<ast::EntityUID> {
         let maybe_ref = self.as_inner();
         // return right away if there's no data, parse provided error
         let refr = maybe_ref?;
@@ -1890,14 +1903,14 @@ impl ASTNode<Option<cst::Ref>> {
             }
         }
     }
-    fn to_expr(&self, errs: Errs<'_>) -> Option<ast::Expr> {
+    fn to_expr(&self, errs: &mut ParseErrors) -> Option<ast::Expr> {
         self.to_ref(errs)
             .map(|euid| construct_expr_ref(euid, self.info.clone()))
     }
 }
 
 impl ASTNode<Option<cst::Literal>> {
-    fn to_expr_or_special(&self, errs: Errs<'_>) -> Option<ExprOrSpecial<'_>> {
+    fn to_expr_or_special(&self, errs: &mut ParseErrors) -> Option<ExprOrSpecial<'_>> {
         let (src, maybe_lit) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let lit = maybe_lit?;
@@ -1923,7 +1936,7 @@ impl ASTNode<Option<cst::Literal>> {
 }
 
 impl ASTNode<Option<cst::RecInit>> {
-    fn to_init(&self, errs: Errs<'_>) -> Option<(SmolStr, ast::Expr)> {
+    fn to_init(&self, errs: &mut ParseErrors) -> Option<(SmolStr, ast::Expr)> {
         let (_src, maybe_lit) = self.as_inner_pair();
         // return right away if there's no data, parse provided error
         let lit = maybe_lit?;
@@ -2145,7 +2158,7 @@ mod tests {
 
     #[test]
     fn show_expr1() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             if 7 then 6 > 5 else !5 || "thursday" && ((8) >= "fish")
@@ -2161,7 +2174,7 @@ mod tests {
 
     #[test]
     fn show_expr2() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             [2,3,4].foo["hello"]
@@ -2177,7 +2190,7 @@ mod tests {
     #[test]
     fn show_expr3() {
         // these exprs are ill-typed, but are allowed by the parser
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr = text_to_cst::parse_expr(
             r#"
             "first".some_ident
@@ -2226,7 +2239,7 @@ mod tests {
 
     #[test]
     fn show_expr4() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             {"one":1,"two":2} has one
@@ -2246,7 +2259,7 @@ mod tests {
 
     #[test]
     fn show_expr5() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr = text_to_cst::parse_expr(
             r#"
             {"one":1,"two":2}.one
@@ -2281,7 +2294,7 @@ mod tests {
         }
 
         // accessing a record with a non-identifier attribute
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             {"this is a valid map key+.-_%()":1,"two":2}["this is a valid map key+.-_%()"]
@@ -2301,7 +2314,7 @@ mod tests {
 
     #[test]
     fn show_expr6_idents() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr = text_to_cst::parse_expr(
             r#"
             {if true then a else b:"b"} ||
@@ -2352,7 +2365,7 @@ mod tests {
 
     #[test]
     fn reserved_idents1() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_expr(
             r#"
             The::true::path::to::"enlightenment".false
@@ -2366,7 +2379,7 @@ mod tests {
         assert!(errs.len() == 2);
         assert!(convert.is_none());
 
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_expr(
             r#"
             if {if: true}.if then {"if":false}["if"] else {when:true}.permit
@@ -2383,7 +2396,7 @@ mod tests {
 
     #[test]
     fn reserved_idents2() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_expr(
             r#"
             if {where: true}.like || {has:false}.in then {"like":false}["in"] else {then:true}.else
@@ -2400,7 +2413,7 @@ mod tests {
 
     #[test]
     fn show_policy1() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             permit(principal:p,action:a,resource:r)when{w}unless{u}advice{"doit"};
@@ -2419,7 +2432,7 @@ mod tests {
 
     #[test]
     fn show_policy2() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             permit(principal,action,resource)when{true};
@@ -2436,7 +2449,7 @@ mod tests {
 
     #[test]
     fn show_policy3() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             permit(principal in User::"jane",action,resource);
@@ -2455,7 +2468,7 @@ mod tests {
 
     #[test]
     fn show_policy4() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             forbid(principal in User::"jane",action,resource)unless{
@@ -2475,7 +2488,7 @@ mod tests {
     #[test]
     fn policy_annotations() {
         // common use-case
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let policy = text_to_cst::parse_policy(
             r#"
             @anno("good annotation")permit(principal,action,resource);
@@ -2490,7 +2503,7 @@ mod tests {
         );
 
         // duplication is error
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let policy = text_to_cst::parse_policy(
             r#"
             @anno("good annotation")
@@ -2506,7 +2519,7 @@ mod tests {
         assert!(errs.len() == 1);
 
         // can have multiple annotations
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let policyset = text_to_cst::parse_policies(
             r#"
             @anno1("first")
@@ -2577,7 +2590,7 @@ mod tests {
 
     #[test]
     fn fail_head1() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             permit(
@@ -2597,7 +2610,7 @@ mod tests {
 
     #[test]
     fn fail_head2() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             permit(
@@ -2617,7 +2630,7 @@ mod tests {
 
     #[test]
     fn fail_head3() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let parse = text_to_cst::parse_policy(
             r#"
             permit(principal,action,resource,context);
@@ -2631,7 +2644,7 @@ mod tests {
 
     #[test]
     fn method_call2() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
                 principal.contains(resource)
@@ -2661,7 +2674,7 @@ mod tests {
 
     #[test]
     fn construct_record1() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
                 {one:"one"}
@@ -2750,7 +2763,7 @@ mod tests {
 
     #[test]
     fn construct_invalid_get() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
             {"one":1, "two":"two"}[0]
@@ -2799,7 +2812,7 @@ mod tests {
 
     #[test]
     fn construct_has() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             {"one":1,"two":2} has "arbitrary+ _string"
@@ -2816,7 +2829,7 @@ mod tests {
             _ => panic!("should be a has expr"),
         }
 
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
             {"one":1,"two":2} has 1
@@ -2832,7 +2845,7 @@ mod tests {
 
     #[test]
     fn construct_like() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             "354 hams" like "*5*"
@@ -2860,7 +2873,7 @@ mod tests {
         assert!(e.is_none());
         assert!(errs.len() == 1);
 
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             "string\\with\\backslashes" like "string\\with\\backslashes"
@@ -2918,7 +2931,7 @@ mod tests {
             _ => panic!("should be a like expr"),
         }
 
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             "string\\*with\\*backslashes\\*and\\*stars" like "string\\\*with\\\*backslashes\\\*and\\\*stars"
@@ -2987,7 +3000,7 @@ mod tests {
         // entities can be accessed using the same notation as records
 
         // ok
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             User::"jane" has age
@@ -3004,7 +3017,7 @@ mod tests {
         }
 
         // ok
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             User::"jane" has "arbitrary+ _string"
@@ -3021,7 +3034,7 @@ mod tests {
         }
 
         // not ok: 1 is not a valid attribute
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
             User::"jane" has 1
@@ -3033,7 +3046,7 @@ mod tests {
         assert!(errs.len() == 1);
 
         // ok
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             User::"jane".age
@@ -3050,7 +3063,7 @@ mod tests {
         }
 
         // ok
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let expr: ast::Expr = text_to_cst::parse_expr(
             r#"
             User::"jane"["arbitrary+ _string"]
@@ -3067,7 +3080,7 @@ mod tests {
         }
 
         // not ok: age is not a string literal
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
             User::"jane"[age]
@@ -3081,7 +3094,7 @@ mod tests {
 
     #[test]
     fn relational_ops1() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(
             r#"
                 3 >= 2 >= 1
@@ -3129,7 +3142,7 @@ mod tests {
 
     #[test]
     fn arithmetic() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_expr(r#" 2 + 4 "#)
             // the cst should be acceptable
             .expect("parse error")
@@ -3242,7 +3255,7 @@ mod tests {
     #[test]
     fn template_tests() {
         for src in CORRECT_TEMPLATES {
-            let mut errs = Vec::new();
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_policy(src)
                 .expect("parse_error")
                 .to_policy_template(ast::PolicyID::from_string("i0"), &mut errs);
@@ -3274,7 +3287,7 @@ mod tests {
     #[test]
     fn test_wrong_template_var() {
         for src in WRONG_VAR_TEMPLATES {
-            let mut errs = vec![];
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_policy(src)
                 .expect("Parse Error")
                 .to_policy_template(ast::PolicyID::from_string("id0"), &mut errs);
@@ -3284,7 +3297,7 @@ mod tests {
 
     #[test]
     fn var_type() {
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         let e = text_to_cst::parse_policy(
             r#"
                 permit(principal,action,resource);
@@ -3460,7 +3473,7 @@ mod tests {
                 Expr::mul(Expr::mul(Expr::var(ast::Var::Principal), 0), -1),
             ),
         ] {
-            let mut errs = Vec::new();
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_expr(es)
                 .expect("should construct a CST")
                 .to_expr(&mut errs)
@@ -3481,7 +3494,7 @@ mod tests {
             // considered as a constant.
             "principal * --1",
         ] {
-            let mut errs = Vec::new();
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_expr(es)
                 .expect("should construct a CST")
                 .to_expr(&mut errs);
@@ -3528,7 +3541,7 @@ mod tests {
                 ),
             ),
         ] {
-            let mut errs = Vec::new();
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_expr(es)
                 .expect("should construct a CST")
                 .to_expr(&mut errs)
@@ -3565,7 +3578,7 @@ mod tests {
                 Expr::neg(Expr::val(9223372036854775807)),
             ),
         ] {
-            let mut errs = Vec::new();
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_expr(es)
                 .expect("should construct a CST")
                 .to_expr(&mut errs)
@@ -3588,12 +3601,12 @@ mod tests {
                 "Literal 9223372036854775808 is too large",
             ),
         ] {
-            let mut errs = Vec::new();
+            let mut errs = ParseErrors::new();
             let e = text_to_cst::parse_expr(es)
                 .expect("should construct a CST")
                 .to_expr(&mut errs);
             assert!(e.is_none());
-            assert!(ParseErrors(errs).to_string().contains(em));
+            assert!(errs.to_string().contains(em));
         }
     }
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -14,51 +14,58 @@
  * limitations under the License.
  */
 
+use std::fmt::{self, Display, Write};
+use std::iter;
+
 use lalrpop_util as lalr;
+use miette::{Diagnostic, LabeledSpan, Severity, SourceCode};
+use phf::phf_map;
 use thiserror::Error;
 
-pub(crate) type RawParseError<'a> = lalr::ParseError<usize, lalr::lexer::Token<'a>, String>;
-pub(crate) type RawErrorRecovery<'a> = lalr::ErrorRecovery<usize, lalr::lexer::Token<'a>, String>;
+use crate::parser::fmt::join_with_conjunction;
+
+pub(crate) type RawLocation = usize;
+pub(crate) type RawToken<'a> = lalr::lexer::Token<'a>;
+pub(crate) type RawUserError = String;
+
+pub(crate) type RawParseError<'a> = lalr::ParseError<RawLocation, RawToken<'a>, RawUserError>;
+pub(crate) type RawErrorRecovery<'a> = lalr::ErrorRecovery<RawLocation, RawToken<'a>, String>;
+
+type OwnedRawParseError = lalr::ParseError<RawLocation, String, RawUserError>;
 
 /// For errors during parsing
-#[derive(Debug, Error, PartialEq, Clone)]
+#[derive(Clone, Debug, Diagnostic, Error, PartialEq)]
 pub enum ParseError {
-    /// Error from the lalrpop parser, no additional information
-    #[error("{0}")]
-    ToCST(String),
-    /// Error in the cst -> ast transform, mostly well-formedness issues
+    /// Error from the CST parser
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ToCST(#[from] ToCSTError),
+    /// Error in the CST -> AST transform, mostly well-formedness issues
     #[error("poorly formed: {0}")]
+    #[diagnostic(code(cedar_policy_core::parser::to_ast_error))]
     ToAST(String),
     /// (Potentially) multiple errors. This variant includes a "context" for
     /// what we were trying to do when we encountered these errors
-    #[error("error while {context}: {}", MultipleParseErrors(errs))]
+    #[error("error while {context}")]
     WithContext {
         /// What we were trying to do
         context: String,
         /// Error(s) we encountered while doing it
-        errs: Vec<ParseError>,
+        #[source]
+        #[diagnostic_source]
+        errs: ParseErrors,
     },
     /// Error concerning restricted expressions
     #[error(transparent)]
     RestrictedExpressionError(#[from] crate::ast::RestrictedExpressionError),
 }
 
-impl ParseError {
-    pub(crate) fn from_raw(e: RawParseError<'_>) -> Self {
-        ParseError::ToCST(format!("{}", e))
-    }
-
-    pub(crate) fn from_recovery(e: RawErrorRecovery<'_>) -> Self {
-        ParseError::from_raw(e.error)
-    }
-}
-
-/// if you wrap a `Vec<ParseError>` in this struct, it gains a Display impl
-/// that displays each parse error on its own line, indented.
-#[derive(Debug, Error)]
+/// Multiple related parse errors.
+#[derive(Clone, Debug, Error, PartialEq)]
 pub struct ParseErrors(pub Vec<ParseError>);
 
 impl ParseErrors {
+    // TODO(spinda): Can we get rid of this?
     /// returns a Vec with stringified versions of the ParserErrors
     pub fn errors_as_strings(&self) -> Vec<String> {
         self.0
@@ -68,31 +75,197 @@ impl ParseErrors {
     }
 }
 
-impl std::fmt::Display for ParseErrors {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", MultipleParseErrors(&self.0))
+impl Display for ParseErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.0[..] {
+            [err] => Display::fmt(err, f),
+            _ => write!(f, "multiple parse errors"),
+        }
+    }
+}
+
+// If `ParseErrors` contains only a single parse error, forward everything
+// through transparently.
+impl Diagnostic for ParseErrors {
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        match &self.0[..] {
+            [err] => err.related(),
+            _ => Some(Box::new(self.0.iter().map(|err| err as &dyn Diagnostic))),
+        }
+    }
+
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match &self.0[..] {
+            [err] => err.code(),
+            _ => None,
+        }
+    }
+
+    fn severity(&self) -> Option<Severity> {
+        match &self.0[..] {
+            [err] => err.severity(),
+            _ => None,
+        }
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match &self.0[..] {
+            [err] => err.help(),
+            _ => None,
+        }
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        match &self.0[..] {
+            [err] => err.url(),
+            _ => None,
+        }
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        match &self.0[..] {
+            [err] => err.source_code(),
+            _ => None,
+        }
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        match &self.0[..] {
+            [err] => err.labels(),
+            _ => None,
+        }
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        match &self.0[..] {
+            [err] => err.diagnostic_source(),
+            _ => None,
+        }
     }
 }
 
 impl From<ParseError> for ParseErrors {
-    fn from(e: ParseError) -> ParseErrors {
-        ParseErrors(vec![e])
+    fn from(err: ParseError) -> Self {
+        vec![err].into()
     }
 }
 
-/// Like [`ParseErrors`], but you don't have to own the `Vec`
-#[derive(Debug, Error)]
-pub struct MultipleParseErrors<'a>(pub &'a [ParseError]);
+impl From<Vec<ParseError>> for ParseErrors {
+    fn from(errs: Vec<ParseError>) -> Self {
+        ParseErrors(errs)
+    }
+}
 
-impl<'a> std::fmt::Display for MultipleParseErrors<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0.is_empty() {
-            write!(f, "no errors found")
-        } else {
-            for err in self.0 {
-                write!(f, "\n  {}", err)?;
-            }
-            Ok(())
+impl FromIterator<ParseError> for ParseErrors {
+    fn from_iter<T: IntoIterator<Item = ParseError>>(errs: T) -> Self {
+        ParseErrors(errs.into_iter().collect())
+    }
+}
+
+/// Error from the CST parser.
+#[derive(Clone, Debug, Error, PartialEq)]
+pub struct ToCSTError {
+    err: OwnedRawParseError,
+}
+
+impl ToCSTError {
+    pub(crate) fn from_raw(err: RawParseError<'_>) -> Self {
+        ToCSTError {
+            err: err.map_token(|token| token.to_string()),
         }
     }
+
+    pub(crate) fn from_recovery(recovery: RawErrorRecovery<'_>) -> Self {
+        ToCSTError::from_raw(recovery.error)
+    }
+}
+
+impl Display for ToCSTError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.err {
+            OwnedRawParseError::InvalidToken { .. } => write!(f, "invalid token"),
+            OwnedRawParseError::UnrecognizedEOF { .. } => write!(f, "unexpected end of input"),
+            OwnedRawParseError::UnrecognizedToken {
+                token: (_, token, _),
+                ..
+            } => write!(f, "unexpected token `{token}`"),
+            OwnedRawParseError::ExtraToken {
+                token: (_, token, _),
+                ..
+            } => write!(f, "extra token `{token}`"),
+            OwnedRawParseError::User { error } => write!(f, "{error}"),
+        }
+    }
+}
+
+impl Diagnostic for ToCSTError {
+    fn code(&self) -> Option<Box<dyn Display + '_>> {
+        Some(Box::new("cedar_policy_core::parser::to_cst_error"))
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        let labeled_span = match &self.err {
+            OwnedRawParseError::InvalidToken { location } => {
+                LabeledSpan::underline(*location..*location)
+            }
+            OwnedRawParseError::UnrecognizedEOF { location, expected } => {
+                LabeledSpan::new_with_span(expected_to_string(expected), *location..*location)
+            }
+            OwnedRawParseError::UnrecognizedToken {
+                token: (token_start, _, token_end),
+                expected,
+            } => LabeledSpan::new_with_span(expected_to_string(expected), *token_start..*token_end),
+            OwnedRawParseError::ExtraToken {
+                token: (token_start, _, token_end),
+            } => LabeledSpan::underline(*token_start..*token_end),
+            // TODO(spinda): Convert user-error type into something with location information.
+            OwnedRawParseError::User { .. } => return None,
+        };
+        Some(Box::new(iter::once(labeled_span)))
+    }
+}
+
+// Keys mirror the token names defined in the `match` block of grammar.lalrpop.
+static FRIENDLY_TOKEN_NAMES: phf::Map<&'static str, &'static str> = phf_map! {
+    "TRUE" => "`true`",
+    "FALSE" => "`false`",
+    "IF" => "`if`",
+
+    "PERMIT" => "`permit`",
+    "FORBID" => "`forbid`",
+    "WHEN" => "`when`",
+    "UNLESS" => "`unless`",
+    "IN" => "`in`",
+    "HAS" => "`has`",
+    "LIKE" => "`like`",
+    "THEN" => "`then`",
+    "ELSE" => "`else`",
+
+    "PRINCIPAL" => "`principal`",
+    "ACTION" => "`action`",
+    "RESOURCE" => "`resource`",
+    "CONTEXT" => "`context`",
+
+    "PRINCIPAL_SLOT" => "`?principal`",
+    "RESOURCE_SLOT" => "`?resource`",
+
+    "IDENTIFIER" => "identifier",
+    "NUMBER" => "number",
+    "STRINGLIT" => "string literal",
+};
+
+fn expected_to_string(expected: &[String]) -> Option<String> {
+    if expected.is_empty() {
+        return None;
+    }
+
+    let mut expected_string = "expected ".to_owned();
+    join_with_conjunction(&mut expected_string, "or", expected, |f, token| {
+        match FRIENDLY_TOKEN_NAMES.get(token.as_str()) {
+            Some(friendly_token_name) => write!(f, "{}", friendly_token_name),
+            None => write!(f, "{}", token.replace("\"", "`")),
+        }
+    })
+    .expect("failed to format expected tokens");
+    Some(expected_string)
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -15,8 +15,10 @@
  */
 
 use lalrpop_util as lalr;
-use std::fmt::Display;
 use thiserror::Error;
+
+pub(crate) type RawParseError<'a> = lalr::ParseError<usize, lalr::lexer::Token<'a>, String>;
+pub(crate) type RawErrorRecovery<'a> = lalr::ErrorRecovery<usize, lalr::lexer::Token<'a>, String>;
 
 /// For errors during parsing
 #[derive(Debug, Error, PartialEq, Clone)]
@@ -41,15 +43,13 @@ pub enum ParseError {
     RestrictedExpressionError(#[from] crate::ast::RestrictedExpressionError),
 }
 
-impl<L: Display, T: Display, E: Display> From<lalr::ParseError<L, T, E>> for ParseError {
-    fn from(e: lalr::ParseError<L, T, E>) -> Self {
+impl ParseError {
+    pub(crate) fn from_raw(e: RawParseError<'_>) -> Self {
         ParseError::ToCST(format!("{}", e))
     }
-}
 
-impl<L: Display, T: Display, E: Display> From<lalr::ErrorRecovery<L, T, E>> for ParseError {
-    fn from(e: lalr::ErrorRecovery<L, T, E>) -> Self {
-        e.error.into()
+    pub(crate) fn from_recovery(e: RawErrorRecovery<'_>) -> Self {
+        ParseError::from_raw(e.error)
     }
 }
 

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -14,14 +14,15 @@
  * limitations under the License.
  */
 
+use std::collections::HashMap;
 use std::error::Error;
 use std::fmt::{self, Display, Write};
 use std::iter;
 use std::ops::{Deref, DerefMut};
 
 use lalrpop_util as lalr;
+use lazy_static::lazy_static;
 use miette::{Diagnostic, LabeledSpan, Severity, SourceCode};
-use phf::phf_map;
 use thiserror::Error;
 
 use crate::ast::RestrictedExpressionError;
@@ -315,34 +316,33 @@ impl Diagnostic for ToCSTError {
     }
 }
 
-// Keys mirror the token names defined in the `match` block of grammar.lalrpop.
-static FRIENDLY_TOKEN_NAMES: phf::Map<&'static str, &'static str> = phf_map! {
-    "TRUE" => "`true`",
-    "FALSE" => "`false`",
-    "IF" => "`if`",
-
-    "PERMIT" => "`permit`",
-    "FORBID" => "`forbid`",
-    "WHEN" => "`when`",
-    "UNLESS" => "`unless`",
-    "IN" => "`in`",
-    "HAS" => "`has`",
-    "LIKE" => "`like`",
-    "THEN" => "`then`",
-    "ELSE" => "`else`",
-
-    "PRINCIPAL" => "`principal`",
-    "ACTION" => "`action`",
-    "RESOURCE" => "`resource`",
-    "CONTEXT" => "`context`",
-
-    "PRINCIPAL_SLOT" => "`?principal`",
-    "RESOURCE_SLOT" => "`?resource`",
-
-    "IDENTIFIER" => "identifier",
-    "NUMBER" => "number",
-    "STRINGLIT" => "string literal",
-};
+lazy_static! {
+    /// Keys mirror the token names defined in the `match` block of
+    /// `grammar.lalrpop`.
+    static ref FRIENDLY_TOKEN_NAMES: HashMap<&'static str, &'static str> = HashMap::from([
+        ("TRUE", "`true`"),
+        ("FALSE", "`false`"),
+        ("IF", "`if`"),
+        ("PERMIT", "`permit`"),
+        ("FORBID", "`forbid`"),
+        ("WHEN", "`when`"),
+        ("UNLESS", "`unless`"),
+        ("IN", "`in`"),
+        ("HAS", "`has`"),
+        ("LIKE", "`like`"),
+        ("THEN", "`then`"),
+        ("ELSE", "`else`"),
+        ("PRINCIPAL", "`principal`"),
+        ("ACTION", "`action`"),
+        ("RESOURCE", "`resource`"),
+        ("CONTEXT", "`context`"),
+        ("PRINCIPAL_SLOT", "`?principal`"),
+        ("RESOURCE_SLOT", "`?resource`"),
+        ("IDENTIFIER", "identifier"),
+        ("NUMBER", "number"),
+        ("STRINGLIT", "string literal"),
+    ]);
+}
 
 fn expected_to_string(expected: &[String]) -> Option<String> {
     if expected.is_empty() {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -242,7 +242,7 @@ impl<'a> IntoIterator for &'a ParseErrors {
     type IntoIter = std::slice::Iter<'a, ParseError>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&self.0).into_iter()
+        self.0.iter()
     }
 }
 
@@ -251,7 +251,7 @@ impl<'a> IntoIterator for &'a mut ParseErrors {
     type IntoIter = std::slice::IterMut<'a, ParseError>;
 
     fn into_iter(self) -> Self::IntoIter {
-        (&mut self.0).into_iter()
+        self.0.iter_mut()
     }
 }
 
@@ -352,10 +352,12 @@ fn expected_to_string(expected: &[String]) -> Option<String> {
     }
 
     let mut expected_string = "expected ".to_owned();
+    // PANIC SAFETY Shouldn't be `Err` since we're writing strings to a string
+    #[allow(clippy::expect_used)]
     join_with_conjunction(&mut expected_string, "or", expected, |f, token| {
         match FRIENDLY_TOKEN_NAMES.get(token.as_str()) {
             Some(friendly_token_name) => write!(f, "{}", friendly_token_name),
-            None => write!(f, "{}", token.replace("\"", "`")),
+            None => write!(f, "{}", token.replace('"', "`")),
         }
     })
     .expect("failed to format expected tokens");

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -428,7 +428,7 @@ impl std::fmt::Display for Slot {
     }
 }
 
-pub fn join_with_conjunction<T, W: Write>(
+pub(crate) fn join_with_conjunction<T, W: Write>(
     f: &mut W,
     conjunction: &str,
     items: impl IntoIterator<Item = T>,

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -428,6 +428,8 @@ impl std::fmt::Display for Slot {
     }
 }
 
+/// Format an iterator as a natural-language string, separating items with
+/// commas and a conjunction (e.g., "and", "or") between the last two items.
 pub(crate) fn join_with_conjunction<T, W: Write>(
     f: &mut W,
     conjunction: &str,

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -9,6 +9,7 @@ extern {
     type Error = String;
 }
 
+// New tokens should be reflected in the `FRIENDLY_TOKEN_NAMES` map in err.rs.
 match {
     // Whitespace and comments
     r"\s*" => { }, // The default whitespace skipping is disabled an `ignore pattern` is specified
@@ -55,15 +56,6 @@ match {
     "||", "&&",
     "+", "-", "*", "/", "%",
     "!",
-
-
-} else {
-    // this will catch anything that is not above.
-    // This means that all tokens are allowed, so
-    // We never get the error of an unknown token.
-    // The other errors (i.e. UnrecognizedToken) are
-    // better.
-    r".",
 }
 
 Comma<E>: Vec<E> = {

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -1,12 +1,15 @@
 use std::str::FromStr;
-use crate::parser::*;
-use crate::parser::node::ASTNode as Node;
+
 use lalrpop_util::{ParseError, ErrorRecovery};
 
-grammar<'err>(errors: &'err mut Vec<ErrorRecovery<usize, Token<'input>, String>>);
+use crate::parser::*;
+use crate::parser::err::{RawErrorRecovery, RawUserError};
+use crate::parser::node::ASTNode as Node;
+
+grammar<'err>(errors: &'err mut Vec<RawErrorRecovery<'input>>);
 
 extern {
-    type Error = String;
+    type Error = RawUserError;
 }
 
 // New tokens should be reflected in the `FRIENDLY_TOKEN_NAMES` map in err.rs.
@@ -348,7 +351,7 @@ Literal: Node<Option<cst::Literal>> = {
     <l:@L> <n:NUMBER> <r:@R> =>? match u64::from_str(n) {
         Ok(n) => Ok(Node::new(Some(cst::Literal::Num(n)),l,r)),
         Err(e) => Err(ParseError::User {
-            error: format!("Integer parse fail: {e}"),
+            error: ASTNode::new(format!("integer parse error: {e}"),l,r),
         }),
     },
     <l:@L> <s:Str> <r:@R>

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -14,28 +14,102 @@
  * limitations under the License.
  */
 
+use std::cmp::Ordering;
+use std::error::Error;
+use std::fmt::{self, Debug, Display};
+use std::hash::{Hash, Hasher};
+use std::ops::Range;
+
 use serde::{Deserialize, Serialize};
 
 /// Describes where in policy source code a node in the CST or expression AST
 /// occurs.
-#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
-pub struct SourceInfo(pub std::ops::Range<usize>);
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct SourceInfo(pub Range<usize>);
 
 impl SourceInfo {
-    /// Get the start of range.
-    pub fn range_start(&self) -> usize {
+    /// Construct a new [`SourceInfo`] from a start offset and a length, in
+    /// bytes.
+    pub const fn new(start: usize, len: usize) -> Self {
+        SourceInfo(start..(start + len))
+    }
+
+    /// Construct a new zero-length [`SourceInfo`] pointing to a specific
+    /// offset.
+    pub const fn from_offset(offset: usize) -> Self {
+        SourceInfo(offset..offset)
+    }
+
+    /// Get the start of range, in bytes.
+    pub const fn range_start(&self) -> usize {
         self.0.start
     }
 
-    /// Get the end of range.
-    pub fn range_end(&self) -> usize {
+    /// Get the end of range, in bytes.
+    pub const fn range_end(&self) -> usize {
         self.0.end
+    }
+
+    /// Get the length of the source range, in bytes.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the end of the range is before the start.
+    pub const fn len(&self) -> usize {
+        assert!(self.range_start() <= self.range_end());
+        self.range_end() - self.range_start()
+    }
+
+    /// Tests whether this [`SourceInfo`] range is a zero-length offset.
+    pub const fn is_offset(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Display for SourceInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_offset() {
+            write!(f, "{}", self.range_start())
+        } else {
+            write!(f, "[{}, {})", self.range_start(), self.range_end())
+        }
+    }
+}
+
+impl Ord for SourceInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.range_start()
+            .cmp(&other.range_start())
+            .then_with(|| self.len().cmp(&other.len()))
+    }
+}
+
+impl PartialOrd for SourceInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl From<usize> for SourceInfo {
+    fn from(offset: usize) -> Self {
+        SourceInfo::from_offset(offset)
+    }
+}
+
+impl From<Range<usize>> for SourceInfo {
+    fn from(range: Range<usize>) -> Self {
+        SourceInfo(range)
+    }
+}
+
+impl From<SourceInfo> for Range<usize> {
+    fn from(info: SourceInfo) -> Self {
+        info.0
     }
 }
 
 /// Metadata for our syntax trees
-// Note that these derives are likely to need explicit impls as we develop further
-#[derive(Debug, Clone)]
+#[derive(Clone, Deserialize, Serialize)]
 pub struct ASTNode<N> {
     /// Main data represented
     pub node: N,
@@ -47,16 +121,26 @@ pub struct ASTNode<N> {
 impl<N> ASTNode<N> {
     /// Create a new Node from main data
     pub fn new(node: N, left: usize, right: usize) -> Self {
-        let info = SourceInfo(left..right);
-        ASTNode { node, info }
+        ASTNode::from_source(left..right, node)
     }
 
     /// Create a new Node from main data
-    pub fn from_source(node: N, info: SourceInfo) -> Self {
-        ASTNode { node, info }
+    pub fn from_source(info: impl Into<SourceInfo>, node: N) -> Self {
+        ASTNode {
+            node,
+            info: info.into(),
+        }
     }
 
-    /// like Option.as_ref()
+    /// Transform the inner value while retaining the attached source info.
+    pub fn map<M>(self, f: impl FnOnce(N) -> M) -> ASTNode<M> {
+        ASTNode {
+            node: f(self.node),
+            info: self.info,
+        }
+    }
+
+    /// Converts from `&ASTNode<N>` to `ASTNode<&N>`.
     pub fn as_ref(&self) -> ASTNode<&N> {
         ASTNode {
             node: &self.node,
@@ -64,17 +148,60 @@ impl<N> ASTNode<N> {
         }
     }
 
-    /// map the main data, leaving the SourceInfo alone
-    pub fn map<D>(self, f: impl FnOnce(N) -> D) -> ASTNode<D> {
+    /// Converts from `&mut ASTNode<N>` to `ASTNode<&mut N>`.
+    pub fn as_mut(&mut self) -> ASTNode<&mut N> {
         ASTNode {
-            node: f(self.node),
-            info: self.info,
+            node: &mut self.node,
+            info: self.info.clone(),
         }
     }
 
-    /// consume the Node, producing the main data and the SourceInfo
+    /// Consume the `ASTNode`, yielding the node and attached source info.
     pub fn into_inner(self) -> (N, SourceInfo) {
         (self.node, self.info)
+    }
+}
+
+impl<N: Clone> ASTNode<&N> {
+    /// Converts a `ASTNode<&N>` to a `ASTNode<N>` by cloning the inner value.
+    pub fn cloned(self) -> ASTNode<N> {
+        self.map(|value| value.clone())
+    }
+}
+
+impl<N: Copy> ASTNode<&N> {
+    /// Converts a `ASTNode<&N>` to a `ASTNode<N>` by copying the inner value.
+    pub fn copied(self) -> ASTNode<N> {
+        self.map(|value| *value)
+    }
+}
+
+impl<N: Debug> Debug for ASTNode<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.node, f)?;
+        write!(f, " @ {}", self.info)
+    }
+}
+
+impl<N: Display> Display for ASTNode<N> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.node, f)
+    }
+}
+
+impl<N: Error> Error for ASTNode<N> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.node.source()
+    }
+
+    fn description(&self) -> &str {
+        #[allow(deprecated)]
+        self.node.description()
+    }
+
+    fn cause(&self) -> Option<&dyn Error> {
+        #[allow(deprecated)]
+        self.node.cause()
     }
 }
 
@@ -86,21 +213,27 @@ impl<N: PartialEq> PartialEq for ASTNode<N> {
     }
 }
 impl<N: Eq> Eq for ASTNode<N> {}
+impl<N: Hash> Hash for ASTNode<N> {
+    /// ignores metadata
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.node.hash(state);
+    }
+}
 
-/// Convenience methods on `ASTNode<Option<T>>`
-impl<T> ASTNode<Option<T>> {
+/// Convenience methods on `ASTNode<Option<N>>`
+impl<N> ASTNode<Option<N>> {
     /// Similar to `.as_inner()`, but also gives access to the `SourceInfo`
-    pub fn as_inner_pair(&self) -> (&SourceInfo, Option<&T>) {
+    pub fn as_inner_pair(&self) -> (&SourceInfo, Option<&N>) {
         (&self.info, self.node.as_ref())
     }
 
-    /// Get the inner data as `&T`, if it exists
-    pub fn as_inner(&self) -> Option<&T> {
+    /// Get the inner data as `&N`, if it exists
+    pub fn as_inner(&self) -> Option<&N> {
         self.node.as_ref()
     }
 
     /// `None` if the node is empty, otherwise a node without the `Option`
-    pub fn collapse(&self) -> Option<ASTNode<&T>> {
+    pub fn collapse(&self) -> Option<ASTNode<&N>> {
         self.node.as_ref().map(|node| ASTNode {
             node,
             info: self.info.clone(),
@@ -111,7 +244,7 @@ impl<T> ASTNode<Option<T>> {
     /// if no main data or if `f` returns `None`.
     pub fn apply<F, R>(&self, f: F) -> Option<R>
     where
-        F: FnOnce(&T, &SourceInfo) -> Option<R>,
+        F: FnOnce(&N, &SourceInfo) -> Option<R>,
     {
         f(self.node.as_ref()?, &self.info)
     }
@@ -120,7 +253,7 @@ impl<T> ASTNode<Option<T>> {
     /// Returns `None` if no main data or if `f` returns `None`.
     pub fn into_apply<F, R>(self, f: F) -> Option<R>
     where
-        F: FnOnce(T, SourceInfo) -> Option<R>,
+        F: FnOnce(N, SourceInfo) -> Option<R>,
     {
         f(self.node?, self.info)
     }

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -61,14 +61,14 @@ impl SourceInfo {
     }
 
     /// Tests whether this [`SourceInfo`] range is a zero-length offset.
-    pub const fn is_offset(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         self.len() == 0
     }
 }
 
 impl Display for SourceInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.is_offset() {
+        if self.is_empty() {
             write!(f, "{}", self.range_start())
         } else {
             write!(f, "[{}, {})", self.range_start(), self.range_end())

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -20,6 +20,7 @@ use std::fmt::{self, Debug, Display};
 use std::hash::{Hash, Hasher};
 use std::ops::Range;
 
+use miette::{Diagnostic, LabeledSpan, Severity, SourceCode};
 use serde::{Deserialize, Serialize};
 
 /// Describes where in policy source code a node in the CST or expression AST
@@ -202,6 +203,40 @@ impl<N: Error> Error for ASTNode<N> {
     fn cause(&self) -> Option<&dyn Error> {
         #[allow(deprecated)]
         self.node.cause()
+    }
+}
+
+impl<N: Diagnostic> Diagnostic for ASTNode<N> {
+    fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.node.code()
+    }
+
+    fn severity(&self) -> Option<Severity> {
+        self.node.severity()
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.node.help()
+    }
+
+    fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.node.url()
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        self.node.source_code()
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.node.labels()
+    }
+
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        self.node.related()
+    }
+
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        self.node.diagnostic_source()
     }
 }
 

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -52,9 +52,9 @@ fn parse_collect_errors<'a, P, T>(
     // convert both parser error types to the local error type
     let mut errors: Vec<err::ParseError> = errs
         .into_iter()
-        .map(|recovery| err::ToCSTError::from_recovery(recovery).into())
+        .map(|recovery| err::ToCSTError::from_raw_err_recovery(recovery).into())
         .collect();
-    let result = result.map_err(|err| err::ToCSTError::from_raw(err).into());
+    let result = result.map_err(|err| err::ToCSTError::from_raw_parse_err(err).into());
 
     // decide to return errors or success
     match result {

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -52,9 +52,9 @@ fn parse_collect_errors<'a, P, T>(
     // convert both parser error types to the local error type
     let mut errors: Vec<err::ParseError> = errs
         .into_iter()
-        .map(err::ParseError::from_recovery)
+        .map(|recovery| err::ToCSTError::from_recovery(recovery).into())
         .collect();
-    let result = result.map_err(err::ParseError::from_raw);
+    let result = result.map_err(|err| err::ToCSTError::from_raw(err).into());
 
     // decide to return errors or success
     match result {

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -33,9 +33,9 @@ use lazy_static::lazy_static;
 
 use super::*;
 
-// This helper function calls a generated parser, collects errors that could be
-// generated multiple ways, and returns a single Result where the error type is
-// `err::ParseError`.
+/// This helper function calls a generated parser, collects errors that could be
+/// generated multiple ways, and returns a single Result where the error type is
+/// [`err::ParseErrors`].
 fn parse_collect_errors<'a, P, T>(
     parser: &P,
     parse: impl FnOnce(

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -89,7 +89,10 @@ impl std::fmt::Display for UnescapeError {
 mod test {
     use super::to_unescaped_string;
     use crate::ast;
-    use crate::parser::{err::ParseError, text_to_cst};
+    use crate::parser::{
+        err::{ParseError, ParseErrors},
+        text_to_cst,
+    };
 
     #[test]
     fn test_string_escape() {
@@ -125,7 +128,7 @@ mod test {
     #[test]
     fn test_pattern_escape() {
         // valid ASCII escapes
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         assert!(
             matches!(text_to_cst::parse_expr(r#""aa" like "\t\r\n\\\0\x42\*""#)
             .expect("failed parsing")
@@ -141,7 +144,7 @@ mod test {
         );
 
         // invalid ASCII escapes
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         assert!(text_to_cst::parse_expr(r#""abc" like "abc\xFF\xFEdef""#)
             .expect("failed parsing")
             .to_expr(&mut errs)
@@ -152,7 +155,7 @@ mod test {
         ));
 
         // valid `\*` surrounded by chars
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         assert!(
             matches!(text_to_cst::parse_expr(r#""aaa" like "👀👀\*🤞🤞\*🤝""#)
             .expect("failed parsing")
@@ -162,7 +165,7 @@ mod test {
         );
 
         // invalid escapes
-        let mut errs = Vec::new();
+        let mut errs = ParseErrors::new();
         assert!(text_to_cst::parse_expr(r#""aaa" like "abc\d\bdef""#)
             .expect("failed parsing")
             .to_expr(&mut errs)

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/cedar-policy/cedar"
 [dependencies]
 cedar-policy-core = { version = "=2.3.0", path = "../cedar-policy-core" }
 pretty = "0.11"
-anyhow = "1.0"
 logos = "0.12.1"
 itertools = "0.10"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.8", features = ["unicode"] }
+miette = "5.9.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -16,4 +16,4 @@ logos = "0.12.1"
 itertools = "0.10"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.8", features = ["unicode"] }
-miette = "5.9.0"
+miette = { version = "5.9.0" }

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -62,10 +62,11 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
                 .non_head_constraints()
                 .eq_shape(p.non_head_constraints()))
         {
-            return Err(miette!(format!(
+            return Err(miette!(
                 "policies differ:\nformatted: {}\ninput: {}",
-                f_p, p
-            )));
+                f_p,
+                p
+            ));
         }
     }
     Ok(())

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -37,9 +37,7 @@ fn tree_to_pretty<T: Doc>(t: &T, context: &mut config::Context<'_>) -> String {
 }
 
 fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
-    let formatted_ast = parse_policyset(ps)
-        .map_err(ParseErrors)
-        .wrap_err("formatter produces invalid policies")?;
+    let formatted_ast = parse_policyset(ps).wrap_err("formatter produces invalid policies")?;
     let (formatted_policies, policies) = (
         formatted_ast.templates().collect::<Vec<&Template>>(),
         ast.templates().collect::<Vec<&Template>>(),
@@ -74,13 +72,11 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
 }
 
 pub fn policies_str_to_pretty(ps: &str, config: &Config) -> Result<String> {
-    let cst = parse_policies(ps)
-        .map_err(ParseErrors)
-        .wrap_err("cannot parse input policies to CSTs")?;
-    let mut errs = Vec::new();
+    let cst = parse_policies(ps).wrap_err("cannot parse input policies to CSTs")?;
+    let mut errs = ParseErrors::new();
     let ast = cst
         .to_policyset(&mut errs)
-        .ok_or(ParseErrors(errs))
+        .ok_or(errs)
         .wrap_err("cannot parse input policies to ASTs")?;
     let tokens = get_token_stream(ps);
     let end_comment_str = &ps[tokens.last().unwrap().span.end..];

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 
 use cedar_policy_core::{
     ast::{EntityUID, Name},
-    parser::err::ParseError,
+    parser::err::{ParseError, ParseErrors},
     transitive_closure,
 };
 use itertools::Itertools;
@@ -69,17 +69,17 @@ pub enum SchemaError {
     CycleInActionHierarchy,
     /// Parse errors occurring while parsing an entity type.
     #[error("Parse error in entity type: {}", Self::format_parse_errs(.0))]
-    EntityTypeParseError(Vec<ParseError>),
+    EntityTypeParseError(ParseErrors),
     /// Parse errors occurring while parsing a namespace identifier.
     #[error("Parse error in namespace identifier: {}", Self::format_parse_errs(.0))]
-    NamespaceParseError(Vec<ParseError>),
+    NamespaceParseError(ParseErrors),
     /// Parse errors occurring while parsing an extension type.
     #[error("Parse error in extension type: {}", Self::format_parse_errs(.0))]
-    ExtensionTypeParseError(Vec<ParseError>),
+    ExtensionTypeParseError(ParseErrors),
     /// Parse errors occurring while parsing the name of one of reusable
     /// declared types.
     #[error("Parse error in common type identifier: {}", Self::format_parse_errs(.0))]
-    CommonTypeParseError(Vec<ParseError>),
+    CommonTypeParseError(ParseErrors),
     /// The schema file included an entity type `Action` in the entity type
     /// list. The `Action` entity type is always implicitly declared, and it
     /// cannot currently have attributes or be in any groups, so there is no

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use cedar_policy_core::{
     ast::{Eid, Entity, EntityType, EntityUID, Id, Name, RestrictedExpr},
     entities::{Entities, JSONValue, TCComputation},
-    parser::err::ParseError,
+    parser::err::ParseErrors,
     transitive_closure::{compute_tc, TCNode},
     FromNormalizedStr,
 };
@@ -577,7 +577,7 @@ impl ValidatorNamespaceDef {
     pub(crate) fn parse_possibly_qualified_name_with_default_namespace(
         name_str: &SmolStr,
         default_namespace: Option<&Name>,
-    ) -> std::result::Result<Name, Vec<ParseError>> {
+    ) -> std::result::Result<Name, ParseErrors> {
         let name = Name::from_normalized_str(name_str)?;
 
         let qualified_name = if name.namespace_components().next().is_some() {
@@ -603,7 +603,7 @@ impl ValidatorNamespaceDef {
     fn parse_unqualified_name_with_namespace(
         type_name: impl AsRef<str>,
         namespace: Option<Name>,
-    ) -> std::result::Result<Name, Vec<ParseError>> {
+    ) -> std::result::Result<Name, ParseErrors> {
         let type_name = Id::from_normalized_str(type_name.as_ref())?;
         match namespace {
             Some(namespace) => Ok(Name::type_in_namespace(type_name, namespace)),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2509,7 +2509,7 @@ permit(principal ==  A :: B
 
         assert!(matches!(result, Err(ParseErrors(_))));
         let error = result.err().unwrap();
-        assert!(error.to_string().contains("Unrecognized token `'`"));
+        assert!(error.to_string().contains("invalid token"));
     }
 
     /// parsing an `EntityUid` from string

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -761,16 +761,14 @@ impl From<cedar_policy_validator::SchemaError> for SchemaError {
                 Self::CycleInActionHierarchy
             }
             cedar_policy_validator::SchemaError::EntityTypeParseError(e) => {
-                Self::EntityTypeParse(ParseErrors(e))
+                Self::EntityTypeParse(e)
             }
-            cedar_policy_validator::SchemaError::NamespaceParseError(e) => {
-                Self::NamespaceParse(ParseErrors(e))
-            }
+            cedar_policy_validator::SchemaError::NamespaceParseError(e) => Self::NamespaceParse(e),
             cedar_policy_validator::SchemaError::CommonTypeParseError(e) => {
-                Self::CommonTypeParseError(ParseErrors(e))
+                Self::CommonTypeParseError(e)
             }
             cedar_policy_validator::SchemaError::ExtensionTypeParseError(e) => {
-                Self::ExtensionTypeParse(ParseErrors(e))
+                Self::ExtensionTypeParse(e)
             }
             cedar_policy_validator::SchemaError::ActionEntityTypeDeclared => {
                 Self::ActionEntityTypeDeclared
@@ -1006,9 +1004,7 @@ impl FromStr for EntityTypeName {
     type Err = ParseErrors;
 
     fn from_str(namespace_type_str: &str) -> Result<Self, Self::Err> {
-        ast::Name::from_normalized_str(namespace_type_str)
-            .map(EntityTypeName)
-            .map_err(ParseErrors)
+        ast::Name::from_normalized_str(namespace_type_str).map(EntityTypeName)
     }
 }
 
@@ -1028,9 +1024,7 @@ impl FromStr for EntityNamespace {
     type Err = ParseErrors;
 
     fn from_str(namespace_str: &str) -> Result<Self, Self::Err> {
-        ast::Name::from_normalized_str(namespace_str)
-            .map(EntityNamespace)
-            .map_err(ParseErrors)
+        ast::Name::from_normalized_str(namespace_str).map(EntityNamespace)
     }
 }
 
@@ -1099,9 +1093,7 @@ impl FromStr for EntityUid {
     // You can't actually `#[deprecated]` a trait implementation or trait
     // method.
     fn from_str(uid_str: &str) -> Result<Self, Self::Err> {
-        ast::EntityUID::from_normalized_str(uid_str)
-            .map(EntityUid)
-            .map_err(ParseErrors)
+        ast::EntityUID::from_normalized_str(uid_str).map(EntityUid)
     }
 }
 
@@ -1388,7 +1380,7 @@ impl Template {
     /// If the `id` is None, the parser will use the default "policy0".
     /// The behavior around None may change in the future.
     pub fn parse(id: Option<String>, src: impl AsRef<str>) -> Result<Self, ParseErrors> {
-        let ast = parser::parse_policy_template(id, src.as_ref()).map_err(ParseErrors)?;
+        let ast = parser::parse_policy_template(id, src.as_ref())?;
         Ok(Self {
             ast,
             lossless: LosslessPolicy::policy_or_template_text(src.as_ref()),
@@ -1764,7 +1756,7 @@ impl Policy {
     /// If `id` is None, then "policy0" will be used.
     /// The behavior around None may change in the future.
     pub fn parse(id: Option<String>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {
-        let inline_ast = parser::parse_policy(id, policy_src.as_ref()).map_err(ParseErrors)?;
+        let inline_ast = parser::parse_policy(id, policy_src.as_ref())?;
         let (_, ast) = ast::Template::link_static_policy(inline_ast);
         Ok(Self {
             ast,
@@ -1947,9 +1939,7 @@ impl FromStr for Expression {
 
     /// create an Expression using Cedar syntax
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        ast::Expr::from_str(expression)
-            .map_err(ParseErrors)
-            .map(Expression)
+        ast::Expr::from_str(expression).map(Expression)
     }
 }
 
@@ -2006,9 +1996,7 @@ impl FromStr for RestrictedExpression {
 
     /// create a `RestrictedExpression` using Cedar syntax
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        ast::RestrictedExpr::from_str(expression)
-            .map_err(ParseErrors)
-            .map(RestrictedExpression)
+        ast::RestrictedExpr::from_str(expression).map(RestrictedExpression)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* #67

*Description of changes:*

This transforms parse errors from something that looks like this:

![image](https://github.com/cedar-policy/cedar/assets/7958605/d41a0711-4bd5-481e-8b9c-152e2ffbbf74)

into something that looks like this:

![image](https://github.com/cedar-policy/cedar/assets/7958605/bbd5ac88-b993-4497-a67b-c8823cd72bd0)

The pretty rendering is powered by the [`miette` crate](https://crates.io/crates/miette/5.1.0), which I've swapped in place of `anyhow`. I've also done a bit of `lalrpop` plumbing to make user-facing token names nice and track source locations for `ParseError::User` messages, made improvements to the underlying `ParseError`/`ParseErrors` types and parsing infrastructure, and added error message format options to the CLI.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*