### PR TITLE
Stricter versioning in 2.0.x

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-cli"
 edition = "2021"
 
-version = "2.0.3"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -12,8 +12,8 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy = { version = "2.0.2", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "2.0.1", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=2.0.5", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=2.0.5", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "cedar-policy-core"
 edition = "2021"
 build = "build.rs"
 
-version = "2.0.3"
+version = "2.0.4"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "cedar-policy-core"
 edition = "2021"
 build = "build.rs"
 
-version = "2.0.4"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1184,7 +1184,9 @@ impl TryFrom<cst::Member> for Expr {
                             Either::Right(expr) => Either::Right(Expr::get_attr(expr, i)),
                         };
                     }
-                    Some(_i) => unimplemented!("other idents?"),
+                    Some(_i) => {
+                        return Err(ParseError::ToAST("Invalid Identifier".to_string()).into())
+                    }
                     None => {
                         return Err(ParseError::ToAST("node should not be empty".to_string()).into())
                     }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -56,6 +56,9 @@ pub fn parse_policyset_to_ests_and_pset(
     let mut errs = Vec::new();
     let cst = text_to_cst::parse_policies(text).map_err(err::ParseErrors)?;
     let pset = cst.to_policyset(&mut errs);
+    if pset.is_none() {
+        return Err(err::ParseErrors(errs));
+    }
     let ests = cst
         .with_generated_policyids()
         .expect("shouldn't be None since parse_policies() didn't return Err")

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -106,11 +106,13 @@ pub fn parse_policy_template_to_est_and_ast(
         None => ast::PolicyID::from_string("policy0"),
     };
     let cst = text_to_cst::parse_policy(text).map_err(err::ParseErrors)?;
-    let ast = cst.to_policy_template(id, &mut errs);
+    let ast = cst
+        .to_policy_template(id, &mut errs)
+        .ok_or_else(|| err::ParseErrors(errs.clone()))?;
     let est = cst.node.map(TryInto::try_into).transpose()?;
-    match (errs.is_empty(), est, ast) {
-        (true, Some(est), Some(ast)) => Ok((est, ast)),
-        (_, _, _) => Err(err::ParseErrors(errs)),
+    match (errs.is_empty(), est) {
+        (true, Some(est)) => Ok((est, ast)),
+        (_, _) => Err(err::ParseErrors(errs)),
     }
 }
 
@@ -148,11 +150,14 @@ pub fn parse_policy_to_est_and_ast(
         None => ast::PolicyID::from_string("policy0"),
     };
     let cst = text_to_cst::parse_policy(text).map_err(err::ParseErrors)?;
-    let ast = cst.to_policy(id, &mut errs);
+    let ast = cst
+        .to_policy(id, &mut errs)
+        .ok_or_else(|| err::ParseErrors(errs.clone()))?;
+
     let est = cst.node.map(TryInto::try_into).transpose()?;
-    match (errs.is_empty(), est, ast) {
-        (true, Some(est), Some(ast)) => Ok((est, ast)),
-        (_, _, _) => Err(err::ParseErrors(errs)),
+    match (errs.is_empty(), est) {
+        (true, Some(est)) => Ok((est, ast)),
+        (_, _) => Err(err::ParseErrors(errs)),
     }
 }
 

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -19,7 +19,7 @@ use std::fmt::Display;
 use thiserror::Error;
 
 /// For errors during parsing
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Clone)]
 pub enum ParseError {
     /// Error from the lalrpop parser, no additional information
     #[error("{0}")]

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cedar-policy-formatter"
-version = "2.0.2"
+version = "2.0.5"
 edition = "2021"
 license-file = "../LICENSE"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=2.0.5", path = "../cedar-policy-core" }
 pretty = "0.11"
 anyhow = "1.0"
 logos = "0.12.1"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0.1", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "2.0.4", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-validator"
 edition = "2021"
 
-version = "2.0.2"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -12,7 +12,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0.4", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=2.0.5", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -12,7 +12,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0.1", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "2.0.4", path = "../cedar-policy-core" }
 cedar-policy-validator = { version = "2.0.1", path = "../cedar-policy-validator" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy"
 edition = "2021"
 
-version = "2.0.3"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -12,8 +12,8 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0.4", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "2.0.1", path = "../cedar-policy-validator" }
+cedar-policy-core = { version = "=2.0.5", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=2.0.5", path = "../cedar-policy-validator" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Description of changes
Enforces stricter versioning in our 2.0.x packages and moves all the packages to lockstep version numbering
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
