### PR TITLE
Updating versions and lockstep v2.0.x

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-cli"
 edition = "2021"
 
-version = "2.0.3"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -12,8 +12,8 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy = { version = "2.0.2", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "2.0.1", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=2.0.5", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=2.0.5", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cedar-policy-formatter"
-version = "2.0.2"
+version = "2.0.5"
 edition = "2021"
 license-file = "../LICENSE"
 license = "Apache-2.0"
@@ -11,7 +11,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=2.0.5", path = "../cedar-policy-core" }
 pretty = "0.11"
 anyhow = "1.0"
 logos = "0.12.1"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-validator"
 edition = "2021"
 
-version = "2.0.2"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -12,7 +12,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0.4", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=2.0.5", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy"
 edition = "2021"
 
-version = "2.0.3"
+version = "2.0.5"
 license-file = "../LICENSE"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -12,8 +12,8 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "2.0.4", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "2.0.1", path = "../cedar-policy-validator" }
+cedar-policy-core = { version = "=2.0.5", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=2.0.5", path = "../cedar-policy-validator" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Description of changes
Enforces stricter versioning and moves 2.0.x package versions into lockstep
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
