### PR TITLE
Fix record LUB that was Open when it could be Closed

### DIFF
--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -543,6 +543,14 @@ fn record_lub_has_typechecks() {
         Expr::from_str("(if 1 > 0 then (if 1 > 0 then {a: 1} else {}) else {}) has a").unwrap(),
         Type::primitive_boolean(),
     );
+    assert_typechecks_empty_schema(
+        Expr::from_str("(if 1 > 0 then {a: true} else {a: false}) has b").unwrap(),
+        Type::singleton_boolean(false),
+    );
+    assert_typechecks_empty_schema(
+        Expr::from_str("(if 1 > 0 then {a: true} else {a: false}) has a").unwrap(),
+        Type::singleton_boolean(true),
+    );
 
     // These cases are imprecise.
     assert_typechecks_empty_schema(


### PR DESCRIPTION
## Description of changes

The record LUB was incorrectly made Open even though the LUB attribtues keys match the input record attributes exactly. This happend only when the records were not in a subtype releation becuase at least one pair of corresponding attirbutes in the record were not in a subtype relation, but the pair of attributes did have a least upper bound. For example, `{a: true}` and `{a: false}`.



## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
