### PR TITLE
Lossless display for policies

### DIFF
--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -139,6 +139,18 @@ impl FromIterator<(SmolStr, CedarValueJson)> for JsonRecord {
     }
 }
 
+impl JsonRecord {
+    /// Iterate over the (k, v) pairs in the record
+    pub fn iter<'s>(&'s self) -> impl Iterator<Item = (&'s SmolStr, &'s CedarValueJson)> {
+        self.values.iter()
+    }
+
+    /// Get the number of attributes in the record
+    pub fn len(&self) -> usize {
+        self.values.len()
+    }
+}
+
 /// Structure expected by the `__entity` escape
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct TypeAndId {
@@ -184,9 +196,9 @@ impl TryFrom<TypeAndId> for EntityUID {
 pub struct FnAndArg {
     /// Extension constructor function
     #[serde(rename = "fn")]
-    ext_fn: SmolStr,
+    pub(crate) ext_fn: SmolStr,
     /// Argument to that constructor
-    arg: Box<CedarValueJson>,
+    pub(crate) arg: Box<CedarValueJson>,
 }
 
 impl CedarValueJson {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -293,6 +293,32 @@ impl From<ast::Expr> for Clause {
     }
 }
 
+impl std::fmt::Display for Policy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (k, v) in self.annotations.iter() {
+            writeln!(f, "@{k}(\"{}\") ", v.escape_debug())?;
+        }
+        write!(
+            f,
+            "{}({}, {}, {})",
+            self.effect, self.principal, self.action, self.resource
+        )?;
+        for condition in &self.conditions {
+            write!(f, " {condition}")?;
+        }
+        write!(f, ";")
+    }
+}
+
+impl std::fmt::Display for Clause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::When(expr) => write!(f, "when {{ {expr} }}"),
+            Self::Unless(expr) => write!(f, "unless {{ {expr} }}"),
+        }
+    }
+}
+
 // PANIC SAFETY: Unit Test Code
 #[allow(clippy::panic)]
 #[cfg(test)]

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1450,7 +1450,7 @@ fn display_cedarvaluejson(f: &mut std::fmt::Formatter<'_>, v: &CedarValueJson) -
                     write!(f, ".{ext_fn}()")?;
                     Ok(())
                 }
-                _ => {
+                Some(ast::CallStyle::FunctionStyle) | None => {
                     write!(f, "{ext_fn}(")?;
                     display_cedarvaluejson(f, &arg)?;
                     write!(f, ")")?;

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1622,9 +1622,9 @@ impl std::fmt::Display for ExprNoExt {
 impl std::fmt::Display for ExtFuncCall {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // PANIC SAFETY: safe due to INVARIANT on `ExtFuncCall`
-        #[allow(clippy::panic_used)]
+        #[allow(clippy::unreachable)]
         let Some((fn_name, args)) = self.call.iter().next() else {
-            panic!("invariant violated: empty ExtFuncCall")
+            unreachable!("invariant violated: empty ExtFuncCall")
         };
         // search for the name and callstyle
         let style = Extensions::all_available().all_funcs().find_map(|ext_fn| {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -18,14 +18,16 @@ use super::utils::unwrap_or_clone;
 use super::FromJsonError;
 use crate::ast;
 use crate::entities::{
-    CedarValueJson, EscapeKind, JsonDeserializationError, JsonDeserializationErrorContext,
-    TypeAndId,
+    CedarValueJson, EscapeKind, FnAndArg, JsonDeserializationError,
+    JsonDeserializationErrorContext, TypeAndId,
 };
+use crate::extensions::Extensions;
 use crate::parser::cst::{self, Ident};
 use crate::parser::err::{ParseError, ParseErrors, ToASTError};
 use crate::parser::unescape;
 use crate::parser::ASTNode;
 use either::Either;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::HashMap;
@@ -248,8 +250,9 @@ pub struct ExtFuncCall {
     /// For example, for `a.isInRange(b)`, the first argument is `a` and the
     /// second argument is `b`.
     ///
-    /// This map should only ever have one k-v pair, but we make it a map in
-    /// order to get the correct JSON structure we want.
+    /// INVARIANT: This map should always have exactly one k-v pair (not more or
+    /// less), but we make it a map in order to get the correct JSON structure
+    /// we want.
     #[serde(flatten)]
     call: HashMap<SmolStr, Vec<Expr>>,
 }
@@ -1403,5 +1406,293 @@ mod test {
                 }
             }
         }
+    }
+}
+
+impl std::fmt::Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ExprNoExt(e) => write!(f, "{e}"),
+            Self::ExtFuncCall(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+fn display_cedarvaluejson(f: &mut std::fmt::Formatter<'_>, v: &CedarValueJson) -> std::fmt::Result {
+    match v {
+        // Add parentheses around negative numeric literals otherwise
+        // round-tripping fuzzer fails for expressions like `(-1)["a"]`.
+        CedarValueJson::Long(n) if *n < 0 => write!(f, "({n})"),
+        CedarValueJson::Long(n) => write!(f, "{n}"),
+        CedarValueJson::Bool(b) => write!(f, "{b}"),
+        CedarValueJson::String(s) => write!(f, "\"{}\"", s.escape_debug()),
+        CedarValueJson::EntityEscape { __entity } => {
+            match ast::EntityUID::try_from(__entity.clone()) {
+                Ok(euid) => write!(f, "{euid}"),
+                Err(e) => write!(f, "(invalid entity uid: {})", e),
+            }
+        }
+        CedarValueJson::ExprEscape { __expr } => write!(f, "({__expr})"),
+        CedarValueJson::ExtnEscape {
+            __extn: FnAndArg { ext_fn, arg },
+        } => {
+            // search for the name and callstyle
+            let style = Extensions::all_available().all_funcs().find_map(|f| {
+                if &f.name().to_string() == ext_fn {
+                    Some(f.style())
+                } else {
+                    None
+                }
+            });
+            match style {
+                Some(ast::CallStyle::MethodStyle) => {
+                    display_cedarvaluejson(f, &arg)?;
+                    write!(f, ".{ext_fn}()")?;
+                    Ok(())
+                }
+                _ => {
+                    write!(f, "{ext_fn}(")?;
+                    display_cedarvaluejson(f, &arg)?;
+                    write!(f, ")")?;
+                    Ok(())
+                }
+            }
+        }
+        CedarValueJson::Set(v) => {
+            write!(f, "[")?;
+            for (i, val) in v.iter().enumerate() {
+                display_cedarvaluejson(f, val)?;
+                if i < (v.len() - 1) {
+                    write!(f, ", ")?;
+                }
+            }
+            write!(f, "]")?;
+            Ok(())
+        }
+        CedarValueJson::Record(m) => {
+            write!(f, "{{")?;
+            for (i, (k, v)) in m.iter().enumerate() {
+                write!(f, "\"{}\": ", k.escape_debug())?;
+                display_cedarvaluejson(f, v)?;
+                if i < (m.len() - 1) {
+                    write!(f, ", ")?;
+                }
+            }
+            write!(f, "}}")?;
+            Ok(())
+        }
+    }
+}
+
+impl std::fmt::Display for ExprNoExt {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            ExprNoExt::Value(v) => display_cedarvaluejson(f, v),
+            ExprNoExt::Var(v) => write!(f, "{v}"),
+            ExprNoExt::Slot(id) => write!(f, "{id}"),
+            ExprNoExt::Unknown { name } => write!(f, "unknown(\"{}\")", name.escape_debug()),
+            ExprNoExt::Not { arg } => write!(f, "!{}", maybe_with_parens(arg)),
+            ExprNoExt::Neg { arg } => {
+                // Always add parentheses instead of calling
+                // `maybe_with_parens`.
+                // This makes sure that we always get a negation operation back
+                // (as opposed to e.g., a negative number) when parsing the
+                // printed form, thus preserving the round-tripping property.
+                write!(f, "-({arg})")
+            }
+            ExprNoExt::Eq { left, right } => write!(
+                f,
+                "{} == {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::NotEq { left, right } => write!(
+                f,
+                "{} != {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::In { left, right } => write!(
+                f,
+                "{} in {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Less { left, right } => write!(
+                f,
+                "{} < {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::LessEq { left, right } => write!(
+                f,
+                "{} <= {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Greater { left, right } => write!(
+                f,
+                "{} > {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::GreaterEq { left, right } => write!(
+                f,
+                "{} >= {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::And { left, right } => write!(
+                f,
+                "{} && {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Or { left, right } => write!(
+                f,
+                "{} || {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Add { left, right } => write!(
+                f,
+                "{} + {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Sub { left, right } => write!(
+                f,
+                "{} - {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Mul { left, right } => write!(
+                f,
+                "{} * {}",
+                maybe_with_parens(left),
+                maybe_with_parens(right)
+            ),
+            ExprNoExt::Contains { left, right } => {
+                write!(f, "{}.contains({right})", maybe_with_parens(left))
+            }
+            ExprNoExt::ContainsAll { left, right } => {
+                write!(f, "{}.containsAll({right})", maybe_with_parens(left))
+            }
+            ExprNoExt::ContainsAny { left, right } => {
+                write!(f, "{}.containsAny({right})", maybe_with_parens(left))
+            }
+            ExprNoExt::GetAttr { left, attr } => write!(
+                f,
+                "{}[\"{}\"]",
+                maybe_with_parens(left),
+                attr.escape_debug()
+            ),
+            ExprNoExt::HasAttr { left, attr } => write!(
+                f,
+                "{} has \"{}\"",
+                maybe_with_parens(left),
+                attr.escape_debug()
+            ),
+            ExprNoExt::Like { left, pattern } => {
+                write!(f, "{} like \"{}\"", maybe_with_parens(left), pattern) // intentionally not using .escape_debug() for pattern
+            }
+            ExprNoExt::If {
+                cond_expr,
+                then_expr,
+                else_expr,
+            } => write!(
+                f,
+                "if {} then {} else {}",
+                maybe_with_parens(cond_expr),
+                maybe_with_parens(then_expr),
+                maybe_with_parens(else_expr)
+            ),
+            ExprNoExt::Set(v) => write!(f, "[{}]", v.iter().join(", ")),
+            ExprNoExt::Record(m) => write!(
+                f,
+                "{{{}}}",
+                m.iter()
+                    .map(|(k, v)| format!("\"{}\": {}", k.escape_debug(), v))
+                    .join(", ")
+            ),
+        }
+    }
+}
+
+impl std::fmt::Display for ExtFuncCall {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // PANIC SAFETY: safe due to INVARIANT on `ExtFuncCall`
+        #[allow(clippy::panic_used)]
+        let Some((fn_name, args)) = self.call.iter().next() else {
+            panic!("invariant violated: empty ExtFuncCall")
+        };
+        // search for the name and callstyle
+        let style = Extensions::all_available().all_funcs().find_map(|ext_fn| {
+            if &ext_fn.name().to_string() == fn_name {
+                Some(ext_fn.style())
+            } else {
+                None
+            }
+        });
+        match (style, args.iter().next()) {
+            (Some(ast::CallStyle::MethodStyle), Some(receiver)) => {
+                write!(
+                    f,
+                    "{}.{}({})",
+                    maybe_with_parens(receiver),
+                    fn_name,
+                    args.iter().skip(1).join(", ")
+                )
+            }
+            (_, _) => {
+                write!(f, "{}({})", fn_name, args.iter().join(", "))
+            }
+        }
+    }
+}
+
+/// returns the `Display` representation of the Expr, adding parens around
+/// the entire string if necessary.
+/// E.g., won't add parens for constants or `principal` etc, but will for things
+/// like `(2 < 5)`.
+/// When in doubt, add the parens.
+fn maybe_with_parens(expr: &Expr) -> String {
+    match expr {
+        Expr::ExprNoExt(ExprNoExt::Value(_)) => expr.to_string(),
+        Expr::ExprNoExt(ExprNoExt::Var(_)) => expr.to_string(),
+        Expr::ExprNoExt(ExprNoExt::Slot(_)) => expr.to_string(),
+        Expr::ExprNoExt(ExprNoExt::Unknown { .. }) => expr.to_string(),
+        Expr::ExprNoExt(ExprNoExt::Not { .. }) => {
+            // we want parens here because things like parse((!x).y)
+            // would be printed into !x.y which has a different meaning
+            format!("({expr})")
+        }
+        Expr::ExprNoExt(ExprNoExt::Neg { .. }) => {
+            // we want parens here because things like parse((-x).y)
+            // would be printed into -x.y which has a different meaning
+            format!("({expr})")
+        }
+        Expr::ExprNoExt(ExprNoExt::Eq { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::NotEq { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::In { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Less { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::LessEq { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Greater { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::GreaterEq { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::And { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Or { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Add { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Sub { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Mul { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Contains { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::HasAttr { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Like { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::If { .. }) => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Set(_)) => expr.to_string(),
+        Expr::ExprNoExt(ExprNoExt::Record(_)) => expr.to_string(),
+        Expr::ExtFuncCall { .. } => format!("({expr})"),
     }
 }

--- a/cedar-policy-core/src/est/head_constraints.rs
+++ b/cedar-policy-core/src/est/head_constraints.rs
@@ -302,7 +302,7 @@ impl std::fmt::Display for ActionInConstraint {
                     .into_euid(|| JsonDeserializationErrorContext::EntityUid)
                 {
                     Ok(euid) => write!(f, "in {euid}"),
-                    Err(e) => write!(f, "in (invalid entity uid: {e}"),
+                    Err(e) => write!(f, "in (invalid entity uid: {e})"),
                 }
             }
             Self::Set { entities } => {

--- a/cedar-policy-core/src/est/head_constraints.rs
+++ b/cedar-policy-core/src/est/head_constraints.rs
@@ -204,17 +204,15 @@ impl ActionConstraint {
 impl std::fmt::Display for PrincipalConstraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::All => write!(f, "principal, "),
+            Self::All => write!(f, "principal"),
             Self::Eq(ec) => {
                 write!(f, "principal ")?;
                 std::fmt::Display::fmt(ec, f)?;
-                write!(f, ", ")?;
                 Ok(())
             }
             Self::In(ic) => {
                 write!(f, "principal ")?;
                 std::fmt::Display::fmt(ic, f)?;
-                write!(f, ", ")?;
                 Ok(())
             }
         }
@@ -224,17 +222,15 @@ impl std::fmt::Display for PrincipalConstraint {
 impl std::fmt::Display for ActionConstraint {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::All => write!(f, "action, "),
+            Self::All => write!(f, "action"),
             Self::Eq(ec) => {
                 write!(f, "action ")?;
                 std::fmt::Display::fmt(ec, f)?;
-                write!(f, ", ")?;
                 Ok(())
             }
             Self::In(aic) => {
                 write!(f, "action ")?;
                 std::fmt::Display::fmt(aic, f)?;
-                write!(f, ", ")?;
                 Ok(())
             }
         }

--- a/cedar-policy-core/src/est/head_constraints.rs
+++ b/cedar-policy-core/src/est/head_constraints.rs
@@ -201,6 +201,131 @@ impl ActionConstraint {
     }
 }
 
+impl std::fmt::Display for PrincipalConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, "principal, "),
+            Self::Eq(ec) => {
+                write!(f, "principal ")?;
+                std::fmt::Display::fmt(ec, f)?;
+                write!(f, ", ")?;
+                Ok(())
+            }
+            Self::In(ic) => {
+                write!(f, "principal ")?;
+                std::fmt::Display::fmt(ic, f)?;
+                write!(f, ", ")?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ActionConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, "action, "),
+            Self::Eq(ec) => {
+                write!(f, "action ")?;
+                std::fmt::Display::fmt(ec, f)?;
+                write!(f, ", ")?;
+                Ok(())
+            }
+            Self::In(aic) => {
+                write!(f, "action ")?;
+                std::fmt::Display::fmt(aic, f)?;
+                write!(f, ", ")?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for ResourceConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::All => write!(f, "resource"),
+            Self::Eq(ec) => {
+                write!(f, "resource ")?;
+                std::fmt::Display::fmt(ec, f)?;
+                Ok(())
+            }
+            Self::In(ic) => {
+                write!(f, "resource ")?;
+                std::fmt::Display::fmt(ic, f)?;
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for EqConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Entity { entity } => {
+                match entity
+                    .clone()
+                    .into_euid(|| JsonDeserializationErrorContext::EntityUid)
+                {
+                    Ok(euid) => write!(f, "== {euid}"),
+                    Err(e) => write!(f, "== (invalid entity uid: {e})"),
+                }
+            }
+            Self::Slot { slot } => write!(f, "== {slot}"),
+        }
+    }
+}
+
+impl std::fmt::Display for PrincipalOrResourceInConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Entity { entity } => {
+                match entity
+                    .clone()
+                    .into_euid(|| JsonDeserializationErrorContext::EntityUid)
+                {
+                    Ok(euid) => write!(f, "in {euid}"),
+                    Err(e) => write!(f, "in (invalid entity uid: {e})"),
+                }
+            }
+            Self::Slot { slot } => write!(f, "in {slot}"),
+        }
+    }
+}
+
+impl std::fmt::Display for ActionInConstraint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Single { entity } => {
+                match entity
+                    .clone()
+                    .into_euid(|| JsonDeserializationErrorContext::EntityUid)
+                {
+                    Ok(euid) => write!(f, "in {euid}"),
+                    Err(e) => write!(f, "in (invalid entity uid: {e}"),
+                }
+            }
+            Self::Set { entities } => {
+                write!(f, "in [")?;
+                for (i, entity) in entities.iter().enumerate() {
+                    match entity
+                        .clone()
+                        .into_euid(|| JsonDeserializationErrorContext::EntityUid)
+                    {
+                        Ok(euid) => write!(f, "{euid}"),
+                        Err(e) => write!(f, "(invalid entity uid: {e})"),
+                    }?;
+                    if i < (entities.len() - 1) {
+                        write!(f, ", ")?;
+                    }
+                }
+                write!(f, "]")?;
+                Ok(())
+            }
+        }
+    }
+}
+
 impl From<ast::PrincipalConstraint> for PrincipalConstraint {
     fn from(constraint: ast::PrincipalConstraint) -> PrincipalConstraint {
         constraint.constraint.into()

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2469,7 +2469,7 @@ impl Policy {
     ///            ]
     ///        }
     /// );
-    /// let policy = Policy::from_json(None, json).unwrap();
+    /// let json_policy = Policy::from_json(None, json).unwrap();
     /// let src = r#"
     ///   permit(
     ///     principal == User::"bob",
@@ -2477,8 +2477,8 @@ impl Policy {
     ///     resource == Album::"trip"
     ///   )
     ///   when { principal.age > 18 };"#;
-    /// let expected_output = Policy::parse(None, src).unwrap();
-    /// assert_eq!(policy.to_string(), expected_output.to_string());
+    /// let text_policy = Policy::parse(None, src).unwrap();
+    /// assert_eq!(json_policy.to_json().unwrap(), text_policy.to_json().unwrap());
     /// ```
     pub fn from_json(
         id: Option<PolicyId>,
@@ -2494,7 +2494,7 @@ impl Policy {
 
     /// Get the JSON representation of this `Policy`.
     ///  ```
-    /// use cedar_policy::Policy;
+    /// # use cedar_policy::Policy;
     /// let src = r#"
     ///   permit(
     ///     principal == User::"bob",
@@ -2502,13 +2502,13 @@ impl Policy {
     ///     resource == Album::"trip"
     ///   )
     ///   when { principal.age > 18 };"#;
-
+    ///
     /// let policy = Policy::parse(None, src).unwrap();
     /// println!("{}", policy);
     /// // convert the policy to JSON
     /// let json = policy.to_json().unwrap();
     /// println!("{}", json);
-    /// assert_eq!(policy.to_string(), Policy::from_json(None, json).unwrap().to_string());
+    /// assert_eq!(json, Policy::from_json(None, json.clone()).unwrap().to_json().unwrap());
     /// ```
     pub fn to_json(&self) -> Result<serde_json::Value, impl std::error::Error> {
         let est = self.lossless.est()?;

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2423,7 +2423,7 @@ impl Policy {
     /// use cedar_policy::{Policy, PolicyId};
     /// use std::str::FromStr;
     ///
-    /// let data : serde_json::Value = serde_json::json!(
+    /// let json: serde_json::Value = serde_json::json!(
     ///        {
     ///            "effect":"permit",
     ///            "principal":{
@@ -2469,7 +2469,7 @@ impl Policy {
     ///            ]
     ///        }
     /// );
-    /// let policy = Policy::from_json(None, data).unwrap();
+    /// let policy = Policy::from_json(None, json).unwrap();
     /// let src = r#"
     ///   permit(
     ///     principal == User::"bob",

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2628,7 +2628,7 @@ impl std::fmt::Display for LosslessPolicy {
                     // need to replace placeholders according to `slots`.
                     // just find-and-replace wouldn't be safe/perfect, we
                     // want to use the actual parser; right now we reuse
-                    // other implementation by just converting to EST and
+                    // another implementation by just converting to EST and
                     // printing that
                     match self.est() {
                         Ok(est) => write!(f, "{est}"),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2146,6 +2146,13 @@ impl Template {
     }
 }
 
+impl std::fmt::Display for Template {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // prefer to display the lossless format
+        self.lossless.fmt(f)
+    }
+}
+
 impl FromStr for Template {
     type Err = ParseErrors;
 


### PR DESCRIPTION
## Description of changes

Adjusts the `Display` trait on toplevel `Policy` and `PolicySet` objects to display the lossless form of the policy.  (It turns out `Template` didn't actually have a `Display` trait implementation, so I added one for `Template` as well.)

This involves creating new functionality to directly pretty-print the EST (ie EST -> text).  To avoid too much code duplication, I refactored the AST `Display` trait to use this code as well, so it actually does AST -> EST -> text.  (AST -> EST is lossless and infallible, so the output should be identical.)

It's very possible there are bugs in v1 of this PR, I am posting it now but intend to run some DRT on it to make sure the pretty-print roundtrip property for AST still holds (despite going through my new EST-printing code now).  Do folks agree that the AST pretty-print property is sufficient and we don't need a separate EST pretty-print property in DRT?

## Issue #, if available

Fixes #125

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

(do folks feel that this change warrants a changelog entry?)

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

(except as discussed above)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
