### PR TITLE
Refactor AST Record case to use `BTreeMap` instead of vec-of-pairs

### DIFF
--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -89,14 +89,10 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
                 self.expression_stack.push(expr);
             }
             ExprKind::Set(elems) => {
-                for expr in elems.as_ref() {
-                    self.expression_stack.push(expr);
-                }
+                self.expression_stack.extend(elems.as_ref());
             }
-            ExprKind::Record { pairs } => {
-                for (_, val_expr) in pairs.as_ref() {
-                    self.expression_stack.push(val_expr);
-                }
+            ExprKind::Record(map) => {
+                self.expression_stack.extend(map.values());
             }
         }
         Some(next_expr)

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -208,7 +208,7 @@ impl Context {
     /// Iterate over the (key, value) pairs in the `Context`
     pub fn iter(&self) -> impl Iterator<Item = (&str, BorrowedRestrictedExpr<'_>)> {
         match self.context.as_ref().expr_kind() {
-            ExprKind::Record { pairs } => pairs
+            ExprKind::Record(map) => map
                 .iter()
                 .map(|(k, v)| (k.as_str(), BorrowedRestrictedExpr::new_unchecked(v))), // given that the invariant holds for `self.context`, it will hold here
             e => panic!("internal invariant violation: expected Expr::Record, got {e:?}"),

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -221,7 +221,7 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExpressionError> {
         }),
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
-        ExprKind::Record { pairs } => pairs.iter().map(|(_, v)| v).try_for_each(is_restricted),
+        ExprKind::Record(map) => map.values().try_for_each(is_restricted),
     }
 }
 

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -72,7 +72,7 @@ impl TryFrom<Expr> for Value {
                 .map(|e| e.clone().try_into())
                 .collect::<Result<Set, _>>()
                 .map(Value::Set),
-            ExprKind::Record { pairs } => pairs
+            ExprKind::Record(map) => map
                 .iter()
                 .map(|(k, v)| v.clone().try_into().map(|v: Value| (k.clone(), v)))
                 .collect::<Result<BTreeMap<SmolStr, Value>, _>>()

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1030,24 +1030,24 @@ mod schema_based_parsing_tests {
         let json_blob = parsed
             .get("json_blob")
             .expect("json_blob attr should exist");
-        let ExprKind::Record { pairs } = json_blob.expr_kind() else { panic!("expected json_blob to be a Record") };
-        let (_, inner1) = pairs
+        let ExprKind::Record(map) = json_blob.expr_kind() else { panic!("expected json_blob to be a Record") };
+        let (_, inner1) = map
             .iter()
-            .find(|(k, _)| k == "inner1")
+            .find(|(k, _)| *k == "inner1")
             .expect("inner1 attr should exist");
         assert!(matches!(
             inner1.expr_kind(),
             &ExprKind::Lit(Literal::Bool(_))
         ));
-        let (_, inner3) = pairs
+        let (_, inner3) = map
             .iter()
-            .find(|(k, _)| k == "inner3")
+            .find(|(k, _)| *k == "inner3")
             .expect("inner3 attr should exist");
         assert!(matches!(inner3.expr_kind(), &ExprKind::Record { .. }));
-        let ExprKind::Record { pairs: innerpairs } = inner3.expr_kind() else { panic!("already checked it was Record") };
-        let (_, innerinner) = innerpairs
+        let ExprKind::Record(innermap) = inner3.expr_kind() else { panic!("already checked it was Record") };
+        let (_, innerinner) = innermap
             .iter()
-            .find(|(k, _)| k == "innerinner")
+            .find(|(k, _)| *k == "innerinner")
             .expect("innerinner attr should exist");
         assert!(matches!(innerinner.expr_kind(), &ExprKind::Record { .. }));
 
@@ -1108,24 +1108,24 @@ mod schema_based_parsing_tests {
         let json_blob = parsed
             .get("json_blob")
             .expect("json_blob attr should exist");
-        let ExprKind::Record { pairs } = json_blob.expr_kind() else { panic!("expected json_blob to be a Record") };
-        let (_, inner1) = pairs
+        let ExprKind::Record(map) = json_blob.expr_kind() else { panic!("expected json_blob to be a Record") };
+        let (_, inner1) = map
             .iter()
-            .find(|(k, _)| k == "inner1")
+            .find(|(k, _)| *k == "inner1")
             .expect("inner1 attr should exist");
         assert!(matches!(
             inner1.expr_kind(),
             &ExprKind::Lit(Literal::Bool(_))
         ));
-        let (_, inner3) = pairs
+        let (_, inner3) = map
             .iter()
-            .find(|(k, _)| k == "inner3")
+            .find(|(k, _)| *k == "inner3")
             .expect("inner3 attr should exist");
         assert!(matches!(inner3.expr_kind(), &ExprKind::Record { .. }));
-        let ExprKind::Record { pairs: innerpairs } = inner3.expr_kind() else { panic!("already checked it was Record") };
-        let (_, innerinner) = innerpairs
+        let ExprKind::Record(innermap) = inner3.expr_kind() else { panic!("already checked it was Record") };
+        let (_, innerinner) = innermap
             .iter()
-            .find(|(k, _)| k == "innerinner")
+            .find(|(k, _)| *k == "innerinner")
             .expect("innerinner attr should exist");
         assert!(matches!(
             innerinner.expr_kind(),

--- a/cedar-policy-core/src/entities/json/jsonvalue.rs
+++ b/cedar-policy-core/src/entities/json/jsonvalue.rs
@@ -237,8 +237,8 @@ impl JSONValue {
                     .map(JSONValue::from_expr)
                     .collect::<Result<_, JsonSerializationError>>()?,
             )),
-            ExprKind::Record { pairs } => {
-                // if `pairs` contains a key which collides with one of our JSON
+            ExprKind::Record(map) => {
+                // if `map` contains a key which collides with one of our JSON
                 // escapes, then we have a problem because it would be interpreted
                 // as an escape when being read back in.
                 // We could be a little more permissive here, but to be
@@ -247,18 +247,15 @@ impl JSONValue {
                 // with the reserved names.
                 let reserved_keys: HashSet<&str> =
                     HashSet::from_iter(["__entity", "__extn", "__expr"]);
-                let collision = pairs
-                    .iter()
-                    .find(|(k, _)| reserved_keys.contains(k.as_str()));
+                let collision = map.keys().find(|k| reserved_keys.contains(k.as_str()));
                 if let Some(collision) = collision {
                     Err(JsonSerializationError::ReservedKey {
-                        key: collision.0.clone(),
+                        key: collision.clone(),
                     })
                 } else {
                     // the common case: the record doesn't use any reserved keys
                     Ok(Self::Record(
-                        pairs
-                            .iter()
+                        map.iter()
                             .map(|(k, v)| {
                                 Ok((
                                     k.clone(),
@@ -530,9 +527,9 @@ impl<'e> ValueParser<'e> {
                     }
                 }
             }
-            ExprKind::Record { pairs } => {
+            ExprKind::Record(map) => {
                 Ok(SchemaType::Record { attrs: {
-                    pairs.iter().map(|(k, v)| {
+                    map.iter().map(|(k, v)| {
                         let attr_type = self.type_of_rexpr(
                             BorrowedRestrictedExpr::new_unchecked(v), // assuming the invariant holds for the record as a whole, it will also hold for each attribute value
                             ctx.clone(),

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -682,8 +682,8 @@ impl From<ast::Expr> for Expr {
             ast::ExprKind::Set(set) => {
                 Expr::set(unwrap_or_clone(set).into_iter().map(Into::into).collect())
             }
-            ast::ExprKind::Record { pairs } => Expr::record(
-                unwrap_or_clone(pairs)
+            ast::ExprKind::Record(map) => Expr::record(
+                unwrap_or_clone(map)
                     .into_iter()
                     .map(|(k, v)| (k, v.into()))
                     .collect(),

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -63,10 +63,7 @@ fn text_in_expr(e: &'_ Expr) -> impl IntoIterator<Item = TextKind<'_>> {
         ExprKind::GetAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::HasAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::Like { pattern, .. } => vec![TextKind::Pattern(pattern.get_elems())],
-        ExprKind::Record { pairs } => pairs
-            .iter()
-            .map(|(attr, _)| TextKind::Identifier(attr))
-            .collect(),
+        ExprKind::Record(map) => map.keys().map(|attr| TextKind::Identifier(attr)).collect(),
         _ => vec![],
     }
 }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -774,8 +774,8 @@ impl<'a> Typechecker<'a> {
                                 .like(strict_expr, pattern.iter().cloned()),
                         )
                     }),
-                ExprKind::Record { pairs } => {
-                    let (attr_names, strict_attr_exprs): (Vec<_>, Vec<_>) = pairs
+                ExprKind::Record(map) => {
+                    let (attr_names, strict_attr_exprs): (Vec<_>, Vec<_>) = map
                         .iter()
                         .map(|(a, e)| (a.clone(), self.strict_transform(e, type_errors)))
                         .unzip();
@@ -1677,11 +1677,11 @@ impl<'a> Typechecker<'a> {
 
             // For records, each (attribute, value) pair in the initializer need
             // to be individually accounted for in the record type.
-            ExprKind::Record { pairs } => {
+            ExprKind::Record(map) => {
                 // Typecheck each attribute initializer expression individually.
-                let record_attr_tys = pairs
-                    .iter()
-                    .map(|(_, value)| self.typecheck(request_env, prior_eff, value, type_errors));
+                let record_attr_tys = map
+                    .values()
+                    .map(|value| self.typecheck(request_env, prior_eff, value, type_errors));
                 // This will cause the return value to be `TypecheckFail` if any
                 // of the attributes did not typecheck.
                 TypecheckAnswer::sequence_all_then_typecheck(
@@ -1697,16 +1697,13 @@ impl<'a> Typechecker<'a> {
                             .iter()
                             .map(|e| e.data().clone())
                             .collect::<Option<Vec<_>>>();
-                        let t = pairs
-                            .iter()
-                            .map(|(attr, _)| attr.clone())
-                            .zip(record_attr_expr_tys);
+                        let t = map.keys().cloned().zip(record_attr_expr_tys);
                         match record_attr_tys {
                             Some(record_attr_tys) => {
                                 // Given the attribute types which we know know
                                 // exist, we pair them with the corresponding
                                 // attribute names to get a record type.
-                                let record_attrs = pairs.iter().map(|(id, _)| id.clone());
+                                let record_attrs = map.keys().cloned();
                                 let record_type_entries =
                                     std::iter::zip(record_attrs, record_attr_tys);
                                 TypecheckAnswer::success(


### PR DESCRIPTION
## Description of changes

Having a `BTreeMap` here is both more ergonomic, and makes the representation simpler (because it disallows duplicate keys at the AST level).  I suspect the `Vec` is a holdover from a long-ago version that allowed computed keys.

One possible objection is that the vec-of-pairs representation would be necessary if we supported computed keys.  I counter that supporting computed keys would require a change to this API anyway; and also a change to the EST format.  Computed keys doesn't seem to be coming anytime soon and I propose that we cross that bridge when we get there.  Until then, this new representation is simpler and has nicer properties.

## Issue #, if available

This will fix AST->EST not being lossless; see comments on #167.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
