### PR TITLE
Entity storage from database or disk

### DIFF
--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -21,7 +21,7 @@
 //! the "authorization engine".
 
 use crate::ast::*;
-use crate::entities::Entities;
+use crate::entities::{Entities, EntityDatabase};
 use crate::evaluator::{EvaluationError, Evaluator};
 use crate::extensions::Extensions;
 use itertools::Either;
@@ -296,10 +296,10 @@ impl Authorizer {
         }
     }
 
-    fn evaluate_policies<'a>(
+    fn evaluate_policies<'a, T: EntityDatabase>(
         &'a self,
         pset: &'a PolicySet,
-        eval: Evaluator<'_>,
+        eval: Evaluator<'a, T>,
     ) -> EvaluationResults<'a> {
         let mut results = EvaluationResults::default();
         let mut satisfied_policies = vec![];

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -254,7 +254,6 @@ pub enum TCComputation {
 }
 
 /// An entity database is something that can retrieve entities based on their id
-/// and can decide if one entity is an ancestor from another
 pub trait EntityDatabase {
     /// Given a list of uids, get the corresponding entities; returns none if the corresponding
     /// entity doesn't exist
@@ -267,6 +266,11 @@ pub trait EntityDatabase {
 
     /// Get an entity given its uid,
     /// or a residual expression if the entity doesn't exist and we are in partial mode
+    /// TODO: This could return a reference Dereference<&Entity>
+    /// This doesn't matter for the traditional "database" case, because if we read from disk,
+    /// then we have to deserialize the entity anyway, so we might as well return the entity.
+    /// OTOH, if we have the database in memory, then we might want to return a reference to avoid the copy
+    /// but then we have to deal with issues relating to the lifetime of the reference.
     fn entity(&self, uid: &EntityUID) -> Dereference<Entity> {
         match self.get_entity_of_uid(uid) {
             Some(e) => Dereference::Data(e),
@@ -276,24 +280,6 @@ pub trait EntityDatabase {
             },
         }
     }
-
-    // fn entity_of_mode(&self, uid: &EntityUID, mode: &Mode) -> Dereference<'_, Entity> {
-    //     match self.get_entity_of_uid(uid) {
-    //         Some(e) => Dereference::Data(e),
-    //         None => match mode {
-    //             Mode::Concrete => Dereference::NoSuchEntity,
-    //             Mode::Partial => Dereference::Residual(Expr::unknown(format!("{uid}"))),
-    //         }
-    //     }
-    // }
-
-    // Get entity from uid, returning a dereference
-    // fn entity(&self, uid: &EntityUID) -> Dereference<'_, Entity> {
-    //     match self.get_entity_of_uid(uid) {
-    //         Some(e) => Dereference::Data(&e),
-    //         None => Dereference::NoSuchEntity,  // TODO: add back residual entities
-    //     }
-    // }
 }
 
 impl<'e> EntityDatabase for Entities {

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -221,6 +221,15 @@ where
             e => panic!("expect() called on {:?}, msg: {msg}", e),
         }
     }
+
+    /// Converts from `Dereference<T>` to `Dereference<&T>`.
+    pub fn as_ref(&self) -> Dereference<&T> {
+        match self {
+            Self::NoSuchEntity => Dereference::NoSuchEntity,
+            Self::Residual(e) => Dereference::Residual(e.clone()),
+            Self::Data(e) => Dereference::Data(e),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -260,7 +260,7 @@ pub trait EntityDatabase {
     /// Given a list of uids, get the corresponding entities; returns none if the corresponding
     /// entity doesn't exist
     /// TODO: accept a list of uids instead of a single one so that the
-    /// implementation can theoretically (in the future) take advantage of parallelism 
+    /// implementation can theoretically (in the future) take advantage of parallelism
     fn get_entity_of_uid(&self, uid: &EntityUID) -> Option<Entity>;
 
     /// Given a uid, get the corresponding entity or a residual expression

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -66,7 +66,7 @@ pub struct Evaluator<'e, T: EntityDatabase> {
 /// This mutable cache avoids duplicating lookups/expression evaluation.
 struct EvaluatorCache<'a> {
     /// Cache of entity attribute values
-    /// Invariant: the uids present in `attrs` are the same as those in `entity_cache` 
+    /// Invariant: the uids present in `attrs` are the same as those in `entity_cache`
     attrs: HashMap<EntityUID, HashMap<SmolStr, PartialValue>>,
 
     /// Cache of entities that have been looked up
@@ -150,7 +150,7 @@ impl<'e> RestrictedEvaluator<'e> {
 
 
 impl<'a> EvaluatorCache<'a> {
-    /// Create a new, empty cache 
+    /// Create a new, empty cache
     fn new() -> Self {
         Self {
             attrs: HashMap::new(),

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -66,7 +66,6 @@ pub struct Evaluator<'e, T: EntityDatabase> {
 /// This mutable cache avoids duplicating lookups/expression evaluation.
 struct EvaluatorCache {
     /// Cache of entities that have been looked up
-    /// TODO: use this to cache entities
     entity_cache: HashMap<EntityUID, Dereference<(Entity, HashMap<SmolStr, Result<PartialValue>>)>>
 }
 
@@ -78,6 +77,7 @@ impl EvaluatorCache {
         }
     }
 
+    /// Get the given entity and its attributes; add it to the cache if it was not already present
     fn get_entity_and_attrs<'e, T: EntityDatabase>(&'e mut self, entities: &T, uid: &EntityUID, extensions: &Extensions<'_>) -> Dereference<&'e (Entity, HashMap<SmolStr, Result<PartialValue>>)> {
         self.entity_cache.entry(uid.clone())
             .or_insert_with(|| {
@@ -100,6 +100,7 @@ impl EvaluatorCache {
             }).as_ref()
     }
 
+    /// Wrapper around `get_entity_and_attrs` which returns only the entity
     fn get_entity<'e, T: EntityDatabase>(&'e mut self, entities: &T, uid: &EntityUID, extensions: &Extensions<'_>) -> Dereference<&'e Entity> {
         match self.get_entity_and_attrs(entities, uid, extensions) {
             Dereference::NoSuchEntity => Dereference::NoSuchEntity,
@@ -108,7 +109,7 @@ impl EvaluatorCache {
         }
     }
 
-    /// Get the given entity's attributes and add it to the cache if it was not already present
+    /// Wrapper around `get_entity_and_attrs` which returns only the attributes
     fn get_attrs<'e, T: EntityDatabase>(&'e mut self, entities: &T, uid: &EntityUID, extensions: &Extensions<'_>) -> Dereference<&'e HashMap<SmolStr, Result<PartialValue>>> {
         match self.get_entity_and_attrs(entities, uid, extensions) {
             Dereference::NoSuchEntity => Dereference::NoSuchEntity,


### PR DESCRIPTION
## Description of changes

Currently, we support loading entities from an `entities.json` file. However, this is not scalable as the number of entities grows; it becomes wasteful to load all entities from disk when most requests only 'touch' a handful of entities.

In this PR, we will provide API to load entities from a database instead of a JSON file. Note that this is currently very much a rough draft.

In a future PR, we will introduce the ability to turn a residual expression that has type boolean into a corresponding SQL query that fetches the entities that make the expression true.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
