### PR TITLE
Tweak internal API for the typechecker

### DIFF
--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -53,6 +53,16 @@ pub enum ValidationMode {
     Permissive,
 }
 
+impl ValidationMode {
+    /// Does this mode apply strict validation rules.
+    fn is_strict(self) -> bool {
+        match self {
+            ValidationMode::Strict => true,
+            ValidationMode::Permissive => false,
+        }
+    }
+}
+
 /// Structure containing the context needed for policy validation. This is
 /// currently only the `EntityType`s and `ActionType`s from a single schema.
 #[derive(Debug)]
@@ -105,9 +115,9 @@ impl Validator {
         t: &'a Template,
         mode: ValidationMode,
     ) -> impl Iterator<Item = ValidationError> + 'a {
-        let typecheck = Typechecker::new(&self.schema);
+        let typecheck = Typechecker::new(&self.schema, mode);
         let mut type_errors = HashSet::new();
-        typecheck.typecheck_policy(t, mode, &mut type_errors);
+        typecheck.typecheck_policy(t, &mut type_errors);
         type_errors.into_iter().map(|type_error| {
             let (kind, location) = type_error.kind_and_location();
             ValidationError::with_policy_id(t.id(), location, ValidationErrorKind::type_error(kind))

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -94,7 +94,7 @@ pub(crate) fn with_typechecker_from_schema<F>(
     F: FnOnce(Typechecker<'_>),
 {
     let schema = schema.try_into().expect("Failed to construct schema.");
-    let typechecker = Typechecker::new(&schema);
+    let typechecker = Typechecker::new(&schema, ValidationMode::default());
     fun(typechecker);
 }
 
@@ -140,11 +140,7 @@ pub(crate) fn assert_policy_typechecks(
 ) {
     with_typechecker_from_schema(schema, |typechecker| {
         let mut type_errors: HashSet<TypeError> = HashSet::new();
-        let typechecked = typechecker.typecheck_policy(
-            &policy.into(),
-            ValidationMode::default(),
-            &mut type_errors,
-        );
+        let typechecked = typechecker.typecheck_policy(&policy.into(), &mut type_errors);
         assert_eq!(type_errors, HashSet::new(), "Did not expect any errors.");
         assert!(typechecked, "Expected that policy would typecheck.");
     });
@@ -157,11 +153,8 @@ pub(crate) fn assert_policy_typecheck_fails(
 ) {
     with_typechecker_from_schema(schema, |typechecker| {
         let mut type_errors: HashSet<TypeError> = HashSet::new();
-        let typechecked = typechecker.typecheck_policy(
-            &static_to_template(policy.clone()),
-            ValidationMode::default(),
-            &mut type_errors,
-        );
+        let typechecked =
+            typechecker.typecheck_policy(&static_to_template(policy.clone()), &mut type_errors);
         assert_expected_type_errors(&expected_type_errors, &type_errors);
         assert!(!typechecked, "Expected that policy would not typecheck.");
     });


### PR DESCRIPTION
## Description of changes

This pulls a small internal API change out of the partial schema validation branch that I wanted to have when working on the update to strict validation.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
