### PR TITLE
remove redundant field from feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -32,14 +32,6 @@ body:
 
   - type: textarea
     attributes:
-      label: Describe the solution you'd like
-      description: |
-        A clear and concise description of your proposed solution.
-    validations:
-      required: true
-
-  - type: textarea
-    attributes:
       label: Describe alternatives you've considered
       description: |
         A clear and concise description of any alternative solutions or features you've considered.
@@ -58,4 +50,3 @@ body:
       options:
         - label: 👋 I may be able to implement this feature request
         - label: ⚠️ This feature might incur a breaking change
-


### PR DESCRIPTION
## Description of changes

The "Describe the solution you'd like" field is redundant with the field above it, which already asks for "a clear and concise description of what you want to happen".

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
