### PR TITLE
Fix panic is cedar_policy::PolicySet::link

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -187,7 +187,10 @@ impl PolicySet {
         }
     }
 
-    /// Attempt to create a new template linked policy and add it to the policy set
+    /// Attempt to create a new template linked policy and add it to the policy
+    /// set. Returns a references to the new template linked policy if
+    /// successful.
+    ///
     /// Errors for two reasons
     ///   1) The the passed SlotEnv either does not match the slots in the templates
     ///   2) The passed link Id conflicts with an Id already in the set
@@ -196,7 +199,7 @@ impl PolicySet {
         template_id: PolicyID,
         new_id: PolicyID,
         values: HashMap<SlotId, EntityUID>,
-    ) -> Result<(), LinkingError> {
+    ) -> Result<&Policy, LinkingError> {
         let t = self
             .get_template(&template_id)
             .ok_or_else(|| LinkingError::NoSuchTemplate {
@@ -209,10 +212,7 @@ impl PolicySet {
             self.links.entry(new_id.clone()),
             self.templates.entry(new_id),
         ) {
-            (Entry::Vacant(links_entry), Entry::Vacant(_)) => {
-                links_entry.insert(r);
-                Ok(())
-            }
+            (Entry::Vacant(links_entry), Entry::Vacant(_)) => Ok(links_entry.insert(r)),
             (Entry::Occupied(oentry), _) => Err(LinkingError::PolicyIdConflict {
                 id: oentry.key().clone(),
             }),

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -36,6 +36,8 @@
   particular, this applies to the action context, so `context has attr` can now
   have type False where before it had type Boolean, creating some new
   short-circuiting opportunities.  The same applies to record literals.
+- Fix a panic in `PolicySet::link` that could occur when the function was called
+  with a policy id corresponding to a static policy.
 
 ## 2.3.0
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1308,17 +1308,14 @@ impl PolicySet {
             .into_iter()
             .map(|(key, value)| (key.into(), value.0))
             .collect();
-        self.ast
+        let linked_ast = self
+            .ast
             .link(
                 template_id.0.clone(),
                 new_id.0.clone(),
                 unwrapped_vals.clone(),
             )
             .map_err(PolicySetError::LinkingError)?;
-        let linked_ast = self
-            .ast
-            .get(&new_id.0)
-            .expect("ast.link() didn't fail above, so this shouldn't fail");
         let linked_lossless = self
             .templates
             .get(&template_id)


### PR DESCRIPTION
Removes two `expects` in this function. One was known to panic when the function was called with a `template_id` corresponding to a static policy. The other could not panic, but small code change can elimiante it.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
