### PR TITLE
error bug bash: breaking changes for `PolicySetError` and `LinkingError`

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -255,12 +255,18 @@ pub enum LinkingError {
     },
 
     /// The attempted instantiation failed as the template did not exist.
-    #[error("failed to find a template with id: {0}")]
-    NoSuchTemplate(PolicyID),
+    #[error("failed to find a template with id: {id}")]
+    NoSuchTemplate {
+        /// [`PolicyID`] of the template we failed to find
+        id: PolicyID,
+    },
 
     /// The new instance conflicts with an existing [`PolicyID`].
-    #[error("template-linked policy id conflicts with an existing policy id")]
-    PolicyIdConflict,
+    #[error("template-linked policy id conflicts with an existing policy id: {id}")]
+    PolicyIdConflict {
+        /// [`PolicyID`] where the conflict exists
+        id: PolicyID,
+    },
 }
 
 impl LinkingError {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -89,8 +89,11 @@ impl From<PolicySet> for LiteralPolicySet {
 pub enum PolicySetError {
     /// There was a duplicate [`PolicyID`] encountered in either the set of
     /// templates or the set of policies.
-    #[error("duplicate template or policy id")]
-    Occupied,
+    #[error("duplicate template or policy id: {id}")]
+    Occupied {
+        /// [`PolicyID`] that was duplicate
+        id: PolicyID,
+    },
 }
 
 // The public interface of `PolicySet` is intentionally narrow, to allow us
@@ -116,7 +119,9 @@ impl PolicySet {
             Entry::Vacant(ventry) => Some(ventry),
             Entry::Occupied(oentry) => {
                 if oentry.get() != &t {
-                    return Err(PolicySetError::Occupied);
+                    return Err(PolicySetError::Occupied {
+                        id: oentry.key().clone(),
+                    });
                 }
                 None
             }
@@ -124,8 +129,10 @@ impl PolicySet {
 
         let link_ventry = match self.links.entry(policy.id().clone()) {
             Entry::Vacant(ventry) => Some(ventry),
-            Entry::Occupied(_) => {
-                return Err(PolicySetError::Occupied);
+            Entry::Occupied(oentry) => {
+                return Err(PolicySetError::Occupied {
+                    id: oentry.key().clone(),
+                });
             }
         };
 
@@ -156,7 +163,12 @@ impl PolicySet {
                 links_entry.insert(p);
                 Ok(())
             }
-            _ => Err(PolicySetError::Occupied),
+            (Entry::Occupied(oentry), _) => Err(PolicySetError::Occupied {
+                id: oentry.key().clone(),
+            }),
+            (_, Entry::Occupied(oentry)) => Err(PolicySetError::Occupied {
+                id: oentry.key().clone(),
+            }),
         }
     }
 
@@ -165,9 +177,11 @@ impl PolicySet {
         // TODO: Use `try_insert` when stabilized.
         // https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.try_insert
         match self.templates.entry(t.id().clone()) {
-            Entry::Occupied(_) => Err(PolicySetError::Occupied),
-            Entry::Vacant(entry) => {
-                entry.insert(Arc::new(t));
+            Entry::Occupied(oentry) => Err(PolicySetError::Occupied {
+                id: oentry.key().clone(),
+            }),
+            Entry::Vacant(ventry) => {
+                ventry.insert(Arc::new(t));
                 Ok(())
             }
         }
@@ -185,7 +199,9 @@ impl PolicySet {
     ) -> Result<(), LinkingError> {
         let t = self
             .get_template(&template_id)
-            .ok_or_else(|| LinkingError::NoSuchTemplate(template_id.clone()))?;
+            .ok_or_else(|| LinkingError::NoSuchTemplate {
+                id: template_id.clone(),
+            })?;
         let r = Template::link(t, new_id.clone(), values)?;
 
         // Both maps must not contain the `new_id`
@@ -197,7 +213,12 @@ impl PolicySet {
                 links_entry.insert(r);
                 Ok(())
             }
-            _ => Err(LinkingError::PolicyIdConflict),
+            (Entry::Occupied(oentry), _) => Err(LinkingError::PolicyIdConflict {
+                id: oentry.key().clone(),
+            }),
+            (_, Entry::Occupied(oentry)) => Err(LinkingError::PolicyIdConflict {
+                id: oentry.key().clone(),
+            }),
         }
     }
 
@@ -300,7 +321,9 @@ mod test {
 
         match r {
             Ok(_) => panic!("Should have failed due to conflict"),
-            Err(LinkingError::PolicyIdConflict) => (),
+            Err(LinkingError::PolicyIdConflict { id }) => {
+                assert_eq!(id, PolicyID::from_string("id"))
+            }
             Err(e) => panic!("Incorrect error: {e}"),
         };
     }
@@ -356,7 +379,7 @@ mod test {
         .expect("Failed to link");
         match pset.add(p2) {
             Ok(_) => panic!("Should have failed due to conflict with existing link id"),
-            Err(PolicySetError::Occupied) => (),
+            Err(PolicySetError::Occupied { id }) => assert_eq!(id, PolicyID::from_string("link")),
         }
 
         let p3 = Template::link(Arc::clone(&template), PolicyID::from_string("link2"), env2)
@@ -387,7 +410,9 @@ mod test {
         .expect("Failed to link");
         match pset.add(p4) {
             Ok(_) => panic!("Should have failed due to conflict on template id"),
-            Err(PolicySetError::Occupied) => (),
+            Err(PolicySetError::Occupied { id }) => {
+                assert_eq!(id, PolicyID::from_string("t"))
+            }
         }
     }
 
@@ -404,7 +429,7 @@ mod test {
         pset.add_static(p1).expect("Failed to add!");
         match pset.add_static(p2) {
             Ok(_) => panic!("Should have failed to due name conflict"),
-            Err(PolicySetError::Occupied) => (),
+            Err(PolicySetError::Occupied { id }) => assert_eq!(id, PolicyID::from_string("id")),
         }
     }
 
@@ -460,7 +485,7 @@ mod test {
             .expect_err("Should fail");
 
         match e {
-            LinkingError::NoSuchTemplate(id) => assert_eq!(tid, id),
+            LinkingError::NoSuchTemplate { id } => assert_eq!(tid, id),
             e => panic!("Wrong error {e}"),
         };
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -101,9 +101,8 @@ impl ASTNode<Option<cst::Policies>> {
                 Some(Either::Right(template)) => {
                     if let Err(e) = pset.add_template(template) {
                         match e {
-                            PolicySetError::Occupied => errs.push(ParseError::ToAST(
-                                "A template with this id already exists within the policy set"
-                                    .to_string(),
+                            PolicySetError::Occupied { id } => errs.push(ParseError::ToAST(
+                                format!("A template with this id already exists within the policy set: {id}")
                             )),
                         };
 
@@ -113,10 +112,11 @@ impl ASTNode<Option<cst::Policies>> {
                 Some(Either::Left(inline_policy)) => {
                     if let Err(e) = pset.add_static(inline_policy) {
                         match e {
-                            PolicySetError::Occupied => errs.push(ParseError::ToAST(
-                                "A policy with this id already exists within the policy set"
-                                    .to_string(),
-                            )),
+                            PolicySetError::Occupied { id } => {
+                                errs.push(ParseError::ToAST(format!(
+                                "A policy with this id already exists within the policy set: {id}"
+                            )))
+                            }
                         };
 
                         complete_set = false

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -29,6 +29,8 @@
     builtin types but missing a required field for that type will generate an
     error stating that a required field is missing instead of claiming that it
     could not find "common types" definition for that builtin type.
+- Some error types now carry more information about the error, with error
+  messages updated appropriately
 - Update how record types are treated by the validator to support "open" and
   "closed" record types.  Record types written in schema are now closed. In
   particular, this applies to the action context, so `context has attr` can now


### PR DESCRIPTION
## Description of changes

Breaking changes split out from #190, for error variants to carry more information about the error.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
