### PR TITLE
[2.3.x] Fix panic is cedar_policy::PolicySet::link

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## 2.3.1
+
+### Fixed
+
+- Fix a panic in `PolicySet::link` that could occur when the function was called
+  with a policy id corresponding to a static policy.
+
 ## 2.3.0
 
 ### Changed

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Fix a panic in `PolicySet::link` that could occur when the function was called
+- Fix a panic in `PolicySet::link()` that could occur when the function was called
   with a policy id corresponding to a static policy.
 
 ## 2.3.0


### PR DESCRIPTION
Removes an `expect` in this function which was to panic when the function was called with a `template_id` corresponding to a static policy.

This PR to the release branch omits a change to `cedar_policy_core::PolicySet::link` because that change depended on a commit which is not in 2.3.x and 2.2.x. That change is not required to fix the panic.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
