### PR TITLE
Upgrade lalrpop to version 0.20.0

### DIFF
--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/cedar-policy/cedar"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_with = { version = "3.0", features = ["json"] }
 serde_json = "1.0"
-lalrpop-util = { version = "0.19.12", features = ["lexer"] }
+lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 lazy_static = "1.4"
 either = "1.8"
 itertools = "0.10"
@@ -45,7 +45,7 @@ arbitrary = ["dep:arbitrary"]
 partial-eval = []
 
 [build-dependencies]
-lalrpop = "0.19.12"
+lalrpop = "0.20.0"
 
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -77,7 +77,7 @@ impl Display for ToCSTError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self.err {
             OwnedRawParseError::InvalidToken { .. } => write!(f, "invalid token"),
-            OwnedRawParseError::UnrecognizedEOF { .. } => write!(f, "unexpected end of input"),
+            OwnedRawParseError::UnrecognizedEof { .. } => write!(f, "unexpected end of input"),
             OwnedRawParseError::UnrecognizedToken {
                 token: (_, token, _),
                 ..
@@ -101,7 +101,7 @@ impl Diagnostic for ToCSTError {
             OwnedRawParseError::InvalidToken { location } => {
                 LabeledSpan::underline(*location..*location)
             }
-            OwnedRawParseError::UnrecognizedEOF { location, expected } => {
+            OwnedRawParseError::UnrecognizedEof { location, expected } => {
                 LabeledSpan::new_with_span(expected_to_string(expected), *location..*location)
             }
             OwnedRawParseError::UnrecognizedToken {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Fix a panic in `PolicySet::link` that could occur when the function was called
   with a policy id corresponding to a static policy.
 - Renamed `cedar_policy_core::est::EstToAstError` to `cedar_policy_core::est::FromJsonError`
+- More precise "expected tokens" lists in some parse errors
 
 ## 2.3.0
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -16,7 +16,7 @@ cedar-policy-validator = { version = "=2.3.0", path = "../cedar-policy-validator
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-lalrpop-util = { version = "0.19.12", features = ["lexer"] }
+lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 itertools = "0.10"
 thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }


### PR DESCRIPTION
This picks up an improvement to some parse errors. For example, the parse errror for `permit;` previosly had long list of many "expected" tokens, but now it knows that `(` is the only token than can come next.

Before:
```
$ cargo run check-parse <<<'permit;'
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `/local/home/jkastner/cedar/cedar/target/debug/cedar check-parse`
Error: cedar_policy_core::parser::to_cst_error

  × failed to parse policy set
  ╰─▶ unexpected token `;`
   ╭─[<stdin>:1:1]
 1 │ permit;
   ·       ┬
   ·       ╰── expected `!=`, `%`, `&&`, `(`, `)`, `*`, `+`, `,`, `-`, `.`, `/`, `:`, `::`, `<`, `<=`, `==`, `>`, `>=`, `[`, `]`, `{`, `||`, `}`, `else`, `has`, `in`, `like`, or `then`
   ╰────

```

After:
```
$ cargo run check-parse <<<'permit;'
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `/local/home/jkastner/cedar/cedar/target/debug/cedar check-parse`
Error: cedar_policy_core::parser::to_cst_error

  × failed to parse policy set
  ╰─▶ unexpected token `;`
   ╭─[<stdin>:1:1]
 1 │ permit;
   ·       ┬
   ·       ╰── expected `(`
   ╰────
```

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
