### PR TITLE
[2.3.x] Check `cedar-policy` SemVer compatibility on pull requests (#168)

### DIFF
--- a/.github/scripts/check-out-base-from-crates-io.sh
+++ b/.github/scripts/check-out-base-from-crates-io.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -euo pipefail
+
+cedar_policy_version="$(
+  cd head &&
+  cargo metadata --format-version 1 |
+    jq --raw-output '.packages[] | select(.name == "cedar-policy") | .version'
+)"
+echo "HEAD has cedar-policy at ${cedar_policy_version}"
+
+tmp_dir="$(mktemp -d)"
+function cleanup {
+  rm -rf "${tmp_dir}"
+}
+trap cleanup EXIT
+
+(
+  cd "${tmp_dir}"
+
+  cat <<EOF >Cargo.toml
+[package]
+name = "cedar-semver-checks"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+cedar-policy = "<=${cedar_policy_version}"
+EOF
+
+  mkdir src
+  touch src/lib.rs
+
+  cargo vendor
+)
+
+mkdir base
+mv "${tmp_dir}/vendor/cedar-policy" base/
+cat <<EOF >base/Cargo.toml
+[workspace]
+members = ["cedar-policy"]
+EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Cargo Build & Test
 on:
   pull_request:
 
-env: 
+env:
   CARGO_TERM_COLOR: always
 jobs:
   build_and_test:
@@ -26,7 +26,7 @@ jobs:
       - run: cargo bench --no-run
   
   cargo_audit:
-    name: Rust project - latest
+    name: Cargo Audit
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,3 +37,39 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo install cargo-audit
       - run: cargo audit --deny warnings --ignore RUSTSEC-2021-0145
+
+  cargo_semver_checks:
+    name: Cargo SemVer Checks
+    runs-on: ubuntu-latest
+    # Make this check mandatory for release branches.
+    continue-on-error: ${{ !startsWith(github.base_ref, 'release/') }}
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: Check out head (${{ github.head_ref }})
+        uses: actions/checkout@v3
+        with:
+          path: head
+      # Pull requests to non-release branches are checked for SemVer breakage
+      # relative to their target branch.
+      - if: ${{ !startsWith(github.base_ref, 'release/') }}
+        name: Check out base (${{ github.base_ref }})
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+          path: base
+      # If this is a release PR, check SemVer relative to the highest version
+      # published to crates.io <= the version from head.
+      - if: ${{ startsWith(github.base_ref, 'release/') }}
+        name: Check out base (from crates.io)
+        run: head/.github/scripts/check-out-base-from-crates-io.sh
+        shell: bash
+      # `cargo semver-checks` doesn't understand `rlib` crates.
+      - run: >-
+          sed -i 's/^crate_type = \["rlib"\]$/crate_type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo install cargo-semver-checks
+      - run: cargo semver-checks check-release --package cedar-policy --baseline-root ../base
+        working-directory: head


### PR DESCRIPTION
## Description of changes

Cherry-pick #168 onto the `release/2.3.x` branch so we can prevent unintended breaking changes in patches.