### PR TITLE
Nits in `IntegerOverflowError` and `RestrictedExprError`

### DIFF
--- a/cedar-integration-tests/corpus_tests/7b316784cf9e60631768b35cb7a7e15ba6d01c05.json
+++ b/cedar-integration-tests/corpus_tests/7b316784cf9e60631768b35cb7a7e15ba6d01c05.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
       ]
     }
   ]

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -202,11 +202,11 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExprError> {
             expr: expr.clone(),
         }),
         ExprKind::UnaryApp { op, .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
-            feature: op.to_string(),
+            feature: op.to_string().into(),
             expr: expr.clone(),
         }),
         ExprKind::BinaryApp { op, .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
-            feature: op.to_string(),
+            feature: op.to_string().into(),
             expr: expr.clone(),
         }),
         ExprKind::MulByConst { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
@@ -331,7 +331,7 @@ pub enum RestrictedExprError {
     #[error("not allowed to use {feature} in a restricted expression: {expr}")]
     InvalidRestrictedExpression {
         /// what disallowed feature appeared in the expression
-        feature: String,
+        feature: SmolStr,
         /// the (sub-)expression that uses the disallowed feature
         expr: Expr,
     },

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -309,7 +309,7 @@ impl<'a> Hash for RestrictedExprShapeOnly<'a> {
     }
 }
 
-/// Errors generated in the restricted_expr module
+/// Errors related to restricted expressions
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum RestrictedExprError {
     /// A "restricted" expression contained a feature that is not allowed

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -182,37 +182,48 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExprError> {
         ExprKind::Lit(_) => Ok(()),
         ExprKind::Unknown { .. } => Ok(()),
         ExprKind::Var(_) => Err(RestrictedExprError::InvalidRestrictedExpression {
-            feature: expr.to_string(),
+            feature: "variables".into(),
+            expr: expr.clone(),
         }),
         ExprKind::Slot(_) => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "template slots".into(),
+            expr: expr.clone(),
         }),
         ExprKind::If { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "if-then-else".into(),
+            expr: expr.clone(),
         }),
         ExprKind::And { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "&&".into(),
+            expr: expr.clone(),
         }),
         ExprKind::Or { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "||".into(),
+            expr: expr.clone(),
         }),
         ExprKind::UnaryApp { op, .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: op.to_string(),
+            expr: expr.clone(),
         }),
         ExprKind::BinaryApp { op, .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: op.to_string(),
+            expr: expr.clone(),
         }),
         ExprKind::MulByConst { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "multiplication".into(),
+            expr: expr.clone(),
         }),
         ExprKind::GetAttr { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
-            feature: "get-attribute".into(),
+            feature: "attribute accesses".into(),
+            expr: expr.clone(),
         }),
         ExprKind::HasAttr { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "'has'".into(),
+            expr: expr.clone(),
         }),
         ExprKind::Like { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
             feature: "'like'".into(),
+            expr: expr.clone(),
         }),
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
@@ -312,13 +323,17 @@ impl<'a> Hash for RestrictedExprShapeOnly<'a> {
 /// Errors related to restricted expressions
 #[derive(Debug, Clone, PartialEq, Error)]
 pub enum RestrictedExprError {
-    /// A "restricted" expression contained a feature that is not allowed
-    /// in "restricted" expressions. The `feature` is just a string description
-    /// of the feature that is not allowed.
-    #[error("not allowed to use {feature} in a restricted expression")]
+    /// An expression was expected to be a "restricted" expression, but contained
+    /// a feature that is not allowed in restricted expressions. The `feature`
+    /// argument is a string description of the feature that is not allowed.
+    /// The `expr` argument is the expression that uses the disallowed feature.
+    /// Note that it is potentially a sub-expression of a larger expression.
+    #[error("not allowed to use {feature} in a restricted expression: {expr}")]
     InvalidRestrictedExpression {
         /// what disallowed feature appeared in the expression
         feature: String,
+        /// the (sub-)expression that uses the disallowed feature
+        expr: Expr,
     },
 
     /// Failed to parse the expression that the restricted expression wraps.

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -139,7 +139,7 @@ pub enum IntegerOverflowError {
     },
 
     /// Overflow during multiplication
-    #[error("integer overflow while attempting to multiply `{arg}` by {constant}")]
+    #[error("integer overflow while attempting to multiply `{arg}` by `{constant}`")]
     Multiplication {
         /// first argument, which wasn't necessarily a constant in the policy
         arg: Value,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -127,7 +127,8 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
 
 #[derive(Debug, PartialEq, Clone, Error)]
 pub enum IntegerOverflowError {
-    #[error("integer overflow while attempting to {} the values {arg1} and {arg2}", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", _ => "perform an operation on" })]
+    /// Overflow during a binary operation
+    #[error("integer overflow while attempting to {} the values `{arg1}` and `{arg2}`", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", _ => "perform an operation on" })]
     BinaryOp {
         /// overflow while evaluating this operator
         op: BinaryOp,
@@ -137,7 +138,8 @@ pub enum IntegerOverflowError {
         arg2: Value,
     },
 
-    #[error("integer overflow while attempting to multiply {arg} by {constant}")]
+    /// Overflow during multiplication
+    #[error("integer overflow while attempting to multiply `{arg}` by {constant}")]
     Multiplication {
         /// first argument, which wasn't necessarily a constant in the policy
         arg: Value,
@@ -145,8 +147,8 @@ pub enum IntegerOverflowError {
         constant: i64,
     },
 
-    /// Overflow during an integer negation operation
-    #[error("integer overflow while attempting to {} the value {arg}", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
+    /// Overflow during a unary operation
+    #[error("integer overflow while attempting to {} the value `{arg}`", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
     UnaryOp {
         /// overflow while evaluating this operator
         op: UnaryOp,


### PR DESCRIPTION
## Description of changes

* Added doc strings & made minimal changes to the error messages in `IntegerOverflowError`.
* Added a new field to `RestrictedExprError::InvalidRestrictedExpression` that records the (sub-)expression that is the source of the error. I _believe_ this is a non-breaking change because `RestrictedExprError` is never directly `pub use`d in `cedar-policy`, so the structure of the the variants shouldn't be visible to external users. Also made minor tweaks to comments and error messages.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
