### PR TITLE
Add `advice` to `EvaluationError`s

### DIFF
--- a/cedar-integration-tests/corpus_tests/a7848e613881d5c8ef76a9b4d2daaf5391f604ca.json
+++ b/cedar-integration-tests/corpus_tests/a7848e613881d5c8ef76a9b4d2daaf5391f604ca.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ed50cb715d57475bc9dacda0ba0dd77c589832e8.json
+++ b/cedar-integration-tests/corpus_tests/ed50cb715d57475bc9dacda0ba0dd77c589832e8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"
       ]
     }
   ]

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -158,11 +158,11 @@ impl ExtensionFunction {
                 if args.is_empty() {
                     func()
                 } else {
-                    Err(evaluator::EvaluationError::WrongNumArguments {
-                        function_name: name.clone(),
-                        expected: 0,
-                        actual: args.len(),
-                    })
+                    Err(evaluator::EvaluationError::wrong_num_arguments(
+                        name.clone(),
+                        0,
+                        args.len(),
+                    ))
                 }
             }),
             Some(return_type),
@@ -182,11 +182,11 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match args.get(0) {
                 Some(arg) => func(arg.clone()),
-                None => Err(evaluator::EvaluationError::WrongNumArguments {
-                    function_name: name.clone(),
-                    expected: 1,
-                    actual: args.len(),
-                }),
+                None => Err(evaluator::EvaluationError::wrong_num_arguments(
+                    name.clone(),
+                    1,
+                    args.len(),
+                )),
             }),
             None,
             vec![arg_type],
@@ -206,11 +206,11 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match &args {
                 &[arg] => func(arg.clone()),
-                _ => Err(evaluator::EvaluationError::WrongNumArguments {
-                    function_name: name.clone(),
-                    expected: 1,
-                    actual: args.len(),
-                }),
+                _ => Err(evaluator::EvaluationError::wrong_num_arguments(
+                    name.clone(),
+                    1,
+                    args.len(),
+                )),
             }),
             Some(return_type),
             vec![arg_type],
@@ -232,11 +232,11 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match &args {
                 &[first, second] => func(first.clone(), second.clone()),
-                _ => Err(evaluator::EvaluationError::WrongNumArguments {
-                    function_name: name.clone(),
-                    expected: 2,
-                    actual: args.len(),
-                }),
+                _ => Err(evaluator::EvaluationError::wrong_num_arguments(
+                    name.clone(),
+                    2,
+                    args.len(),
+                )),
             }),
             Some(return_type),
             vec![arg_types.0, arg_types.1],
@@ -261,11 +261,11 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match &args {
                 &[first, second, third] => func(first.clone(), second.clone(), third.clone()),
-                _ => Err(evaluator::EvaluationError::WrongNumArguments {
-                    function_name: name.clone(),
-                    expected: 3,
-                    actual: args.len(),
-                }),
+                _ => Err(evaluator::EvaluationError::wrong_num_arguments(
+                    name.clone(),
+                    3,
+                    args.len(),
+                )),
             }),
             Some(return_type),
             vec![arg_types.0, arg_types.1, arg_types.2],

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -104,7 +104,7 @@ impl Authorizer {
                 errors.extend(partial.residuals.policies().map(|p| {
                     AuthorizationError::PolicyEvaluationError {
                         id: p.id().clone(),
-                        error: EvaluationError::NonValue(p.condition()),
+                        error: EvaluationError::non_value(p.condition()),
                     }
                 }));
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -87,7 +87,7 @@ impl<'e> RestrictedEvaluator<'e> {
     pub fn interpret(&self, e: BorrowedRestrictedExpr<'_>) -> Result<Value> {
         match self.partial_interpret(e)? {
             PartialValue::Value(v) => Ok(v),
-            PartialValue::Residual(r) => Err(EvaluationError::NonValue(r)),
+            PartialValue::Residual(r) => Err(EvaluationError::non_value(r)),
         }
     }
 
@@ -137,7 +137,7 @@ impl<'e> RestrictedEvaluator<'e> {
             },
             // PANIC SAFETY Unreachable via invariant on restricted expressions
             #[allow(clippy::unreachable)]
-            expr =>unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
+            expr => unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
         }
     }
 }
@@ -238,7 +238,7 @@ impl<'q, 'e> Evaluator<'e> {
     pub fn interpret(&self, e: &Expr, slots: &SlotEnv) -> Result<Value> {
         match self.partial_interpret(e, slots)? {
             PartialValue::Value(v) => Ok(v),
-            PartialValue::Residual(r) => Err(EvaluationError::NonValue(r)),
+            PartialValue::Residual(r) => Err(EvaluationError::non_value(r)),
         }
     }
 
@@ -254,7 +254,7 @@ impl<'q, 'e> Evaluator<'e> {
             ExprKind::Lit(lit) => Ok(lit.clone().into()),
             ExprKind::Slot(id) => slots
                 .get(id)
-                .ok_or_else(|| err::EvaluationError::UnlinkedSlot(*id))
+                .ok_or_else(|| err::EvaluationError::unlinked_slot(*id))
                 .map(|euid| PartialValue::from(euid.clone())),
             ExprKind::Var(v) => match v {
                 Var::Principal => Ok(self.principal.evaluate(*v)),
@@ -332,9 +332,7 @@ impl<'q, 'e> Evaluator<'e> {
                         let i = arg.get_as_long()?;
                         match i.checked_neg() {
                             Some(v) => Ok(v.into()),
-                            None => Err(EvaluationError::IntegerOverflow(
-                                IntegerOverflowError::UnaryOp { op: *op, arg },
-                            )),
+                            None => Err(IntegerOverflowError::UnaryOp { op: *op, arg }.into()),
                         }
                     }
                 },
@@ -372,23 +370,21 @@ impl<'q, 'e> Evaluator<'e> {
                             BinaryOp::LessEq => Ok((i1 <= i2).into()),
                             BinaryOp::Add => match i1.checked_add(i2) {
                                 Some(sum) => Ok(sum.into()),
-                                None => Err(EvaluationError::IntegerOverflow(
-                                    IntegerOverflowError::BinaryOp {
-                                        op: *op,
-                                        arg1,
-                                        arg2,
-                                    },
-                                )),
+                                None => Err(IntegerOverflowError::BinaryOp {
+                                    op: *op,
+                                    arg1,
+                                    arg2,
+                                }
+                                .into()),
                             },
                             BinaryOp::Sub => match i1.checked_sub(i2) {
                                 Some(diff) => Ok(diff.into()),
-                                None => Err(EvaluationError::IntegerOverflow(
-                                    IntegerOverflowError::BinaryOp {
-                                        op: *op,
-                                        arg1,
-                                        arg2,
-                                    },
-                                )),
+                                None => Err(IntegerOverflowError::BinaryOp {
+                                    op: *op,
+                                    arg1,
+                                    arg2,
+                                }
+                                .into()),
                             },
                             // PANIC SAFETY `op` is checked to be one of the above
                             #[allow(clippy::unreachable)]
@@ -399,25 +395,18 @@ impl<'q, 'e> Evaluator<'e> {
                     }
                     // hierarchy membership operator; see note on `BinaryOp::In`
                     BinaryOp::In => {
-                        let uid1 = arg1.get_as_entity().map_err(|e|
-                            // If arg1 is not an entity and arg2 is a set, then possibly
-                            // the user intended `arg2.contains(arg1)` rather than `arg1 in arg2`.
-                            // If arg2 is a record, then possibly they intended `arg2 has arg1`.
-                            if let EvaluationError::TypeError { expected, actual, advice } = e {
-                                match arg2 {
-                                    Value::Set(_) => EvaluationError::TypeError {
-                                        expected,
-                                        actual,
-                                        advice: Some("`in` is for checking the entity hierarchy, use `.contains()` to test set membership".into()),
-                                    },
-                                    Value::Record(_) => EvaluationError::TypeError {
-                                        expected,
-                                        actual,
-                                        advice: Some("`in` is for checking the entity hierarchy, use `has` to test if a record has a key".into()),
-                                    },
-                                    _ => EvaluationError::TypeError { expected, actual, advice }
-                                }
-                            } else {
+                        let uid1 = arg1.get_as_entity().map_err(|mut e|
+                            {
+                                // If arg1 is not an entity and arg2 is a set, then possibly
+                                // the user intended `arg2.contains(arg1)` rather than `arg1 in arg2`.
+                                // If arg2 is a record, then possibly they intended `arg2 has arg1`.
+                                if matches!(e.error_kind(), EvaluationErrorKind::TypeError { .. }) {
+                                    match arg2 {
+                                        Value::Set(_) => e.set_advice("`in` is for checking the entity hierarchy, use `.contains()` to test set membership".into()),
+                                        Value::Record(_) =>  e.set_advice("`in` is for checking the entity hierarchy, use `has` to test if a record has a key".into()),
+                                        _ => {}
+                                    }
+                                };
                                 e
                             })?;
                         match self.entities.entity(uid1) {
@@ -437,11 +426,7 @@ impl<'q, 'e> Evaluator<'e> {
                         Value::Set(Set { authoritative, .. }) => {
                             Ok((authoritative.contains(&arg2)).into())
                         }
-                        _ => Err(EvaluationError::TypeError {
-                            expected: vec![Type::Set],
-                            actual: arg1.type_of(),
-                            advice: None,
-                        }),
+                        _ => Err(EvaluationError::type_error(vec![Type::Set], arg1.type_of())),
                     },
                     // ContainsAll and ContainsAny, which work on Sets
                     BinaryOp::ContainsAll | BinaryOp::ContainsAny => {
@@ -499,12 +484,11 @@ impl<'q, 'e> Evaluator<'e> {
                     let i1 = arg.get_as_long()?;
                     match i1.checked_mul(*constant) {
                         Some(prod) => Ok(prod.into()),
-                        None => Err(EvaluationError::IntegerOverflow(
-                            IntegerOverflowError::Multiplication {
-                                arg,
-                                constant: *constant,
-                            },
-                        )),
+                        None => Err(IntegerOverflowError::Multiplication {
+                            arg,
+                            constant: *constant,
+                        }
+                        .into()),
                     }
                 }
                 PartialValue::Residual(r) => Ok(PartialValue::Residual(Expr::mul(r, *constant))),
@@ -537,14 +521,13 @@ impl<'q, 'e> Evaluator<'e> {
                         Dereference::Data(e) => Ok(e.get(attr).is_some().into()),
                     }
                 }
-                PartialValue::Value(val) => Err(err::EvaluationError::TypeError {
-                    expected: vec![
+                PartialValue::Value(val) => Err(err::EvaluationError::type_error(
+                    vec![
                         Type::Record,
                         Type::entity_type(names::ANY_ENTITY_TYPE.clone()),
                     ],
-                    actual: val.type_of(),
-                    advice: None,
-                }),
+                    val.type_of(),
+                )),
                 PartialValue::Residual(r) => Ok(Expr::has_attr(r, attr.clone()).into()),
             },
             ExprKind::Like { expr, pattern } => {
@@ -599,11 +582,10 @@ impl<'q, 'e> Evaluator<'e> {
                 .map(|val| Ok(val.get_as_entity()?.clone()))
                 .collect::<Result<Vec<EntityUID>>>()?,
             _ => {
-                return Err(EvaluationError::TypeError {
-                    expected: vec![Type::Set, Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
-                    actual: arg2.type_of(),
-                    advice: None,
-                })
+                return Err(EvaluationError::type_error(
+                    vec![Type::Set, Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
+                    arg2.type_of(),
+                ))
             }
         };
         for uid2 in rhs {
@@ -666,7 +648,7 @@ impl<'q, 'e> Evaluator<'e> {
                                 .filter_map(|(k, v)| if k == attr { Some(v) } else { None })
                                 .next()
                                 .ok_or_else(|| {
-                                    EvaluationError::RecordAttrDoesNotExist(
+                                    EvaluationError::record_attr_does_not_exist(
                                         attr.clone(),
                                         pairs.iter().map(|(f, _)| f.clone()).collect(),
                                     )
@@ -678,7 +660,7 @@ impl<'q, 'e> Evaluator<'e> {
                                 attr.clone(),
                             )))
                         } else {
-                            Err(EvaluationError::RecordAttrDoesNotExist(
+                            Err(EvaluationError::record_attr_does_not_exist(
                                 attr.clone(),
                                 pairs.iter().map(|(f, _)| f.clone()).collect(),
                             ))
@@ -692,7 +674,7 @@ impl<'q, 'e> Evaluator<'e> {
                 .as_ref()
                 .get(attr)
                 .ok_or_else(|| {
-                    EvaluationError::RecordAttrDoesNotExist(
+                    EvaluationError::record_attr_does_not_exist(
                         attr.clone(),
                         attrs.iter().map(|(f, _)| f.clone()).collect(),
                     )
@@ -702,18 +684,19 @@ impl<'q, 'e> Evaluator<'e> {
                 match self.entity_attr_values.get(uid.as_ref()) {
                     Dereference::NoSuchEntity => Err(match *uid.entity_type() {
                         EntityType::Unspecified => {
-                            EvaluationError::UnspecifiedEntityAccess(attr.clone())
+                            EvaluationError::unspecified_entity_access(attr.clone())
                         }
-                        EntityType::Concrete(_) => EvaluationError::EntityDoesNotExist(uid.clone()),
+                        EntityType::Concrete(_) => {
+                            EvaluationError::entity_does_not_exist(uid.clone())
+                        }
                     }),
                     Dereference::Residual(r) => {
                         Ok(PartialValue::Residual(Expr::get_attr(r, attr.clone())))
                     }
                     Dereference::Data(attrs) => attrs
                         .get(attr)
-                        .ok_or_else(|| EvaluationError::EntityAttrDoesNotExist {
-                            entity: uid,
-                            attr: attr.clone(),
+                        .ok_or_else(|| {
+                            EvaluationError::entity_attr_does_not_exist(uid, attr.clone())
                         })
                         .cloned(),
                 }
@@ -721,14 +704,13 @@ impl<'q, 'e> Evaluator<'e> {
             PartialValue::Value(v) => {
                 // PANIC SAFETY Entity type name is fully static and a valid unqualified `Name`
                 #[allow(clippy::unwrap_used)]
-                Err(EvaluationError::TypeError {
-                    expected: vec![
+                Err(EvaluationError::type_error(
+                    vec![
                         Type::Record,
                         Type::entity_type(Name::parse_unqualified_name("any_entity_type").unwrap()),
                     ],
-                    actual: v.type_of(),
-                    advice: None,
-                })
+                    v.type_of(),
+                ))
             }
         }
     }
@@ -737,7 +719,7 @@ impl<'q, 'e> Evaluator<'e> {
     pub fn interpret_inline_policy(&self, e: &Expr) -> Result<Value> {
         match self.partial_interpret(e, &HashMap::new())? {
             PartialValue::Value(v) => Ok(v),
-            PartialValue::Residual(r) => Err(err::EvaluationError::NonValue(r)),
+            PartialValue::Residual(r) => Err(err::EvaluationError::non_value(r)),
         }
     }
 
@@ -773,11 +755,10 @@ impl Value {
     pub(crate) fn get_as_bool(&self) -> Result<bool> {
         match self {
             Value::Lit(Literal::Bool(b)) => Ok(*b),
-            _ => Err(EvaluationError::TypeError {
-                expected: vec![Type::Bool],
-                actual: self.type_of(),
-                advice: None,
-            }),
+            _ => Err(EvaluationError::type_error(
+                vec![Type::Bool],
+                self.type_of(),
+            )),
         }
     }
 
@@ -786,11 +767,10 @@ impl Value {
     pub(crate) fn get_as_long(&self) -> Result<i64> {
         match self {
             Value::Lit(Literal::Long(i)) => Ok(*i),
-            _ => Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: self.type_of(),
-                advice: None,
-            }),
+            _ => Err(EvaluationError::type_error(
+                vec![Type::Long],
+                self.type_of(),
+            )),
         }
     }
 
@@ -799,11 +779,10 @@ impl Value {
     pub(crate) fn get_as_string(&self) -> Result<&SmolStr> {
         match self {
             Value::Lit(Literal::String(s)) => Ok(s),
-            _ => Err(EvaluationError::TypeError {
-                expected: vec![Type::String],
-                actual: self.type_of(),
-                advice: None,
-            }),
+            _ => Err(EvaluationError::type_error(
+                vec![Type::String],
+                self.type_of(),
+            )),
         }
     }
 
@@ -811,11 +790,7 @@ impl Value {
     pub(crate) fn get_as_set(&self) -> Result<&Set> {
         match self {
             Value::Set(s) => Ok(s),
-            _ => Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: self.type_of(),
-                advice: None,
-            }),
+            _ => Err(EvaluationError::type_error(vec![Type::Set], self.type_of())),
         }
     }
 
@@ -824,11 +799,10 @@ impl Value {
     pub(crate) fn get_as_entity(&self) -> Result<&EntityUID> {
         match self {
             Value::Lit(Literal::EntityUID(uid)) => Ok(uid.as_ref()),
-            _ => Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
-                actual: self.type_of(),
-                advice: None,
-            }),
+            _ => Err(EvaluationError::type_error(
+                vec![Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
+                self.type_of(),
+            )),
         }
     }
 }
@@ -838,7 +812,7 @@ fn stack_size_check() -> Result<()> {
     #[cfg(not(target_arch = "wasm32"))]
     {
         if stacker::remaining_stack().unwrap_or(0) < REQUIRED_STACK_SPACE {
-            return Err(EvaluationError::RecursionLimit);
+            return Err(EvaluationError::recursion_limit());
         }
     }
     Ok(())
@@ -1176,10 +1150,10 @@ pub mod test {
                 Expr::val(EntityUID::with_eid("entity_with_attrs")),
                 "doesnotexist".into()
             )),
-            Err(EvaluationError::EntityAttrDoesNotExist {
-                entity: Arc::new(EntityUID::with_eid("entity_with_attrs")),
-                attr: "doesnotexist".into()
-            })
+            Err(EvaluationError::entity_attr_does_not_exist(
+                Arc::new(EntityUID::with_eid("entity_with_attrs")),
+                "doesnotexist".into()
+            ))
         );
         // get_attr on an attr which does exist (and has integer type)
         assert_eq!(
@@ -1214,7 +1188,7 @@ pub mod test {
                 Expr::val(EntityUID::with_eid("doesnotexist")),
                 "foo".into()
             )),
-            Err(EvaluationError::EntityDoesNotExist(Arc::new(
+            Err(EvaluationError::entity_does_not_exist(Arc::new(
                 EntityUID::with_eid("doesnotexist")
             )))
         );
@@ -1232,7 +1206,7 @@ pub mod test {
                 Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
                 "bar".into()
             )),
-            Err(EvaluationError::UnspecifiedEntityAccess("bar".into()))
+            Err(EvaluationError::unspecified_entity_access("bar".into()))
         );
     }
 
@@ -1277,11 +1251,7 @@ pub mod test {
                 Expr::val(3),
                 Expr::val(8)
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Bool],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Bool], Type::String))
         );
         // if principal then 3 else 8
         assert_eq!(
@@ -1290,13 +1260,12 @@ pub mod test {
                 Expr::val(3),
                 Expr::val(8)
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Bool],
-                actual: Type::Entity {
+            Err(EvaluationError::type_error(
+                vec![Type::Bool],
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
                 },
-                advice: None,
-            })
+            ))
         );
         // if true then "hello" else 2
         assert_eq!(
@@ -1386,7 +1355,7 @@ pub mod test {
                 Expr::val(3),
                 Expr::get_attr(Expr::record(vec![]), "foo".into()),
             )),
-            Err(EvaluationError::RecordAttrDoesNotExist(
+            Err(EvaluationError::record_attr_does_not_exist(
                 "foo".into(),
                 vec![]
             ))
@@ -1398,7 +1367,7 @@ pub mod test {
                 Expr::get_attr(Expr::record(vec![]), "foo".into()),
                 Expr::val(3),
             )),
-            Err(EvaluationError::RecordAttrDoesNotExist(
+            Err(EvaluationError::record_attr_does_not_exist(
                 "foo".into(),
                 vec![]
             ))
@@ -1453,32 +1422,30 @@ pub mod test {
                 Expr::set(vec![Expr::val(8)]),
                 "hello".into()
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Set,
-                advice: None,
-            })
+                Type::Set,
+            ))
         );
         // indexing into empty set
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(Expr::set(vec![]), "hello".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Set,
-                advice: None,
-            })
+                Type::Set,
+            ))
         );
         // set("hello", 2, true, <entity foo>)
         let mixed_set = Expr::set(vec![
@@ -1499,17 +1466,16 @@ pub mod test {
         // set("hello", 2, true, <entity foo>)["hello"]
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(mixed_set, "hello".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Set,
-                advice: None,
-            })
+                Type::Set,
+            ))
         );
         // set(set(8, 2), set(13, 702), set(3))
         let set_of_sets = Expr::set(vec![
@@ -1534,17 +1500,16 @@ pub mod test {
         // set(set(8, 2), set(13, 702), set(3))["hello"]
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(set_of_sets.clone(), "hello".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Set,
-                advice: None,
-            })
+                Type::Set,
+            ))
         );
         // set(set(8, 2), set(13, 702), set(3))["ham"]["eggs"]
         assert_eq!(
@@ -1552,17 +1517,16 @@ pub mod test {
                 Expr::get_attr(set_of_sets, "ham".into()),
                 "eggs".into()
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Set,
-                advice: None,
-            })
+                Type::Set,
+            ))
         );
     }
 
@@ -1595,7 +1559,7 @@ pub mod test {
         // {"ham": 3, "eggs": 7}["what"]
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(ham_and_eggs, "what".into())),
-            Err(EvaluationError::RecordAttrDoesNotExist(
+            Err(EvaluationError::record_attr_does_not_exist(
                 "what".into(),
                 vec!["eggs".into(), "ham".into()]
             ))
@@ -1796,62 +1760,58 @@ pub mod test {
         // indexing into something that's not a record, 1010122["hello"]
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(Expr::val(1010122), "hello".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Long,
-                advice: None,
-            })
+                Type::Long,
+            ))
         );
         // indexing into something that's not a record, "hello"["eggs"]
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(Expr::val("hello"), "eggs".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::String,
-                advice: None,
-            })
+                Type::String,
+            ))
         );
         // has_attr on something that's not a record, has(1010122.hello)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(Expr::val(1010122), "hello".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::Long,
-                advice: None,
-            })
+                Type::Long,
+            ))
         );
         // has_attr on something that's not a record, has("hello".eggs)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(Expr::val("hello"), "eggs".into())),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Record,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     ),
                 ],
-                actual: Type::String,
-                advice: None,
-            })
+                Type::String,
+            ))
         );
     }
 
@@ -1874,22 +1834,17 @@ pub mod test {
         // not(8)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::not(Expr::val(8))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Bool],
-                actual: Type::Long,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Bool], Type::Long))
         );
         // not(action)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::not(Expr::var(Var::Action))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Bool],
-                actual: Type::Entity {
+            Err(EvaluationError::type_error(
+                vec![Type::Bool],
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
                 },
-                advice: None,
-            })
+            ))
         );
         // not(not(true))
         assert_eq!(
@@ -1954,21 +1909,16 @@ pub mod test {
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::neg(Expr::val(std::i64::MIN))),
-            Err(EvaluationError::IntegerOverflow(
-                IntegerOverflowError::UnaryOp {
-                    op: UnaryOp::Neg,
-                    arg: Value::from(std::i64::MIN)
-                }
-            )),
+            Err(IntegerOverflowError::UnaryOp {
+                op: UnaryOp::Neg,
+                arg: Value::from(std::i64::MIN)
+            }
+            .into()),
         );
         // neg(false)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::neg(Expr::val(false))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // neg([1, 2, 3])
         assert_eq!(
@@ -1977,11 +1927,7 @@ pub mod test {
                 Expr::val(2),
                 Expr::val(3)
             ]))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Set,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Set))
         );
     }
 
@@ -2282,173 +2228,97 @@ pub mod test {
         // false < true
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(false), Expr::val(true))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // false < false
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(false), Expr::val(false))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // true <= false
         assert_eq!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val(true), Expr::val(false))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // false <= false
         assert_eq!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val(false), Expr::val(false))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // false > true
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greater(Expr::val(false), Expr::val(true))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // true > true
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greater(Expr::val(true), Expr::val(true))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // true >= false
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(true), Expr::val(false))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // true >= true
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(true), Expr::val(true))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // bc < zzz
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("bc"), Expr::val("zzz"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // banana < zzz
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("banana"), Expr::val("zzz"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // "" < zzz
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(""), Expr::val("zzz"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // a < 1
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("a"), Expr::val("1"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // a < A
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("a"), Expr::val("A"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // A < A
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("A"), Expr::val("A"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // zebra < zebras
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("zebra"), Expr::val("zebras"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // zebra <= zebras
         assert_eq!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val("zebra"), Expr::val("zebras"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // zebras <= zebras
         assert_eq!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val("zebras"), Expr::val("zebras"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // zebras <= Zebras
         assert_eq!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val("zebras"), Expr::val("Zebras"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // 123 > 78
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greater(Expr::val("123"), Expr::val("78"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // <space>zebras >= zebras
         assert_eq!(
@@ -2456,74 +2326,42 @@ pub mod test {
                 Expr::val(" zebras"),
                 Expr::val("zebras")
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // "" >= ""
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(""), Expr::val(""))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // "" >= _hi
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(""), Expr::val("_hi"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // 🦀 >= _hi
         assert_eq!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val("🦀"), Expr::val("_hi"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // 2 < "4"
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(2), Expr::val("4"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // "4" < 2
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("4"), Expr::val(2))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // false < 1
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(false), Expr::val(1))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // 1 < false
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(1), Expr::val(false))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Bool,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Bool))
         );
         // [1, 2] < [47, 0]
         assert_eq!(
@@ -2531,11 +2369,7 @@ pub mod test {
                 Expr::set(vec![Expr::val(1), Expr::val(2)]),
                 Expr::set(vec![Expr::val(47), Expr::val(0)])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Set,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::Set))
         );
     }
 
@@ -2563,22 +2397,17 @@ pub mod test {
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::add(Expr::val(std::i64::MAX), Expr::val(1))),
-            Err(EvaluationError::IntegerOverflow(
-                IntegerOverflowError::BinaryOp {
-                    op: BinaryOp::Add,
-                    arg1: Value::from(std::i64::MAX),
-                    arg2: Value::from(1),
-                }
-            ))
+            Err(IntegerOverflowError::BinaryOp {
+                op: BinaryOp::Add,
+                arg1: Value::from(std::i64::MAX),
+                arg2: Value::from(1),
+            }
+            .into())
         );
         // 7 + "3"
         assert_eq!(
             eval.interpret_inline_policy(&Expr::add(Expr::val(7), Expr::val("3"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // 44 - 31
         assert_eq!(
@@ -2593,22 +2422,17 @@ pub mod test {
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::sub(Expr::val(std::i64::MIN + 2), Expr::val(3))),
-            Err(EvaluationError::IntegerOverflow(
-                IntegerOverflowError::BinaryOp {
-                    op: BinaryOp::Sub,
-                    arg1: Value::from(std::i64::MIN + 2),
-                    arg2: Value::from(3),
-                }
-            ))
+            Err(IntegerOverflowError::BinaryOp {
+                op: BinaryOp::Sub,
+                arg1: Value::from(std::i64::MIN + 2),
+                arg2: Value::from(3),
+            }
+            .into())
         );
         // "ham" - "ha"
         assert_eq!(
             eval.interpret_inline_policy(&Expr::sub(Expr::val("ham"), Expr::val("ha"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // 5 * (-3)
         assert_eq!(
@@ -2623,21 +2447,16 @@ pub mod test {
         // "5" * 0
         assert_eq!(
             eval.interpret_inline_policy(&Expr::mul(Expr::val("5"), 0)),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
         );
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::mul(Expr::val(std::i64::MAX - 1), 3)),
-            Err(EvaluationError::IntegerOverflow(
-                IntegerOverflowError::Multiplication {
-                    arg: Value::from(std::i64::MAX - 1),
-                    constant: 3,
-                }
-            ))
+            Err(IntegerOverflowError::Multiplication {
+                arg: Value::from(std::i64::MAX - 1),
+                constant: 3,
+            }
+            .into())
         );
     }
 
@@ -2786,11 +2605,7 @@ pub mod test {
         // 3 contains 7
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains(Expr::val(3), Expr::val(7))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::Long,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::Long))
         );
         // { ham: "eggs" } contains "ham"
         assert_eq!(
@@ -2798,11 +2613,7 @@ pub mod test {
                 Expr::record(vec![("ham".into(), Expr::val("eggs"))]),
                 Expr::val("ham")
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::Record,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::Record))
         );
         // wrong argument order
         assert_eq!(
@@ -2810,11 +2621,7 @@ pub mod test {
                 Expr::val(3),
                 Expr::set(vec![Expr::val(1), Expr::val(3), Expr::val(7)])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::Long,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::Long))
         );
     }
 
@@ -3006,14 +2813,13 @@ pub mod test {
                     Expr::val(true),
                 ])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(
+            Err(EvaluationError::type_error(
+                vec![Type::entity_type(
                     Name::parse_unqualified_name("any_entity_type")
                         .expect("should be a valid identifier")
                 )],
-                actual: Type::Bool,
-                advice: None,
-            })
+                Type::Bool,
+            ))
         );
         // A in [A, B] where A and B do not exist
         assert_eq!(
@@ -3062,14 +2868,13 @@ pub mod test {
         // "foo" in "foobar"
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_in(Expr::val("foo"), Expr::val("foobar"))),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(
+            Err(EvaluationError::type_error(
+                vec![Type::entity_type(
                     Name::parse_unqualified_name("any_entity_type")
                         .expect("should be a valid identifier")
                 )],
-                actual: Type::String,
-                advice: None,
-            })
+                Type::String,
+            ))
         );
         // "spoon" in A (where has(A.spoon))
         assert_eq!(
@@ -3077,14 +2882,13 @@ pub mod test {
                 Expr::val("spoon"),
                 Expr::val(EntityUID::with_eid("entity_with_attrs"))
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(
+            Err(EvaluationError::type_error(
+                vec![Type::entity_type(
                     Name::parse_unqualified_name("any_entity_type")
                         .expect("should be a valid identifier")
                 )],
-                actual: Type::String,
-                advice: None,
-            })
+                Type::String,
+            ))
         );
         // 3 in [34, -2, 7]
         assert_eq!(
@@ -3092,14 +2896,14 @@ pub mod test {
                 Expr::val(3),
                 Expr::set(vec![Expr::val(34), Expr::val(-2), Expr::val(7)])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(
+            Err(EvaluationError::type_error_with_advice(
+                vec![Type::entity_type(
                     Name::parse_unqualified_name("any_entity_type")
                         .expect("should be a valid identifier")
                 )],
-                actual: Type::Long,
-                advice: Some("`in` is for checking the entity hierarchy, use `.contains()` to test set membership".into()),
-            })
+                Type::Long,
+                "`in` is for checking the entity hierarchy, use `.contains()` to test set membership".into(),
+            ))
         );
         // "foo" in { "foo": 2, "bar": true }
         assert_eq!(
@@ -3110,14 +2914,14 @@ pub mod test {
                     ("bar".into(), Expr::val(true)),
                 ])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::entity_type(
+            Err(EvaluationError::type_error_with_advice(
+                vec![Type::entity_type(
                     Name::parse_unqualified_name("any_entity_type")
                         .expect("should be a valid identifier")
                 )],
-                actual: Type::String,
-                advice: Some("`in` is for checking the entity hierarchy, use `has` to test if a record has a key".into()),
-            })
+                Type::String,
+                "`in` is for checking the entity hierarchy, use `has` to test if a record has a key".into(),
+            ))
         );
         // A in { "foo": 2, "bar": true }
         assert_eq!(
@@ -3128,17 +2932,16 @@ pub mod test {
                     ("bar".into(), Expr::val(true)),
                 ])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![
+            Err(EvaluationError::type_error(
+                vec![
                     Type::Set,
                     Type::entity_type(
                         Name::parse_unqualified_name("any_entity_type")
                             .expect("should be a valid identifier")
                     )
                 ],
-                actual: Type::Record,
-                advice: None,
-            })
+                Type::Record,
+            ))
         );
     }
 
@@ -3342,11 +3145,7 @@ pub mod test {
         // type error
         assert_eq!(
             eval.interpret_inline_policy(&Expr::like(Expr::val(354), vec![])),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::String],
-                actual: Type::Long,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::String], Type::Long))
         );
         // 'contains' is not allowed on strings
         assert_eq!(
@@ -3354,11 +3153,7 @@ pub mod test {
                 Expr::val("ham and ham"),
                 Expr::val("ham")
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::String))
         );
         // '\0' should not match '*'
         assert_eq!(
@@ -3536,11 +3331,7 @@ pub mod test {
                 Expr::val("ham"),
                 Expr::val("ham and eggs")
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::String))
         );
         // {"2": "ham", "3": "eggs"} containsall {"2": "ham"} ?
         assert_eq!(
@@ -3551,11 +3342,7 @@ pub mod test {
                     ("3".into(), Expr::val("eggs"))
                 ])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::Record,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::Record))
         );
         // test for [1, -22] contains_any of [1, -22, 34]
         assert_eq!(
@@ -3655,11 +3442,7 @@ pub mod test {
                 Expr::val("ham"),
                 Expr::val("ham and eggs")
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::String,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::String))
         );
         // test for {"2": "ham"} contains_any of {"2": "ham", "3": "eggs"}
         assert_eq!(
@@ -3670,11 +3453,7 @@ pub mod test {
                     ("3".into(), Expr::val("eggs"))
                 ])
             )),
-            Err(EvaluationError::TypeError {
-                expected: vec![Type::Set],
-                actual: Type::Record,
-                advice: None,
-            })
+            Err(EvaluationError::type_error(vec![Type::Set], Type::Record))
         );
         Ok(())
     }
@@ -3806,10 +3585,12 @@ pub mod test {
         let slots = HashMap::new();
         let r = evaluator.partial_interpret(&e, &slots);
         match r {
-            Err(EvaluationError::UnlinkedSlot(slotid)) => {
-                assert_eq!(slotid, SlotId::principal())
-            }
-            Err(e) => panic!("Got wrong error: {e}"),
+            Err(e) => match e.error_kind() {
+                EvaluationErrorKind::UnlinkedSlot(slotid) => {
+                    assert_eq!(*slotid, SlotId::principal())
+                }
+                _ => panic!("Got wrong error: {e}"),
+            },
             Ok(v) => panic!("Got wrong response: {v}"),
         };
 
@@ -3867,6 +3648,16 @@ pub mod test {
         );
     }
 
+    fn assert_restricted_expression_error(v: Result<PartialValue>) {
+        match v {
+            Err(e) => assert!(matches!(
+                e.error_kind(),
+                EvaluationErrorKind::InvalidRestrictedExpression { .. }
+            )),
+            Ok(v) => panic!("Got wrong response: {v}"),
+        }
+    }
+
     #[test]
     fn restricted_expressions() {
         let exts = Extensions::all_available();
@@ -3897,72 +3688,62 @@ pub mod test {
                 .and_then(|e| evaluator.partial_interpret(e)),
             Ok(Value::from(EntityUID::with_eid("alice")).into())
         );
-        assert!(matches!(
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::var(Var::Principal))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::var(Var::Action))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::var(Var::Resource))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::var(Var::Context))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
-            BorrowedRestrictedExpr::new(&Expr::ite(Expr::val(true), Expr::val(7), Expr::val(12)),)
+        );
+        assert_restricted_expression_error(
+            BorrowedRestrictedExpr::new(&Expr::ite(Expr::val(true), Expr::val(7), Expr::val(12)))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::and(Expr::val("bogus"), Expr::val(true)))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::or(Expr::val("bogus"), Expr::val(true)))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::not(Expr::val(true)))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::is_in(
                 Expr::val(EntityUID::with_eid("alice")),
-                Expr::val(EntityUID::with_eid("some_group"))
+                Expr::val(EntityUID::with_eid("some_group")),
             ))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::is_eq(
                 Expr::val(EntityUID::with_eid("alice")),
-                Expr::val(EntityUID::with_eid("some_group"))
+                Expr::val(EntityUID::with_eid("some_group")),
             ))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
+        );
         #[cfg(feature = "ipaddr")]
         assert!(matches!(
             BorrowedRestrictedExpr::new(&Expr::call_extension_fn(
@@ -3973,38 +3754,35 @@ pub mod test {
             .and_then(|e| evaluator.partial_interpret(e)),
             Ok(PartialValue::Value(Value::ExtensionValue(_)))
         ));
-        assert!(matches!(
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::get_attr(
                 Expr::val(EntityUID::with_eid("alice")),
-                "pancakes".into()
-            ),)
+                "pancakes".into(),
+            ))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::has_attr(
                 Expr::val(EntityUID::with_eid("alice")),
-                "pancakes".into()
-            ),)
+                "pancakes".into(),
+            ))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::like(
                 Expr::val("abcdefg12"),
                 vec![
                     PatternElem::Char('a'),
                     PatternElem::Char('b'),
                     PatternElem::Char('c'),
-                    PatternElem::Wildcard
-                ]
-            ),)
+                    PatternElem::Wildcard,
+                ],
+            ))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
+        );
         assert!(matches!(
             BorrowedRestrictedExpr::new(&Expr::set([Expr::val("hi"), Expr::val("there")]))
                 .map_err(Into::into)
@@ -4022,24 +3800,22 @@ pub mod test {
         ));
 
         // complex expressions -- for instance, violation not at top level
-        assert!(matches!(
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::set([
                 Expr::val("hi"),
-                Expr::and(Expr::val("bogus"), Expr::val(false))
-            ]),)
+                Expr::and(Expr::val("bogus"), Expr::val(false)),
+            ]))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::call_extension_fn(
                 "ip".parse().expect("should be a valid Name"),
                 vec![Expr::var(Var::Principal)],
-            ),)
+            ))
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
-            Err(EvaluationError::InvalidRestrictedExpression { .. })
-        ));
+        );
     }
 
     #[test]

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -830,6 +830,8 @@ pub mod test {
         parser::{parse_expr, parse_policy_template},
     };
 
+    use cool_asserts::assert_matches;
+
     // Many of these tests use this Request
     pub fn basic_request() -> Request {
         Request::new(
@@ -3650,10 +3652,10 @@ pub mod test {
 
     fn assert_restricted_expression_error(v: Result<PartialValue>) {
         match v {
-            Err(e) => assert!(matches!(
+            Err(e) => assert_matches!(
                 e.error_kind(),
                 EvaluationErrorKind::InvalidRestrictedExpression { .. }
-            )),
+            ),
             Ok(v) => panic!("Got wrong response: {v}"),
         }
     }
@@ -3745,7 +3747,7 @@ pub mod test {
             .and_then(|e| evaluator.partial_interpret(e)),
         );
         #[cfg(feature = "ipaddr")]
-        assert!(matches!(
+        assert_matches!(
             BorrowedRestrictedExpr::new(&Expr::call_extension_fn(
                 "ip".parse().expect("should be a valid Name"),
                 vec![Expr::val("222.222.222.222")]
@@ -3753,7 +3755,7 @@ pub mod test {
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
             Ok(PartialValue::Value(Value::ExtensionValue(_)))
-        ));
+        );
         assert_restricted_expression_error(
             BorrowedRestrictedExpr::new(&Expr::get_attr(
                 Expr::val(EntityUID::with_eid("alice")),
@@ -3783,13 +3785,13 @@ pub mod test {
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
         );
-        assert!(matches!(
+        assert_matches!(
             BorrowedRestrictedExpr::new(&Expr::set([Expr::val("hi"), Expr::val("there")]))
                 .map_err(Into::into)
                 .and_then(|e| evaluator.partial_interpret(e)),
             Ok(PartialValue::Value(Value::Set(_)))
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             BorrowedRestrictedExpr::new(&Expr::record([
                 ("hi".into(), Expr::val(1001)),
                 ("foo".into(), Expr::val("bar"))
@@ -3797,7 +3799,7 @@ pub mod test {
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
             Ok(PartialValue::Value(Value::Record(_)))
-        ));
+        );
 
         // complex expressions -- for instance, violation not at top level
         assert_restricted_expression_error(

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -53,12 +53,14 @@ pub enum EvaluationError {
     /// Tried to evaluate an operation on values with incorrect types for that
     /// operation
     // INVARIANT `expected` must be non-empty
-    #[error("{}", pretty_type_error(expected, actual))]
+    #[error("{}", pretty_type_error(expected, actual, advice))]
     TypeError {
         /// Expected (one of) these types
         expected: Vec<Type>,
         /// Encountered this type instead
         actual: Type,
+        /// Optional advice on how to fix the error
+        advice: Option<String>,
     },
 
     /// Wrong number of arguments provided to an extension function
@@ -107,8 +109,8 @@ pub enum EvaluationError {
 
 /// helper function for pretty-printing type errors
 /// INVARIANT: `expected` must have at least one value
-fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
-    match expected.len() {
+fn pretty_type_error(expected: &[Type], actual: &Type, advice: &Option<String>) -> String {
+    let err_msg = match expected.len() {
         // PANIC SAFETY, `expected` is non-empty by invariant
         #[allow(clippy::unreachable)]
         0 => unreachable!("should expect at least one type"),
@@ -122,6 +124,11 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
                 expected.iter().join(", ")
             )
         }
+    };
+    if let Some(help_msg) = advice {
+        format!("{}. {}", err_msg, help_msg)
+    } else {
+        err_msg
     }
 }
 

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -313,9 +313,9 @@ mod tests {
                             .expect("should be a valid identifier")
                     )
                 }
-                _ => panic!("Expected an decimal ExtensionErr, got {:?}", e),
+                _ => panic!("Expected a decimal ExtensionErr, got {:?}", e),
             },
-            Ok(_) => panic!("Expected an decimal ExtensionErr, got Ok"),
+            Ok(_) => panic!("Expected a decimal ExtensionErr, got Ok"),
         }
     }
 

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -195,6 +195,7 @@ fn as_decimal(v: &Value) -> Result<&Decimal, evaluator::EvaluationError> {
                 name: Decimal::typename(),
             }],
             actual: v.type_of(),
+            advice: None,
         }),
     }
 }
@@ -599,6 +600,7 @@ mod tests {
                     name: Name::parse_unqualified_name("decimal")
                         .expect("should be a valid identifier")
                 },
+                advice: None,
             })
         );
         assert_eq!(
@@ -611,6 +613,7 @@ mod tests {
                         .expect("should be a valid identifier")
                 }],
                 actual: Type::String,
+                advice: None,
             })
         );
         // bad use of `lessThan` as function

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -20,7 +20,7 @@ use regex::Regex;
 
 use crate::ast::{
     CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, ExtensionValue,
-    ExtensionValueWithArgs, Name, StaticallyTyped, Type, Value,
+    ExtensionValueWithArgs, Literal, Name, StaticallyTyped, Type, Value,
 };
 use crate::entities::SchemaType;
 use crate::evaluator;
@@ -51,6 +51,10 @@ mod names {
         pub static ref GREATER_THAN_OR_EQUAL : Name = Name::parse_unqualified_name("greaterThanOrEqual").expect("should be a valid identifier");
     }
 }
+
+/// Help message to display when a String was provided where a decimal value was expected.
+/// This error is likely due to confusion between "1.23" and decimal("1.23").
+const ADVICE_MSG: &str = "Maybe you forgot to apply the `decimal` constructor?";
 
 /// Potential errors when working with decimal values. Note that these are
 /// converted to evaluator::Err::ExtensionErr (which takes a string argument)
@@ -161,10 +165,10 @@ impl ExtensionValue for Decimal {
 const EXTENSION_NAME: &str = "decimal";
 
 fn extension_err(msg: impl Into<String>) -> evaluator::EvaluationError {
-    evaluator::EvaluationError::FailedExtensionFunctionApplication {
-        extension_name: names::DECIMAL_FROM_STR_NAME.clone(),
-        msg: msg.into(),
-    }
+    evaluator::EvaluationError::failed_extension_function_application(
+        names::DECIMAL_FROM_STR_NAME.clone(),
+        msg.into(),
+    )
 }
 
 /// Cedar function that constructs a `decimal` Cedar type from a
@@ -190,13 +194,19 @@ fn as_decimal(v: &Value) -> Result<&Decimal, evaluator::EvaluationError> {
                 .expect("already typechecked, so this downcast should succeed");
             Ok(d)
         }
-        _ => Err(evaluator::EvaluationError::TypeError {
-            expected: vec![Type::Extension {
+        Value::Lit(Literal::String(_)) => Err(evaluator::EvaluationError::type_error_with_advice(
+            vec![Type::Extension {
                 name: Decimal::typename(),
             }],
-            actual: v.type_of(),
-            advice: None,
-        }),
+            v.type_of(),
+            ADVICE_MSG.into(),
+        )),
+        _ => Err(evaluator::EvaluationError::type_error(
+            vec![Type::Extension {
+                name: Decimal::typename(),
+            }],
+            v.type_of(),
+        )),
     }
 }
 
@@ -291,17 +301,20 @@ mod tests {
     /// Asserts that a `Result` is an `Err::ExtensionErr` with our extension name
     fn assert_decimal_err<T>(res: evaluator::Result<T>) {
         match res {
-            Err(evaluator::EvaluationError::FailedExtensionFunctionApplication {
-                extension_name,
-                msg,
-            }) => {
-                println!("{msg}");
-                assert_eq!(
+            Err(e) => match e.error_kind() {
+                evaluator::EvaluationErrorKind::FailedExtensionFunctionApplication {
                     extension_name,
-                    Name::parse_unqualified_name("decimal").expect("should be a valid identifier")
-                )
-            }
-            Err(e) => panic!("Expected an decimal ExtensionErr, got {:?}", e),
+                    msg,
+                } => {
+                    println!("{msg}");
+                    assert_eq!(
+                        *extension_name,
+                        Name::parse_unqualified_name("decimal")
+                            .expect("should be a valid identifier")
+                    )
+                }
+                _ => panic!("Expected an decimal ExtensionErr, got {:?}", e),
+            },
             Ok(_) => panic!("Expected an decimal ExtensionErr, got Ok"),
         }
     }
@@ -594,27 +607,27 @@ mod tests {
             eval.interpret_inline_policy(
                 &parse_expr(r#"decimal("1.23") < decimal("1.24")"#).expect("parsing error")
             ),
-            Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Extension {
+            Err(evaluator::EvaluationError::type_error_with_advice(
+                vec![Type::Long],
+                Type::Extension {
                     name: Name::parse_unqualified_name("decimal")
                         .expect("should be a valid identifier")
                 },
-                advice: None,
-            })
+                ADVICE_MSG.into(),
+            ))
         );
         assert_eq!(
             eval.interpret_inline_policy(
                 &parse_expr(r#"decimal("-1.23").lessThan("1.23")"#).expect("parsing error")
             ),
-            Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
+            Err(evaluator::EvaluationError::type_error_with_advice(
+                vec![Type::Extension {
                     name: Name::parse_unqualified_name("decimal")
                         .expect("should be a valid identifier")
                 }],
-                actual: Type::String,
-                advice: None,
-            })
+                Type::String,
+                ADVICE_MSG.into(),
+            ))
         );
         // bad use of `lessThan` as function
         parse_expr(r#"lessThan(decimal("-1.23"), decimal("1.23"))"#).expect_err("should fail");

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -607,13 +607,12 @@ mod tests {
             eval.interpret_inline_policy(
                 &parse_expr(r#"decimal("1.23") < decimal("1.24")"#).expect("parsing error")
             ),
-            Err(evaluator::EvaluationError::type_error_with_advice(
+            Err(evaluator::EvaluationError::type_error(
                 vec![Type::Long],
                 Type::Extension {
                     name: Name::parse_unqualified_name("decimal")
                         .expect("should be a valid identifier")
                 },
-                ADVICE_MSG.into(),
             ))
         );
         assert_eq!(

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -128,10 +128,10 @@ impl ExtensionValue for IPAddr {
 }
 
 fn extension_err(msg: impl Into<String>) -> evaluator::EvaluationError {
-    evaluator::EvaluationError::FailedExtensionFunctionApplication {
-        extension_name: names::EXTENSION_NAME.clone(),
-        msg: msg.into(),
-    }
+    evaluator::EvaluationError::failed_extension_function_application(
+        names::EXTENSION_NAME.clone(),
+        msg.into(),
+    )
 }
 
 /// Check whether `s` contains at least three occurences of `c`
@@ -191,125 +191,59 @@ fn ip_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     Ok(Value::ExtensionValue(Arc::new(ipaddr)).into())
 }
 
+fn as_ipaddr(v: &Value) -> Result<&IPAddr, evaluator::EvaluationError> {
+    match v {
+        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => {
+            // PANIC SAFETY Conditional above performs a typecheck
+            #[allow(clippy::expect_used)]
+            let ipaddr = ev
+                .value()
+                .as_any()
+                .downcast_ref::<IPAddr>()
+                .expect("already typechecked, so this downcast should succeed");
+            Ok(ipaddr)
+        }
+        Value::Lit(Literal::String(_)) => Err(evaluator::EvaluationError::type_error_with_advice(
+            vec![Type::Extension {
+                name: IPAddr::typename(),
+            }],
+            v.type_of(),
+            ADVICE_MSG.into(),
+        )),
+        _ => Err(evaluator::EvaluationError::type_error(
+            vec![Type::Extension {
+                name: IPAddr::typename(),
+            }],
+            v.type_of(),
+        )),
+    }
+}
+
 /// Cedar function which tests whether an `ipaddr` Cedar type is an IPv4
 /// address, returning a Cedar bool
 fn is_ipv4(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr_ev = match arg {
-        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => ev,
-        // If applied to a string: maybe you meant to apply the ip constructor?
-        _ => {
-            let advice = if matches!(&arg, Value::Lit(Literal::String(_))) {
-                Some(ADVICE_MSG.into())
-            } else {
-                None
-            };
-            return Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
-                    name: IPAddr::typename(),
-                }],
-                actual: arg.type_of(),
-                advice,
-            });
-        }
-    };
-    // PANIC SAFETY Typechecking performed above
-    #[allow(clippy::expect_used)]
-    let ipaddr = ipaddr_ev
-        .value()
-        .as_any()
-        .downcast_ref::<IPAddr>()
-        .expect("already typechecked above, so this downcast should succeed");
+    let ipaddr = as_ipaddr(&arg)?;
     Ok(ipaddr.is_ipv4().into())
 }
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is an IPv6
 /// address, returning a Cedar bool
 fn is_ipv6(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr_ev = match arg {
-        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => ev,
-        // If applied to a string: maybe you meant to apply the ip constructor?
-        _ => {
-            let advice = if matches!(&arg, Value::Lit(Literal::String(_))) {
-                Some(ADVICE_MSG.into())
-            } else {
-                None
-            };
-            return Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
-                    name: IPAddr::typename(),
-                }],
-                actual: arg.type_of(),
-                advice,
-            });
-        }
-    };
-    // PANIC SAFETY Typechecking performed above
-    #[allow(clippy::expect_used)]
-    let ipaddr = ipaddr_ev
-        .value()
-        .as_any()
-        .downcast_ref::<IPAddr>()
-        .expect("already typechecked above, so this downcast should succeed");
+    let ipaddr = as_ipaddr(&arg)?;
     Ok(ipaddr.is_ipv6().into())
 }
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is a
 /// loopback address, returning a Cedar bool
 fn is_loopback(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr_ev = match arg {
-        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => ev,
-        _ => {
-            let advice = if matches!(&arg, Value::Lit(Literal::String(_))) {
-                Some(ADVICE_MSG.into())
-            } else {
-                None
-            };
-            return Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
-                    name: IPAddr::typename(),
-                }],
-                actual: arg.type_of(),
-                advice,
-            });
-        }
-    };
-    // PANIC SAFETY Typechecking performed above
-    #[allow(clippy::expect_used)]
-    let ipaddr = ipaddr_ev
-        .value()
-        .as_any()
-        .downcast_ref::<IPAddr>()
-        .expect("already typechecked above, so this downcast should succeed");
+    let ipaddr = as_ipaddr(&arg)?;
     Ok(ipaddr.is_loopback().into())
 }
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is a
 /// multicast address, returning a Cedar bool
 fn is_multicast(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr_ev = match arg {
-        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => ev,
-        _ => {
-            let advice = if matches!(&arg, Value::Lit(Literal::String(_))) {
-                Some(ADVICE_MSG.into())
-            } else {
-                None
-            };
-            return Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
-                    name: IPAddr::typename(),
-                }],
-                actual: arg.type_of(),
-                advice,
-            });
-        }
-    };
-    // PANIC SAFETY Typechecking performed above
-    #[allow(clippy::expect_used)]
-    let ipaddr = ipaddr_ev
-        .value()
-        .as_any()
-        .downcast_ref::<IPAddr>()
-        .expect("already typechecked above, so this downcast should succeed");
+    let ipaddr = as_ipaddr(&arg)?;
     Ok(ipaddr.is_multicast().into())
 }
 
@@ -317,54 +251,8 @@ fn is_multicast(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
 /// in the IP range represented by the second `ipaddr` Cedar type, returning
 /// a Cedar bool
 fn is_in_range(child: Value, parent: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let child_ev = match child {
-        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => ev,
-        _ => {
-            let advice = if matches!(&child, Value::Lit(Literal::String(_))) {
-                Some(ADVICE_MSG.into())
-            } else {
-                None
-            };
-            return Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
-                    name: IPAddr::typename(),
-                }],
-                actual: child.type_of(),
-                advice,
-            });
-        }
-    };
-    let parent_ev = match parent {
-        Value::ExtensionValue(ev) if ev.typename() == IPAddr::typename() => ev,
-        _ => {
-            let advice = if matches!(&parent, Value::Lit(Literal::String(_))) {
-                Some(ADVICE_MSG.into())
-            } else {
-                None
-            };
-            return Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
-                    name: IPAddr::typename(),
-                }],
-                actual: parent.type_of(),
-                advice,
-            });
-        }
-    };
-    // PANIC SAFETY Typechecking performed above
-    #[allow(clippy::expect_used)]
-    let child_ip = child_ev
-        .value()
-        .as_any()
-        .downcast_ref::<IPAddr>()
-        .expect("already typechecked above, so this downcast should succeed");
-    // PANIC SAFETY Typechecking performed above
-    #[allow(clippy::expect_used)]
-    let parent_ip = parent_ev
-        .value()
-        .as_any()
-        .downcast_ref::<IPAddr>()
-        .expect("already typechecked above, so this downcast should succeed");
+    let child_ip = as_ipaddr(&child)?;
+    let parent_ip = as_ipaddr(&parent)?;
     Ok(child_ip.is_in_range(parent_ip).into())
 }
 
@@ -435,16 +323,19 @@ mod tests {
     /// `Err::ExtensionErr` with our extension name
     fn assert_ipaddr_err<T>(res: evaluator::Result<T>) {
         match res {
-            Err(evaluator::EvaluationError::FailedExtensionFunctionApplication {
-                extension_name,
-                ..
-            }) => {
-                assert_eq!(
+            Err(e) => match e.error_kind() {
+                evaluator::EvaluationErrorKind::FailedExtensionFunctionApplication {
                     extension_name,
-                    Name::parse_unqualified_name("ipaddr").expect("should be a valid identifier")
-                )
-            }
-            Err(e) => panic!("Expected an ipaddr ExtensionErr, got {:?}", e),
+                    ..
+                } => {
+                    assert_eq!(
+                        *extension_name,
+                        Name::parse_unqualified_name("ipaddr")
+                            .expect("should be a valid identifier")
+                    )
+                }
+                _ => panic!("Expected an ipaddr ExtensionErr, got {:?}", e),
+            },
             Ok(_) => panic!("Expected an ipaddr ExtensionErr, got Ok"),
         }
     }
@@ -601,11 +492,10 @@ mod tests {
                     Expr::val(1)
                 ))]
             )),
-            Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::String],
-                actual: Type::Set,
-                advice: None,
-            })
+            Err(evaluator::EvaluationError::type_error(
+                vec![Type::String],
+                Type::Set
+            ))
         );
 
         // test that < on ipaddr values is an error
@@ -620,14 +510,13 @@ mod tests {
                     vec![Expr::val("10.0.0.10")],
                 )
             )),
-            Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Long],
-                actual: Type::Extension {
+            Err(evaluator::EvaluationError::type_error(
+                vec![Type::Long],
+                Type::Extension {
                     name: Name::parse_unqualified_name("ipaddr")
                         .expect("should be a valid identifier")
                 },
-                advice: None,
-            })
+            ))
         );
         // test that isIpv4 on a String is an error
         assert_eq!(
@@ -635,14 +524,14 @@ mod tests {
                 Name::parse_unqualified_name("isIpv4").expect("should be a valid identifier"),
                 vec![Expr::val("127.0.0.1")]
             )),
-            Err(evaluator::EvaluationError::TypeError {
-                expected: vec![Type::Extension {
+            Err(evaluator::EvaluationError::type_error_with_advice(
+                vec![Type::Extension {
                     name: Name::parse_unqualified_name("ipaddr")
                         .expect("should be a valid identifier")
                 }],
-                actual: Type::String,
-                advice: Some(ADVICE_MSG.into()),
-            })
+                Type::String,
+                ADVICE_MSG.into(),
+            ))
         );
     }
 

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -29,10 +29,10 @@ fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {
     let msg = v.get_as_string()?;
     // PANIC SAFETY: This name is fully static, and is a valid extension name
     #[allow(clippy::unwrap_used)]
-    let err = EvaluationError::FailedExtensionFunctionApplication {
-        extension_name: "partial_evaluation".parse().unwrap(),
-        msg: msg.to_string(),
-    };
+    let err = EvaluationError::failed_extension_function_application(
+        "partial_evaluation".parse().unwrap(),
+        msg.to_string(),
+    );
     Err(err)
 }
 


### PR DESCRIPTION
## Description of changes

* Refactored `EvaluationError` into the following form, which matches our current `ValidationError` structure. The `advice` field contains an optional string with additional help information. If we were using [miette](https://docs.rs/miette/latest/miette/), this field would be labeled as `#[help]`. But for this PR, I'm considering updating to miette out of scope (see issue #182). This new structure should make supporting location information simpler in the future.
```
pub enum EvaluationError {
  advice: Option<String>,
  error_kind: EvaluationErrorKind.
}
```
* Added advice in 4 error cases that seem likely:
  * Using `in` instead of `.contains()`
     `3 in [34, -2, 7]` --> "type error: expected (entity of type any_entity_type), got long. `in` is for checking the entity hierarchy, use `.contains()` to test set membership"
  * Using `in` instead of `has`
    `"foo" in { "foo": 2, "bar": true }` --> "type error: expected (entity of type any_entity_type), got string. `in` is for checking the entity hierarchy, use `has` to test if a record has a key"
  * Using an IP-related function on a string instead of an IP value
    `"127.0.0.1".isIpv4()` --> "type error: expected ipaddr, got string. Maybe you forgot to apply the `ip` constructor?"
  * Using a decimal-related function on a string instead of a decimal value
    `"1.23".lessThan("2.34")` --> "type error: expected decimal, got string. Maybe you forgot to apply the `decimal` constructor?"

## Issue #, if available

#177

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
