### PR TITLE
Expose `AuthorizationError`

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -691,12 +691,12 @@ impl std::fmt::Display for Expr {
                         args[1..].iter().join(", ")
                     )
                 } else {
-                    // a function without a name or a method-style function
-                    // call with with zero arguments can only occur when
-                    // manually constructing an AST,
-                    // and even then, this form will be representable because the entire name and
-                    // all the args can be displayed with proper syntax. However, it will not parse
-                    // because the parser requires the extention name.
+                    // This case can only be reached for a manually constructed AST.
+                    // In order to reach this case, either the function name `fn_name`
+                    // is not in the list of available extension functions, or this
+                    // is a method-style function call with zero arguments. Both of
+                    // these cases can be displayed, but neither will parse. The
+                    // resulting `ParseError` will be `NotAFunction`.
                     write!(f, "{}({})", fn_name, args.iter().join(", "))
                 }
             }

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -863,7 +863,7 @@ impl Response {
 }
 
 /// Decision returned from the `Authorizer`
-#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum Decision {
     /// The `Authorizer` determined that the request should be allowed
     Allow,

--- a/cedar-policy-core/src/authorizer/err.rs
+++ b/cedar-policy-core/src/authorizer/err.rs
@@ -19,7 +19,7 @@ use crate::evaluator::EvaluationError;
 use thiserror::Error;
 
 /// Errors that can occur during authorization
-#[derive(Debug, PartialEq, Clone, Error)]
+#[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum AuthorizationError {
     /// Failed to eagerly evaluate entity attributes when initializing the `Evaluator`.
     #[error("error occurred while evaluating entity attributes: {0}")]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+
 - Move public API for partial evaluation behind experimental feature flag.
 - Added an option to eagerly evaluate entity attributes and re-use across calls to `is_authorized`
 - Revamped errors in cst-to-ast transformation
@@ -14,6 +15,8 @@
   - `namespace` to get the namespace as a single string.
 - Fixed bug (#150) around implicit namespaces in action definitions.
 - Support `Request`s with `Unknown` fields for partial evaluation.
+- Export the `cedar_policy_core::evaluator::EvaluationError` and
+  `cedar_policy_core::authorizer::AuthorizationError` error types.
 
 ### Changed
 
@@ -49,10 +52,13 @@
 - More precise "expected tokens" lists in some parse errors
 - Renamed `cedar_policy_core::entities::JsonDeserializationError::ExtensionsError` to `cedar_policy_core::entities::JsonDeserializationError::FailedExtensionsFunctionLookup`.
 - Renamed variants in `cedar_policy::SchemaError`
+- The `Diagnostics::errors()` function now returns an iterator over `AuthorizationError`s.
+- The `Response::new()` constructor now expects a `Vec<AuthorizationError>` as its third argument.
 
 ## 2.3.0
 
 ### Changed
+
 - Implementation of
 [RFC 9](https://github.com/cedar-policy/rfcs/blob/main/text/0009-disallow-whitespace-in-entityuid.md)
 which disallows embedded whitespace, comments, and control characters in the
@@ -68,22 +74,27 @@ discussion in the RFC.
 ## 2.2.0
 
 ### Added
+
 - `Entities::write_to_json` function to api.rs
 
 ## 2.1.0
 
 ### Added
+
 - `Schema::action_entities` to provide access to action entities defined in a schema.
 
 ### Changed
+
 - Update `cedar-policy-core` dependency.
 
 ### Fixed
+
 - Resolve warning in `Cargo.toml` due to having both `license` and `license-file` metadata entries.
 
 ## 2.0.3
 
 ### Fixed
+
 - Update `Cargo.toml` metadata to correctly represent this crate as Apache-2.0 licensed.
 
 ## 2.0.2

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -431,7 +431,7 @@ impl Authorizer {
 }
 
 /// Authorization response returned from the `Authorizer`
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Response {
     /// Authorization decision
     decision: Decision,
@@ -442,7 +442,7 @@ pub struct Response {
 /// Authorization response returned from `is_authorized_partial`.
 /// It can either be a full concrete response, or a residual response.
 #[cfg(feature = "partial-eval")]
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PartialResponse {
     /// A full, concrete response.
     Concrete(Response),
@@ -461,7 +461,7 @@ pub struct ResidualResponse {
 }
 
 /// Diagnostics providing more information on how a `Decision` was reached
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Diagnostics {
     /// `PolicyId`s of the policies that contributed to the decision.
     /// If no policies applied to the request, this set will be empty.
@@ -528,7 +528,11 @@ impl From<authorizer::Response> for Response {
 #[cfg(feature = "partial-eval")]
 impl ResidualResponse {
     /// Create a new `ResidualResponse`
-    pub fn new(residuals: PolicySet, reason: HashSet<PolicyId>, errors: HashSet<String>) -> Self {
+    pub fn new(
+        residuals: PolicySet,
+        reason: HashSet<PolicyId>,
+        errors: Vec<AuthorizationError>,
+    ) -> Self {
         Self {
             residuals,
             diagnostics: Diagnostics { reason, errors },

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -622,7 +622,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic] // this currently returns a parse error due to using Policy::parse instead of PolicySet::parse
     fn test_authorized_with_template_as_policy_should_fail() {
         let call = r#"
 	             { "principal": "User::\"alice\""
@@ -630,9 +629,7 @@ mod test {
 	             , "resource" : "Photo::\"door\""
 	             , "context" : {}
 	             , "slice" : {
-	                   "policies" : {
-                        "ID0": "permit(principal == ?principal, action, resource);"
-                      }
+	                   "policies" : "permit(principal == ?principal, action, resource);"
 	                 , "entities" : []
                      , "templates" : {}
 	             }

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -703,6 +703,7 @@ mod test {
                     }
                     AuthorizationAnswer::Success { response } => {
                         assert_eq!(response.decision, Decision::Deny);
+                        assert_eq!(response.diagnostics.errors.len(), 0);
                     }
                 }
             }

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -124,8 +124,8 @@ impl InterfaceDiagnostics {
     }
 
     /// Get the errors
-    pub fn errors(&self) -> impl Iterator<Item = String> + '_ {
-        self.errors.iter().cloned()
+    pub fn errors(&self) -> impl Iterator<Item = &str> + '_ {
+        self.errors.iter().map(String::as_str)
     }
 }
 

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -84,11 +84,22 @@ pub struct InterfaceDiagnostics {
 }
 
 impl InterfaceResponse {
+    // Construct an `InterfaceResponse`
     fn new(decision: Decision, reason: HashSet<PolicyId>, errors: HashSet<String>) -> Self {
         Self {
             decision,
             diagnostics: InterfaceDiagnostics { reason, errors },
         }
+    }
+
+    /// Get the authorization decision
+    pub fn decision(&self) -> Decision {
+        self.decision
+    }
+
+    /// Get the authorization diagnostics
+    pub fn diagnostics(&self) -> &InterfaceDiagnostics {
+        &self.diagnostics
     }
 }
 
@@ -103,6 +114,18 @@ impl From<Response> for InterfaceResponse {
                 .map(ToString::to_string)
                 .collect(),
         )
+    }
+}
+
+impl InterfaceDiagnostics {
+    /// Get the policies that contributed to the decision
+    pub fn reason(&self) -> impl Iterator<Item = &PolicyId> {
+        self.reason.iter()
+    }
+
+    /// Get the errors
+    pub fn errors(&self) -> impl Iterator<Item = String> + '_ {
+        self.errors.iter().cloned()
     }
 }
 

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -65,7 +65,7 @@ pub fn json_is_authorized(input: &str) -> InterfaceResult {
 }
 
 /// Interface version of a `Response` that uses `InterfaceDiagnostics` for simpler (de)serialization
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct InterfaceResponse {
     /// Authorization decision
     decision: Decision,
@@ -84,8 +84,8 @@ pub struct InterfaceDiagnostics {
 }
 
 impl InterfaceResponse {
-    // Construct an `InterfaceResponse`
-    fn new(decision: Decision, reason: HashSet<PolicyId>, errors: HashSet<String>) -> Self {
+    /// Construct an `InterfaceResponse`
+    pub fn new(decision: Decision, reason: HashSet<PolicyId>, errors: HashSet<String>) -> Self {
         Self {
             decision,
             diagnostics: InterfaceDiagnostics { reason, errors },

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -35,12 +35,16 @@ thread_local!(
 );
 
 /// Construct and ask the authorizer the request.
-fn is_authorized(call: AuthorizationCall) -> Response {
+fn is_authorized(call: AuthorizationCall) -> AuthorizationAnswer {
     match call.get_components() {
         Ok((request, policies, entities)) => {
-            AUTHORIZER.with(|authorizer| authorizer.is_authorized(&request, &policies, &entities))
+            AUTHORIZER.with(|authorizer| AuthorizationAnswer::Success {
+                response: authorizer
+                    .is_authorized(&request, &policies, &entities)
+                    .into(),
+            })
         }
-        Err(ans) => ans,
+        Err(errors) => AuthorizationAnswer::ParseFailed { errors },
     }
 }
 
@@ -51,25 +55,62 @@ fn is_authorized(call: AuthorizationCall) -> Response {
 pub fn json_is_authorized(input: &str) -> InterfaceResult {
     serde_json::from_str::<AuthorizationCall>(input).map_or_else(
         |e| InterfaceResult::fail_internally(format!("error parsing call: {e:}")),
-        |call| InterfaceResult::succeed(is_authorized(call)),
+        |call| match is_authorized(call) {
+            answer @ AuthorizationAnswer::Success { .. } => InterfaceResult::succeed(answer),
+            AuthorizationAnswer::ParseFailed { errors } => {
+                InterfaceResult::fail_bad_request(errors)
+            }
+        },
     )
 }
 
-/// Create a `Response` with `Deny`, no reasons, and the
-/// given error messages.
-///
-/// This is returned due to marshalling/parsing errors.
-fn empty_failure<S: Into<String>>(msgs: impl IntoIterator<Item = S>) -> Response {
-    Response::new(
-        Decision::Deny,
-        HashSet::new(),
-        msgs.into_iter().map(Into::into).collect(),
-    )
+/// Interface version of a `Response` that uses `InterfaceDiagnostics` for simpler (de)serialization
+#[derive(Debug, Serialize, Deserialize)]
+pub struct InterfaceResponse {
+    /// Authorization decision
+    decision: Decision,
+    /// Diagnostics providing more information on how this decision was reached
+    diagnostics: InterfaceDiagnostics,
 }
 
-/// Convert an `Error` to a `Response`, adding the given message
-fn error_to_response(e: impl std::error::Error, msg: String) -> Response {
-    empty_failure([msg, e.to_string()])
+/// Interface version of `Diagnostics` that stores error messages as strings for simpler (de)serialization
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct InterfaceDiagnostics {
+    /// `PolicyId`s of the policies that contributed to the decision.
+    /// If no policies applied to the request, this set will be empty.
+    reason: HashSet<PolicyId>,
+    /// Set of error messages that occurred
+    errors: HashSet<String>,
+}
+
+impl InterfaceResponse {
+    fn new(decision: Decision, reason: HashSet<PolicyId>, errors: HashSet<String>) -> Self {
+        Self {
+            decision,
+            diagnostics: InterfaceDiagnostics { reason, errors },
+        }
+    }
+}
+
+impl From<Response> for InterfaceResponse {
+    fn from(response: Response) -> Self {
+        Self::new(
+            response.decision(),
+            response.diagnostics().reason().cloned().collect(),
+            response
+                .diagnostics()
+                .errors()
+                .map(ToString::to_string)
+                .collect(),
+        )
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+enum AuthorizationAnswer {
+    ParseFailed { errors: Vec<String> },
+    Success { response: InterfaceResponse },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -88,31 +129,31 @@ struct AuthorizationCall {
 }
 
 impl AuthorizationCall {
-    fn get_components(self) -> Result<(Request, PolicySet, Entities), Response> {
+    fn get_components(self) -> Result<(Request, PolicySet, Entities), Vec<String>> {
         let schema = self
             .schema
             .map(Schema::from_json_value)
             .transpose()
-            .map_err(|e| empty_failure([e.to_string()]))?;
+            .map_err(|e| [e.to_string()])?;
         let principal = match self.principal {
             Some(p) => Some(
                 EntityUid::from_json(p)
-                    .map_err(|e| error_to_response(e, "Failed to parse principal".into()))?,
+                    .map_err(|e| ["Failed to parse principal".into(), e.to_string()])?,
             ),
             None => None,
         };
         let action = EntityUid::from_json(self.action)
-            .map_err(|e| error_to_response(e, "Failed to parse action".into()))?;
+            .map_err(|e| ["Failed to parse action".into(), e.to_string()])?;
         let resource = match self.resource {
             Some(r) => Some(
                 EntityUid::from_json(r)
-                    .map_err(|e| error_to_response(e, "Failed to parse resource".into()))?,
+                    .map_err(|e| ["Failed to parse resource".into(), e.to_string()])?,
             ),
             None => None,
         };
 
         let context = Context::from_json_value(self.context, schema.as_ref().map(|s| (s, &action)))
-            .map_err(|e| empty_failure([e.to_string()]))?;
+            .map_err(|e| [e.to_string()])?;
         let q = Request::new(principal, Some(action), resource, context);
         let (policies, entities) = self.slice.try_into(schema.as_ref())?;
         Ok((q, policies, entities))
@@ -166,7 +207,7 @@ struct RecvdSlice {
 
 impl RecvdSlice {
     #[allow(clippy::too_many_lines)]
-    fn try_into(self, schema: Option<&Schema>) -> Result<(PolicySet, Entities), Response> {
+    fn try_into(self, schema: Option<&Schema>) -> Result<(PolicySet, Entities), Vec<String>> {
         fn parse_instantiation(v: &Link) -> Result<(SlotId, EntityUid), Vec<String>> {
             let slot = match v.slot.as_str() {
                 "?principal" => SlotId::principal(),
@@ -273,7 +314,7 @@ impl RecvdSlice {
         if errs.is_empty() {
             Ok((policies, entities))
         } else {
-            Err(empty_failure(errs))
+            Err(errs)
         }
     }
 }
@@ -558,6 +599,7 @@ mod test {
     }
 
     #[test]
+    #[should_panic] // this currently returns a parse error due to using Policy::parse instead of PolicySet::parse
     fn test_authorized_with_template_as_policy_should_fail() {
         let call = r#"
 	             { "principal": "User::\"alice\""
@@ -632,10 +674,17 @@ mod test {
     fn assert_is_authorized(result: InterfaceResult) {
         match result {
             InterfaceResult::Success { result } => {
-                let response: Response = serde_json::from_str(result.as_str()).unwrap();
-                println!("{response:?}");
-                assert_eq!(response.decision(), Decision::Allow);
-                assert_eq!(response.diagnostics().errors().count(), 0);
+                let parsed_result: AuthorizationAnswer =
+                    serde_json::from_str(result.as_str()).unwrap();
+                match parsed_result {
+                    AuthorizationAnswer::ParseFailed { .. } => {
+                        panic!("expected parse to succeed, but got {parsed_result:?}")
+                    }
+                    AuthorizationAnswer::Success { response } => {
+                        assert_eq!(response.decision, Decision::Allow);
+                        assert_eq!(response.diagnostics.errors.len(), 0);
+                    }
+                }
             }
             InterfaceResult::Failure { .. } => {
                 panic!("Expected a successful response, not {result:?}");
@@ -646,8 +695,16 @@ mod test {
     fn assert_is_not_authorized(result: InterfaceResult) {
         match result {
             InterfaceResult::Success { result } => {
-                let response: Response = serde_json::from_str(result.as_str()).unwrap();
-                assert_eq!(response.decision(), Decision::Deny);
+                let parsed_result: AuthorizationAnswer =
+                    serde_json::from_str(result.as_str()).unwrap();
+                match parsed_result {
+                    AuthorizationAnswer::ParseFailed { .. } => {
+                        panic!("expected parse to succeed, but got {parsed_result:?}")
+                    }
+                    AuthorizationAnswer::Success { response } => {
+                        assert_eq!(response.decision, Decision::Deny);
+                    }
+                }
             }
             InterfaceResult::Failure { .. } => {
                 panic!("Expected a successful response, not {result:?}");

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -38,6 +38,7 @@ use crate::{
 };
 use serde::Deserialize;
 use std::{
+    collections::HashSet,
     env,
     path::{Path, PathBuf},
     str::FromStr,
@@ -306,8 +307,11 @@ pub fn perform_integration_test_from_json_custom(
                 .diagnostics()
                 .reason()
                 .map(ToString::to_string)
-                .collect::<Vec<String>>(),
-            json_request.reasons,
+                .collect::<HashSet<String>>(),
+            json_request
+                .reasons
+                .into_iter()
+                .collect::<HashSet<String>>(),
             "test {} failed for request \"{}\"",
             jsonfile.display(),
             &json_request.desc
@@ -317,8 +321,8 @@ pub fn perform_integration_test_from_json_custom(
                 .diagnostics()
                 .errors()
                 .map(ToString::to_string)
-                .collect::<Vec<String>>(),
-            json_request.errors,
+                .collect::<HashSet<String>>(),
+            json_request.errors.into_iter().collect::<HashSet<String>>(),
             "test {} failed for request \"{}\"",
             jsonfile.display(),
             &json_request.desc

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -38,7 +38,6 @@ use crate::{
 };
 use serde::Deserialize;
 use std::{
-    collections::HashSet,
     env,
     path::{Path, PathBuf},
     str::FromStr,
@@ -297,30 +296,19 @@ pub fn perform_integration_test_from_json_custom(
                 .into()
         };
 
-        assert_eq!(
-            response.decision(),
+        let expected_response = InterfaceResponse::new(
             json_request.decision,
-            "test {} failed for request \"{}\"",
-            jsonfile.display(),
-            &json_request.desc
-        );
-        assert_eq!(
-            response
-                .diagnostics()
-                .reason()
-                .map(ToString::to_string)
-                .collect::<HashSet<String>>(),
             json_request
                 .reasons
                 .into_iter()
-                .collect::<HashSet<String>>(),
-            "test {} failed for request \"{}\"",
-            jsonfile.display(),
-            &json_request.desc
+                .map(|s| PolicyId::from_str(&s).unwrap())
+                .collect(),
+            json_request.errors.into_iter().collect(),
         );
+
         assert_eq!(
-            response.diagnostics().errors().collect::<HashSet<String>>(),
-            json_request.errors.into_iter().collect::<HashSet<String>>(),
+            response,
+            expected_response,
             "test {} failed for request \"{}\"",
             jsonfile.display(),
             &json_request.desc

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -16,7 +16,7 @@
 
 use cedar_policy::*;
 
-use std::{collections::HashSet, error::Error, str::FromStr};
+use std::{error::Error, str::FromStr};
 
 #[test]
 fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
@@ -139,7 +139,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
     // Check that we got the "Allow" result and it was based on the added policy
     assert_eq!(
         auth.is_authorized(&request2, &policies, &entities),
-        Response::new(Decision::Allow, [alice_view_id].into(), HashSet::new())
+        Response::new(Decision::Allow, [alice_view_id].into(), Vec::new())
     );
 
     // request with Account::"jane" and an unspecified action


### PR DESCRIPTION
## Description of changes

* Publicly exposed the `EvaluationError` and `AuthorizationError` error types.
* Changed the `errors` field of the `Diagnostics` type from `HashMap<String>` to `Vec<AuthorizationError>`. 
  * A `HashMap` would probably be more accurate, since users shouldn't depend on the ordering of errors, but this requires `AuthorizationError` to be hashable, which is a pain since the errors can contains `Expr`s, `Value`s, other `HashMap`s, etc.
* Removed some unused code in `integration_testing.rs`. The code was checking for a parse error where only an AuthorizationError can be returned.
* Changed `Response` to not be (de)serializable. The only code that relies on this being the case is in `src/frontend`. Defined a new `InterfaceResponse` type there to make things simpler.
  * It would also be possible to make `Response` (de)serializable directly, but this is a pain for the same reason given above for hashing.

This is a major breaking change since it changes the public APIs `Diagnostics::errors()` and `Response::new()`, the public type `EvaluationError`, and the traits derived for `Response`.

I expect a downstream failure in `cedar-spec/cedar-drt` since `Response`  is no longer (de)serializable. I will have a PR up with a fix before I merge this PR.

## Issue #, if available

#114

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
