### PR TITLE
Bugfix/aaronjeline/261

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1533,11 +1533,19 @@ pub mod test_generators {
 }
 
 #[cfg(test)]
+// PANIC SAFETY: Unit Test Code
+#[allow(clippy::indexing_slicing)]
 mod test {
     use std::collections::HashSet;
 
     use super::{test_generators::*, *};
-    use crate::ast::{entity, name, EntityUID};
+    use crate::{
+        ast::{entity, name, EntityUID},
+        parser::{
+            err::{ParseError, ParseErrors, ToASTError},
+            parse_policy,
+        },
+    };
 
     #[test]
     fn literal_and_borrowed() {
@@ -1865,5 +1873,18 @@ mod test {
             PrincipalOrResourceConstraint::Eq(EntityReference::euid(EntityUID::with_eid("test")));
         let s = t.display(PrincipalOrResource::Principal);
         assert_eq!(s, "principal == test_entity_type::\"test\"");
+    }
+
+    #[test]
+    fn unexpected_templates() {
+        let policy_str = r#"permit(principal == ?principal, action, resource);"#;
+        let ParseErrors(errs) = parse_policy(Some("id".into()), policy_str).err().unwrap();
+        assert_eq!(errs.len(), 1);
+        assert_eq!(&errs[0], &ParseError::ToAST(ToASTError::UnexpectedTemplate));
+        let policy_str =
+            r#"permit(principal == ?principal, action, resource) when { ?principal == 3 } ;"#;
+        let ParseErrors(errs) = parse_policy(Some("id".into()), policy_str).err().unwrap();
+        assert_eq!(errs.len(), 2);
+        assert!(errs.contains(&ParseError::ToAST(ToASTError::UnexpectedTemplate)));
     }
 }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1879,12 +1879,12 @@ mod test {
     fn unexpected_templates() {
         let policy_str = r#"permit(principal == ?principal, action, resource);"#;
         let ParseErrors(errs) = parse_policy(Some("id".into()), policy_str).err().unwrap();
-        assert_eq!(errs.len(), 1);
         assert_eq!(&errs[0], &ParseError::ToAST(ToASTError::UnexpectedTemplate));
+        assert_eq!(errs.len(), 1);
         let policy_str =
             r#"permit(principal == ?principal, action, resource) when { ?principal == 3 } ;"#;
         let ParseErrors(errs) = parse_policy(Some("id".into()), policy_str).err().unwrap();
-        assert_eq!(errs.len(), 2);
         assert!(errs.contains(&ParseError::ToAST(ToASTError::UnexpectedTemplate)));
+        assert_eq!(errs.len(), 2);
     }
 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1362,26 +1362,32 @@ fn ident_to_str_len(i: &Ident) -> usize {
     }
 }
 
-#[test]
-fn test_invalid_expr_from_cst_name() {
-    let path = vec![ASTNode::new(
-        Some(cst::Ident::Ident("some_long_str".into())),
-        0,
-        12,
-    )];
-    let name = ASTNode::new(Some(cst::Ident::Else), 13, 16);
-    let cst_name = cst::Name { path, name };
+#[cfg(test)]
+// PANIC SAFETY: this is unit test code
+#[allow(clippy::indexing_slicing)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_invalid_expr_from_cst_name() {
+        let path = vec![ASTNode::new(
+            Some(cst::Ident::Ident("some_long_str".into())),
+            0,
+            12,
+        )];
+        let name = ASTNode::new(Some(cst::Ident::Else), 13, 16);
+        let cst_name = cst::Name { path, name };
 
-    match Expr::try_from(cst_name) {
-        Ok(_) => panic!("wrong error"),
-        Err(e) => {
-            assert!(e.len() == 1);
-            match &e[0] {
-                ParseError::ToAST(ToASTError::InvalidExpression(e)) => {
-                    println!("{:?}", e);
-                    assert_eq!(e.name.info.range_end(), 16);
+        match Expr::try_from(cst_name) {
+            Ok(_) => panic!("wrong error"),
+            Err(e) => {
+                assert!(e.len() == 1);
+                match &e[0] {
+                    ParseError::ToAST(ToASTError::InvalidExpression(e)) => {
+                        println!("{:?}", e);
+                        assert_eq!(e.name.info.range_end(), 16);
+                    }
+                    _ => panic!("wrong error"),
                 }
-                _ => panic!("wrong error"),
             }
         }
     }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -162,7 +162,7 @@ impl ASTNode<Option<cst::Policy>> {
         match ast::StaticPolicy::try_from(tp) {
             Ok(p) => Some(p),
             Err(_) => {
-                errs.push(err::ParseError::ToAST(ToASTError::SlotsInConditionClause));
+                errs.push(err::ParseError::ToAST(ToASTError::UnexpectedTemplate));
                 None
             }
         }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -163,11 +163,20 @@ impl ASTNode<Option<cst::Policy>> {
         // we delay short-circuiting the option in order to prevent adding the same error twice
 
         let policy = tp.map(ast::StaticPolicy::try_from);
+        // Check if our above values actually contains a Static Policy
+        // The possible states are as follows:
+        // None -> The source failed to parse completely
+        // Some(Err(_)) -> The source parsed as a template, but not a static policy
+        // Some(Ok(p)) -> We have a policy
+        // We want to add `[ToASTError::UnexpectedTemplate]` in two cases:
+        //  1) The obvious: if we parsed a template not a StaticPolicy
+        //  2) Even if we fail to parse anything, if our parse errors include anything about slots,
+        //     we also throw in this error. Ideally we'd do this if the partially parsed AST included
+        //     any template slots at all, but we don't have an easy mechanism for that currently
+        let is_template = policy.as_ref().map(|r| r.is_err()).unwrap_or(false);
 
         let found_slot_error =
             errs.contains(&ParseError::ToAST(ToASTError::SlotsInConditionClause));
-
-        let is_template = policy.as_ref().map(|r| r.is_err()).unwrap_or(false);
 
         if found_slot_error || is_template {
             errs.push(err::ParseError::ToAST(ToASTError::UnexpectedTemplate));

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -87,16 +87,13 @@ pub enum ToASTError {
     #[error(
         "expected a static policy, got a template. Try removing template slots from this policy"
     )]
-    InvalidTemplate,
+    UnexpectedTemplate,
     /// Returned when we attempt to parse a policy with malformed or conflicting annotations
     #[error("this policy uses poorly formed or duplicate annotations")]
     BadAnnotations,
     /// Returned when a policy contains Template Slots in the condition clause. This is not currently supported.
     #[error("template slots are currently unsupported in policy condition clauses")]
     SlotsInConditionClause,
-    /// Returned when a template is found when attempting to parse a policy
-    #[error("a policy was expected but a template was found")]
-    UnexpectedTemplate,
     /// Returned when a policy is missing one of the 3 required scope clauses. (`principal`, `action`, and `resource`)
     #[error("this policy is missing the {0} variable in the scope")]
     MissingScopeConstraint(Var),

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -94,6 +94,9 @@ pub enum ToASTError {
     /// Returned when a policy contains Template Slots in the condition clause. This is not currently supported.
     #[error("template slots are currently unsupported in policy condition clauses")]
     SlotsInConditionClause,
+    /// Returned when a template is found when attempting to parse a policy
+    #[error("a policy was expected but a template was found")]
+    UnexpectedTemplate,
     /// Returned when a policy is missing one of the 3 required scope clauses. (`principal`, `action`, and `resource`)
     #[error("this policy is missing the {0} variable in the scope")]
     MissingScopeConstraint(Var),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1893,8 +1893,8 @@ impl Policy {
     /// If `id` is Some, the policy will be given that Policy Id.
     /// If `id` is None, then "policy0" will be used.
     /// The behavior around None may change in the future.
-    /// 
-    /// This can fail if the policy fails to parse. 
+    ///
+    /// This can fail if the policy fails to parse.
     /// It can also fail if a template was passed in, as this function only accepts static
     /// policies
     pub fn parse(id: Option<String>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1895,8 +1895,8 @@ impl Policy {
     /// The behavior around None may change in the future.
     /// 
     /// This can fail if the policy fails to parse. 
-    /// It can also fail if a valid template was passed in, as this function only accepts Static
-    /// Policies
+    /// It can also fail if a template was passed in, as this function only accepts static
+    /// policies
     pub fn parse(id: Option<String>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {
         let inline_ast = parser::parse_policy(id, policy_src.as_ref())?;
         let (_, ast) = ast::Template::link_static_policy(inline_ast);

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1893,6 +1893,10 @@ impl Policy {
     /// If `id` is Some, the policy will be given that Policy Id.
     /// If `id` is None, then "policy0" will be used.
     /// The behavior around None may change in the future.
+    /// 
+    /// This can fail if the policy fails to parse. 
+    /// It can also fail if a valid template was passed in, as this function only accepts Static
+    /// Policies
     pub fn parse(id: Option<String>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {
         let inline_ast = parser::parse_policy(id, policy_src.as_ref())?;
         let (_, ast) = ast::Template::link_static_policy(inline_ast);


### PR DESCRIPTION
## Description of changes
Adds docstrings and changes the error message around failing to parse a policy because it was a template

## Issue #, if available
#261 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
