### PR TITLE
Apply formatter to integration tests

### DIFF
--- a/cedar-integration-tests/tests/decimal/policies_1.cedar
+++ b/cedar-integration-tests/tests/decimal/policies_1.cedar
@@ -1,7 +1,6 @@
-permit(
-    principal,
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
-) when {
-    context.confidence_score.greaterThan(decimal("0.75"))
-};
+permit (
+  principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when { context.confidence_score.greaterThan(decimal("0.75")) };

--- a/cedar-integration-tests/tests/decimal/policies_2.cedar
+++ b/cedar-integration-tests/tests/decimal/policies_2.cedar
@@ -1,7 +1,10 @@
-permit(
-    principal,
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
-) when {
-    context.confidence_score.greaterThanOrEqual(decimal("0.4")) && context.confidence_score.lessThanOrEqual(decimal("0.5"))
+permit (
+  principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when
+{
+  context.confidence_score.greaterThanOrEqual(decimal("0.4")) &&
+  context.confidence_score.lessThanOrEqual(decimal("0.5"))
 };

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_1a.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_1a.cedar
@@ -1,6 +1,6 @@
 // Scenario 1A: One Principal, One Action, One Resource
-permit(
-    principal == User::"alice",
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
+permit (
+  principal == User::"alice",
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_2a.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_2a.cedar
@@ -1,6 +1,6 @@
 // Scenario 2A: Anyone in a given group can view a given photo
-permit(
-    principal in UserGroup::"jane_friends",
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
+permit (
+  principal in UserGroup::"jane_friends",
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_2b.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_2b.cedar
@@ -1,6 +1,6 @@
 // Scenario 2B: Alice can view any photo in Jane's "Vacation" album
-permit(
-    principal == User::"alice",
-    action == Action::"view",
-    resource in Album::"jane_vacation"
+permit (
+  principal == User::"alice",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_2c.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_2c.cedar
@@ -1,6 +1,6 @@
 // Scenario 2C: Alice can view, edit, or comment on any photo in Jane's "Vacation" album
-permit(
-    principal == User::"alice",
-    action in [Action::"view", Action::"edit", Action::"comment"],
-    resource in Album::"jane_vacation"
+permit (
+  principal == User::"alice",
+  action in [Action::"view", Action::"edit", Action::"comment"],
+  resource in Album::"jane_vacation"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_3a.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_3a.cedar
@@ -1,6 +1,6 @@
 // Scenario 3A: Any Principal can view jane's "Vacation" album
-permit(
-    principal,
-    action == Action::"view",
-    resource in Album::"jane_vacation"
+permit (
+  principal,
+  action == Action::"view",
+  resource in Album::"jane_vacation"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_3b.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_3b.cedar
@@ -1,6 +1,6 @@
 // Scenario 3B: Alice can perform specified actions on any resource in Jane's account
-permit(
-    principal == User::"alice",
-    action in [Action::"listAlbums", Action::"listPhotos", Action::"view"],
-    resource in Account::"jane"
+permit (
+  principal == User::"alice",
+  action in [Action::"listAlbums", Action::"listPhotos", Action::"view"],
+  resource in Account::"jane"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_3c.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_3c.cedar
@@ -1,6 +1,6 @@
 // Scenario 3C: Alice can perform any action on resources in jane's "Vacation" album
-permit(
-    principal == User::"alice",
-    action,
-    resource in Album::"jane_vacation"
+permit (
+  principal == User::"alice",
+  action,
+  resource in Album::"jane_vacation"
 );

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_4a.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_4a.cedar
@@ -1,10 +1,9 @@
 // Scenario 4A: The album device_prototypes is viewable by anyone in the
 // department HardwareEngineering with job level at least 5
-permit(
-    principal,
-    action in [Action::"listPhotos", Action::"view"],
-    resource in Album::"device_prototypes"
-) when {
-    principal.department == "HardwareEngineering" &&
-    principal.jobLevel >= 5
-};
+permit (
+  principal,
+  action in [Action::"listPhotos", Action::"view"],
+  resource in Album::"device_prototypes"
+)
+when
+{ principal.department == "HardwareEngineering" && principal.jobLevel >= 5 };

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_4c.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_4c.cedar
@@ -1,11 +1,9 @@
 // Scenario 4C: Alice is allowed to perform any action that is `readOnly` and
 // which applies to Photos or Albums. Note that this policy uses attributes on
 // `action` which is not permitted by the validator.
-permit(
-    principal == User::"alice",
-    action,
-    resource
-) when {
-    action.readOnly &&
-    ["Photo", "Album"].contains(action.appliesTo)
-};
+permit (
+  principal == User::"alice",
+  action,
+  resource
+)
+when { action.readOnly && ["Photo", "Album"].contains(action.appliesTo) };

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_4d.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_4d.cedar
@@ -4,7 +4,5 @@
 // .owner, but they do have .account.owner)
 // (but some resources, like Account itself, don't have .account, so we
 // also added a `has` check)
-permit(principal, action, resource)
-when {
-    resource has account && principal == resource.account.owner
-};
+permit (principal, action, resource)
+when { resource has account && principal == resource.account.owner };

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_4e.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_4e.cedar
@@ -3,10 +3,9 @@
 //
 // (slightly adapted from the doc: in our sandbox_b, resources don't have
 // .owner, but they do have .account.owner)
-permit(
-    principal,
-    action == Action::"view",
-    resource
-) when {
-    principal.department == resource.account.owner.department
-};
+permit (
+  principal,
+  action == Action::"view",
+  resource
+)
+when { principal.department == resource.account.owner.department };

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_4f.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_4f.cedar
@@ -5,8 +5,9 @@
 // .owner, but they do have .account.owner)
 // (but some resources, like Account itself, don't have .account, so we
 // also added a `has` check)
-permit(principal, action, resource)
-when {
-    (resource has account && principal == resource.account.owner) ||
-    resource.admins.contains(principal)
+permit (principal, action, resource)
+when
+{
+  (resource has account && principal == resource.account.owner) ||
+  resource.admins.contains(principal)
 };

--- a/cedar-integration-tests/tests/example_use_cases_doc/policies_5b.cedar
+++ b/cedar-integration-tests/tests/example_use_cases_doc/policies_5b.cedar
@@ -1,15 +1,16 @@
 // Scenario 5B: Anyone can upload photos to albums in Alice's account as long as
 // the photo is a JPEG or PNG with maximum size of 1MB. However, members of the
 // group AVTeam can also create RAW files up to 100MB in size.
-permit(
-    principal,
-    action == Action::"addPhoto",
-    resource in Account::"alice"
-) when {
-    (["JPEG", "PNG"].contains(context.photo.filetype) &&
-     context.photo.filesize_mb <= 1)
-    ||
-    (context.photo.filetype == "RAW" &&
-     context.photo.filesize_mb <= 100 &&
-     principal in UserGroup::"AVTeam")
+permit (
+  principal,
+  action == Action::"addPhoto",
+  resource in Account::"alice"
+)
+when
+{
+  (["JPEG", "PNG"].contains(context.photo.filetype) &&
+   context.photo.filesize_mb <= 1) ||
+  (context.photo.filetype == "RAW" &&
+   context.photo.filesize_mb <= 100 &&
+   principal in UserGroup::"AVTeam")
 };

--- a/cedar-integration-tests/tests/ip/policies_1.cedar
+++ b/cedar-integration-tests/tests/ip/policies_1.cedar
@@ -1,7 +1,6 @@
-permit(
-    principal,
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
-) when {
-    context.source_ip == ip("222.222.222.222")
-};
+permit (
+  principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when { context.source_ip == ip("222.222.222.222") };

--- a/cedar-integration-tests/tests/ip/policies_2.cedar
+++ b/cedar-integration-tests/tests/ip/policies_2.cedar
@@ -1,7 +1,7 @@
-permit(
-    principal,
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
-) when {
-    !(context.source_ip.isLoopback()) && !(context.source_ip.isMulticast())
-};
+permit (
+  principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when
+{ !(context.source_ip.isLoopback()) && !(context.source_ip.isMulticast()) };

--- a/cedar-integration-tests/tests/ip/policies_3.cedar
+++ b/cedar-integration-tests/tests/ip/policies_3.cedar
@@ -1,7 +1,6 @@
-permit(
-    principal,
-    action == Action::"view",
-    resource == Photo::"VacationPhoto94.jpg"
-) when {
-    context.source_ip.isInRange(ip("222.222.222.0/24"))
-};
+permit (
+  principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when { context.source_ip.isInRange(ip("222.222.222.0/24")) };

--- a/cedar-integration-tests/tests/multi/policies_1.cedar
+++ b/cedar-integration-tests/tests/multi/policies_1.cedar
@@ -1,14 +1,13 @@
 // This test has two Permit policies, and tests that we give the right Reason
 // for each Allow
-
-permit(
-    principal == User::"alice",
-    action == Action::"view",
-    resource in Album::"jane_vacation"
+permit (
+  principal == User::"alice",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
 );
 
-permit(
-    principal == User::"bob",
-    action in [Action::"view", Action::"edit"],
-    resource in Account::"bob"
+permit (
+  principal == User::"bob",
+  action in [Action::"view", Action::"edit"],
+  resource in Account::"bob"
 );

--- a/cedar-integration-tests/tests/multi/policies_2.cedar
+++ b/cedar-integration-tests/tests/multi/policies_2.cedar
@@ -1,15 +1,14 @@
 // This test has a Permit, and a Forbid that partially overrides it
-
 // Anyone can view photos in jane's "Vacation" album
-permit(
-    principal,
-    action == Action::"view",
-    resource in Album::"jane_vacation"
+permit (
+  principal,
+  action == Action::"view",
+  resource in Album::"jane_vacation"
 );
 
 // except bob
-forbid(
-    principal == User::"bob",
-    action == Action::"view",
-    resource in Album::"jane_vacation"
+forbid (
+  principal == User::"bob",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
 );

--- a/cedar-integration-tests/tests/multi/policies_3.cedar
+++ b/cedar-integration-tests/tests/multi/policies_3.cedar
@@ -1,15 +1,14 @@
 // This test has a slightly more complicated forbid policy partially overriding
 // a permit policy
-
 // Alice's friends can view all of her photos
-permit(
-    principal in UserGroup::"alice_friends",
-    action == Action::"view",
-    resource in Account::"alice"
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
 );
 
 // but, as a general rule, anything marked private can only be viewed by the
 // account owner
-forbid(principal, action, resource)
-    when { resource.private }
-    unless { resource has account && resource.account.owner == principal };
+forbid (principal, action, resource)
+when { resource.private }
+unless { resource has account && resource.account.owner == principal };

--- a/cedar-integration-tests/tests/multi/policies_4.cedar
+++ b/cedar-integration-tests/tests/multi/policies_4.cedar
@@ -1,27 +1,25 @@
 // Multiple permit and multiple forbid policies, which could apply in various
 // combinations
-
 // Alice's friends can view all of her photos
-permit(
-    principal in UserGroup::"alice_friends",
-    action == Action::"view",
-    resource in Account::"alice"
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
 );
 
 // Anyone in the Sales department can view Alice's vacation photos
-permit(
-    principal,
-    action,
-    resource in Album::"alice_vacation"
-) when {
-    principal.department == "Sales"
-};
+permit (
+  principal,
+  action,
+  resource in Album::"alice_vacation"
+)
+when { principal.department == "Sales" };
 
 // anything marked private can only be viewed by the account owner
-forbid(principal, action, resource)
-    when { resource.private }
-    unless { resource has account && resource.account.owner == principal };
+forbid (principal, action, resource)
+when { resource.private }
+unless { resource has account && resource.account.owner == principal };
 
 // deny all requests that have context.authenticated set to false
-forbid(principal, action, resource)
-    when { !context.authenticated };
+forbid (principal, action, resource)
+when { !context.authenticated };

--- a/cedar-integration-tests/tests/multi/policies_5.cedar
+++ b/cedar-integration-tests/tests/multi/policies_5.cedar
@@ -1,18 +1,19 @@
 // Anyone in the Sales department can perform any action on Alice's vacation photos
-permit(
-    principal,
-    action,
-    resource in Album::"alice_vacation"
-) when {
-    principal.department == "Sales"
-};
+permit (
+  principal,
+  action,
+  resource in Album::"alice_vacation"
+)
+when { principal.department == "Sales" };
 
 // Deny all requests that have context.authenticated set to false
-forbid(principal, action, resource)
+forbid (principal, action, resource)
 unless { context.authenticated };
 
 // Users with job level >= 7 can view any resource
-permit(principal, action == Action::"view", resource)
-when {
-    principal.jobLevel >= 7
-};
+permit (
+  principal,
+  action == Action::"view",
+  resource
+)
+when { principal.jobLevel >= 7 };


### PR DESCRIPTION
## Description of changes

While playing around with the new VSCode extension, I realized that our integration tests hadn't been formatted. This PR is the result of running the latest version of `cedar-policy-formatter` on all the (non-corpus) test policies using the CLI w/ default settings.

@shaobo-he-aws The only behavior that I thought was a little strange was that the formatter deletes whitespace between comments (see cedar-integration-tests/tests/multi/policies_3.cedar). This isn't necessarily a bad thing, but may be unexpected for users. Would it be easy to fix?

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
