### PR TITLE
Add a check-schema command to the CLI

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Added
+- A `check-schema` command to check that a schema file parses.
+
 ### Changed
 - Input policies for `check-parse` command can be read from standard input.
 - Duplicate policy ids in `@id` annotations cause the CLI to exit gracefully

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -94,6 +94,8 @@ pub enum Commands {
     Validate(ValidateArgs),
     /// Check that policies successfully parse
     CheckParse(CheckParseArgs),
+    /// Check that a schema successfully parses.
+    CheckSchema(CheckSchemaArgs),
     /// Link a template
     Link(LinkArgs),
     /// Format a policy set
@@ -115,6 +117,13 @@ pub struct CheckParseArgs {
     /// File containing the policy set
     #[clap(short, long = "policies", value_name = "FILE")]
     pub policies_file: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct CheckSchemaArgs {
+    /// File containing the schema
+    #[clap(short, long = "schema", value_name = "FILE")]
+    pub schema_file: String,
 }
 
 /// This struct contains the arguments that together specify a request.
@@ -382,6 +391,16 @@ impl Termination for CedarExitCode {
 
 pub fn check_parse(args: &CheckParseArgs) -> CedarExitCode {
     match read_policy_set(args.policies_file.as_ref()) {
+        Ok(_) => CedarExitCode::Success,
+        Err(e) => {
+            println!("Error: {e:?}");
+            CedarExitCode::Failure
+        }
+    }
+}
+
+pub fn check_schema(args: &CheckSchemaArgs) -> CedarExitCode {
+    match read_schema_file(&args.schema_file) {
         Ok(_) => CedarExitCode::Success,
         Err(e) => {
             println!("Error: {e:?}");

--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -20,8 +20,8 @@ use clap::Parser;
 use miette::ErrorHook;
 
 use cedar_policy_cli::{
-    authorize, check_parse, evaluate, format_policies, link, validate, CedarExitCode, Cli,
-    Commands, ErrorFormat,
+    authorize, check_parse, check_schema, evaluate, format_policies, link, validate, CedarExitCode,
+    Cli, Commands, ErrorFormat,
 };
 
 fn main() -> CedarExitCode {
@@ -44,6 +44,7 @@ fn main() -> CedarExitCode {
         Commands::Authorize(args) => authorize(&args),
         Commands::Evaluate(args) => evaluate(&args).0,
         Commands::CheckParse(args) => check_parse(&args),
+        Commands::CheckSchema(args) => check_schema(&args),
         Commands::Validate(args) => validate(&args),
         Commands::Format(args) => format_policies(&args),
         Commands::Link(args) => link(&args),


### PR DESCRIPTION
## Description of changes

I added `check-schema` to the CLI so that I could play with schema error messages conveniently. Might be useful to merge.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
