### PR TITLE
Bring in a commit that fixes DRT build failure

### DIFF
--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -478,6 +478,7 @@ impl SchemaType {
 impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType> {
         use cedar_policy_core::ast::Name;
+        use std::collections::BTreeSet;
 
         Ok(SchemaType::Type(match u.int_in_range::<u8>(1..=8)? {
             1 => SchemaTypeVariant::String,
@@ -488,7 +489,7 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
             },
             5 => {
                 let attributes = {
-                    let attr_names: HashSet<String> = u.arbitrary()?;
+                    let attr_names: BTreeSet<String> = u.arbitrary()?;
                     attr_names
                         .into_iter()
                         .map(|attr_name| Ok((attr_name.into(), u.arbitrary()?)))


### PR DESCRIPTION
## Description of changes

Currently DRT cannot build with the release 2.3.2 because the implementation of `SchemaType`'s `Arbitrary` trait does not import `HashSet`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
