### PR TITLE
Expose EvaluationErrorKind

### DIFF
--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -24,8 +24,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 mod err;
-pub use err::EvaluationError;
 pub(crate) use err::*;
+pub use err::{EvaluationError, EvaluationErrorKind};
 use itertools::Either;
 use smol_str::SmolStr;
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,7 @@
   - `namespace` to get the namespace as a single string.
 - Fixed bug (#150) around implicit namespaces in action definitions.
 - Support `Request`s with `Unknown` fields for partial evaluation.
-- Export the `cedar_policy_core::evaluator::EvaluationError` and
+- Export the `cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind}` and
   `cedar_policy_core::authorizer::AuthorizationError` error types.
 
 ### Changed

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -30,7 +30,7 @@ use cedar_policy_core::entities;
 use cedar_policy_core::entities::JsonDeserializationErrorContext;
 use cedar_policy_core::entities::{ContextSchema, Dereference, JsonDeserializationError};
 use cedar_policy_core::est;
-pub use cedar_policy_core::evaluator::EvaluationError;
+pub use cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind};
 use cedar_policy_core::evaluator::{Evaluator, RestrictedEvaluator};
 pub use cedar_policy_core::extensions;
 use cedar_policy_core::extensions::Extensions;


### PR DESCRIPTION
## Description of changes

Quick followup to #260. In that PR, I forgot to expose `EvaluationErrorKind`, which is used during testing in `cedar-spec`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
