### PR TITLE
Typecheck template based on possible instantiation types

### DIFF
--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1422,6 +1422,18 @@ impl ValidatorEntityType {
     pub fn attributes(&self) -> impl Iterator<Item = (&SmolStr, &AttributeType)> {
         self.attributes.iter()
     }
+
+    /// Return `true` if this entity type has an `EntityType` declared as a
+    /// possible descendant in the schema. This takes an `EntityType` rather
+    /// than a `Name`, It's not possible to declare the unspecified entity type
+    /// is a descendant of an entity type in the schema, so we can return false
+    /// in the unspecified case.
+    pub fn has_descendant_entity_type(&self, ety: &EntityType) -> bool {
+        match ety {
+            EntityType::Concrete(ety) => self.descendants.contains(ety),
+            EntityType::Unspecified => false,
+        }
+    }
 }
 
 impl TCNode<Name> for ValidatorEntityType {

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -510,8 +510,8 @@ impl<'a> Typechecker<'a> {
 
     /// Get the entity types which could instantiate the slot given in this
     /// template based on the policy scope constraints. We use this function to
-    /// avoid typechecking with for slot bindings that will always be false
-    /// based only on the scope constraints.
+    /// avoid typechecking with slot bindings that will always be false based
+    /// only on the scope constraints.
     fn possible_slot_instantiations(
         &self,
         t: &Template,

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -50,9 +50,10 @@ use crate::{
 use super::type_error::TypeError;
 
 use cedar_policy_core::ast::{
-    BinaryOp, EntityType, EntityUID, Expr, ExprBuilder, ExprKind, Literal, Name, Template, UnaryOp,
-    Var,
+    BinaryOp, EntityType, EntityUID, Expr, ExprBuilder, ExprKind, Literal, Name,
+    PrincipalOrResourceConstraint, SlotId, Template, UnaryOp, Var,
 };
+use itertools::Itertools;
 
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
@@ -313,7 +314,10 @@ impl<'a> Typechecker<'a> {
     /// typechecks it under every schema-defined request environment. The result contains
     /// these environments and the individual typechecking response for each, in no
     /// particular order.
-    pub fn typecheck_by_request_env(&self, t: &Template) -> Vec<(RequestEnv, PolicyCheck)> {
+    pub fn typecheck_by_request_env<'b>(
+        &'b self,
+        t: &'b Template,
+    ) -> Vec<(RequestEnv, PolicyCheck)> {
         self.apply_typecheck_fn_by_request_env(t, |request, expr| {
             let mut type_errors = Vec::new();
             let empty_prior_eff = EffectSet::new();
@@ -337,8 +341,11 @@ impl<'a> Typechecker<'a> {
 
     /// A strict variant of `typecheck_by_request_env` which is used by cedar policy
     /// analysis.
-    pub fn typecheck_by_request_env_strict(&self, t: &Template) -> Vec<(RequestEnv, PolicyCheck)> {
-        self.apply_typecheck_fn_by_request_env(t, |request, expr| {
+    pub fn typecheck_by_request_env_strict<'b>(
+        &'b self,
+        t: &'b Template,
+    ) -> Vec<(RequestEnv, PolicyCheck)> {
+        self.apply_typecheck_fn_by_request_env(t, move |request, expr| {
             let mut type_errors = Vec::new();
             let ty =
                 self.typecheck_strict(request, expr, Type::primitive_boolean(), &mut type_errors);
@@ -364,9 +371,9 @@ impl<'a> Typechecker<'a> {
 
     /// Utility abstracting the common logic for strict and regular typechecking
     /// by request environment.
-    fn apply_typecheck_fn_by_request_env<F, C>(
-        &self,
-        t: &Template,
+    fn apply_typecheck_fn_by_request_env<'b, F, C>(
+        &'b self,
+        t: &'b Template,
         typecheck_fn: F,
     ) -> Vec<(RequestEnv, C)>
     where
@@ -379,7 +386,10 @@ impl<'a> Typechecker<'a> {
         // explicit that `expect_type` will be called for every element of
         // request_env without short circuiting.
         let policy_condition = &t.condition();
-        for requeste in self.all_envs() {
+        for requeste in self
+            .unlinked_request_envs()
+            .flat_map(|env| self.link_request_env(env, t))
+        {
             let check = typecheck_fn(&requeste, policy_condition);
             result_checks.push((requeste, check))
         }
@@ -399,32 +409,38 @@ impl<'a> Typechecker<'a> {
         policy_templates: &[&Template],
     ) -> Vec<(RequestEnv, Vec<PolicyCheck>)> {
         let mut env_checks = Vec::new();
-        for request in self.all_envs() {
+        for request in self.unlinked_request_envs() {
             let mut policy_checks = Vec::new();
             for t in policy_templates.iter() {
-                let mut type_errors = Vec::new();
-                let policy_condition = &t.condition();
-                let ty = self.typecheck_strict(
-                    &request,
-                    policy_condition,
-                    Type::primitive_boolean(),
-                    &mut type_errors,
-                );
+                for linked_env in self.link_request_env(request.clone(), t) {
+                    let mut type_errors = Vec::new();
+                    let policy_condition = &t.condition();
+                    let ty = self.typecheck_strict(
+                        &linked_env,
+                        policy_condition,
+                        Type::primitive_boolean(),
+                        &mut type_errors,
+                    );
 
-                // Again, look for the literal `false` instead of the type
-                // false.
-                match ty.typed_expr() {
-                    Some(typed_expr) => {
-                        let is_false = typed_expr.eq_shape(&Expr::val(false));
-                        match (is_false, ty.typechecked()) {
-                            (false, false) => policy_checks.push(PolicyCheck::Fail(type_errors)),
-                            (false, true) => {
-                                policy_checks.push(PolicyCheck::Success(typed_expr.clone()));
+                    // Again, look for the literal `false` instead of the type
+                    // false.
+                    match ty.typed_expr() {
+                        Some(typed_expr) => {
+                            let is_false = typed_expr.eq_shape(&Expr::val(false));
+                            match (is_false, ty.typechecked()) {
+                                (false, false) => {
+                                    policy_checks.push(PolicyCheck::Fail(type_errors))
+                                }
+                                (false, true) => {
+                                    policy_checks.push(PolicyCheck::Success(typed_expr.clone()));
+                                }
+                                (true, _) => {
+                                    policy_checks.push(PolicyCheck::Irrelevant(type_errors))
+                                }
                             }
-                            (true, _) => policy_checks.push(PolicyCheck::Irrelevant(type_errors)),
                         }
+                        None => policy_checks.push(PolicyCheck::Fail(type_errors)),
                     }
-                    None => policy_checks.push(PolicyCheck::Fail(type_errors)),
                 }
             }
             env_checks.push((request, policy_checks));
@@ -432,7 +448,7 @@ impl<'a> Typechecker<'a> {
         env_checks
     }
 
-    fn all_envs(&self) -> impl Iterator<Item = RequestEnv> {
+    fn unlinked_request_envs<'b>(&'b self) -> impl Iterator<Item = RequestEnv> + 'b {
         // Gather all of the actions declared in the schema.
         let all_actions = self
             .schema
@@ -441,22 +457,98 @@ impl<'a> Typechecker<'a> {
 
         // For every action compute the cross product of the principal and
         // resource applies_to sets.
-        all_actions.flat_map(|action| {
+        all_actions.flat_map(move |action| {
             action
                 .applies_to
                 .applicable_principal_types()
-                .flat_map(|principal| {
+                .flat_map(move |principal| {
                     action
                         .applies_to
                         .applicable_resource_types()
-                        .map(|resource| RequestEnv {
+                        .map(move |resource| RequestEnv {
                             principal,
                             action: &action.name,
                             resource,
                             context: &action.context,
+                            principal_slot: None,
+                            resource_slot: None,
                         })
                 })
         })
+    }
+
+    /// Given a request environment and a template, return new environments
+    /// formed by instantiating template slots with possible entity types.
+    fn link_request_env<'b>(
+        &'b self,
+        env: RequestEnv<'b>,
+        t: &'b Template,
+    ) -> impl Iterator<Item = RequestEnv> + 'b {
+        self.possible_slot_instantiations(
+            t,
+            SlotId::principal(),
+            env.principal,
+            t.principal_constraint().as_inner(),
+        )
+        .flat_map(move |p_slot| {
+            self.possible_slot_instantiations(
+                t,
+                SlotId::resource(),
+                env.resource,
+                t.resource_constraint().as_inner(),
+            )
+            .map(move |r_slot| RequestEnv {
+                principal: env.principal,
+                action: env.action,
+                resource: env.resource,
+                context: env.context,
+                principal_slot: p_slot.clone(),
+                resource_slot: r_slot.clone(),
+            })
+        })
+    }
+
+    /// Get the entity types which could instantiate the slot given in this
+    /// template based on the policy scope constraints. We use this function to
+    /// avoid typechecking with for slot bindings that will always be false
+    /// based only on the scope constraints.
+    fn possible_slot_instantiations(
+        &self,
+        t: &Template,
+        slot_id: SlotId,
+        var: &'a EntityType,
+        constraint: &PrincipalOrResourceConstraint,
+    ) -> Box<dyn Iterator<Item = Option<EntityType>> + 'a> {
+        if t.slots().contains(&slot_id) {
+            let all_entity_types = self.schema.entity_types();
+            match constraint {
+                // The condition is `var = ?slot`, so the policy can only apply
+                // if the slot has the same entity type as `var`.
+                PrincipalOrResourceConstraint::Eq(_) => {
+                    Box::new(std::iter::once(Some(var.clone())))
+                }
+                // The condition is `var in ?slot`, so the policy can only apply
+                // if the var is some descendant of the slot.
+                PrincipalOrResourceConstraint::In(_) => Box::new(
+                    all_entity_types
+                        .filter(|(_, ety)| ety.has_descendant_entity_type(var))
+                        .map(|(name, _)| Some(EntityType::Concrete(name.clone())))
+                        .chain(std::iter::once(Some(var.clone()))),
+                ),
+                // The template uses the slot, but without a scope constraint.
+                // This can't happen for the moment because slots may only
+                // appear in head constraints, but if we ever see this, then the
+                // only correct way to proceed is by returning all entity types
+                // as possible instantiations.
+                PrincipalOrResourceConstraint::Any => Box::new(
+                    all_entity_types.map(|(name, _)| Some(EntityType::Concrete(name.clone()))),
+                ),
+            }
+        } else {
+            // If the template does not contain this slot, then we don't need to
+            // consider its instantiations..
+            Box::new(std::iter::once(None))
+        }
     }
 
     fn typecheck_strict<'b>(
@@ -1087,9 +1179,23 @@ impl<'a> Typechecker<'a> {
             ),
             // Template Slots, always has to be an entity.
             ExprKind::Slot(slotid) => TypecheckAnswer::success(
-                ExprBuilder::with_data(Some(Type::any_entity_reference()))
-                    .with_same_source_info(e)
-                    .slot(*slotid),
+                ExprBuilder::with_data(Some(if slotid.is_principal() {
+                    request_env
+                        .principal_slot
+                        .clone()
+                        .map(|ety| Type::possibly_unspecified_entity_reference(ety))
+                        .unwrap_or(Type::any_entity_reference())
+                } else if slotid.is_resource() {
+                    request_env
+                        .resource_slot
+                        .clone()
+                        .map(|ety| Type::possibly_unspecified_entity_reference(ety))
+                        .unwrap_or(Type::any_entity_reference())
+                } else {
+                    Type::any_entity_reference()
+                }))
+                .with_same_source_info(e)
+                .slot(*slotid),
             ),
 
             // Literal booleans get singleton type according to their value.

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -143,6 +143,8 @@ where
             action: &EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
             resource: &EntityType::Concrete("Photo".parse().unwrap()),
             context: &Attributes::with_attributes(None),
+            principal_slot: None,
+            resource_slot: None,
         },
     )
 }

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -75,6 +75,8 @@ impl Typechecker<'_> {
                     .expect("Placeholder type \"Resource\" failed to parse as valid type name."),
             ),
             context: &Attributes::with_attributes(None),
+            principal_slot: None,
+            resource_slot: None,
         };
         let mut type_errors = Vec::new();
         let ans = self.typecheck(&request_env, &EffectSet::new(), e, &mut type_errors);
@@ -148,13 +150,12 @@ pub(crate) fn assert_policy_typechecks(
 
 pub(crate) fn assert_policy_typecheck_fails(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
-    policy: StaticPolicy,
+    policy: impl Into<Arc<Template>>,
     expected_type_errors: Vec<TypeError>,
 ) {
     with_typechecker_from_schema(schema, |typechecker| {
         let mut type_errors: HashSet<TypeError> = HashSet::new();
-        let typechecked =
-            typechecker.typecheck_policy(&static_to_template(policy.clone()), &mut type_errors);
+        let typechecked = typechecker.typecheck_policy(&policy.into(), &mut type_errors);
         assert_expected_type_errors(&expected_type_errors, &type_errors);
         assert!(!typechecked, "Expected that policy would not typecheck.");
     });

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -33,12 +33,15 @@ use super::schema::{
 /// Contains the four variables bound in the type environment. These together
 /// represent the full type of (principal, action, resource, context)
 /// authorization request.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct RequestEnv<'a> {
     pub principal: &'a EntityType,
     pub action: &'a EntityUID,
     pub resource: &'a EntityType,
     pub context: &'a Attributes,
+
+    pub principal_slot: Option<EntityType>,
+    pub resource_slot: Option<EntityType>,
 }
 
 /// The main type structure.


### PR DESCRIPTION
Rather than typechecking a template once using `AnyEntity` for the type of the slot, we can typecheck it once for each possible entity type that could instantiate that slot. 

This does not affect current permissive validation. It is instead intended to support strict typechecking templates after the coming strict validation changes. It will also support more precise template typechecking if template slots are allowed in policy bodies in the future.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT 

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
