### PR TITLE
Adds APis for adding entities to `Entities`

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -104,11 +104,11 @@ impl Entities {
         self.entities.values()
     }
 
-    /// Adds the `[crate::ast::Entity]` to this `[Entities]`.
+    /// Adds the [`crate::ast::Entity`] to this [`Entities`].
     /// Fails if the passed iterator contains any duplicate entities with this structure,
     /// or if any error is encountered in the transitive closure computation.
     ///
-    /// If you pass `TCComputation::AssumeAlreadyComputed`, then the caller is
+    /// If you pass [`TCComputation::AssumeAlreadyComputed`], then the caller is
     /// responsible for ensuring that TC and DAG hold before calling this method.
     pub fn add_entities(
         mut self,

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -468,7 +468,7 @@ mod json_parsing_tests {
         let parser: EntityJsonParser<'_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
-            {"uid":{"__expr":"Test::\"george\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"george\"", "Test::\"alice\"", "Test::\"bob\""]}]);
+            {"uid":{"__expr":"Test::\"george\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"george\"", "Test::\"janet\""]}]);
 
         let stream = parser
             .iter_from_json_value(new)
@@ -482,9 +482,9 @@ mod json_parsing_tests {
             .unwrap();
         // Despite this being a cycle, alice doesn't have the appropriate edges to form the cycle, so we get this error
         let expected = TcError::MissingTcEdge {
-            child: r#"Test::"alice""#.parse().unwrap(),
+            child: r#"Test::"janet""#.parse().unwrap(),
             parent: r#"Test::"george""#.parse().unwrap(),
-            grandparent: r#"Test::"alice""#.parse().unwrap(),
+            grandparent: r#"Test::"janet""#.parse().unwrap(),
         };
         match es {
             EntitiesError::TransitiveClosureError(e) => assert_eq!(&expected, e.as_ref()),
@@ -510,7 +510,7 @@ mod json_parsing_tests {
             .err()
             .unwrap();
         let expected = TcError::MissingTcEdge {
-            child: r#"Test::"alice""#.parse().unwrap(),
+            child: r#"Test::"janet""#.parse().unwrap(),
             parent: r#"Test::"george""#.parse().unwrap(),
             grandparent: r#"Test::"henry""#.parse().unwrap(),
         };
@@ -540,7 +540,7 @@ mod json_parsing_tests {
         let expected = TcError::MissingTcEdge {
             child: r#"Test::"jeff""#.parse().unwrap(),
             parent: r#"Test::"alice""#.parse().unwrap(),
-            grandparent: r#"Test::"george""#.parse().unwrap(),
+            grandparent: r#"Test::"bob""#.parse().unwrap(),
         };
         match es {
             EntitiesError::TransitiveClosureError(e) => assert_eq!(&expected, e.as_ref()),
@@ -553,7 +553,7 @@ mod json_parsing_tests {
         let parser: EntityJsonParser<'_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
-            {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"alice\"", "Test::\"bob\"", "Test::\"george\""]}]);
+            {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"alice\"", "Test::\"bob\""]}]);
 
         let stream = parser
             .iter_from_json_value(new)
@@ -568,7 +568,7 @@ mod json_parsing_tests {
         let jeff = es.entity(&euid).unwrap();
         assert!(jeff.is_descendant_of(&r#"Test::"alice""#.parse().unwrap()));
         assert!(jeff.is_descendant_of(&r#"Test::"bob""#.parse().unwrap()));
-        assert!(jeff.is_descendant_of(&r#"Test::"george""#.parse().unwrap()));
+        assert!(!jeff.is_descendant_of(&r#"Test::"george""#.parse().unwrap()));
         simple_entities_still_sane(&es);
     }
 
@@ -589,7 +589,7 @@ mod json_parsing_tests {
         let euid = r#"Test::"george""#.parse().unwrap();
         let jeff = es.entity(&euid).unwrap();
         assert!(jeff.is_descendant_of(&r#"Test::"henry""#.parse().unwrap()));
-        let alice = es.entity(&r#"Test::"alice""#.parse().unwrap()).unwrap();
+        let alice = es.entity(&r#"Test::"janet""#.parse().unwrap()).unwrap();
         assert!(alice.is_descendant_of(&r#"Test::"henry""#.parse().unwrap()));
         simple_entities_still_sane(&es);
     }
@@ -692,7 +692,12 @@ mod json_parsing_tests {
                 {
                     "uid" : { "__expr" : "Test::\"alice\"" },
                     "attrs" : { "bar" : 2},
-                    "parents" : ["Test::\"bob\"", "Test::\"george\""]
+                    "parents" : ["Test::\"bob\""]
+                },
+                {
+                    "uid" : { "__expr" : "Test::\"janet\"" },
+                    "attrs" : { "bar" : 2},
+                    "parents" : ["Test::\"george\""]
                 },
                 {
                     "uid" : { "__expr" : "Test::\"bob\"" },
@@ -712,13 +717,11 @@ mod json_parsing_tests {
     /// Ensure the initial conditions of the entiites still hold
     fn simple_entities_still_sane(e: &Entities) {
         let bob = r#"Test::"bob""#.parse().unwrap();
-        let george = r#"Test::"george""#.parse().unwrap();
         let alice = e.entity(&r#"Test::"alice""#.parse().unwrap()).unwrap();
         let bar = alice.get("bar").unwrap();
         let two = RestrictedExpr::new(Expr::val(2)).unwrap();
         assert_eq!(bar, &two);
         assert!(alice.is_descendant_of(&bob));
-        assert!(alice.is_descendant_of(&george));
         let bob = e.entity(&bob).unwrap();
         assert!(bob.ancestors().collect::<Vec<_>>().is_empty());
     }

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -27,6 +27,9 @@ pub enum EntitiesError {
     /// Error occurring in deserialization of entities
     #[error("entities deserialization error: {0}")]
     Deserialization(#[from] crate::entities::JsonDeserializationError),
+    /// Error constructing the `[crate::entities::Entities]` as there is a duplicate Entity UID
+    #[error("Duplicate entity entry: {0}")]
+    Duplicate(EntityUID),
     /// Errors occurring while computing or enforcing transitive closure on the
     /// entity hierarchy.
     #[error("transitive closure computation/enforcement error: {0}")]

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -117,6 +117,42 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
         self.parse_ejsons(ejsons)
     }
 
+    /// Parse an entities JSON file (in `&str` form) into an iterator over [Entity]s
+    pub fn iter_from_json_str(
+        &self,
+        json: &str,
+    ) -> Result<impl Iterator<Item = Result<Entity, EntitiesError>> + '_, EntitiesError> {
+        let ejsons: Vec<EntityJSON> =
+            serde_json::from_str(json).map_err(JsonDeserializationError::from)?;
+        Ok(ejsons
+            .into_iter()
+            .map(|ejson| self.parse_ejson(ejson).map_err(EntitiesError::from)))
+    }
+
+    /// Parse an entities JSON file (in `serde_json::Value` form) into an iterator over [Entity]s
+    pub fn iter_from_json_value(
+        &self,
+        json: serde_json::Value,
+    ) -> Result<impl Iterator<Item = Result<Entity, EntitiesError>> + '_, EntitiesError> {
+        let ejsons: Vec<EntityJSON> =
+            serde_json::from_value(json).map_err(JsonDeserializationError::from)?;
+        Ok(ejsons
+            .into_iter()
+            .map(|ejson| self.parse_ejson(ejson).map_err(EntitiesError::from)))
+    }
+
+    /// Parse an entities JSON file (in `std::io::Read` form) into an iterator over  [Entity]s
+    pub fn iter_from_json_file(
+        &self,
+        json: impl std::io::Read,
+    ) -> Result<impl Iterator<Item = Result<Entity, EntitiesError>> + '_, EntitiesError> {
+        let ejsons: Vec<EntityJSON> =
+            serde_json::from_reader(json).map_err(JsonDeserializationError::from)?;
+        Ok(ejsons
+            .into_iter()
+            .map(|ejson| self.parse_ejson(ejson).map_err(EntitiesError::from)))
+    }
+
     /// internal function that creates an `Entities` from a stream of `EntityJSON`
     fn parse_ejsons(
         &self,

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -96,28 +96,28 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
         }
     }
 
-    /// Parse an entities JSON file (in `&str` form) into an `Entities` object
+    /// Parse an entities JSON file (in [`&str`] form) into an [`Entities`] object
     pub fn from_json_str(&self, json: &str) -> Result<Entities, EntitiesError> {
         let ejsons: Vec<EntityJSON> =
             serde_json::from_str(json).map_err(JsonDeserializationError::from)?;
         self.parse_ejsons(ejsons)
     }
 
-    /// Parse an entities JSON file (in `serde_json::Value` form) into an `Entities` object
+    /// Parse an entities JSON file (in [`serde_json::Value`] form) into an [`Entities`] object
     pub fn from_json_value(&self, json: serde_json::Value) -> Result<Entities, EntitiesError> {
         let ejsons: Vec<EntityJSON> =
             serde_json::from_value(json).map_err(JsonDeserializationError::from)?;
         self.parse_ejsons(ejsons)
     }
 
-    /// Parse an entities JSON file (in `std::io::Read` form) into an `Entities` object
+    /// Parse an entities JSON file (in [`std::io::Read`] form) into an [`Entities`] object
     pub fn from_json_file(&self, json: impl std::io::Read) -> Result<Entities, EntitiesError> {
         let ejsons: Vec<EntityJSON> =
             serde_json::from_reader(json).map_err(JsonDeserializationError::from)?;
         self.parse_ejsons(ejsons)
     }
 
-    /// Parse an entities JSON file (in `&str` form) into an iterator over [Entity]s
+    /// Parse an entities JSON file (in [`&str`] form) into an iterator over [Entity]s
     pub fn iter_from_json_str(
         &self,
         json: &str,
@@ -129,7 +129,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
             .map(|ejson| self.parse_ejson(ejson).map_err(EntitiesError::from)))
     }
 
-    /// Parse an entities JSON file (in `serde_json::Value` form) into an iterator over [Entity]s
+    /// Parse an entities JSON file (in [`serde_json::Value`] form) into an iterator over [`Entity`]s
     pub fn iter_from_json_value(
         &self,
         json: serde_json::Value,
@@ -141,7 +141,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
             .map(|ejson| self.parse_ejson(ejson).map_err(EntitiesError::from)))
     }
 
-    /// Parse an entities JSON file (in `std::io::Read` form) into an iterator over  [Entity]s
+    /// Parse an entities JSON file (in [`std::io::Read`] form) into an iterator over  [`Entity`]s
     pub fn iter_from_json_file(
         &self,
         json: impl std::io::Read,
@@ -153,7 +153,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
             .map(|ejson| self.parse_ejson(ejson).map_err(EntitiesError::from)))
     }
 
-    /// internal function that creates an `Entities` from a stream of `EntityJSON`
+    /// internal function that creates an [`Entities`] from a stream of [`EntityJSON`]
     fn parse_ejsons(
         &self,
         ejsons: impl IntoIterator<Item = EntityJSON>,

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -117,7 +117,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
         self.parse_ejsons(ejsons)
     }
 
-    /// Parse an entities JSON file (in [`&str`] form) into an iterator over [Entity]s
+    /// Parse an entities JSON file (in [`&str`] form) into an iterator over [`Entity`]s
     pub fn iter_from_json_str(
         &self,
         json: &str,

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -854,11 +854,10 @@ impl TryFrom<cst::Relation> for Expr {
                     let target_expr = target.try_into()?;
                     let pat_expr: Expr = pattern.try_into()?;
                     let pat_str = pat_expr.into_string_literal().map_err(|e| {
-                        ParseError::ToAST(ToASTError::InvalidPattern(format!(
-                            "{}",
+                        ParseError::ToAST(ToASTError::InvalidPattern(
                             serde_json::to_string(&e)
-                                .unwrap_or_else(|_| "<malformed est>".to_string())
-                        )))
+                                .unwrap_or_else(|_| "<malformed est>".to_string()),
+                        ))
                     })?;
                     Ok(Expr::like(target_expr, pat_str))
                 }

--- a/cedar-policy-core/src/transitive_closure/err.rs
+++ b/cedar-policy-core/src/transitive_closure/err.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 /// error type is parametrized by a type `K` which is the type of a unique
 /// identifier for graph nodes and the type returned by `get_key` on the
 /// `TCNode` trait.
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum TcError<K: Debug + Display> {
     /// Error raised when `TCComputation::EnforceAlreadyComputed` finds that the
     /// TC was in fact not already computed

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Move public API for partial evaluation behind experimental feature flag.
 - Added an option to eagerly evaluate entity attributes and re-use across calls to `is_authorized`
 - Revamped errors in cst-to-ast transformation
+- Adds APIs to `Entities` to make it easy to add a collection of entities to an existing `Entities` structure
 
 ### Added
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -196,6 +196,95 @@ impl Entities {
         .map(Entities)
     }
 
+    /// Add all of the [`Entity`]s in the collection to this [`Entities`] structure, re-computing the transitive closure
+    /// Re-computing the transitive closure can be expensive, so it is advised to not call this method in a loop
+    pub fn add_entities(
+        self,
+        entities: impl IntoIterator<Item = Entity>,
+    ) -> Result<Self, EntitiesError> {
+        Ok(Self(self.0.add_entities(
+            entities.into_iter().map(|e| e.0),
+            entities::TCComputation::ComputeNow,
+        )?))
+    }
+
+    /// Parse an entities JSON file (in [&str] form) and add them into this [`Entities`] structure, re-computing the transitive closure
+    ///
+    /// If a `schema` is provided, this will inform the parsing: for instance, it
+    /// will allow `__entity` and `__extn` escapes to be implicit, and it will error
+    /// if attributes have the wrong types (e.g., string instead of integer).
+    /// Re-computing the transitive closure can be expensive, so it is advised to not call this method in a loop
+    pub fn add_entities_from_json_str(
+        self,
+        json: &str,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let eparser = entities::EntityJsonParser::new(
+            schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0)),
+            Extensions::all_available(),
+            entities::TCComputation::ComputeNow,
+        );
+        let new_entities = eparser
+            .iter_from_json_str(json)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self(self.0.add_entities(
+            new_entities,
+            entities::TCComputation::ComputeNow,
+        )?))
+    }
+
+    /// Parse an entities JSON file (in [`serde_json::Value`] form) and add them into this [`Entities`] structure, re-computing the transitive closure
+    ///
+    /// If a `schema` is provided, this will inform the parsing: for instance, it
+    /// will allow `__entity` and `__extn` escapes to be implicit, and it will error
+    /// if attributes have the wrong types (e.g., string instead of integer).
+    ///
+    /// Re-computing the transitive closure can be expensive, so it is advised to not call this method in a loop
+    pub fn add_entities_from_json_value(
+        self,
+        json: serde_json::Value,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let eparser = entities::EntityJsonParser::new(
+            schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0)),
+            Extensions::all_available(),
+            entities::TCComputation::ComputeNow,
+        );
+        let new_entities = eparser
+            .iter_from_json_value(json)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self(self.0.add_entities(
+            new_entities,
+            entities::TCComputation::ComputeNow,
+        )?))
+    }
+
+    /// Parse an entities JSON file (in [`std::io::Read`] form) and add them into this [`Entities`] structure, re-computing the transitive closure
+    ///
+    /// If a `schema` is provided, this will inform the parsing: for instance, it
+    /// will allow `__entity` and `__extn` escapes to be implicit, and it will error
+    /// if attributes have the wrong types (e.g., string instead of integer).
+    ///
+    /// Re-computing the transitive closure can be expensive, so it is advised to not call this method in a loop
+    pub fn add_entities_from_json_file(
+        self,
+        json: impl std::io::Read,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let eparser = entities::EntityJsonParser::new(
+            schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0)),
+            Extensions::all_available(),
+            entities::TCComputation::ComputeNow,
+        );
+        let new_entities = eparser
+            .iter_from_json_file(json)?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self(self.0.add_entities(
+            new_entities,
+            entities::TCComputation::ComputeNow,
+        )?))
+    }
+
     /// Parse an entities JSON file (in `&str` form) into an `Entities` object
     ///
     /// If a `schema` is provided, this will inform the parsing: for instance, it


### PR DESCRIPTION
## Description of changes
Adds APIs to the `Entities` structure that allow you to add a collection of `Entity` objects to an existing `Entities` structure.
## Issue #, if available
#272 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
