### PR TITLE
add a new getter to a Core type, and small improvements to docs

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -27,23 +27,20 @@ use super::{Expr, Literal, PartialValue, Value, Var};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Request {
     /// Principal associated with the request
-    /// None means that variable will result in a residual for partial evaluation.
     pub(crate) principal: EntityUIDEntry,
 
     /// Action associated with the request
-    /// None means that variable will result in a residual for partial evaluation.
     pub(crate) action: EntityUIDEntry,
 
     /// Resource associated with the request
-    /// None means that variable will result in a residual for partial evaluation.
     pub(crate) resource: EntityUIDEntry,
 
-    /// Context associated with the request
-    /// None means that variable will result in a residual for partial evaluation.
+    /// Context associated with the request.
+    /// `None` means that variable will result in a residual for partial evaluation.
     pub(crate) context: Option<Context>,
 }
 
-/// An entry in a  request for a Entity UID.
+/// An entry in a request for a Entity UID.
 /// It may either be a concrete EUID
 /// or an unknown in the case of partial evaluation
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,6 +65,14 @@ impl EntityUIDEntry {
     /// Create an entry with a concrete EntityUID
     pub fn concrete(euid: EntityUID) -> Self {
         Self::Concrete(Arc::new(euid))
+    }
+
+    /// Get the UID of the entry, or `None` if it is unknown (partial evaluation)
+    pub fn uid(&self) -> Option<&EntityUID> {
+        match self {
+            Self::Concrete(euid) => Some(&euid),
+            Self::Unknown => None,
+        }
     }
 }
 


### PR DESCRIPTION
Just adding another convenience getter on a Core type (not exposed publicly).

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
