### PR TITLE
Deny some rustdoc lints and add `cargo doc` to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - run: cargo test --verbose --features "experimental"
       - run: cargo test --verbose
+      - run: cargo doc --all-features
       - run: cargo clippy
       - run: ./panic_safety.sh
       - run: cargo test --verbose -- --ignored

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -21,6 +21,7 @@ jobs:
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - run: cargo test --verbose --features "experimental"
       - run: cargo test --verbose
+      - run: cargo doc --all-features
       - run: cargo clippy
       - run: ./panic_safety.sh
       - run: cargo test --verbose -- --ignored

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1955,11 +1955,11 @@ impl Policy {
     }
 
     /// To avoid panicking, this function may only be called when `slot` is the
-    /// SlotId corresponding to the scope constraint from which the entity
+    /// `SlotId` corresponding to the scope constraint from which the entity
     /// reference `r` was extracted. I.e., If `r` is taken from the principal
     /// scope constraint, `slot` must be `?principal`. This ensures that the
-    /// SlotId exists in the policy (and therefore the slot environment map)
-    /// whenever the EntityReference `r` is the Slot variant.
+    /// `SlotId` exists in the policy (and therefore the slot environment map)
+    /// whenever the `EntityReference` `r` is the Slot variant.
     fn convert_entity_reference<'a>(
         &'a self,
         r: &'a ast::EntityReference,

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -16,11 +16,7 @@
 
 //! Public Rust interface for Cedar
 #![forbid(unsafe_code)]
-#![warn(
-    rust_2018_idioms,
-    clippy::pedantic,
-    clippy::nursery
-)]
+#![warn(rust_2018_idioms, clippy::pedantic, clippy::nursery)]
 #![deny(
     missing_docs,
     missing_debug_implementations,

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -17,11 +17,20 @@
 //! Public Rust interface for Cedar
 #![forbid(unsafe_code)]
 #![warn(
-    missing_docs,
-    missing_debug_implementations,
     rust_2018_idioms,
     clippy::pedantic,
     clippy::nursery
+)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_html_tags,
+    rustdoc::invalid_rust_codeblocks,
+    rustdoc::bare_urls,
+    clippy::doc_markdown
 )]
 #![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
 


### PR DESCRIPTION
## Description of changes

Build documentation in CI and fail for some doc specific lints. Docs get built for all our crates, but stricter linting only applies to `cedar-policy`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
