### PR TITLE
Improve error messages when attribute is not found

### DIFF
--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -19,13 +19,16 @@
 use std::{collections::BTreeSet, fmt::Display};
 
 use cedar_policy_core::{
-    ast::{CallStyle, Expr},
+    ast::{CallStyle, EntityUID, Expr, ExprKind, Var},
     parser::SourceInfo,
 };
+
+use crate::types::{EntityLUB, EntityRecordKind, RequestEnv};
 
 use super::types::Type;
 
 use itertools::Itertools;
+use smol_str::SmolStr;
 use thiserror::Error;
 
 /// The structure for type errors. A type errors knows the expression that
@@ -108,7 +111,7 @@ impl TypeError {
 
     pub(crate) fn unsafe_attribute_access(
         on_expr: Expr,
-        attribute: String,
+        attribute_access: AttributeAccess,
         suggestion: Option<String>,
         may_exist: bool,
     ) -> Self {
@@ -116,19 +119,22 @@ impl TypeError {
             on_expr: Some(on_expr),
             source_location: None,
             kind: TypeErrorKind::UnsafeAttributeAccess(UnsafeAttributeAccess {
-                attribute,
+                attribute_access,
                 suggestion,
                 may_exist,
             }),
         }
     }
 
-    pub(crate) fn unsafe_optional_attribute_access(on_expr: Expr, optional: String) -> Self {
+    pub(crate) fn unsafe_optional_attribute_access(
+        on_expr: Expr,
+        attribute_access: AttributeAccess,
+    ) -> Self {
         Self {
             on_expr: Some(on_expr),
             source_location: None,
             kind: TypeErrorKind::UnsafeOptionalAttributeAccess(UnsafeOptionalAttributeAccess {
-                optional,
+                attribute_access,
             }),
         }
     }
@@ -221,8 +227,8 @@ pub enum TypeErrorKind {
     /// The typechecker detected an access to a record or entity attribute
     /// that it could not statically guarantee would be present.
     #[error(
-        "attribute `{}` not found in record or entity{}{}",
-        .0.attribute,
+        "attribute {} not found{}{}",
+        .0.attribute_access,
         match &.0.suggestion {
             Some(suggestion) => format!(", did you mean `{suggestion}`"),
             None => "".to_string(),
@@ -236,7 +242,7 @@ pub enum TypeErrorKind {
     UnsafeAttributeAccess(UnsafeAttributeAccess),
     /// The typechecker could not conclude that an access to an optional
     /// attribute was safe.
-    #[error("Unable to guarantee safety of access to optional attribute: {}", .0.optional)]
+    #[error("unable to guarantee safety of access to optional attribute {}", .0.attribute_access)]
     UnsafeOptionalAttributeAccess(UnsafeOptionalAttributeAccess),
     /// The typechecker found that a policy condition will always evaluate to false.
     #[error(
@@ -288,7 +294,7 @@ pub struct TypesMustMatch {
 /// Structure containing details about a missing attribute error.
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct UnsafeAttributeAccess {
-    attribute: String,
+    attribute_access: AttributeAccess,
     suggestion: Option<String>,
     /// When this is true, the attribute might still exist, but the validator
     /// cannot guarantee that it will.
@@ -298,7 +304,7 @@ pub struct UnsafeAttributeAccess {
 /// Structure containing details about an unsafe optional attribute error.
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct UnsafeOptionalAttributeAccess {
-    optional: String,
+    attribute_access: AttributeAccess,
 }
 
 /// Structure containing details about an undefined function error.
@@ -331,4 +337,72 @@ pub struct WrongCallStyle {
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub struct FunctionArgumentValidationError {
     msg: String,
+}
+
+/// Contains more detailed information about an attribute access when it occurs
+/// on an entity type expression or on the `context` variable. Track a `Vec` of
+/// attributes rather than a single attribute so that on `principal.foo.bar` can
+/// report that the record attribute `foo` of an entity type (e.g., `User`)
+/// needs attributes `bar` instead of giving up when the immediate target of the
+/// attribute access is not a entity.
+#[derive(Debug, Hash, Eq, PartialEq)]
+pub(crate) enum AttributeAccess {
+    /// The attribute access is some sequence of attributes accesses eventually
+    /// targeting an EntityLUB.
+    EntityLUB(EntityLUB, Vec<SmolStr>),
+    /// The attribute access is some sequence of attributes accesses eventually
+    /// targeting the context variable.
+    Context(EntityUID, Vec<SmolStr>),
+    /// Other cases where we do not attempt to give more information about the
+    /// access. This includes any access on the `AnyEntity` type and on record
+    /// types other than the `context` variable.
+    Other(Vec<SmolStr>),
+}
+
+impl AttributeAccess {
+    pub(crate) fn from_expr(
+        req_env: &RequestEnv,
+        mut expr: &Expr<Option<Type>>,
+    ) -> AttributeAccess {
+        let mut attrs: Vec<SmolStr> = Vec::new();
+        loop {
+            if let Some(Type::EntityOrRecord(EntityRecordKind::Entity(lub))) = expr.data() {
+                return AttributeAccess::EntityLUB(lub.clone(), attrs);
+            } else if let ExprKind::Var(Var::Context) = expr.expr_kind() {
+                return AttributeAccess::Context(req_env.action.clone(), attrs);
+            } else if let ExprKind::GetAttr {
+                expr: sub_expr,
+                attr,
+            } = expr.expr_kind()
+            {
+                expr = sub_expr;
+                attrs.push(attr.clone());
+            } else {
+                return AttributeAccess::Other(attrs);
+            }
+        }
+    }
+}
+
+impl Display for AttributeAccess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AttributeAccess::EntityLUB(lub, attrs) => write!(
+                f,
+                "`{}` for entity type{}",
+                attrs.iter().rev().join("."),
+                match lub.get_single_entity() {
+                    Some(single) => format!(" {}", single),
+                    _ => format!("s {}", lub.iter().join(", ")),
+                },
+            ),
+            AttributeAccess::Context(action, attrs) => write!(
+                f,
+                "`{}` in context for {}",
+                attrs.iter().rev().join("."),
+                action
+            ),
+            AttributeAccess::Other(attrs) => write!(f, "`{}`", attrs.iter().rev().join(".")),
+        }
+    }
 }

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -351,7 +351,8 @@ pub(crate) enum AttributeAccess {
     /// targeting an EntityLUB.
     EntityLUB(EntityLUB, Vec<SmolStr>),
     /// The attribute access is some sequence of attributes accesses eventually
-    /// targeting the context variable.
+    /// targeting the context variable. The context being accessed is identified
+    /// by the `EntityUID` for the associated action.
     Context(EntityUID, Vec<SmolStr>),
     /// Other cases where we do not attempt to give more information about the
     /// access. This includes any access on the `AnyEntity` type and on record

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -44,7 +44,7 @@ use crate::{
     types::{
         AttributeType, Effect, EffectSet, EntityRecordKind, OpenTag, Primitive, RequestEnv, Type,
     },
-    ValidationMode,
+    AttributeAccess, ValidationMode,
 };
 
 use super::type_error::TypeError;
@@ -1606,7 +1606,7 @@ impl<'a> Typechecker<'a> {
                                 } else {
                                     type_errors.push(TypeError::unsafe_optional_attribute_access(
                                         e.clone(),
-                                        attr.to_string(),
+                                        AttributeAccess::from_expr(request_env, &annot_expr),
                                     ));
                                     TypecheckAnswer::fail(annot_expr)
                                 }
@@ -1617,7 +1617,7 @@ impl<'a> Typechecker<'a> {
                                 let suggestion = fuzzy_search(attr, &borrowed);
                                 type_errors.push(TypeError::unsafe_attribute_access(
                                     e.clone(),
-                                    attr.to_string(),
+                                    AttributeAccess::from_expr(request_env, &annot_expr),
                                     suggestion,
                                     Type::may_have_attr(self.schema, typ_actual, attr),
                                 ));

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -26,7 +26,8 @@ use serde_json::json;
 use smol_str::SmolStr;
 
 use crate::{
-    type_error::TypeError, types::Type, AttributesOrContext, EntityType, NamespaceDefinition,
+    type_error::TypeError, types::Type, AttributeAccess, AttributesOrContext, EntityType,
+    NamespaceDefinition,
 };
 
 use super::test_utils::{
@@ -601,7 +602,7 @@ fn record_get_attr_incompatible() {
         Expr::get_attr(if_expr.clone(), attr.clone()),
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(if_expr, attr.clone()),
-            attr.to_string(),
+            AttributeAccess::Other(vec![attr]),
             None,
             true,
         )],
@@ -650,7 +651,7 @@ fn record_get_attr_does_not_exist() {
         Expr::get_attr(Expr::record([]), attr.clone()),
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::record([]), attr.clone()),
-            attr.to_string(),
+            AttributeAccess::Other(vec![attr]),
             None,
             false,
         )],
@@ -669,7 +670,7 @@ fn record_get_attr_lub_does_not_exist() {
         Expr::get_attr(if_expr.clone(), attr.clone()),
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(if_expr, attr.clone()),
-            attr.to_string(),
+            AttributeAccess::Other(vec![attr]),
             None,
             false,
         )],

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -32,7 +32,11 @@ use super::test_utils::{
     assert_policy_typecheck_fails, assert_policy_typechecks, assert_typecheck_fails,
     assert_typechecks,
 };
-use crate::{type_error::TypeError, types::Type, SchemaFragment, ValidatorSchema};
+use crate::{
+    type_error::TypeError,
+    types::{EntityLUB, Type},
+    AttributeAccess, SchemaFragment, ValidatorSchema,
+};
 
 fn namespaced_entity_type_schema() -> SchemaFragment {
     serde_json::from_str(
@@ -351,7 +355,10 @@ fn multiple_namespaces_attributes() {
         None,
         vec![TypeError::unsafe_attribute_access(
             Expr::from_str("B::Foo::\"foo\".x").unwrap(),
-            "x".to_string(),
+            AttributeAccess::EntityLUB(
+                EntityLUB::single_entity("B::Foo".parse().unwrap()),
+                vec!["x".into()],
+            ),
             None,
             false,
         )],

--- a/cedar-policy-validator/src/typecheck/test_unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test_unspecified_entity.rs
@@ -22,7 +22,7 @@ use cedar_policy_core::{
     parser::parse_policy,
 };
 
-use crate::{type_error::TypeError, NamespaceDefinition};
+use crate::{type_error::TypeError, AttributeAccess, NamespaceDefinition};
 
 use super::test_utils;
 
@@ -89,7 +89,7 @@ fn spec_principal_unspec_resource() {
         policy,
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Resource), "name".into()),
-            "name".to_string(),
+            AttributeAccess::Other(vec!["name".into()]),
             None,
             true,
         )],
@@ -107,7 +107,7 @@ fn spec_resource_unspec_principal() {
         policy,
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Principal), "name".into()),
-            "name".to_string(),
+            AttributeAccess::Other(vec!["name".into()]),
             None,
             true,
         )],
@@ -132,7 +132,7 @@ fn unspec_resource_unspec_principal() {
         policy,
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Principal), "name".into()),
-            "name".to_string(),
+            AttributeAccess::Other(vec!["name".into()]),
             None,
             true,
         )],
@@ -147,7 +147,7 @@ fn unspec_resource_unspec_principal() {
         policy,
         vec![TypeError::unsafe_attribute_access(
             Expr::get_attr(Expr::var(Var::Resource), "name".into()),
-            "name".to_string(),
+            AttributeAccess::Other(vec!["name".into()]),
             None,
             true,
         )],

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -695,7 +695,7 @@ pub struct EntityLUB {
 impl EntityLUB {
     /// Create a least upper bound of a single entity type. This is the same as
     /// just that entity type.
-    fn single_entity(entity_type_name: Name) -> Self {
+    pub(crate) fn single_entity(entity_type_name: Name) -> Self {
         Self {
             lub_elements: [entity_type_name].into_iter().collect(),
         }
@@ -766,7 +766,7 @@ impl EntityLUB {
     /// Generate the least upper bound of this EntityLUB and another. This
     /// returns an EntityLUB for the union of the entity types in both argument
     /// LUBs. The attributes of the LUB are not computed.
-    fn least_upper_bound(&self, other: &EntityLUB) -> EntityLUB {
+    pub(crate) fn least_upper_bound(&self, other: &EntityLUB) -> EntityLUB {
         EntityLUB {
             lub_elements: self
                 .lub_elements
@@ -786,6 +786,11 @@ impl EntityLUB {
     /// comprising this LUB.
     pub(crate) fn iter(&self) -> impl Iterator<Item = &Name> {
         self.lub_elements.iter()
+    }
+
+    // Get the number of entity types in this set.
+    pub(crate) fn len(&self) -> usize {
+        self.lub_elements.len()
     }
 
     fn to_type_json(&self) -> serde_json::value::Map<String, serde_json::value::Value> {

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -788,11 +788,6 @@ impl EntityLUB {
         self.lub_elements.iter()
     }
 
-    // Get the number of entity types in this set.
-    pub(crate) fn len(&self) -> usize {
-        self.lub_elements.len()
-    }
-
     fn to_type_json(&self) -> serde_json::value::Map<String, serde_json::value::Value> {
         let mut ordered_lub_elems = self.lub_elements.iter().collect::<Vec<_>>();
         // We want the display order of elements of the set to be consistent.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Renamed variants in `cedar_policy::SchemaError`
 - The `Diagnostics::errors()` function now returns an iterator over `AuthorizationError`s.
 - The `Response::new()` constructor now expects a `Vec<AuthorizationError>` as its third argument.
+- Improved validation error messages for access to undeclared attributes and
+  unsafe access to optional attributes to report the target of the access (fix #175).
 
 ## 2.3.3
 


### PR DESCRIPTION
## Description of changes

Fixing #175.

Error messages for unsafe attribute accesses more detailed information about an attribute access when it occurs in an entity type expression or on the `context` variable.

e.g.,

```
Validation error on policy policy0 at offset 100-118: attribute `bar` for entity type User not found, did you mean `score`
Validation error on policy policy0 at offset 181-192: attribute `foo` in context for Action::"view" not found
```

instead of 

```
Validation error on policy policy0 at offset 100-118: attribute `bar` not found in record or entity, did you mean `score`
Validation error on policy policy0 at offset 181-192: attribute `foo` not found in record or entity
```

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
