### PR TITLE
Bugfix/aaronjeline/pe invariant

### DIFF
--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -4938,6 +4938,5 @@ pub mod test {
             .expect("Failed to parse");
         let r = eval.partial_evaluate(&static_policy.into())
             .expect("Failed to evaluate");
-        println!("{:?}", r);
     }
 }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -619,7 +619,7 @@ impl<'q, 'e> Evaluator<'e> {
                     self.partial_interpret(alternative, slots)
                 }
             }
-            PartialValue::Residual(_) => {
+            PartialValue::Residual(guard) => {
                 let (consequent, consequent_errored) = self.run_to_error(consequent, slots);
                 let (alternative, alternative_errored) = self.run_to_error(alternative, slots);
                 // If both branches errored, the expression will always error
@@ -4904,5 +4904,40 @@ pub mod test {
             "b".into(),
         );
         assert!(eval.partial_eval_expr(&e).is_err());
+    }
+
+
+    use std::collections::HashSet;
+
+    #[test]
+    fn partial_ite() {
+        let es = Entities::from_entities([
+            Entity::new(r#"R::a::"u1c""#.parse().unwrap(), HashMap::new(), HashSet::new()),
+            Entity::new(r#"R::a::"""#.parse().unwrap(), HashMap::new(), HashSet::new()),
+        ], TCComputation::ComputeNow)
+            .unwrap();
+        let exts = Extensions::none();
+        let q = Request::new_with_unknowns(
+            EntityUIDEntry::concrete(r#"R::a::"u1c""#.parse().unwrap()),
+            EntityUIDEntry::concrete("R::Action::\"action\"".parse().unwrap()),
+            EntityUIDEntry::Unknown,
+            Some(Context::empty()));
+        let eval = Evaluator::new(&q, &es, &exts).unwrap();
+
+        let pset: &str = r#"forbid(
+            principal in R::a::"u1c",
+            action in [R::Action::"action"],
+            resource == R::a::""
+          ) when {
+            ((true && (!(!(resource in [])))) &&
+            ((if (resource in []) then (if true then principal else principal) else R::a::"") in [action])) && (resource in resource)
+          };"#;
+
+        let static_policy =
+        parser::parse_policy(Some("id".into()), pset)
+            .expect("Failed to parse");
+        let r = eval.partial_evaluate(&static_policy.into())
+            .expect("Failed to evaluate");
+        println!("{:?}", r);
     }
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- [Experimental] Fixes a bug around partially-evaluating conditionals.
+
 ### Added
 
 - Added an option to eagerly evaluate entity attributes and re-use across calls to `is_authorized`


### PR DESCRIPTION
## Description of changes
Fixes a bug in partial-evaluation where residual-results from conditional guard were not used correctly, leading to an invariant violation.
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.


I confirm that this PR (choose one, and delete the other options):

- [ X Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
