### PR TITLE
better lifetime bound for some returned values

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -265,7 +265,7 @@ impl<'a> From<BorrowedRestrictedExpr<'a>> for &'a Expr {
 }
 
 impl<'a> AsRef<Expr> for BorrowedRestrictedExpr<'a> {
-    fn as_ref(&self) -> &Expr {
+    fn as_ref(&self) -> &'a Expr {
         self.0
     }
 }
@@ -279,8 +279,8 @@ impl RestrictedExpr {
 
 impl<'a> Deref for BorrowedRestrictedExpr<'a> {
     type Target = Expr;
-    fn deref(&self) -> &Expr {
-        self.as_ref()
+    fn deref(&self) -> &'a Expr {
+        self.0
     }
 }
 


### PR DESCRIPTION
Totally back-compatible, just gives callers a better lifetime bound for the lifetime of the returned `Expr`.  This aids in doing some operations on `BorrowedRestrictedExpr` without cloning the underlying `Expr`.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
