### PR TITLE
Formatting of error messages

### DIFF
--- a/cedar-policy-core/src/authorizer/err.rs
+++ b/cedar-policy-core/src/authorizer/err.rs
@@ -22,11 +22,11 @@ use thiserror::Error;
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum AuthorizationError {
     /// Failed to eagerly evaluate entity attributes when initializing the `Evaluator`.
-    #[error("error occurred while evaluating entity attributes: {0}")]
+    #[error("Error occurred while evaluating entity attributes: {0}.")]
     AttributeEvaluationError(EvaluationError),
 
     /// An error occurred when evaluating a policy.
-    #[error("error occurred while evaluating policy `{}`: {}", &.id, &.error)]
+    #[error("Error occurred while evaluating policy '{}': {}.", &.id, &.error)]
     PolicyEvaluationError {
         /// Id of the policy with an error
         id: PolicyID,

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -28,7 +28,7 @@ pub enum EntitiesError {
     #[error("Entities deserialization error: {0}.")]
     Deserialization(#[from] crate::entities::JsonDeserializationError),
     /// Error constructing the `[crate::entities::Entities]` as there is a duplicate Entity UID
-    #[error("Duplicate entity entry: {0}.")]
+    #[error("Duplicate entry of entity '{0}'.")]
     Duplicate(EntityUID),
     /// Errors occurring while computing or enforcing transitive closure on the
     /// entity hierarchy.

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -22,17 +22,17 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum EntitiesError {
     /// Error occurring in serialization of entities
-    #[error("entities serialization error: {0}")]
+    #[error("Entities serialization error: {0}.")]
     Serialization(#[from] crate::entities::JsonSerializationError),
     /// Error occurring in deserialization of entities
-    #[error("entities deserialization error: {0}")]
+    #[error("Entities deserialization error: {0}.")]
     Deserialization(#[from] crate::entities::JsonDeserializationError),
     /// Error constructing the `[crate::entities::Entities]` as there is a duplicate Entity UID
-    #[error("Duplicate entity entry: {0}")]
+    #[error("Duplicate entity entry: {0}.")]
     Duplicate(EntityUID),
     /// Errors occurring while computing or enforcing transitive closure on the
     /// entity hierarchy.
-    #[error("transitive closure computation/enforcement error: {0}")]
+    #[error("Transitive closure computation/enforcement error: {0}.")]
     TransitiveClosureError(#[from] Box<transitive_closure::TcError<EntityUID>>),
 }
 

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -27,27 +27,27 @@ pub enum FromJsonError {
     #[error(transparent)]
     JsonDeserializationError(#[from] JsonDeserializationError),
     /// Tried to convert an EST representing a template to an AST representing a static policy
-    #[error("tried to convert JSON representing a template to a static policy: {0}")]
+    #[error("Tried to convert JSON representing a template to a static policy: {0}")]
     TemplateToPolicy(#[from] ast::UnexpectedSlotError),
     /// Slot name was not valid for the position it was used in. (Currently, principal slots must
     /// be named `?principal`, and resource slots must be named `?resource`.)
-    #[error("invalid slot name, or used in wrong position")]
+    #[error("Invalid slot name, or used in wrong position.")]
     InvalidSlotName,
     /// EST contained a template slot for `action`. This is not currently allowed
-    #[error("specified a slot for action")]
+    #[error("Specified a slot for action.")]
     ActionSlot,
     /// EST contained the empty JSON object `{}` where a key (operator) was expected
-    #[error("missing operator, found empty object")]
+    #[error("Missing operator, found empty object.")]
     MissingOperator,
     /// EST contained an object with multiple keys (operators) where a single operator was expected
-    #[error("found multiple operators where one was expected: {ops:?}")]
+    #[error("Found multiple operators where one was expected: {ops:?}.")]
     MultipleOperators {
         /// the multiple operators that were found where one was expected
         ops: Vec<SmolStr>,
     },
     /// At most one of the operands in `a * b * c * d * ...` can be a non-{constant int}
     #[error(
-        "multiplication must be by a constant int: neither `{arg1}` nor `{arg2}` is a constant"
+        "Multiplication must be by a constant int: neither `{arg1}` nor `{arg2}` is a constant."
     )]
     MultiplicationByNonConstant {
         /// First non-constant argument
@@ -56,7 +56,7 @@ pub enum FromJsonError {
         arg2: ast::Expr,
     },
     /// Error thrown while processing string escapes
-    #[error("invalid escape patterns: {:?}", .0.iter().map(|e| e.to_string()).collect::<Vec<String>>())]
+    #[error("Invalid escape patterns: {:?}", .0.iter().map(|e| e.to_string()).collect::<Vec<String>>())]
     UnescapeError(Vec<unescape::UnescapeError>),
 }
 
@@ -64,7 +64,7 @@ pub enum FromJsonError {
 #[derive(Debug, PartialEq, Error)]
 pub enum InstantiationError {
     /// Template contains this slot, but a value wasn't provided for it
-    #[error("failed to instantiate template: no value provided for {slot}")]
+    #[error("Failed to instantiate template: no value provided for '{slot}'.")]
     MissedSlot {
         /// Slot which didn't have a value provided for it
         slot: ast::SlotId,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -181,12 +181,12 @@ impl From<RestrictedExprError> for EvaluationError {
 pub enum EvaluationErrorKind {
     /// Tried to lookup this entity UID, but it didn't exist in the provided
     /// entities
-    #[error("entity does not exist: {0}")]
+    #[error("Entity '{0}' does not exist.")]
     EntityDoesNotExist(Arc<EntityUID>),
 
     /// Tried to get this attribute, but the specified entity didn't
     /// have that attribute
-    #[error("`{}` does not have the attribute: {}", &.entity, &.attr)]
+    #[error("Entity '{}' does not have the attribute '{}'.", &.entity, &.attr)]
     EntityAttrDoesNotExist {
         /// Entity that didn't have the attribute
         entity: Arc<EntityUID>,
@@ -195,12 +195,12 @@ pub enum EvaluationErrorKind {
     },
 
     /// Tried to access an attribute of an unspecified entity
-    #[error("cannot access attribute of unspecified entity: {0}")]
+    #[error("Cannot access attribute of unspecified entity '{0}'.")]
     UnspecifiedEntityAccess(SmolStr),
 
     /// Tried to get an attribute of a (non-entity) record, but that record
     /// didn't have that attribute
-    #[error("record does not have the attribute: {0}. Available attributes: {1:?}")]
+    #[error("Record does not have the attribute '{0}'. Available attributes: {1:?}")]
     RecordAttrDoesNotExist(SmolStr, Vec<SmolStr>),
 
     /// An error occurred when looking up an extension function
@@ -219,7 +219,7 @@ pub enum EvaluationErrorKind {
     },
 
     /// Wrong number of arguments provided to an extension function
-    #[error("wrong number of arguments provided to extension function {function_name}: expected {expected}, got {actual}")]
+    #[error("Extension function '{function_name}' expected {expected} argument(s) but got {actual}.")]
     WrongNumArguments {
         /// arguments to this function
         function_name: Name,
@@ -239,11 +239,11 @@ pub enum EvaluationErrorKind {
 
     /// Thrown when a policy is evaluated with a slot that is not linked to an
     /// [`EntityUID`]
-    #[error("template slot `{0}` was not linked")]
+    #[error("Template slot '{0}' was not linked.")]
     UnlinkedSlot(SlotId),
 
     /// Evaluation error thrown by an extension function
-    #[error("error while evaluating {extension_name} extension function: {msg}")]
+    #[error("Error occurred while evaluating extension function '{extension_name}': {msg}.")]
     FailedExtensionFunctionApplication {
         /// Name of the extension throwing the error
         extension_name: Name,
@@ -254,11 +254,11 @@ pub enum EvaluationErrorKind {
     /// This error is raised if an expression contains unknowns and cannot be
     /// reduced to a [`Value`]. In order to return partial results, use the
     /// partial evaluation APIs instead.
-    #[error("the expression contains unknown(s): {0}")]
+    #[error("The expression contains unknown(s): '{0}'.")]
     NonValue(Expr),
 
     /// Maximum recursion limit reached for expression evaluation
-    #[error("recursion limit reached")]
+    #[error("Recursion limit reached.")]
     RecursionLimit,
 }
 
@@ -271,12 +271,12 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
         0 => unreachable!("should expect at least one type"),
         // PANIC SAFETY. `len` is 1 in this branch
         #[allow(clippy::indexing_slicing)]
-        1 => format!("type error: expected {}, got {}", expected[0], actual),
+        1 => format!("Expected type '{}', got type '{}'.", expected[0], actual),
         _ => {
             use itertools::Itertools;
             format!(
-                "type error: expected one of [{}], got {actual}",
-                expected.iter().join(", ")
+                "Expected type one of ['{}'], got '{actual}'.",
+                expected.iter().join("', '")
             )
         }
     }
@@ -285,7 +285,7 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum IntegerOverflowError {
     /// Overflow during a binary operation
-    #[error("integer overflow while attempting to {} the values `{arg1}` and `{arg2}`", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", _ => "perform an operation on" })]
+    #[error("Integer overflow while attempting to {} the values '{arg1}' and '{arg2}'.", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", _ => "perform an operation on" })]
     BinaryOp {
         /// overflow while evaluating this operator
         op: BinaryOp,
@@ -296,7 +296,7 @@ pub enum IntegerOverflowError {
     },
 
     /// Overflow during multiplication
-    #[error("integer overflow while attempting to multiply `{arg}` by `{constant}`")]
+    #[error("Integer overflow while attempting to multiply '{arg}' by '{constant}'.")]
     Multiplication {
         /// first argument, which wasn't necessarily a constant in the policy
         arg: Value,
@@ -305,7 +305,7 @@ pub enum IntegerOverflowError {
     },
 
     /// Overflow during a unary operation
-    #[error("integer overflow while attempting to {} the value `{arg}`", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
+    #[error("Integer overflow while attempting to {} the value '{arg}'.", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
     UnaryOp {
         /// overflow while evaluating this operator
         op: UnaryOp,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1033,75 +1033,75 @@ impl Schema {
 #[derive(Debug, Error)]
 pub enum SchemaError {
     /// Error thrown by the `serde_json` crate during deserialization
-    #[error("failed to parse schema: {0}")]
+    #[error("Failed to parse schema: {0}")]
     Serde(#[from] serde_json::Error),
     /// Errors occurring while computing or enforcing transitive closure on
     /// action hierarchy.
-    #[error("transitive closure computation/enforcement error on action hierarchy: {0}")]
+    #[error("Transitive closure computation/enforcement error on action hierarchy: {0}")]
     ActionTransitiveClosure(String),
     /// Errors occurring while computing or enforcing transitive closure on
     /// entity type hierarchy.
     #[error("transitive closure computation/enforcement error on entity type hierarchy: {0}")]
     EntityTypeTransitiveClosure(String),
     /// Error generated when processing a schema file that uses unsupported features
-    #[error("unsupported feature used in schema: {0}")]
+    #[error("Ensupported feature used in schema: {0}")]
     UnsupportedFeature(String),
     /// Undeclared entity type(s) used in the `memberOf` field of an entity
     /// type, the `appliesTo` fields of an action, or an attribute type in a
     /// context or entity attribute record. Entity types in the error message
     /// are fully qualified, including any implicit or explicit namespaces.
-    #[error("undeclared entity type(s): {0:?}")]
+    #[error("Undeclared entity type(s): {0:?}.")]
     UndeclaredEntityTypes(HashSet<String>),
     /// Undeclared action(s) used in the `memberOf` field of an action.
-    #[error("undeclared action(s): {0:?}")]
+    #[error("Undeclared action(s): {0:?}.")]
     UndeclaredActions(HashSet<String>),
     /// Undeclared common type(s) used in entity or context attributes.
-    #[error("undeclared common type(s): {0:?}")]
+    #[error("Undeclared common type(s): {0:?}.")]
     UndeclaredCommonTypes(HashSet<String>),
     /// Duplicate specifications for an entity type. Argument is the name of
     /// the duplicate entity type.
-    #[error("duplicate entity type: {0}")]
+    #[error("Duplicate entity type '{0}'.")]
     DuplicateEntityType(String),
     /// Duplicate specifications for an action. Argument is the name of the
     /// duplicate action.
-    #[error("duplicate action: {0}")]
+    #[error("Duplicate action '{0}'.")]
     DuplicateAction(String),
     /// Duplicate specification for a reusable type declaration.
-    #[error("duplicate common type: {0}")]
+    #[error("Duplicate common type '{0}'.")]
     DuplicateCommonType(String),
     /// Cycle in the schema's action hierarchy.
-    #[error("cycle in action hierarchy")]
+    #[error("Cycle in action hierarchy.")]
     CycleInActionHierarchy,
     /// Parse errors occurring while parsing an entity type.
-    #[error("parse error in entity type: {0}")]
+    #[error("Error parsing entity type. {0}")]
     ParseEntityType(ParseErrors),
     /// Parse errors occurring while parsing a namespace identifier.
-    #[error("parse error in namespace identifier: {0}")]
+    #[error("Error parsing namespace identifier. {0}")]
     ParseNamespace(ParseErrors),
     /// Parse errors occurring while parsing an extension type.
-    #[error("parse error in extension type: {0}")]
+    #[error("Error parsing extension type. {0}")]
     ParseExtensionType(ParseErrors),
     /// Parse errors occurring while parsing the name of a reusable
     /// declared type.
-    #[error("parse error in common type identifier: {0}")]
+    #[error("Error parsing common type identifier: {0}")]
     ParseCommonType(ParseErrors),
     /// The schema file included an entity type `Action` in the entity type
     /// list. The `Action` entity type is always implicitly declared, and it
     /// cannot currently have attributes or be in any groups, so there is no
     /// purposes in adding an explicit entry.
-    #[error("entity type `Action` declared in `entityTypes` list")]
+    #[error("Entity type 'Action' declared in 'entityTypes' list.")]
     ActionEntityTypeDeclared,
     /// `context` or `shape` fields are not records
-    #[error("`{0}` is not a record")]
+    #[error("'{0}' is not a record.")]
     ContextOrShapeNotRecord(ContextOrShape),
     /// An action entity (transitively) has an attribute that is an empty set.
     /// The validator cannot assign a type to an empty set.
     /// This error variant should only be used when `PermitAttributes` is enabled.
-    #[error("action `{0}` has an attribute that is an empty set")]
+    #[error("Action '{0}' has an attribute that is an empty set.")]
     ActionAttributesContainEmptySet(EntityUid),
     /// An action entity (transitively) has an attribute of unsupported type (`ExprEscape`, `EntityEscape` or `ExtnEscape`).
     /// This error variant should only be used when `PermitAttributes` is enabled.
-    #[error("action `{0}` has an attribute with unsupported JSON representation: {1}")]
+    #[error("Action '{0}' has an attribute with unsupported JSON representation: {1}.")]
     UnsupportedActionAttribute(EntityUid, String),
 }
 
@@ -1260,7 +1260,7 @@ impl<'a> From<cedar_policy_validator::ValidationError<'a>> for ValidationError<'
 
 impl<'a> std::fmt::Display for ValidationError<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Validation error on policy {}", self.location.policy_id)?;
+        write!(f, "Validation error on policy '{}'.", self.location.policy_id)?;
         if let (Some(range_start), Some(range_end)) =
             (self.location().range_start(), self.location().range_end())
         {
@@ -1316,7 +1316,7 @@ pub fn confusable_string_checker<'a>(
 }
 
 #[derive(Debug, Error)]
-#[error("Warning on policy {}: {}", .location.policy_id, .kind)]
+#[error("Warning on policy '{}': {}.", .location.policy_id, .kind)]
 /// Warnings found in Cedar policies
 pub struct ValidationWarning<'a> {
     location: SourceLocation<'a>,
@@ -1558,19 +1558,19 @@ impl std::fmt::Display for EntityUid {
 pub enum PolicySetError {
     /// There was a duplicate [`PolicyId`] encountered in either the set of
     /// templates or the set of policies.
-    #[error("duplicate template or policy id: {id}")]
+    #[error("Duplicate template or policy ID: '{id}'.")]
     AlreadyDefined {
         /// [`PolicyId`] that was duplicate
         id: PolicyId,
     },
     /// Error when linking a template
-    #[error("unable to link template: {0}")]
+    #[error("Unable to link template: {0}.")]
     LinkingError(#[from] ast::LinkingError),
     /// Expected a static policy, but a template-linked policy was provided
-    #[error("expected a static policy, but a template-linked policy was provided")]
+    #[error("Expected a static policy, but a template-linked policy was provided.")]
     ExpectedStatic,
     /// Expected a template, but a static policy was provided.
-    #[error("expected a template, but a static policy was provided")]
+    #[error("Expected a template, but a static policy was provided.")]
     ExpectedTemplate,
 }
 
@@ -2956,7 +2956,7 @@ pub enum ContextJsonError {
     #[error(transparent)]
     JsonDeserialization(#[from] JsonDeserializationError),
     /// The supplied action doesn't exist in the supplied schema
-    #[error("action `{action}` doesn't exist in the supplied schema")]
+    #[error("Action '{action}' does not exist in the supplied schema.")]
     MissingAction {
         /// UID of the action which doesn't exist
         action: EntityUid,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1564,7 +1564,7 @@ pub enum PolicySetError {
         id: PolicyId,
     },
     /// Error when linking a template
-    #[error("Unable to link template: {0}.")]
+    #[error("Unable to link template: {0}")]
     LinkingError(#[from] ast::LinkingError),
     /// Expected a static policy, but a template-linked policy was provided
     #[error("Expected a static policy, but a template-linked policy was provided.")]


### PR DESCRIPTION
## Description of changes
This PR formats error messages by following sentence case, wrapping tokens/keywords in ' and refining some of the strings.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
