### PR TITLE
Undeprecating EntityUid's impl of FromStr

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1542,7 +1542,7 @@ impl FromStr for EntityUid {
     /// Examples:
     /// ```
     ///  use cedar_policy::EntityUid;
-    ///  let euid : EntityUid = r#"Foo::Bar::"george""#.parse().unwrap();
+    ///  let euid: EntityUid = r#"Foo::Bar::"george""#.parse().unwrap();
     ///  // Get the type of this euid (`Foo::Bar`)
     ///  euid.type_name();
     /// ```

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1541,8 +1541,10 @@ impl FromStr for EntityUid {
     ///
     /// Examples:
     /// ```
-    /// Foo::Bar::"george"
-    /// PhotoFlash::Albums::"VacationPhotos"
+    ///  use cedar_policy::EntityUid;
+    ///  let euid : EntityUid = r#"Foo::Bar::"george""#.parse().unwrap();
+    ///  // Get the type of this euid (`Foo::Bar`)
+    ///  euid.type_name();
     /// ```
     ///
     /// This [`FromStr`] implementation requires the _normalized_ representation of the

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1530,17 +1530,28 @@ impl EntityUid {
     }
 }
 
-// This FromStr implementation requires the _normalized_ representation of the
-// UID. See https://github.com/cedar-policy/rfcs/pull/9/.
 impl FromStr for EntityUid {
     type Err = ParseErrors;
 
-    /// This is deprecated (starting with Cedar 1.2); use
-    /// `EntityUid::from_type_name_and_id()` or `EntityUid::from_json()`
-    /// instead.
-    //
-    // You can't actually `#[deprecated]` a trait implementation or trait
-    // method.
+    /// Parse an [`EntityUid`].
+    ///
+    /// An [`EntityUid`] consists of a sequence of [`EntityTypeName`]s joined by `::`,
+    /// followed by a quoted [`EntityId`].
+    /// For the formal grammar, see <https://docs.cedarpolicy.com/policies/syntax-grammar.html#entity>
+    ///
+    /// Examples:
+    /// ```
+    /// Foo::Bar::"george"
+    /// PhotoFlash::Albums::"VacationPhotos"
+    /// ```
+    ///
+    /// This [`FromStr`] implementation requires the _normalized_ representation of the
+    /// UID. See <https://github.com/cedar-policy/rfcs/pull/9/>.
+    ///
+    /// A note on safety:
+    ///
+    /// __DO NOT__ create [`EntityUid`]'s via string concatenation.
+    /// If you have separate components of an [`EntityUid`], use [`EntityUid::from_type_name_and_id`]
     fn from_str(uid_str: &str) -> Result<Self, Self::Err> {
         ast::EntityUID::from_normalized_str(uid_str).map(EntityUid)
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1535,8 +1535,8 @@ impl FromStr for EntityUid {
 
     /// Parse an [`EntityUid`].
     ///
-    /// An [`EntityUid`] consists of a sequence of [`EntityTypeName`]s joined by `::`,
-    /// followed by a quoted [`EntityId`].
+    /// An [`EntityUid`] consists of an [`EntityTypeName`] followed by a quoted [`EntityId`].
+    /// The two are joined by a `::`.
     /// For the formal grammar, see <https://docs.cedarpolicy.com/policies/syntax-grammar.html#entity>
     ///
     /// Examples:
@@ -1545,6 +1545,8 @@ impl FromStr for EntityUid {
     ///  let euid: EntityUid = r#"Foo::Bar::"george""#.parse().unwrap();
     ///  // Get the type of this euid (`Foo::Bar`)
     ///  euid.type_name();
+    ///  // Or the id
+    ///  euid.id();
     /// ```
     ///
     /// This [`FromStr`] implementation requires the _normalized_ representation of the


### PR DESCRIPTION
## Description of changes
Un-Deprecates and adjusts the documentation for `EntityUid`'s implementation of `FromStr`
## Issue #, if available
#180 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):


- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
