### PR TITLE
Add `ParseError::primary_source_span`

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Support `Request`s with `Unknown` fields for partial evaluation.
 - Export the `cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind}` and
   `cedar_policy_core::authorizer::AuthorizationError` error types.
+- Added an API to `ParseError` to quickly get the primary source span
 
 ### Changed
 


### PR DESCRIPTION
## Description of changes

This is a quick API for determining a primary source span from a `ParseError`, without having to interact with `Diagnostic` or `LabeledSpan`s.

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
