### PR TITLE
Consistency pass over error messages

### DIFF
--- a/cedar-integration-tests/corpus_tests/005b19a44b16074bb1322d9d25512abfe121daff.json
+++ b/cedar-integration-tests/corpus_tests/005b19a44b16074bb1322d9d25512abfe121daff.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0241a89fbf150dd7b0577a17c0e4ab3d89e59b34.json
+++ b/cedar-integration-tests/corpus_tests/0241a89fbf150dd7b0577a17c0e4ab3d89e59b34.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/02a49223197987f55c4eb3a434db07b1d23a377a.json
+++ b/cedar-integration-tests/corpus_tests/02a49223197987f55c4eb3a434db07b1d23a377a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type l::l::A::r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/03628ca780763f86b2c24cfdbd7a98bc0df23e2d.json
+++ b/cedar-integration-tests/corpus_tests/03628ca780763f86b2c24cfdbd7a98bc0df23e2d.json
@@ -33,7 +33,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/046c5a37b575d3dbabeaae9997b2f94c42061491.json
+++ b/cedar-integration-tests/corpus_tests/046c5a37b575d3dbabeaae9997b2f94c42061491.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::D::Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/04ab8774dce503da2421cd6d038f69c5601734bc.json
+++ b/cedar-integration-tests/corpus_tests/04ab8774dce503da2421cd6d038f69c5601734bc.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/05ced0c2a3b26e996cd9857050b5cb568f3c55a4.json
+++ b/cedar-integration-tests/corpus_tests/05ced0c2a3b26e996cd9857050b5cb568f3c55a4.json
@@ -33,7 +33,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/06d021d379ba0cc92ffbb243a9024b20a9dac326.json
+++ b/cedar-integration-tests/corpus_tests/06d021d379ba0cc92ffbb243a9024b20a9dac326.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/07c8a8cfabada6bb90447010829e8e73fc84580d.json
+++ b/cedar-integration-tests/corpus_tests/07c8a8cfabada6bb90447010829e8e73fc84580d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0821f9d8ec765af8242685b3dce67d7b4f358ec2.json
+++ b/cedar-integration-tests/corpus_tests/0821f9d8ec765af8242685b3dce67d7b4f358ec2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/08500c1c65e96341b3eef33c68658af8078fd824.json
+++ b/cedar-integration-tests/corpus_tests/08500c1c65e96341b3eef33c68658af8078fd824.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/08b97eac230b3d3f0877670ac672eaeff6b040b0.json
+++ b/cedar-integration-tests/corpus_tests/08b97eac230b3d3f0877670ac672eaeff6b040b0.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -55,7 +55,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -67,7 +67,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -79,7 +79,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -91,7 +91,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/098ba12b4f5c65c43dd6f6ec2ba0e59642149b25.json
+++ b/cedar-integration-tests/corpus_tests/098ba12b4f5c65c43dd6f6ec2ba0e59642149b25.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0c0777cdd6151d7e1f444ff3ac045d45e99de86f.json
+++ b/cedar-integration-tests/corpus_tests/0c0777cdd6151d7e1f444ff3ac045d45e99de86f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0c367b79cc920e0feaf83ea234081b5ed3e76fa5.json
+++ b/cedar-integration-tests/corpus_tests/0c367b79cc920e0feaf83ea234081b5ed3e76fa5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0c504a6e9b059221d5f7cadc7c33b075f40fa27c.json
+++ b/cedar-integration-tests/corpus_tests/0c504a6e9b059221d5f7cadc7c33b075f40fa27c.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/0ef8dad0b5a647ae0a7c1dd48d2bfb403009d4eb.json
+++ b/cedar-integration-tests/corpus_tests/0ef8dad0b5a647ae0a7c1dd48d2bfb403009d4eb.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0f77f6c224018df9fc00f3068dc4a4cb198b78e1.json
+++ b/cedar-integration-tests/corpus_tests/0f77f6c224018df9fc00f3068dc4a4cb198b78e1.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0ff6d747c763a5a1c6266cb4a4e7ae80cc8d6234.json
+++ b/cedar-integration-tests/corpus_tests/0ff6d747c763a5a1c6266cb4a4e7ae80cc8d6234.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/106c7942e09695b70e209e67e8df5655de990003.json
+++ b/cedar-integration-tests/corpus_tests/106c7942e09695b70e209e67e8df5655de990003.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/107926a401aafb1e4f5723ba817fd79792b4541b.json
+++ b/cedar-integration-tests/corpus_tests/107926a401aafb1e4f5723ba817fd79792b4541b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/10aea06c714dbebcb199fd92684892b0df616040.json
+++ b/cedar-integration-tests/corpus_tests/10aea06c714dbebcb199fd92684892b0df616040.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/10fcd998b35b276ab130e82d0b618ed9ee17c343.json
+++ b/cedar-integration-tests/corpus_tests/10fcd998b35b276ab130e82d0b618ed9ee17c343.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/138f76b366b2306738303807e1936a89f7f2762b.json
+++ b/cedar-integration-tests/corpus_tests/138f76b366b2306738303807e1936a89f7f2762b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1394e48d6330fa784673907ee1460d41a4e2659b.json
+++ b/cedar-integration-tests/corpus_tests/1394e48d6330fa784673907ee1460d41a4e2659b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A97w::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/13c95d614c44c554c6f335fd59c6e95cbd0ad9cc.json
+++ b/cedar-integration-tests/corpus_tests/13c95d614c44c554c6f335fd59c6e95cbd0ad9cc.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/14b98c1a51be833bbaf6cb341851e2ff30a8223b.json
+++ b/cedar-integration-tests/corpus_tests/14b98c1a51be833bbaf6cb341851e2ff30a8223b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/14baa465818b2da2f72d88d491dbbb20d0fe58bb.json
+++ b/cedar-integration-tests/corpus_tests/14baa465818b2da2f72d88d491dbbb20d0fe58bb.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/14e83b8120617ff2c6781d31c8c787af29d10bd7.json
+++ b/cedar-integration-tests/corpus_tests/14e83b8120617ff2c6781d31c8c787af29d10bd7.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type y)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/15563f0ff844401488c49316ba8cb82f870c3caa.json
+++ b/cedar-integration-tests/corpus_tests/15563f0ff844401488c49316ba8cb82f870c3caa.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got record"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1571103f55b41633bd2465963f25a783b98d46ac.json
+++ b/cedar-integration-tests/corpus_tests/1571103f55b41633bd2465963f25a783b98d46ac.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/163083371b5763682e22beff81ec7dc11208e336.json
+++ b/cedar-integration-tests/corpus_tests/163083371b5763682e22beff81ec7dc11208e336.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16837047727ca7d0c2d7ce7be3a30d78e25c1313.json
+++ b/cedar-integration-tests/corpus_tests/16837047727ca7d0c2d7ce7be3a30d78e25c1313.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16c049e91f396ebf938fb47fd7f0432b4db1e2b0.json
+++ b/cedar-integration-tests/corpus_tests/16c049e91f396ebf938fb47fd7f0432b4db1e2b0.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16c992ac81a16c5bba204e9ba8e7b5b4f15f3c49.json
+++ b/cedar-integration-tests/corpus_tests/16c992ac81a16c5bba204e9ba8e7b5b4f15f3c49.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/170466057a2b0d393044c1cb000aea4a624cb320.json
+++ b/cedar-integration-tests/corpus_tests/170466057a2b0d393044c1cb000aea4a624cb320.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1744b70eb7f065316e50f3a750afbbf6e9c242ee.json
+++ b/cedar-integration-tests/corpus_tests/1744b70eb7f065316e50f3a750afbbf6e9c242ee.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/17668072f20aabadd9a184797bf67efb9c07ad98.json
+++ b/cedar-integration-tests/corpus_tests/17668072f20aabadd9a184797bf67efb9c07ad98.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/177a22b9e2eae9a5db91db8c064db7dbc4976235.json
+++ b/cedar-integration-tests/corpus_tests/177a22b9e2eae9a5db91db8c064db7dbc4976235.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c2c15353c3261b6f53162583408aebbf8d259e8.json
+++ b/cedar-integration-tests/corpus_tests/1c2c15353c3261b6f53162583408aebbf8d259e8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c473ec0a248a595b1dde9b9a357404233b05583.json
+++ b/cedar-integration-tests/corpus_tests/1c473ec0a248a595b1dde9b9a357404233b05583.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A000::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c56d0ecf8bcdccadcf11f9c01742360b1f5cbfd.json
+++ b/cedar-integration-tests/corpus_tests/1c56d0ecf8bcdccadcf11f9c01742360b1f5cbfd.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1dbfb0d25adfd0ba48b9759273247ce82f8da3e5.json
+++ b/cedar-integration-tests/corpus_tests/1dbfb0d25adfd0ba48b9759273247ce82f8da3e5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1dc0dbcb9b9121975d3398e1e6a2893b6361cbea.json
+++ b/cedar-integration-tests/corpus_tests/1dc0dbcb9b9121975d3398e1e6a2893b6361cbea.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1e92f99bd2bca10ab16f9f78768fdd849c1f930a.json
+++ b/cedar-integration-tests/corpus_tests/1e92f99bd2bca10ab16f9f78768fdd849c1f930a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1eac86e06597f6e0416b884fc15a81bffa608603.json
+++ b/cedar-integration-tests/corpus_tests/1eac86e06597f6e0416b884fc15a81bffa608603.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1f2be35f573d7d1955f3a95af4f940cc6f4fe290.json
+++ b/cedar-integration-tests/corpus_tests/1f2be35f573d7d1955f3a95af4f940cc6f4fe290.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type n::g::F::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1f4f3648c4747c20ca5a99a1859e68a8feac3c1a.json
+++ b/cedar-integration-tests/corpus_tests/1f4f3648c4747c20ca5a99a1859e68a8feac3c1a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1fda47630d60a4aa8f8e54b61d736d8952c4a7f9.json
+++ b/cedar-integration-tests/corpus_tests/1fda47630d60a4aa8f8e54b61d736d8952c4a7f9.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type ZJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1ffe07c987be353018d565e8e6efd95c7c100ef5.json
+++ b/cedar-integration-tests/corpus_tests/1ffe07c987be353018d565e8e6efd95c7c100ef5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/211dc14823e42409dac2149cd417c42a96ad49e1.json
+++ b/cedar-integration-tests/corpus_tests/211dc14823e42409dac2149cd417c42a96ad49e1.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/228801b00e79ed2e44f08cc699ca7e766266fbf5.json
+++ b/cedar-integration-tests/corpus_tests/228801b00e79ed2e44f08cc699ca7e766266fbf5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/250bea468a24ef02741251907f89fe5165b1b7b5.json
+++ b/cedar-integration-tests/corpus_tests/250bea468a24ef02741251907f89fe5165b1b7b5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/26b830fd9423f8de3ddc676eaea3bc442a68fe12.json
+++ b/cedar-integration-tests/corpus_tests/26b830fd9423f8de3ddc676eaea3bc442a68fe12.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/274f63c71d3849f3100d4100b20c3da8832edc98.json
+++ b/cedar-integration-tests/corpus_tests/274f63c71d3849f3100d4100b20c3da8832edc98.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/29a58ad3bd458097fd0a19b29f16e2435339f87f.json
+++ b/cedar-integration-tests/corpus_tests/29a58ad3bd458097fd0a19b29f16e2435339f87f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/2adbc697e6a4307319167e11381a5264e8da8746.json
+++ b/cedar-integration-tests/corpus_tests/2adbc697e6a4307319167e11381a5264e8da8746.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/314551a580d1c09170f5fbfbdfa1339d757e36e7.json
+++ b/cedar-integration-tests/corpus_tests/314551a580d1c09170f5fbfbdfa1339d757e36e7.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/315dfa7040e05eacefa4c9ad4ed26555beb7433e.json
+++ b/cedar-integration-tests/corpus_tests/315dfa7040e05eacefa4c9ad4ed26555beb7433e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/33089fa566a0c0200b65f768e03955cc56073945.json
+++ b/cedar-integration-tests/corpus_tests/33089fa566a0c0200b65f768e03955cc56073945.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/33c9613909304c44134d611ad69d72b474ee46e3.json
+++ b/cedar-integration-tests/corpus_tests/33c9613909304c44134d611ad69d72b474ee46e3.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/33fd42aeebe4235b607ec620224210d394e169b6.json
+++ b/cedar-integration-tests/corpus_tests/33fd42aeebe4235b607ec620224210d394e169b6.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3499f81f5953dccba2a97c7f97f4c5fc46be27ca.json
+++ b/cedar-integration-tests/corpus_tests/3499f81f5953dccba2a97c7f97f4c5fc46be27ca.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/351318d1185cadb972352f0fd6df3a6801b6df44.json
+++ b/cedar-integration-tests/corpus_tests/351318d1185cadb972352f0fd6df3a6801b6df44.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type lbwwwQw00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/352f61b4d81394cf50e3228ce1bce32da88862f5.json
+++ b/cedar-integration-tests/corpus_tests/352f61b4d81394cf50e3228ce1bce32da88862f5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3741301f229f701463ccb88679111a6ee8ec5f3c.json
+++ b/cedar-integration-tests/corpus_tests/3741301f229f701463ccb88679111a6ee8ec5f3c.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type FwGwwwGw)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3789f3fb4358bddc1dac1aa750ce1a17e8fed5ed.json
+++ b/cedar-integration-tests/corpus_tests/3789f3fb4358bddc1dac1aa750ce1a17e8fed5ed.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/38d1fcf284cdf4f1c53cb41c358b757918075cc0.json
+++ b/cedar-integration-tests/corpus_tests/38d1fcf284cdf4f1c53cb41c358b757918075cc0.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 0"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/39310c282d59af031138d9d5c4a34fb72ee09942.json
+++ b/cedar-integration-tests/corpus_tests/39310c282d59af031138d9d5c4a34fb72ee09942.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3c41a82958bcbdb29cbf5f6484151423d17f73d8.json
+++ b/cedar-integration-tests/corpus_tests/3c41a82958bcbdb29cbf5f6484151423d17f73d8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3c4c1d09710a15a2e915c4be60ec4c9755322cf1.json
+++ b/cedar-integration-tests/corpus_tests/3c4c1d09710a15a2e915c4be60ec4c9755322cf1.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3f7b0ffba42bc51579c020cef13dd8e226b1838c.json
+++ b/cedar-integration-tests/corpus_tests/3f7b0ffba42bc51579c020cef13dd8e226b1838c.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/409414c9f886f7fc05131ff28e7e2e1fe5dc98f8.json
+++ b/cedar-integration-tests/corpus_tests/409414c9f886f7fc05131ff28e7e2e1fe5dc98f8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/41720d33fd4859c3997248e38c3c2b706cfd290d.json
+++ b/cedar-integration-tests/corpus_tests/41720d33fd4859c3997248e38c3c2b706cfd290d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/443a284848778e4b40c74fb093209b78e9eade2a.json
+++ b/cedar-integration-tests/corpus_tests/443a284848778e4b40c74fb093209b78e9eade2a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/458d087908efdf7dbdc6f52607eba655bf5fddb2.json
+++ b/cedar-integration-tests/corpus_tests/458d087908efdf7dbdc6f52607eba655bf5fddb2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/464729a46d258bcaaf394e5c69445e2c3eb2cfd7.json
+++ b/cedar-integration-tests/corpus_tests/464729a46d258bcaaf394e5c69445e2c3eb2cfd7.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/46f466ac9e298b4a1a776d92ab79d7cb0d2a8f7c.json
+++ b/cedar-integration-tests/corpus_tests/46f466ac9e298b4a1a776d92ab79d7cb0d2a8f7c.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/49aeadff64691c2fabe84335637947046a07af31.json
+++ b/cedar-integration-tests/corpus_tests/49aeadff64691c2fabe84335637947046a07af31.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Bsmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/49f2b384a40672e51691593bab92fcb170160508.json
+++ b/cedar-integration-tests/corpus_tests/49f2b384a40672e51691593bab92fcb170160508.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::A::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4bf1f9af8f34ec7092c461766c881f600ffb4f71.json
+++ b/cedar-integration-tests/corpus_tests/4bf1f9af8f34ec7092c461766c881f600ffb4f71.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type sqp1R111o1)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4c6237f576091e1bee1fe087fe515a0f9299cea6.json
+++ b/cedar-integration-tests/corpus_tests/4c6237f576091e1bee1fe087fe515a0f9299cea6.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4d87471123d5d2fcc845ad62f0a378747d1a8a3b.json
+++ b/cedar-integration-tests/corpus_tests/4d87471123d5d2fcc845ad62f0a378747d1a8a3b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -55,7 +55,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -67,7 +67,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -79,7 +79,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -91,7 +91,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4d95dd953c772afec1afee2f596e2cbd1418eb14.json
+++ b/cedar-integration-tests/corpus_tests/4d95dd953c772afec1afee2f596e2cbd1418eb14.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4f7c9ab77e4079e780601dea7a76263027b5ab69.json
+++ b/cedar-integration-tests/corpus_tests/4f7c9ab77e4079e780601dea7a76263027b5ab69.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Kfhhhhhh)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/53e72c4fde0d52b6941af1e722e15e03c51d13a2.json
+++ b/cedar-integration-tests/corpus_tests/53e72c4fde0d52b6941af1e722e15e03c51d13a2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/54dc49893ab1147dc7febeda5d35646d75f9279a.json
+++ b/cedar-integration-tests/corpus_tests/54dc49893ab1147dc7febeda5d35646d75f9279a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/55d14b8867ce5ed85dd8f30e97a54cd834e77627.json
+++ b/cedar-integration-tests/corpus_tests/55d14b8867ce5ed85dd8f30e97a54cd834e77627.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/56aaf321d34a8330373a5a4c21c140bd6e330cd2.json
+++ b/cedar-integration-tests/corpus_tests/56aaf321d34a8330373a5a4c21c140bd6e330cd2.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/56d4d9311bcdf16e69d505374f59e457440a8aa2.json
+++ b/cedar-integration-tests/corpus_tests/56d4d9311bcdf16e69d505374f59e457440a8aa2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
+        "error occurred while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/56d4d9311bcdf16e69d505374f59e457440a8aa2.json
+++ b/cedar-integration-tests/corpus_tests/56d4d9311bcdf16e69d505374f59e457440a8aa2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: entity does not exist: A0000::\"\""
+        "error occurred while evaluating policy `policy0`: entity does not exist: `A0000::\"\"`"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/575d96f86187dc6fb7ca8b3896f225b66318b7c7.json
+++ b/cedar-integration-tests/corpus_tests/575d96f86187dc6fb7ca8b3896f225b66318b7c7.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/585652a4c05f9b6d0b92999377d7a635f409b73a.json
+++ b/cedar-integration-tests/corpus_tests/585652a4c05f9b6d0b92999377d7a635f409b73a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5957f6406f64415729cbdfb64df1aed9e55091aa.json
+++ b/cedar-integration-tests/corpus_tests/5957f6406f64415729cbdfb64df1aed9e55091aa.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5a2dc81292f0d8dbcf7f8150459c4d62dd9a7841.json
+++ b/cedar-integration-tests/corpus_tests/5a2dc81292f0d8dbcf7f8150459c4d62dd9a7841.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5b426cc601268dd506e394ef2ab467a302267409.json
+++ b/cedar-integration-tests/corpus_tests/5b426cc601268dd506e394ef2ab467a302267409.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5b53a9d55eee49d43010321b95a98f3f9a30e2db.json
+++ b/cedar-integration-tests/corpus_tests/5b53a9d55eee49d43010321b95a98f3f9a30e2db.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5c2e65275c8bebc22d36a958acbb1651fa208b11.json
+++ b/cedar-integration-tests/corpus_tests/5c2e65275c8bebc22d36a958acbb1651fa208b11.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5ca000e7f1540ba4c90f6a110288612212e12707.json
+++ b/cedar-integration-tests/corpus_tests/5ca000e7f1540ba4c90f6a110288612212e12707.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5d14d9f3cd916cbfb24b2847d264e5d26ea36026.json
+++ b/cedar-integration-tests/corpus_tests/5d14d9f3cd916cbfb24b2847d264e5d26ea36026.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5e75403e4dd3959be0326292d1070386da5a1e37.json
+++ b/cedar-integration-tests/corpus_tests/5e75403e4dd3959be0326292d1070386da5a1e37.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function lessThan: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5f6f43e48c3d29e6d4a95ada9734f3086e67fe80.json
+++ b/cedar-integration-tests/corpus_tests/5f6f43e48c3d29e6d4a95ada9734f3086e67fe80.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5f8c11c34b2bf708ee41de0b188ec771a8605a46.json
+++ b/cedar-integration-tests/corpus_tests/5f8c11c34b2bf708ee41de0b188ec771a8605a46.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/604a41216284beed5afa69f4b724c92d17b36812.json
+++ b/cedar-integration-tests/corpus_tests/604a41216284beed5afa69f4b724c92d17b36812.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/60651d7140cea972984d740f037e2ff585b033f7.json
+++ b/cedar-integration-tests/corpus_tests/60651d7140cea972984d740f037e2ff585b033f7.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/62216c7d61a110e80e1bae89f57424161302dd67.json
+++ b/cedar-integration-tests/corpus_tests/62216c7d61a110e80e1bae89f57424161302dd67.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/624156ac4fff56421b32744f2ac8b14b89cf642b.json
+++ b/cedar-integration-tests/corpus_tests/624156ac4fff56421b32744f2ac8b14b89cf642b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/64b6091559a40a09a53f633f18677ce292b71fcc.json
+++ b/cedar-integration-tests/corpus_tests/64b6091559a40a09a53f633f18677ce292b71fcc.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/65a41a239147613edda56c85a5fe6c8f6cfb2aa1.json
+++ b/cedar-integration-tests/corpus_tests/65a41a239147613edda56c85a5fe6c8f6cfb2aa1.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/65c5f63b53b6783dbf4d4bb4e97b8a95b4c2b7ac.json
+++ b/cedar-integration-tests/corpus_tests/65c5f63b53b6783dbf4d4bb4e97b8a95b4c2b7ac.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Ruwa1u)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/65d7ad80c51c5bfa56e22a5c11073a26fa23143d.json
+++ b/cedar-integration-tests/corpus_tests/65d7ad80c51c5bfa56e22a5c11073a26fa23143d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/66a64b3581d4f1bb3143a0cc6ebf6919af364cd2.json
+++ b/cedar-integration-tests/corpus_tests/66a64b3581d4f1bb3143a0cc6ebf6919af364cd2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Dosnm00000000)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/68318f2eefc7de93d2490f6452c804087a99b619.json
+++ b/cedar-integration-tests/corpus_tests/68318f2eefc7de93d2490f6452c804087a99b619.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/69d41647b14ed47571fe950f2fbda31127455843.json
+++ b/cedar-integration-tests/corpus_tests/69d41647b14ed47571fe950f2fbda31127455843.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6bd85935b72b96cef2480563a8b387fbe994645c.json
+++ b/cedar-integration-tests/corpus_tests/6bd85935b72b96cef2480563a8b387fbe994645c.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6cfc2e19564dc9b5d218fb1b7c5387cf4ff164bd.json
+++ b/cedar-integration-tests/corpus_tests/6cfc2e19564dc9b5d218fb1b7c5387cf4ff164bd.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6e57104bd2645f6d8da6fb3b46cac26ec681221a.json
+++ b/cedar-integration-tests/corpus_tests/6e57104bd2645f6d8da6fb3b46cac26ec681221a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6fa62d99a95be2f5acd33b1d6072299cfab24505.json
+++ b/cedar-integration-tests/corpus_tests/6fa62d99a95be2f5acd33b1d6072299cfab24505.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r::W::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6fd8189e2fe88662dc06a04df0676824c692e94a.json
+++ b/cedar-integration-tests/corpus_tests/6fd8189e2fe88662dc06a04df0676824c692e94a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: jj"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7284584f3d64e4a462729a2952f283b5a6bfe3ea.json
+++ b/cedar-integration-tests/corpus_tests/7284584f3d64e4a462729a2952f283b5a6bfe3ea.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/74cb1c7bc7c5cd009274db3878641b5f68615989.json
+++ b/cedar-integration-tests/corpus_tests/74cb1c7bc7c5cd009274db3878641b5f68615989.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/74fc6528dec498d8409c8a72a7f24be4f27e1888.json
+++ b/cedar-integration-tests/corpus_tests/74fc6528dec498d8409c8a72a7f24be4f27e1888.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7876eafee5c27b4be49c894923a72008dd32edc5.json
+++ b/cedar-integration-tests/corpus_tests/7876eafee5c27b4be49c894923a72008dd32edc5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/78e6dc287b333b74145e3812acca38315b888cd5.json
+++ b/cedar-integration-tests/corpus_tests/78e6dc287b333b74145e3812acca38315b888cd5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/79e20304effab67d62ee64404284039250203aa5.json
+++ b/cedar-integration-tests/corpus_tests/79e20304effab67d62ee64404284039250203aa5.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type m::r::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b01b2db594cc56ad84353cc76e1fdad524005db.json
+++ b/cedar-integration-tests/corpus_tests/7b01b2db594cc56ad84353cc76e1fdad524005db.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b8a0adcf9a94ba713b2b01a3e63f16cdc5a6463.json
+++ b/cedar-integration-tests/corpus_tests/7b8a0adcf9a94ba713b2b01a3e63f16cdc5a6463.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b9bcbbc7a191f346a4b355e999c0e7af112f464.json
+++ b/cedar-integration-tests/corpus_tests/7b9bcbbc7a191f346a4b355e999c0e7af112f464.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7c86e43a5b649553003524a121d788581e8b519b.json
+++ b/cedar-integration-tests/corpus_tests/7c86e43a5b649553003524a121d788581e8b519b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7d62dbe121e6b9f46e46c164b14c997bde13304b.json
+++ b/cedar-integration-tests/corpus_tests/7d62dbe121e6b9f46e46c164b14c997bde13304b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7e545a5af2c43e384fee0bb2520166cc2a89f0b7.json
+++ b/cedar-integration-tests/corpus_tests/7e545a5af2c43e384fee0bb2520166cc2a89f0b7.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7f763280b38e3ae0b4ae15829f53fcd5b8937b62.json
+++ b/cedar-integration-tests/corpus_tests/7f763280b38e3ae0b4ae15829f53fcd5b8937b62.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/82e0009729d4fe23f1ca9992ea9311b61228b36a.json
+++ b/cedar-integration-tests/corpus_tests/82e0009729d4fe23f1ca9992ea9311b61228b36a.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/83296094a7d88d71a4a7b7cbe8d92117cb97f6c0.json
+++ b/cedar-integration-tests/corpus_tests/83296094a7d88d71a4a7b7cbe8d92117cb97f6c0.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/834280c350074a677889fb77ec7849eb89d4d304.json
+++ b/cedar-integration-tests/corpus_tests/834280c350074a677889fb77ec7849eb89d4d304.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8499dc3608bd9a3b4dcb97a74e219d48b1de6f5e.json
+++ b/cedar-integration-tests/corpus_tests/8499dc3608bd9a3b4dcb97a74e219d48b1de6f5e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/84f41f5ea0f77e2b817e38052fd58b2593c09f9f.json
+++ b/cedar-integration-tests/corpus_tests/84f41f5ea0f77e2b817e38052fd58b2593c09f9f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/870c25a990be727397d9239cd5a34f904c341e77.json
+++ b/cedar-integration-tests/corpus_tests/870c25a990be727397d9239cd5a34f904c341e77.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/88854732ff8c1610ddd340cf53aeeae79e33d222.json
+++ b/cedar-integration-tests/corpus_tests/88854732ff8c1610ddd340cf53aeeae79e33d222.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/88ae543a35ed13de3dc6e368575b1873114207bb.json
+++ b/cedar-integration-tests/corpus_tests/88ae543a35ed13de3dc6e368575b1873114207bb.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/88dfaaec78187b7e68e9ddd7ba4772e5786c89bd.json
+++ b/cedar-integration-tests/corpus_tests/88dfaaec78187b7e68e9ddd7ba4772e5786c89bd.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8b215be721bd036c5218e7540fc43a8b339e1254.json
+++ b/cedar-integration-tests/corpus_tests/8b215be721bd036c5218e7540fc43a8b339e1254.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8b6ca5e1fd6e3a0e977cddc8421b6566261e8147.json
+++ b/cedar-integration-tests/corpus_tests/8b6ca5e1fd6e3a0e977cddc8421b6566261e8147.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type nww_ww00000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8c36035fd556368746cadc0f161f7b650cca9cd6.json
+++ b/cedar-integration-tests/corpus_tests/8c36035fd556368746cadc0f161f7b650cca9cd6.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8dcfa6e09d836dedaeb71e79585d2bf8e3ef8bcc.json
+++ b/cedar-integration-tests/corpus_tests/8dcfa6e09d836dedaeb71e79585d2bf8e3ef8bcc.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8f4a8dd71968997861794d08fc5a32d135f848ee.json
+++ b/cedar-integration-tests/corpus_tests/8f4a8dd71968997861794d08fc5a32d135f848ee.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8fb94680726921adf01d87fcef5aedc39e1ce6b1.json
+++ b/cedar-integration-tests/corpus_tests/8fb94680726921adf01d87fcef5aedc39e1ce6b1.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9250519ce2283cfeec18cbbd341db4bd9fc56423.json
+++ b/cedar-integration-tests/corpus_tests/9250519ce2283cfeec18cbbd341db4bd9fc56423.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got record"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/942be69eda5e79fd772b447f062a7d9d543097c3.json
+++ b/cedar-integration-tests/corpus_tests/942be69eda5e79fd772b447f062a7d9d543097c3.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/94c0be79f2fdbf7665d653e48e8c770bed3d74df.json
+++ b/cedar-integration-tests/corpus_tests/94c0be79f2fdbf7665d653e48e8c770bed3d74df.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/94d1ab0699264fbb5eafc162905fb5200072fe87.json
+++ b/cedar-integration-tests/corpus_tests/94d1ab0699264fbb5eafc162905fb5200072fe87.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type Ahhmm)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/960d3e9de3aa8f15b17f855ffd831ac8c1b9632f.json
+++ b/cedar-integration-tests/corpus_tests/960d3e9de3aa8f15b17f855ffd831ac8c1b9632f.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9693f3116d0a2863b0014b2760b84ae20555f640.json
+++ b/cedar-integration-tests/corpus_tests/9693f3116d0a2863b0014b2760b84ae20555f640.json
@@ -15,7 +15,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -29,7 +29,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -99,7 +99,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -113,7 +113,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/97ecdb5a989451af145fda48ed60b28661bf1130.json
+++ b/cedar-integration-tests/corpus_tests/97ecdb5a989451af145fda48ed60b28661bf1130.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9ae2a4802b9d0889173964d21b2a63126f31d94f.json
+++ b/cedar-integration-tests/corpus_tests/9ae2a4802b9d0889173964d21b2a63126f31d94f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9b55589e73bf3330a31b529138b4a61a0a5918e0.json
+++ b/cedar-integration-tests/corpus_tests/9b55589e73bf3330a31b529138b4a61a0a5918e0.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d0a212b70378bf1433d4b49c52df64c1398b8cd.json
+++ b/cedar-integration-tests/corpus_tests/9d0a212b70378bf1433d4b49c52df64c1398b8cd.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d1dac4b5e28cc86db794732f1a2db6be9e18a0e.json
+++ b/cedar-integration-tests/corpus_tests/9d1dac4b5e28cc86db794732f1a2db6be9e18a0e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d4ca98f581b4ef94b815572be787be546d99ce9.json
+++ b/cedar-integration-tests/corpus_tests/9d4ca98f581b4ef94b815572be787be546d99ce9.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d708a846df604daa636403c267203ff2284d091.json
+++ b/cedar-integration-tests/corpus_tests/9d708a846df604daa636403c267203ff2284d091.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9deac7d6cae0d5e05635469c985c01f9a22e0d1b.json
+++ b/cedar-integration-tests/corpus_tests/9deac7d6cae0d5e05635469c985c01f9a22e0d1b.json
@@ -15,7 +15,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -29,7 +29,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -99,7 +99,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     },
     {
@@ -113,7 +113,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: record does not have the attribute: f. Available attributes: [\"\"]"
+        "error occurred while evaluating policy `policy0`: record does not have the attribute `f`. Available attributes: [\"\"]"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9dfb0e9489663d11ba0b18dc6c295586054d890f.json
+++ b/cedar-integration-tests/corpus_tests/9dfb0e9489663d11ba0b18dc6c295586054d890f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9e9dffc95a866861e43df9e9012d6be10996ed36.json
+++ b/cedar-integration-tests/corpus_tests/9e9dffc95a866861e43df9e9012d6be10996ed36.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9f1c21662ae11397c3676997c668326235093b42.json
+++ b/cedar-integration-tests/corpus_tests/9f1c21662ae11397c3676997c668326235093b42.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9f4d739955479dd973a11169342840d58c77101f.json
+++ b/cedar-integration-tests/corpus_tests/9f4d739955479dd973a11169342840d58c77101f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9fdb5ebfe43720d72298b5a5bc00dba586d0f996.json
+++ b/cedar-integration-tests/corpus_tests/9fdb5ebfe43720d72298b5a5bc00dba586d0f996.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a54f9c6bdd7a65aad28eea03eaef38ef77f3914f.json
+++ b/cedar-integration-tests/corpus_tests/a54f9c6bdd7a65aad28eea03eaef38ef77f3914f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a77b6b9fe492bdd0c3e41e011921a5960d92bd06.json
+++ b/cedar-integration-tests/corpus_tests/a77b6b9fe492bdd0c3e41e011921a5960d92bd06.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a8b757dff29c824709e5fcd3aeacdf2aa8cfebae.json
+++ b/cedar-integration-tests/corpus_tests/a8b757dff29c824709e5fcd3aeacdf2aa8cfebae.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a8c129e6673079a29c3d31194c0a5fa5f35b811f.json
+++ b/cedar-integration-tests/corpus_tests/a8c129e6673079a29c3d31194c0a5fa5f35b811f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a90bb06aa3fe36f3f82b8ab373d3a9eeba170538.json
+++ b/cedar-integration-tests/corpus_tests/a90bb06aa3fe36f3f82b8ab373d3a9eeba170538.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ad3fbf26c2855d5aaf75f48b29b649bd05692a10.json
+++ b/cedar-integration-tests/corpus_tests/ad3fbf26c2855d5aaf75f48b29b649bd05692a10.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ad60db88a7f37324e6c885200699a54b47768294.json
+++ b/cedar-integration-tests/corpus_tests/ad60db88a7f37324e6c885200699a54b47768294.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got string"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ae2c67d1713bca35a2ef40518399e6d3af5f342b.json
+++ b/cedar-integration-tests/corpus_tests/ae2c67d1713bca35a2ef40518399e6d3af5f342b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got set"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b09c050c89c695099088ec2c50e89094ecf2683e.json
+++ b/cedar-integration-tests/corpus_tests/b09c050c89c695099088ec2c50e89094ecf2683e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type g::r::A::Q::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b1cdf5f8969de06b11f9fe69168f746032eca879.json
+++ b/cedar-integration-tests/corpus_tests/b1cdf5f8969de06b11f9fe69168f746032eca879.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b24ab34a4e77453be45d5743cce301254b9d4f70.json
+++ b/cedar-integration-tests/corpus_tests/b24ab34a4e77453be45d5743cce301254b9d4f70.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b26b72b174aded01b6b866bbeb34751b7297733b.json
+++ b/cedar-integration-tests/corpus_tests/b26b72b174aded01b6b866bbeb34751b7297733b.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b5cd7ecd8056ac97a3c1081cdbe2bcbc48832bce.json
+++ b/cedar-integration-tests/corpus_tests/b5cd7ecd8056ac97a3c1081cdbe2bcbc48832bce.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b7c122bef1ed48427641aa2ba120554dedf15bba.json
+++ b/cedar-integration-tests/corpus_tests/b7c122bef1ed48427641aa2ba120554dedf15bba.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 4"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b9ba0cd046f46175d9c494da778329fb92e1b1c8.json
+++ b/cedar-integration-tests/corpus_tests/b9ba0cd046f46175d9c494da778329fb92e1b1c8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ba4d87ce7c6c3bca381073a32ddf47de29f6c23a.json
+++ b/cedar-integration-tests/corpus_tests/ba4d87ce7c6c3bca381073a32ddf47de29f6c23a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bab94d26d2fcf63c2c0bf4c0b1d783f53ea4e52f.json
+++ b/cedar-integration-tests/corpus_tests/bab94d26d2fcf63c2c0bf4c0b1d783f53ea4e52f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/babfcc8b3847d347f710f4a46ae1ac192986c981.json
+++ b/cedar-integration-tests/corpus_tests/babfcc8b3847d347f710f4a46ae1ac192986c981.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bad207c3066f1ffbd151959fd7bdf29c07b02298.json
+++ b/cedar-integration-tests/corpus_tests/bad207c3066f1ffbd151959fd7bdf29c07b02298.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bb18e52bb813c138683e38f2e1ebc7dfd3131ad7.json
+++ b/cedar-integration-tests/corpus_tests/bb18e52bb813c138683e38f2e1ebc7dfd3131ad7.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bba8300156d7b101f3fabdb9a5b66650eef37d04.json
+++ b/cedar-integration-tests/corpus_tests/bba8300156d7b101f3fabdb9a5b66650eef37d04.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/bbc1b27f8b8e179db4fc826a1ac81a70c7f0f014.json
+++ b/cedar-integration-tests/corpus_tests/bbc1b27f8b8e179db4fc826a1ac81a70c7f0f014.json
@@ -33,7 +33,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bc1eb67eb0bd87437d450690c1cb44032123b3dd.json
+++ b/cedar-integration-tests/corpus_tests/bc1eb67eb0bd87437d450690c1cb44032123b3dd.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bc9ab20725b791a5660f678694db33cb4a1ccefe.json
+++ b/cedar-integration-tests/corpus_tests/bc9ab20725b791a5660f678694db33cb4a1ccefe.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd1752d749a28ba01382db7bb02a0a972d2c401a.json
+++ b/cedar-integration-tests/corpus_tests/bd1752d749a28ba01382db7bb02a0a972d2c401a.json
@@ -33,7 +33,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd52aeabb79ad9249ef0960923b730c571327ffe.json
+++ b/cedar-integration-tests/corpus_tests/bd52aeabb79ad9249ef0960923b730c571327ffe.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/be3efdc8162eb23ea015be57b9d18094521b1551.json
+++ b/cedar-integration-tests/corpus_tests/be3efdc8162eb23ea015be57b9d18094521b1551.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/be4eb076d2594dfc30f6c2b6abba097fbc9ddbff.json
+++ b/cedar-integration-tests/corpus_tests/be4eb076d2594dfc30f6c2b6abba097fbc9ddbff.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c1884023c6fee7b6a8d8b93dd10119065e46edfd.json
+++ b/cedar-integration-tests/corpus_tests/c1884023c6fee7b6a8d8b93dd10119065e46edfd.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c1c19d5d03c6d67f35702459eaf182a1b36471ad.json
+++ b/cedar-integration-tests/corpus_tests/c1c19d5d03c6d67f35702459eaf182a1b36471ad.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type O)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c48188b8ac4d4f2191db06c508ee38bd1eda54a3.json
+++ b/cedar-integration-tests/corpus_tests/c48188b8ac4d4f2191db06c508ee38bd1eda54a3.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c589f1386d9a37a56828e2f7adcde859ff2e7573.json
+++ b/cedar-integration-tests/corpus_tests/c589f1386d9a37a56828e2f7adcde859ff2e7573.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c58bd14e00106a71304c6235f5086baf3967b3c0.json
+++ b/cedar-integration-tests/corpus_tests/c58bd14e00106a71304c6235f5086baf3967b3c0.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c58f2dcfcaf1078ac26d626b32fe4e55d108a62a.json
+++ b/cedar-integration-tests/corpus_tests/c58f2dcfcaf1078ac26d626b32fe4e55d108a62a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c61ef4bc690f842dab4e57f05e83ba0331adc190.json
+++ b/cedar-integration-tests/corpus_tests/c61ef4bc690f842dab4e57f05e83ba0331adc190.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ca2a5665590dadaa410ae37be42cf8c38ebf5228.json
+++ b/cedar-integration-tests/corpus_tests/ca2a5665590dadaa410ae37be42cf8c38ebf5228.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ca4a7fbd3617faa7e877b6038d722296a4b9d27d.json
+++ b/cedar-integration-tests/corpus_tests/ca4a7fbd3617faa7e877b6038d722296a4b9d27d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cb4b59edfc9f9d6201f583176e0a6cf4445aafe4.json
+++ b/cedar-integration-tests/corpus_tests/cb4b59edfc9f9d6201f583176e0a6cf4445aafe4.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cb91f70a3b580008e79ad7d2f79c554604d4bf4f.json
+++ b/cedar-integration-tests/corpus_tests/cb91f70a3b580008e79ad7d2f79c554604d4bf4f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cc28740c4d1065a1f7db2d69103dea6bd50cbb4e.json
+++ b/cedar-integration-tests/corpus_tests/cc28740c4d1065a1f7db2d69103dea6bd50cbb4e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cd24b45d64e569bf8a44d0cb26cadd19d02bb896.json
+++ b/cedar-integration-tests/corpus_tests/cd24b45d64e569bf8a44d0cb26cadd19d02bb896.json
@@ -15,7 +15,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -29,7 +29,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -99,7 +99,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     },
     {
@@ -113,7 +113,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute: A"
+        "error occurred while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ce29db8c629bdec52719f2c8d30dd323fbb2ba2e.json
+++ b/cedar-integration-tests/corpus_tests/ce29db8c629bdec52719f2c8d30dd323fbb2ba2e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ce937b05f78203ed138b10bafa0bcaecb8240e5c.json
+++ b/cedar-integration-tests/corpus_tests/ce937b05f78203ed138b10bafa0bcaecb8240e5c.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ceb5a1ff1b0982afc158333c77c32248f432b958.json
+++ b/cedar-integration-tests/corpus_tests/ceb5a1ff1b0982afc158333c77c32248f432b958.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/cefaca00ac959a2b9fc2f68db187e24290d6fa39.json
+++ b/cedar-integration-tests/corpus_tests/cefaca00ac959a2b9fc2f68db187e24290d6fa39.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cfdc0aa13f242dd5caecf75aed878d8bdf5015c0.json
+++ b/cedar-integration-tests/corpus_tests/cfdc0aa13f242dd5caecf75aed878d8bdf5015c0.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d1c32f30179c22ca32ee6b9a78b6467c4609e103.json
+++ b/cedar-integration-tests/corpus_tests/d1c32f30179c22ca32ee6b9a78b6467c4609e103.json
@@ -33,7 +33,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -45,7 +45,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d2fa250e2aba06b4c57ebe4937327d3ef25aa6be.json
+++ b/cedar-integration-tests/corpus_tests/d2fa250e2aba06b4c57ebe4937327d3ef25aa6be.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d3d751f8974775fad771c94efabf90348ff5c0c8.json
+++ b/cedar-integration-tests/corpus_tests/d3d751f8974775fad771c94efabf90348ff5c0c8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type any_entity_type)], got string"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d7f8fbf3df419726990afb22a94eff94e1aad654.json
+++ b/cedar-integration-tests/corpus_tests/d7f8fbf3df419726990afb22a94eff94e1aad654.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -57,7 +57,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -69,7 +69,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d805f68cb4896eb79d0581c2d210692d1f2a3b2a.json
+++ b/cedar-integration-tests/corpus_tests/d805f68cb4896eb79d0581c2d210692d1f2a3b2a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A3::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d874dce35c50c45ac609f378a680b7b8caaeba71.json
+++ b/cedar-integration-tests/corpus_tests/d874dce35c50c45ac609f378a680b7b8caaeba71.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d8d09ed3ce3ca1bbb7581ba1f5035cff45ea969d.json
+++ b/cedar-integration-tests/corpus_tests/d8d09ed3ce3ca1bbb7581ba1f5035cff45ea969d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/da188d700d07ee66e9aed294ec88e256f96a0099.json
+++ b/cedar-integration-tests/corpus_tests/da188d700d07ee66e9aed294ec88e256f96a0099.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/dc10006036dd185ebf256e9ff21f88aa2bc720bd.json
+++ b/cedar-integration-tests/corpus_tests/dc10006036dd185ebf256e9ff21f88aa2bc720bd.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ddcacf2669cc2037f337afa4ba73f1e07b4a9450.json
+++ b/cedar-integration-tests/corpus_tests/ddcacf2669cc2037f337afa4ba73f1e07b4a9450.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/defd5589c286ff2dda5865ae0a230c9ef13d90ab.json
+++ b/cedar-integration-tests/corpus_tests/defd5589c286ff2dda5865ae0a230c9ef13d90ab.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type C22::C233::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/df2ea141f627d2600b135b349b67b8865a9510be.json
+++ b/cedar-integration-tests/corpus_tests/df2ea141f627d2600b135b349b67b8865a9510be.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/df717142035535be823880e938720aaf57529996.json
+++ b/cedar-integration-tests/corpus_tests/df717142035535be823880e938720aaf57529996.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e02e2ae73a80519758593d2206484b8292d2c004.json
+++ b/cedar-integration-tests/corpus_tests/e02e2ae73a80519758593d2206484b8292d2c004.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e0f6913f9fa8b06d1b2a1b8b6c02087585d7f986.json
+++ b/cedar-integration-tests/corpus_tests/e0f6913f9fa8b06d1b2a1b8b6c02087585d7f986.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e1c6e1fbb078a7b301b99741c2c13e7648f0ba5a.json
+++ b/cedar-integration-tests/corpus_tests/e1c6e1fbb078a7b301b99741c2c13e7648f0ba5a.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e265048e41123c7389400efd99019d7a42fb70cb.json
+++ b/cedar-integration-tests/corpus_tests/e265048e41123c7389400efd99019d7a42fb70cb.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e2c3298a9025cabbcf814803d3a81cf93ced082e.json
+++ b/cedar-integration-tests/corpus_tests/e2c3298a9025cabbcf814803d3a81cf93ced082e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e3f5ca95a7fabe1adf9e44fdd782d45071ca5b89.json
+++ b/cedar-integration-tests/corpus_tests/e3f5ca95a7fabe1adf9e44fdd782d45071ca5b89.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e5e6199a3ae1e1ac97512ce3fa10eec795b71302.json
+++ b/cedar-integration-tests/corpus_tests/e5e6199a3ae1e1ac97512ce3fa10eec795b71302.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type W::v::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e707a4f91770c47e0c8a8ba6b52a37a816a5c93d.json
+++ b/cedar-integration-tests/corpus_tests/e707a4f91770c47e0c8a8ba6b52a37a816a5c93d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e724a7ae0f37a356481bfd94170d5e699c0c4315.json
+++ b/cedar-integration-tests/corpus_tests/e724a7ae0f37a356481bfd94170d5e699c0c4315.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type A000::a)"
+        "error occurred while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e7458302450d25b602e878ab27e3e460a03ce21d.json
+++ b/cedar-integration-tests/corpus_tests/e7458302450d25b602e878ab27e3e460a03ce21d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type A)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e8740bccf611aacef35d92682b472b951ccdb86e.json
+++ b/cedar-integration-tests/corpus_tests/e8740bccf611aacef35d92682b472b951ccdb86e.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ea1deadd3d188a9751dfddb6bb567d6e190152e6.json
+++ b/cedar-integration-tests/corpus_tests/ea1deadd3d188a9751dfddb6bb567d6e190152e6.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ea3b3bb7b61997bc73aa38c5229b58386ddc2606.json
+++ b/cedar-integration-tests/corpus_tests/ea3b3bb7b61997bc73aa38c5229b58386ddc2606.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ea67eaf13be16e92be8c2465e7fd55899e0abf80.json
+++ b/cedar-integration-tests/corpus_tests/ea67eaf13be16e92be8c2465e7fd55899e0abf80.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/eae3e1fd9f742fe24356b3508199c42e6aa33f09.json
+++ b/cedar-integration-tests/corpus_tests/eae3e1fd9f742fe24356b3508199c42e6aa33f09.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/eb94687cfe8e7a96150ffd9eb9601dc1eda7c66e.json
+++ b/cedar-integration-tests/corpus_tests/eb94687cfe8e7a96150ffd9eb9601dc1eda7c66e.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/ec9dd30e89a3764e03ddea1cdd980fbfcfc7b2b2.json
+++ b/cedar-integration-tests/corpus_tests/ec9dd30e89a3764e03ddea1cdd980fbfcfc7b2b2.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got bool"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ed1329e9a9e4ae97dda03d5e6f8dbcc1cd4262f9.json
+++ b/cedar-integration-tests/corpus_tests/ed1329e9a9e4ae97dda03d5e6f8dbcc1cd4262f9.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ee1fa449052339701d1c55068e63f92c7db896b8.json
+++ b/cedar-integration-tests/corpus_tests/ee1fa449052339701d1c55068e63f92c7db896b8.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ee4b7cbdbb7fcfed6d5e64fdb6e9745a6e70302e.json
+++ b/cedar-integration-tests/corpus_tests/ee4b7cbdbb7fcfed6d5e64fdb6e9745a6e70302e.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/eff2557e80c650481f9850bc32dbd8a483ef8077.json
+++ b/cedar-integration-tests/corpus_tests/eff2557e80c650481f9850bc32dbd8a483ef8077.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function isInRange: expected 2, got 3"
+        "error occurred while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f1218de44cefa25cec4475be3b7b4e3a8226fb37.json
+++ b/cedar-integration-tests/corpus_tests/f1218de44cefa25cec4475be3b7b4e3a8226fb37.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type x)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f49bf87abd8fad00a3d20364ecb4da7b19ceb31b.json
+++ b/cedar-integration-tests/corpus_tests/f49bf87abd8fad00a3d20364ecb4da7b19ceb31b.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f5f7588b66978d1dd2254338fbb68ed6ee64a2f0.json
+++ b/cedar-integration-tests/corpus_tests/f5f7588b66978d1dd2254338fbb68ed6ee64a2f0.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f7a661059947830ab159b0ed8f0093f339a49d7d.json
+++ b/cedar-integration-tests/corpus_tests/f7a661059947830ab159b0ed8f0093f339a49d7d.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type any_entity_type)], got long"
+        "error occurred while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f7ce74c11891a7f12cb5572bb109bd86118a25fa.json
+++ b/cedar-integration-tests/corpus_tests/f7ce74c11891a7f12cb5572bb109bd86118a25fa.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f9038335a4482bba1a886183685e4de56fd62a10.json
+++ b/cedar-integration-tests/corpus_tests/f9038335a4482bba1a886183685e4de56fd62a10.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected (entity of type any_entity_type), got long"
+        "error occurred while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f93f63d216acc608101bc400cb436f26296bf478.json
+++ b/cedar-integration-tests/corpus_tests/f93f63d216acc608101bc400cb436f26296bf478.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type G666666)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f9c354e3ba7eb40a2a786e83eba1831d1c00a8ce.json
+++ b/cedar-integration-tests/corpus_tests/f9c354e3ba7eb40a2a786e83eba1831d1c00a8ce.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f9e02a91691711a8be7fb43dc371d5a1d58aca0f.json
+++ b/cedar-integration-tests/corpus_tests/f9e02a91691711a8be7fb43dc371d5a1d58aca0f.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fae02fa9de9b4bdbb061e07c183ff5bab73d20cf.json
+++ b/cedar-integration-tests/corpus_tests/fae02fa9de9b4bdbb061e07c183ff5bab73d20cf.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fbb67cf9a24d6f669bc498ce002672d38048b513.json
+++ b/cedar-integration-tests/corpus_tests/fbb67cf9a24d6f669bc498ce002672d38048b513.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type OJJJ)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fc68e0680604a1abef56806cd2b3d0867a3a2e12.json
+++ b/cedar-integration-tests/corpus_tests/fc68e0680604a1abef56806cd2b3d0867a3a2e12.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type r)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fd4855a6b7c2e0189ede9509e242a8463c29e380.json
+++ b/cedar-integration-tests/corpus_tests/fd4855a6b7c2e0189ede9509e242a8463c29e380.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fd6c0162c36cf2a9f7b0f1f63cba50e26b7c7473.json
+++ b/cedar-integration-tests/corpus_tests/fd6c0162c36cf2a9f7b0f1f63cba50e26b7c7473.json
@@ -23,7 +23,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -35,7 +35,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -59,7 +59,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -71,7 +71,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     },
     {
@@ -95,7 +95,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type Action)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fdbc43fb8590b30134d3051354baca39abcc4846.json
+++ b/cedar-integration-tests/corpus_tests/fdbc43fb8590b30134d3051354baca39abcc4846.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type a)"
+        "error occurred while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
       ]
     }
   ]

--- a/cedar-integration-tests/tests/multi/5.json
+++ b/cedar-integration-tests/tests/multi/5.json
@@ -25,7 +25,7 @@
             },
             "decision": "Deny",
             "reasons": [],
-            "errors": ["error occurred while evaluating policy `policy0`: cannot access attribute of unspecified entity: `department`", "error occurred while evaluating policy `policy2`: cannot access attribute of unspecified entity: `jobLevel`"]
+            "errors": ["error occurred while evaluating policy `policy0`: cannot access attribute `department` of unspecified entity", "error occurred while evaluating policy `policy2`: cannot access attribute `jobLevel` of unspecified entity"]
         },
         {
             "desc": "a request with unspecified entities should be implicitly denied",
@@ -48,7 +48,7 @@
             },
             "decision": "Deny",
             "reasons": ["policy1"],
-            "errors": ["error occurred while evaluating policy `policy2`: cannot access attribute of unspecified entity: `jobLevel`"]
+            "errors": ["error occurred while evaluating policy `policy2`: cannot access attribute `jobLevel` of unspecified entity"]
         },
         {
             "desc": "giuseppe should be able to read any file",

--- a/cedar-integration-tests/tests/multi/5.json
+++ b/cedar-integration-tests/tests/multi/5.json
@@ -25,7 +25,7 @@
             },
             "decision": "Deny",
             "reasons": [],
-            "errors": ["error occurred while evaluating policy `policy0`: cannot access attribute of unspecified entity: department", "error occurred while evaluating policy `policy2`: cannot access attribute of unspecified entity: jobLevel"]
+            "errors": ["error occurred while evaluating policy `policy0`: cannot access attribute of unspecified entity: `department`", "error occurred while evaluating policy `policy2`: cannot access attribute of unspecified entity: `jobLevel`"]
         },
         {
             "desc": "a request with unspecified entities should be implicitly denied",
@@ -48,7 +48,7 @@
             },
             "decision": "Deny",
             "reasons": ["policy1"],
-            "errors": ["error occurred while evaluating policy `policy2`: cannot access attribute of unspecified entity: jobLevel"]
+            "errors": ["error occurred while evaluating policy `policy2`: cannot access attribute of unspecified entity: `jobLevel`"]
         },
         {
             "desc": "giuseppe should be able to read any file",

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -778,7 +778,7 @@ impl std::str::FromStr for Expr {
 #[derive(Debug, Clone, Error)]
 pub enum SubstitutionError {
     /// The supplied value did not match the type annotation on the unknown.
-    #[error("Expected a value of type {expected}, got a value of type {actual}")]
+    #[error("expected a value of type {expected}, got a value of type {actual}")]
     TypeError {
         /// The expected type, ie: the type the unknown was annotated with
         expected: Type,

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -255,14 +255,14 @@ pub enum LinkingError {
     },
 
     /// The attempted instantiation failed as the template did not exist.
-    #[error("failed to find a template with id: {id}")]
+    #[error("failed to find a template with id `{id}`")]
     NoSuchTemplate {
         /// [`PolicyID`] of the template we failed to find
         id: PolicyID,
     },
 
     /// The new instance conflicts with an existing [`PolicyID`].
-    #[error("template-linked policy id conflicts with an existing policy id: {id}")]
+    #[error("template-linked policy id `{id}` conflicts with an existing policy id")]
     PolicyIdConflict {
         /// [`PolicyID`] where the conflict exists
         id: PolicyID,
@@ -288,7 +288,7 @@ fn describe_arity_error(unbound_values: &[SlotId], extra_values: &[SlotId]) -> S
         (0,0) => unreachable!(),
         (_unbound, 0) => format!("the following slots were not provided as arguments: {}", unbound_values.iter().join(",")),
         (0, _extra) => format!("the following slots were provided as arguments, but did not exist in the template: {}", extra_values.iter().join(",")),
-        (_unbound, _extra) => format!("the following slots were not provided as arguments: {}\nthe following slots were provided as arguments, but did not exist in the template: {}", unbound_values.iter().join(","), extra_values.iter().join(","))
+        (_unbound, _extra) => format!("the following slots were not provided as arguments: {}. The following slots were provided as arguments, but did not exist in the template: {}", unbound_values.iter().join(","), extra_values.iter().join(","))
     }
 }
 
@@ -569,11 +569,11 @@ mod hashing_tests {
 /// Errors that can happen during policy reification
 #[derive(Debug, Error)]
 pub enum ReificationError {
-    /// The PolicyID linked to did not exist
-    #[error("The PolicyID linked to does not exist")]
+    /// The [`PolicyID`] linked to did not exist
+    #[error("the id linked to does not exist")]
     NoSuchTemplate(PolicyID),
     /// Error instantiating the policy
-    #[error("{0}")]
+    #[error(transparent)]
     Instantiation(#[from] LinkingError),
 }
 
@@ -1148,7 +1148,7 @@ pub enum UnexpectedSlotError {
     #[error("found a slot where none was expected")]
     Unnamed,
     /// Unexpected Slot with a name
-    #[error("found slot {0} where none was expected")]
+    #[error("found slot `{0}` where none was expected")]
     Named(SlotId),
 }
 

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -89,7 +89,7 @@ impl From<PolicySet> for LiteralPolicySet {
 pub enum PolicySetError {
     /// There was a duplicate [`PolicyID`] encountered in either the set of
     /// templates or the set of policies.
-    #[error("duplicate template or policy id: {id}")]
+    #[error("duplicate template or policy id `{id}`")]
     Occupied {
         /// [`PolicyID`] that was duplicate
         id: PolicyID,

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -329,7 +329,7 @@ pub enum RestrictedExprError {
     /// argument is a string description of the feature that is not allowed.
     /// The `expr` argument is the expression that uses the disallowed feature.
     /// Note that it is potentially a sub-expression of a larger expression.
-    #[error("not allowed to use {feature} in a restricted expression: {expr}")]
+    #[error("not allowed to use {feature} in a restricted expression: `{expr}`")]
     InvalidRestrictedExpression {
         /// what disallowed feature appeared in the expression
         feature: SmolStr,

--- a/cedar-policy-core/src/ast/types.rs
+++ b/cedar-policy-core/src/ast/types.rs
@@ -81,7 +81,7 @@ impl std::fmt::Display for Type {
             Self::Record => write!(f, "record"),
             Self::Entity { ty } => match ty {
                 EntityType::Unspecified => write!(f, "(entity of unspecified type)"),
-                EntityType::Concrete(name) => write!(f, "(entity of type {})", name),
+                EntityType::Concrete(name) => write!(f, "(entity of type `{}`)", name),
             },
             Self::Extension { name } => write!(f, "{}", name),
         }

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -44,7 +44,7 @@ pub enum Value {
 /// An error that can be thrown converting an expression to a value
 pub enum NotValue {
     /// General error for non-values
-    #[error("Not A Value")]
+    #[error("not a value")]
     NotValue,
 }
 

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1769,7 +1769,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type HR)), but actually has type record"#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but actually has type record"#),
             "actual error message was {}",
             err
         );
@@ -1815,7 +1815,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type Employee), but actually has type (entity of type HR)"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but actually has type (entity of type `HR`)"#),
             "actual error message was {}",
             err
         );
@@ -2598,7 +2598,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type XYZCorp::Employee), but actually has type (entity of type Employee)"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but actually has type (entity of type `Employee`)"#),
             "actual error message was {}",
             err
         );
@@ -2621,7 +2621,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to employee being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"`Employee::"12UA45"` has type `Employee` which is not declared in the schema. Did you mean XYZCorp::Employee?"#),
+            err.to_string().contains(r#"`Employee::"12UA45"` has type `Employee` which is not declared in the schema. Did you mean `XYZCorp::Employee`?"#),
             "actual error message was {}",
             err
         );

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -975,7 +975,7 @@ mod json_parsing_tests {
             EntitiesError::Deserialization(err) => {
                 assert!(
                     err.to_string().contains(
-                        r#"in uid field of <unknown entity>, expected a literal entity reference, but got: "hello""#
+                        r#"in uid field of <unknown entity>, expected a literal entity reference, but got `"hello"`"#
                     ),
                     "actual error message was {}",
                     err
@@ -999,7 +999,7 @@ mod json_parsing_tests {
         match err {
             EntitiesError::Deserialization(err) => assert!(
                 err.to_string()
-                    .contains(r#"expected a literal entity reference, but got: "hello""#),
+                    .contains(r#"expected a literal entity reference, but got `"hello"`"#),
                 "actual error message was {}",
                 err
             ),
@@ -1679,7 +1679,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
-            err.to_string().contains(r#"in attribute "numDirectReports" on Employee::"12UA45", type mismatch: attribute was expected to have type long, but actually has type string"#),
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but actually has type string"#),
             "actual error message was {}",
             err
         );
@@ -1726,7 +1726,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on manager");
         assert!(
             err.to_string()
-                .contains(r#"in attribute "manager" on Employee::"12UA45", expected a literal entity reference, but got: "34FB87""#),
+                .contains(r#"in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#),
             "actual error message was {}",
             err
         );
@@ -1769,7 +1769,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute "hr_contacts" on Employee::"12UA45", type mismatch: attribute was expected to have type (set of (entity of type HR)), but actually has type record"#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type HR)), but actually has type record"#),
             "actual error message was {}",
             err
         );
@@ -1815,7 +1815,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute "manager" on Employee::"12UA45", type mismatch: attribute was expected to have type (entity of type Employee), but actually has type (entity of type HR)"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type Employee), but actually has type (entity of type HR)"#),
             "actual error message was {}",
             err
         );
@@ -1862,7 +1862,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute "home_ip" on Employee::"12UA45", type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
             "actual error message was {}",
             err
         );
@@ -1907,7 +1907,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to missing attribute \"inner2\"");
         assert!(
-            err.to_string().contains(r#"in attribute "json_blob" on Employee::"12UA45", expected the record to have an attribute "inner2", but it doesn't"#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#),
             "actual error message was {}",
             err
         );
@@ -1953,7 +1953,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on attribute \"inner1\"");
         assert!(
-            err.to_string().contains(r#"in attribute "json_blob" on Employee::"12UA45", type mismatch: attribute was expected to have type record with attributes: "#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type record with attributes: "#),
             "actual error message was {}",
             err
         );
@@ -2031,7 +2031,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to unexpected attribute \"inner4\"");
         assert!(
-            err.to_string().contains(r#"in attribute "json_blob" on Employee::"12UA45", record attribute "inner4" shouldn't exist"#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, record attribute `inner4` should not exist"#),
             "actual error message was {}",
             err
         );
@@ -2075,7 +2075,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to missing attribute \"numDirectReports\"");
         assert!(
-            err.to_string().contains(r#"expected entity `Employee::"12UA45"` to have an attribute "numDirectReports", but it doesn't"#),
+            err.to_string().contains(r#"expected entity `Employee::"12UA45"` to have an attribute `numDirectReports`, but it does not"#),
             "actual error message was {}",
             err
         );
@@ -2123,7 +2123,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to unexpected attribute \"wat\"");
         assert!(
             err.to_string().contains(
-                r#"attribute "wat" on `Employee::"12UA45"` shouldn't exist according to the schema"#
+                r#"attribute `wat` on `Employee::"12UA45"` should not exist according to the schema"#
             ),
             "actual error message was {}",
             err
@@ -2598,7 +2598,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute "manager" on XYZCorp::Employee::"12UA45", type mismatch: attribute was expected to have type (entity of type XYZCorp::Employee), but actually has type (entity of type Employee)"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type XYZCorp::Employee), but actually has type (entity of type Employee)"#),
             "actual error message was {}",
             err
         );
@@ -2621,7 +2621,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to employee being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"`Employee::"12UA45"` has type `Employee` which is not declared in the schema; did you mean XYZCorp::Employee?"#),
+            err.to_string().contains(r#"`Employee::"12UA45"` has type `Employee` which is not declared in the schema. Did you mean XYZCorp::Employee?"#),
             "actual error message was {}",
             err
         );

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -22,13 +22,13 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum EntitiesError {
     /// Error occurring in serialization of entities
-    #[error("entities serialization error: {0}")]
+    #[error("error during entity serialization: {0}")]
     Serialization(#[from] crate::entities::JsonSerializationError),
     /// Error occurring in deserialization of entities
-    #[error("entities deserialization error: {0}")]
+    #[error("error during entity deserialization: {0}")]
     Deserialization(#[from] crate::entities::JsonDeserializationError),
     /// Error constructing the `[crate::entities::Entities]` as there is a duplicate Entity UID
-    #[error("Duplicate entity entry: {0}")]
+    #[error("duplicate entity entry `{0}`")]
     Duplicate(EntityUID),
     /// Errors occurring while computing or enforcing transitive closure on the
     /// entity hierarchy.

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -104,7 +104,7 @@ pub enum JsonDeserializationError {
     },
     /// Schema-based parsing needed an implicit extension constructor, but no suitable
     /// constructor was found
-    #[error("{ctx}, missing extension constructor for type {arg_type} -> {return_type}")]
+    #[error("{ctx}, missing extension constructor for {arg_type} -> {return_type}")]
     MissingImpliedConstructor {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -145,7 +145,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, encountered this attribute on this entity, but that
     /// attribute shouldn't exist on entities of this type
-    #[error("attribute `{:?}` on `{uid}` should not exist according to the schema", &.attr)]
+    #[error("attribute `{attr}` on `{uid}` should not exist according to the schema")]
     UnexpectedEntityAttr {
         /// Entity that had the unexpected attribute
         uid: EntityUID,
@@ -154,7 +154,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, encountered this attribute on a record, but
     /// that attribute shouldn't exist on that record
-    #[error("{ctx}, record attribute `{record_attr:?}` should not exist according to the schema")]
+    #[error("{ctx}, record attribute `{record_attr}` should not exist according to the schema")]
     UnexpectedRecordAttr {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -163,7 +163,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, didn't encounter this attribute of an
     /// entity, but that attribute should have existed
-    #[error("expected entity `{uid}` to have an attribute `{attr:?}`, but it does not")]
+    #[error("expected entity `{uid}` to have an attribute `{attr}`, but it does not")]
     MissingRequiredEntityAttr {
         /// Entity that is missing a required attribute
         uid: EntityUID,
@@ -172,7 +172,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, didn't encounter this attribute of a
     /// record, but that attribute should have existed
-    #[error("{ctx}, expected the record to have an attribute `{record_attr:?}`, but it does not")]
+    #[error("{ctx}, expected the record to have an attribute `{record_attr}`, but it does not")]
     MissingRequiredRecordAttr {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -278,8 +278,8 @@ pub enum JsonDeserializationErrorContext {
 impl std::fmt::Display for JsonDeserializationErrorContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::EntityAttribute { uid, attr } => write!(f, "in attribute {attr:?} on {uid}"),
-            Self::EntityParents { uid } => write!(f, "in parents field of {uid}"),
+            Self::EntityAttribute { uid, attr } => write!(f, "in attribute `{attr}` on `{uid}`"),
+            Self::EntityParents { uid } => write!(f, "in parents field of `{uid}`"),
             Self::EntityUid => write!(f, "in uid field of <unknown entity>"),
             Self::Context => write!(f, "while parsing context"),
         }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -52,12 +52,12 @@ impl Display for EscapeKind {
 #[derive(Debug, Error)]
 pub enum JsonDeserializationError {
     /// Error thrown by the `serde_json` crate
-    #[error("{0}")]
+    #[error(transparent)]
     Serde(#[from] serde_json::Error),
     /// Contents of an escape failed to parse.
     /// Note that escape `__expr` is deprecated and once it is
     /// removed, `EscapeKind::Expr` will also be removed
-    #[error("failed to parse escape `{kind}`: {value}, errors: {errs}")]
+    #[error("failed to parse escape `{kind}` with value `{value}`: {errs}")]
     ParseEscape {
         /// Escape kind
         kind: EscapeKind,
@@ -73,7 +73,7 @@ pub enum JsonDeserializationError {
     #[error(transparent)]
     FailedExtensionFunctionLookup(#[from] ExtensionFunctionLookupError),
     /// A field that needs to be a literal entity reference, was some other JSON value
-    #[error("{ctx}, expected a literal entity reference, but got: {got}")]
+    #[error("{ctx}, expected a literal entity reference, but got `{got}`")]
     ExpectedLiteralEntityRef {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -81,7 +81,7 @@ pub enum JsonDeserializationError {
         got: Box<Expr>,
     },
     /// A field that needs to be an extension value, was some other JSON value
-    #[error("{ctx}, expected an extension value, but got: {got}")]
+    #[error("{ctx}, expected an extension value, but got `{got}`")]
     ExpectedExtnValue {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -104,7 +104,7 @@ pub enum JsonDeserializationError {
     },
     /// Schema-based parsing needed an implicit extension constructor, but no suitable
     /// constructor was found
-    #[error("{ctx}, missing extension constructor for {arg_type} -> {return_type}")]
+    #[error("{ctx}, missing extension constructor for type {arg_type} -> {return_type}")]
     MissingImpliedConstructor {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -119,8 +119,8 @@ pub enum JsonDeserializationError {
         &.uid.entity_type(),
         match .suggested_types.as_slice() {
             [] => String::new(),
-            [ty] => format!("; did you mean {ty}?"),
-            tys => format!("; did you mean one of {:?}?", tys.iter().map(ToString::to_string).collect::<Vec<String>>())
+            [ty] => format!(". Did you mean {ty}?"),
+            tys => format!(". Did you mean one of {:?}?", tys.iter().map(ToString::to_string).collect::<Vec<String>>())
         }
     )]
     UnexpectedEntityType {
@@ -145,7 +145,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, encountered this attribute on this entity, but that
     /// attribute shouldn't exist on entities of this type
-    #[error("attribute {:?} on `{uid}` shouldn't exist according to the schema", &.attr)]
+    #[error("attribute `{:?}` on `{uid}` should not exist according to the schema", &.attr)]
     UnexpectedEntityAttr {
         /// Entity that had the unexpected attribute
         uid: EntityUID,
@@ -154,7 +154,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, encountered this attribute on a record, but
     /// that attribute shouldn't exist on that record
-    #[error("{ctx}, record attribute {record_attr:?} shouldn't exist according to the schema")]
+    #[error("{ctx}, record attribute `{record_attr:?}` should not exist according to the schema")]
     UnexpectedRecordAttr {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -163,7 +163,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, didn't encounter this attribute of an
     /// entity, but that attribute should have existed
-    #[error("expected entity `{uid}` to have an attribute {attr:?}, but it doesn't")]
+    #[error("expected entity `{uid}` to have an attribute `{attr:?}`, but it does not")]
     MissingRequiredEntityAttr {
         /// Entity that is missing a required attribute
         uid: EntityUID,
@@ -172,7 +172,7 @@ pub enum JsonDeserializationError {
     },
     /// During schema-based parsing, didn't encounter this attribute of a
     /// record, but that attribute should have existed
-    #[error("{ctx}, expected the record to have an attribute {record_attr:?}, but it doesn't")]
+    #[error("{ctx}, expected the record to have an attribute `{record_attr:?}`, but it does not")]
     MissingRequiredRecordAttr {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
@@ -220,25 +220,25 @@ pub enum JsonDeserializationError {
 #[derive(Debug, Error)]
 pub enum JsonSerializationError {
     /// Error thrown by `serde_json`
-    #[error("{0}")]
+    #[error(transparent)]
     Serde(#[from] serde_json::Error),
     /// Extension-function calls with 0 arguments are not currently supported in
     /// our JSON format.
-    #[error("extension-function calls with 0 arguments are not currently supported in our JSON format. found call of {func}")]
+    #[error("unsupported call to `{func}`. Extension function calls with 0 arguments are not currently supported in our JSON format")]
     ExtnCall0Arguments {
         /// Name of the function which was called with 0 arguments
         func: Name,
     },
     /// Extension-function calls with 2 or more arguments are not currently
     /// supported in our JSON format.
-    #[error("extension-function calls with 2 or more arguments are not currently supported in our JSON format. found call of {func}")]
+    #[error("unsupported call to `{func}`. Extension function calls with 2 or more arguments are not currently supported in our JSON format")]
     ExtnCall2OrMoreArguments {
         /// Name of the function which was called with 2 or more arguments
         func: Name,
     },
     /// Encountered a `Record` which can't be serialized to JSON because it
     /// contains a key which is reserved as a JSON escape.
-    #[error("record uses reserved key: {key}")]
+    #[error("record uses reserved key `{key}`")]
     ReservedKey {
         /// Reserved key which was used by the `Record`
         key: SmolStr,
@@ -246,7 +246,7 @@ pub enum JsonSerializationError {
     /// Encountered an `ExprKind` which we didn't expect. Either a case is
     /// missing in `JSONValue::from_expr()`, or an internal invariant was
     /// violated and there is a non-restricted expression in `RestrictedExpr`
-    #[error("unexpected restricted expression: {kind:?}")]
+    #[error("unexpected restricted expression `{kind:?}`")]
     UnexpectedRestrictedExprKind {
         /// `ExprKind` which we didn't expect to find
         kind: ExprKind,

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -119,7 +119,7 @@ pub enum JsonDeserializationError {
         &.uid.entity_type(),
         match .suggested_types.as_slice() {
             [] => String::new(),
-            [ty] => format!(". Did you mean {ty}?"),
+            [ty] => format!(". Did you mean `{ty}`?"),
             tys => format!(". Did you mean one of {:?}?", tys.iter().map(ToString::to_string).collect::<Vec<String>>())
         }
     )]

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -184,7 +184,7 @@ impl std::fmt::Display for SchemaType {
             }
             Self::Entity { ty } => match ty {
                 EntityType::Unspecified => write!(f, "(entity of unspecified type)"),
-                EntityType::Concrete(name) => write!(f, "(entity of type {})", name),
+                EntityType::Concrete(name) => write!(f, "(entity of type `{}`)", name),
             },
             Self::Extension { name } => write!(f, "{}", name),
         }

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -31,7 +31,7 @@ pub enum FromJsonError {
     TemplateToPolicy(#[from] ast::UnexpectedSlotError),
     /// Slot name was not valid for the position it was used in. (Currently, principal slots must
     /// be named `?principal`, and resource slots must be named `?resource`.)
-    #[error("invalid slot name or slot used in wrong position. Principal slots must be named `?principal`, and resource slots must be named `?resource`")]
+    #[error("invalid slot name or slot used in wrong position. Principal slots must be named `?principal` and resource slots must be named `?resource`")]
     InvalidSlotName,
     /// EST contained a template slot for `action`. This is not currently allowed
     #[error("slots are not allowed for actions")]

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -31,10 +31,10 @@ pub enum FromJsonError {
     TemplateToPolicy(#[from] ast::UnexpectedSlotError),
     /// Slot name was not valid for the position it was used in. (Currently, principal slots must
     /// be named `?principal`, and resource slots must be named `?resource`.)
-    #[error("invalid slot name, or used in wrong position")]
+    #[error("invalid slot name or slot used in wrong position. Principal slots must be named `?principal`, and resource slots must be named `?resource`")]
     InvalidSlotName,
     /// EST contained a template slot for `action`. This is not currently allowed
-    #[error("specified a slot for action")]
+    #[error("slots are not allowed for actions")]
     ActionSlot,
     /// EST contained the empty JSON object `{}` where a key (operator) was expected
     #[error("missing operator, found empty object")]
@@ -64,7 +64,7 @@ pub enum FromJsonError {
 #[derive(Debug, PartialEq, Error)]
 pub enum InstantiationError {
     /// Template contains this slot, but a value wasn't provided for it
-    #[error("failed to instantiate template: no value provided for {slot}")]
+    #[error("failed to instantiate template: no value provided for `{slot}`")]
     MissedSlot {
         /// Slot which didn't have a value provided for it
         slot: ast::SlotId,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -181,7 +181,7 @@ impl From<RestrictedExprError> for EvaluationError {
 pub enum EvaluationErrorKind {
     /// Tried to lookup this entity UID, but it didn't exist in the provided
     /// entities
-    #[error("entity does not exist: `{0}`")]
+    #[error("entity `{0}` does not exist")]
     EntityDoesNotExist(Arc<EntityUID>),
 
     /// Tried to get this attribute, but the specified entity didn't
@@ -195,7 +195,7 @@ pub enum EvaluationErrorKind {
     },
 
     /// Tried to access an attribute of an unspecified entity
-    #[error("cannot access attribute of unspecified entity: `{0}`")]
+    #[error("cannot access attribute `{0}` of unspecified entity")]
     UnspecifiedEntityAccess(SmolStr),
 
     /// Tried to get an attribute of a (non-entity) record, but that record

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -181,12 +181,12 @@ impl From<RestrictedExprError> for EvaluationError {
 pub enum EvaluationErrorKind {
     /// Tried to lookup this entity UID, but it didn't exist in the provided
     /// entities
-    #[error("entity does not exist: {0}")]
+    #[error("entity does not exist: `{0}`")]
     EntityDoesNotExist(Arc<EntityUID>),
 
     /// Tried to get this attribute, but the specified entity didn't
     /// have that attribute
-    #[error("`{}` does not have the attribute: {}", &.entity, &.attr)]
+    #[error("`{}` does not have the attribute `{}`", &.entity, &.attr)]
     EntityAttrDoesNotExist {
         /// Entity that didn't have the attribute
         entity: Arc<EntityUID>,
@@ -195,12 +195,12 @@ pub enum EvaluationErrorKind {
     },
 
     /// Tried to access an attribute of an unspecified entity
-    #[error("cannot access attribute of unspecified entity: {0}")]
+    #[error("cannot access attribute of unspecified entity: `{0}`")]
     UnspecifiedEntityAccess(SmolStr),
 
     /// Tried to get an attribute of a (non-entity) record, but that record
     /// didn't have that attribute
-    #[error("record does not have the attribute: {0}. Available attributes: {1:?}")]
+    #[error("record does not have the attribute `{0}`. Available attributes: {1:?}")]
     RecordAttrDoesNotExist(SmolStr, Vec<SmolStr>),
 
     /// An error occurred when looking up an extension function
@@ -219,7 +219,7 @@ pub enum EvaluationErrorKind {
     },
 
     /// Wrong number of arguments provided to an extension function
-    #[error("wrong number of arguments provided to extension function {function_name}: expected {expected}, got {actual}")]
+    #[error("wrong number of arguments provided to extension function `{function_name}`: expected {expected}, got {actual}")]
     WrongNumArguments {
         /// arguments to this function
         function_name: Name,
@@ -243,7 +243,7 @@ pub enum EvaluationErrorKind {
     UnlinkedSlot(SlotId),
 
     /// Evaluation error thrown by an extension function
-    #[error("error while evaluating {extension_name} extension function: {msg}")]
+    #[error("error while evaluating `{extension_name}` extension function: {msg}")]
     FailedExtensionFunctionApplication {
         /// Name of the extension throwing the error
         extension_name: Name,
@@ -254,7 +254,7 @@ pub enum EvaluationErrorKind {
     /// This error is raised if an expression contains unknowns and cannot be
     /// reduced to a [`Value`]. In order to return partial results, use the
     /// partial evaluation APIs instead.
-    #[error("the expression contains unknown(s): {0}")]
+    #[error("the expression contains unknown(s): `{0}`")]
     NonValue(Expr),
 
     /// Maximum recursion limit reached for expression evaluation

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -136,14 +136,14 @@ impl<'a> Extensions<'a> {
 #[derive(Debug, PartialEq, Eq, Clone, Error)]
 pub enum ExtensionFunctionLookupError {
     /// Tried to call a function that doesn't exist
-    #[error("extension function does not exist: {name}")]
+    #[error("extension function `{name}` does not exist")]
     FuncDoesNotExist {
         /// Name of the function that doesn't exist
         name: Name,
     },
 
     /// Attempted to typecheck an expression that had no type
-    #[error("extension function has no type: {name}")]
+    #[error("extension function `{name}` has no type")]
     HasNoType {
         /// Name of the function that returns no type
         name: Name,
@@ -151,7 +151,7 @@ pub enum ExtensionFunctionLookupError {
 
     /// Tried to call a function but it was defined multiple times (e.g., by
     /// multiple different extensions)
-    #[error("function is defined {num_defs} times: {name}")]
+    #[error("extension function `{name}` is defined {num_defs} times")]
     FuncMultiplyDefined {
         /// Name of the function that is multiply defined
         name: Name,
@@ -162,7 +162,7 @@ pub enum ExtensionFunctionLookupError {
     /// Two extension constructors (in the same or different extensions) had
     /// exactly the same type signature.  This is currently not allowed.
     #[error(
-        "multiple extension constructors with the same type signature {arg_type} -> {return_type}"
+        "multiple extension constructors have the same type signature {arg_type} -> {return_type}"
     )]
     MultipleConstructorsSameSignature {
         /// return type of the shared constructor signature

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -62,11 +62,11 @@ const ADVICE_MSG: &str = "Maybe you forgot to apply the `decimal` constructor?";
 #[derive(Debug, Error)]
 enum Error {
     /// Error parsing the input string as a decimal value
-    #[error("input string is not a well-formed decimal value: {0}")]
+    #[error("`{0}` is not a well-formed decimal value")]
     FailedParse(String),
 
     /// Too many digits after the decimal point
-    #[error("too many digits after the decimal, we support at most {NUM_DIGITS}: {0}")]
+    #[error("too many digits after the decimal in `{0}`. We support at most {NUM_DIGITS} digits")]
     TooManyDigits(String),
 
     /// Overflow occurred when converting to a decimal value

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -75,7 +75,7 @@ impl IPAddr {
             Err(e1) => match parse_ipnet(str.as_ref()) {
                 Ok(net) => net.trunc(),
                 Err(e2) => return Err(format!(
-                    "error parsing IP address from string:\n  failed to parse as single address: {}\n  failed to parse as subnet: {}", e1, e2)),
+                    "error parsing IP address from string. Failed to parse as single address: {}. Failed to parse as subnet: `{}`", e1, e2)),
             }
         };
         Ok(Self { addr })
@@ -173,7 +173,7 @@ fn parse_ipnet(s: &str) -> Result<ipnet::IpNet, String> {
 fn str_contains_colons_and_dots(s: &str) -> Result<(), String> {
     if contains_at_least_two(s, ':') && contains_at_least_two(s, '.') {
         return Err(format!(
-            "error parsing IP address from string: We don't accept IPv4 embedded in IPv6 (e.g., ::ffff:127.0.0.1). Found: {}", &s.to_string()));
+            "error parsing IP address from string: We do not accept IPv4 embedded in IPv6 (e.g., ::ffff:127.0.0.1). Found: `{}`", &s.to_string()));
     }
     Ok(())
 }

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -75,7 +75,7 @@ impl IPAddr {
             Err(e1) => match parse_ipnet(str.as_ref()) {
                 Ok(net) => net.trunc(),
                 Err(e2) => return Err(format!(
-                    "error parsing IP address from string. Failed to parse as single address: {}. Failed to parse as subnet: `{}`", e1, e2)),
+                    "error parsing IP address from string. Failed to parse as single address: `{}`. Failed to parse as subnet: `{}`", e1, e2)),
             }
         };
         Ok(Self { addr })

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -147,10 +147,10 @@ pub enum ToASTError {
     /// Returned when a policy scope clauses uses an operator beyond `==` or `in`.
     #[error("policy scope constraints must either `==` or `in`. Found `{0}`")]
     InvalidConstraintOperator(cst::RelOp),
-    /// Returned when the right hand side of `==` in a policy scope clause is not a single Entity UID or template slot.
+    /// Returned when the right hand side of `==` in a policy scope clause is not a single Entity UID or a template slot.
     /// This is valid in Cedar conditions, but not in the Scope
     #[error(
-        "the right hand side of equality in the policy scope must be a single entity uid or template slot"
+        "the right hand side of equality in the policy scope must be a single entity uid or a template slot"
     )]
     InvalidScopeEqualityRHS,
     /// Returned when an Entity UID used as an action does not have the type `Action`
@@ -253,7 +253,7 @@ pub enum ToASTError {
     #[error("a path is not valid in this context")]
     InvalidPath,
     /// Returned when a string needs to be fully normalized
-    #[error("`{kind}` needs to be normalized (e.g., whitespace removed): `{src}` The normalized form is `{normalized_src}`")]
+    #[error("`{kind}` needs to be normalized (e.g., whitespace removed): `{src}`. The normalized form is `{normalized_src}`")]
     NonNormalizedString {
         /// The kind of string we are expecting
         kind: &'static str,

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -53,7 +53,7 @@ pub enum ParseError {
     #[diagnostic(transparent)]
     ToCST(#[from] ToCSTError),
     /// Error in the CST -> AST transform, mostly well-formedness issues.
-    #[error("poorly formed: {0}")]
+    #[error(transparent)]
     #[diagnostic(code(cedar_policy_core::parser::to_ast_err))]
     ToAST(#[from] ToASTError),
     /// Error concerning restricted expressions.
@@ -94,14 +94,14 @@ pub enum ParseLiteralError {
 #[non_exhaustive]
 pub enum ToASTError {
     /// Returned when we attempt to parse a template with a conflicting id
-    #[error("a template with this id already exists in the policy set: {0}")]
+    #[error("a template with id `{0}` already exists in the policy set")]
     DuplicateTemplateId(PolicyID),
     /// Returned when we attempt to parse a policy with a conflicting id
-    #[error("a policy with this id already exists in the policy set: {0}")]
+    #[error("a policy with id `{0}` already exists in the policy set")]
     DuplicatePolicyId(PolicyID),
     /// Returned when a template is encountered but a static policy is expected
     #[error(
-        "expected a static policy, got a template. Try removing template slots from this policy"
+        "expected a static policy, got a template. Try removing the template slots from this policy"
     )]
     UnexpectedTemplate,
     /// Returned when we attempt to parse a policy with malformed or conflicting annotations
@@ -111,18 +111,18 @@ pub enum ToASTError {
     #[error("template slots are currently unsupported in policy condition clauses")]
     SlotsInConditionClause,
     /// Returned when a policy is missing one of the 3 required scope clauses. (`principal`, `action`, and `resource`)
-    #[error("this policy is missing the {0} variable in the scope")]
+    #[error("this policy is missing the `{0}` variable in the scope")]
     MissingScopeConstraint(Var),
     /// Returned when a policy has an extra scope clause. This is not valid syntax
-    #[error("this policy has an extra head constraint in the scope; a policy must have exactly `principal`, `action`, and `resource` constraints: {0}")]
+    #[error("this policy has an extra head constraint in the scope; a policy must have exactly `principal`, `action`, and `resource` constraints: `{0}`")]
     ExtraHeadConstraints(cst::VariableDef),
     /// Returned when a policy uses a reserved keyword as an identifier.
-    #[error("this identifier is reserved and cannot be used: {0}")]
+    #[error("this identifier is reserved and cannot be used: `{0}`")]
     ReservedIdentifier(cst::Ident),
     /// Returned when a policy contains an invalid identifier.
     /// This error is not currently returned, but is here for future-proofing.
     /// See [`cst::Ident::Invalid`]
-    #[error("not a valid identifier: {0}")]
+    #[error("not a valid identifier: `{0}`")]
     InvalidIdentifier(String),
     /// Returned when a policy uses a effect keyword beyond `permit` or `forbid`
     #[error("not a valid policy effect: `{0}`. Effect must be either `permit` or `forbid`")]
@@ -131,10 +131,10 @@ pub enum ToASTError {
     #[error("not a valid policy condition: `{0}`. Condition must be either `when` or `unless`")]
     InvalidCondition(cst::Ident),
     /// Returned when a policy uses a variable in the scope beyond `principal`, `action`, or `resource`
-    #[error("expected a variable that's valid in the policy scope. Must be one of `principal`, `action`, or `resource`. Found: {0}")]
+    #[error("expected a variable that is valid in the policy scope. Must be one of `principal`, `action`, or `resource`. Found: `{0}`")]
     InvalidScopeConstraintVariable(cst::Ident),
     /// Returned when a policy contains an invalid method name
-    #[error("not a valid method name: {0}")]
+    #[error("not a valid method name: `{0}`")]
     InvalidMethodName(String),
     /// Returned when a policy scope clause contains the wrong variable. (`principal` must be in the first clause, etc...)
     #[error("the variable `{got}` is invalid in this policy scope clause, the variable `{expected}` is expected")]
@@ -150,11 +150,11 @@ pub enum ToASTError {
     /// Returned when the right hand side of `==` in a policy scope clause is not a single Entity UID or template slot.
     /// This is valid in Cedar conditions, but not in the Scope
     #[error(
-        "right hand side of equality in policy scope must be a single Entity UID or template slot"
+        "the right hand side of equality in the policy scope must be a single entity uid or template slot"
     )]
     InvalidScopeEqualityRHS,
     /// Returned when an Entity UID used as an action does not have the type `Action`
-    #[error("expected an EntityUID with the type `Action`. Got: {0}. Action entities must have type `Action`")]
+    #[error("expected an entity uid with the type `Action`. Got: `{0}`. Action entities must have type `Action`")]
     InvalidActionType(crate::ast::EntityUID),
     /// Returned when a condition clause is empty
     #[error("{}condition clause cannot be empty", match .0 { Some(ident) => format!("`{}` ", ident), None => "".to_string() })]
@@ -166,7 +166,7 @@ pub enum ToASTError {
     #[error("internal invariant violated. Membership chain did not resolve to an expression")]
     MembershipInvariantViolation,
     /// Returned for a non-parse-able string literal
-    #[error("invalid string literal: `\"{0}\"`")]
+    #[error("invalid string literal: `{0}`")]
     InvalidString(String),
     /// Returned for attempting to use an arbitrary variable name. Cedar does not support arbitrary variables.
     #[error("arbitrary variables are not supported; did you mean to enclose `{0}` in quotes to make a string? The valid Cedar variable are `principal`, `action`, `resource`, and `context`")]
@@ -186,7 +186,7 @@ pub enum ToASTError {
     #[error("`{0}` is a method, not a function. Use a method-style call: `e.{0}(..)`")]
     FunctionCallOnMethod(crate::ast::Id),
     /// Returned when the right hand side of a `like` expression is not a constant pattern literal
-    #[error("right hand side of a `like` expression must be a pattern literal. Got: {0}")]
+    #[error("right hand side of a `like` expression must be a pattern literal. Got: `{0}`")]
     InvalidPattern(String),
     /// Returned when an unexpected node is in the policy scope clause
     #[error("expected a {expected}, found a `{got}` statement")]
@@ -198,7 +198,7 @@ pub enum ToASTError {
     },
     /// Returned when a policy contains ambiguous ordering of operators.
     /// This can be resolved by using parenthesis to make order explicit
-    #[error("multiple relational operators (>, ==, in, etc.) without parentheses")]
+    #[error("relational operators (>, ==, in, etc.) must be used with parentheses to make ordering explicit")]
     AmbiguousOperators,
     /// Returned when a policy uses the division operator (`/`), which is not supported
     #[error("division is not supported")]
@@ -225,7 +225,7 @@ pub enum ToASTError {
     #[error("variables cannot be called as functions. `{0}(...)` is not a valid function call")]
     VariableCall(crate::ast::Var),
     /// Returned when a policy attempts to call a method on a value that has no methods
-    #[error("Attempted to call `{0}.{1}`, but `{0}` does not have any methods")]
+    #[error("attempted to call `{0}.{1}`, but `{0}` does not have any methods")]
     NoMethods(crate::ast::Name, ast::Id),
     /// Returned when a policy attempts to call a function that does not exist
     #[error("`{0}` is not a function")]
@@ -235,7 +235,7 @@ pub enum ToASTError {
     UnsupportedEntityLiterals,
     /// Returned when an expression is the target of a function call.
     /// Functions are not first class values in Cedar
-    #[error("function calls in Cedar must be of the form: `<name>(arg1, arg2, ...)`")]
+    #[error("function calls must be of the form: `<name>(arg1, arg2, ...)`")]
     ExpressionCall,
     /// Returned when a policy attempts to access the fields of a value with no fields
     #[error("incorrect member access `{0}.{1}`, `{0}` has no fields or methods")]
@@ -244,7 +244,7 @@ pub enum ToASTError {
     #[error("incorrect indexing expression `{0}[{1}]`, `{0}` has no fields")]
     InvalidIndex(crate::ast::Name, SmolStr),
     /// Returned when the contents of an indexing expression is not a string literal
-    #[error("The contents of an index expression must be a string literal")]
+    #[error("the contents of an index expression must be a string literal")]
     NonStringIndex,
     /// Returned when a user attempts to use type-constraint syntax. This is not currently supported
     #[error("type constraints are not currently supported")]
@@ -253,7 +253,7 @@ pub enum ToASTError {
     #[error("a path is not valid in this context")]
     InvalidPath,
     /// Returned when a string needs to be fully normalized
-    #[error("{kind} needs to be normalized (e.g., whitespace removed): `{src}` The normalized form is `{normalized_src}`")]
+    #[error("`{kind}` needs to be normalized (e.g., whitespace removed): `{src}` The normalized form is `{normalized_src}`")]
     NonNormalizedString {
         /// The kind of string we are expecting
         kind: &'static str,
@@ -266,10 +266,10 @@ pub enum ToASTError {
     #[error("data should not be empty")]
     MissingNodeData,
     /// Returned when the right hand side of a `has` expression is neither a field name or a string literal
-    #[error("the right-hand-side of a `has` expression must be a field name or a string literal")]
+    #[error("the right hand side of a `has` expression must be a field name or string literal")]
     HasNonLiteralRHS,
     /// Returned when a CST expression is invalid
-    #[error("{0} is not a valid expression")]
+    #[error("`{0}` is not a valid expression")]
     InvalidExpression(cst::Name),
     /// Returned when a function has wrong arity
     #[error("call to `{name}` requires exactly {expected} argument{}, but got {got} arguments", if .expected == &1 { "" } else { "s" })]
@@ -282,10 +282,10 @@ pub enum ToASTError {
         got: usize,
     },
     /// Returned when a string contains invalid escapes
-    #[error("{0}")]
+    #[error(transparent)]
     Unescape(#[from] UnescapeError),
     /// Returns when a policy scope has incorrect EntityUIDs/Template Slots
-    #[error("{0}")]
+    #[error(transparent)]
     RefCreation(#[from] RefCreationError),
 }
 

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -198,7 +198,7 @@ pub enum ToASTError {
     },
     /// Returned when a policy contains ambiguous ordering of operators.
     /// This can be resolved by using parenthesis to make order explicit
-    #[error("relational operators (>, ==, in, etc.) must be used with parentheses to make ordering explicit")]
+    #[error("multiple relational operators (>, ==, in, etc.) must be used with parentheses to make ordering explicit")]
     AmbiguousOperators,
     /// Returned when a policy uses the division operator (`/`), which is not supported
     #[error("division is not supported")]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -154,7 +154,7 @@ pub enum ToASTError {
     )]
     InvalidScopeEqualityRHS,
     /// Returned when an Entity UID used as an action does not have the type `Action`
-    #[error("expected an entity uid with the type `Action`. Got: `{0}`. Action entities must have type `Action`")]
+    #[error("expected an entity uid with the type `Action` but got `{0}`. Action entities must have type `Action`")]
     InvalidActionType(crate::ast::EntityUID),
     /// Returned when a condition clause is empty
     #[error("{}condition clause cannot be empty", match .0 { Some(ident) => format!("`{}` ", ident), None => "".to_string() })]
@@ -186,7 +186,7 @@ pub enum ToASTError {
     #[error("`{0}` is a method, not a function. Use a method-style call: `e.{0}(..)`")]
     FunctionCallOnMethod(crate::ast::Id),
     /// Returned when the right hand side of a `like` expression is not a constant pattern literal
-    #[error("right hand side of a `like` expression must be a pattern literal. Got: `{0}`")]
+    #[error("right hand side of a `like` expression must be a pattern literal, but got `{0}`")]
     InvalidPattern(String),
     /// Returned when an unexpected node is in the policy scope clause
     #[error("expected a {expected}, found a `{got}` statement")]

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -118,7 +118,7 @@ impl std::fmt::Display for UnescapeError {
     // PANIC SAFETY By invariant, the range will always be within the bounds of `input`
     #[allow(clippy::indexing_slicing)]
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}: {}", self.err, &self.input[self.range.clone()])
+        write!(f, "{:?}: `{}`", self.err, &self.input[self.range.clone()])
     }
 }
 

--- a/cedar-policy-core/src/transitive_closure/err.rs
+++ b/cedar-policy-core/src/transitive_closure/err.rs
@@ -37,7 +37,7 @@ pub enum TcError<K: Debug + Display> {
         grandparent: K,
     },
     /// Error raised when enforce_dag finds that the graph is not a DAG
-    #[error("input graph has a cycle. Vertex {} has a loop.", .vertex_with_loop)]
+    #[error("input graph has a cycle containing vertex `{}`", .vertex_with_loop)]
     HasCycle {
         /// Because DAG enforcement can only be called after compute_tc/enforce_tc, a cycle will manifest as a vertex with a loop
         vertex_with_loop: K,

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -54,14 +54,14 @@ pub enum SchemaError {
     UndeclaredCommonTypes(HashSet<String>),
     /// Duplicate specifications for an entity type. Argument is the name of
     /// the duplicate entity type.
-    #[error("duplicate entity type: {0}")]
+    #[error("duplicate entity type `{0}`")]
     DuplicateEntityType(String),
     /// Duplicate specifications for an action. Argument is the name of the
     /// duplicate action.
-    #[error("duplicate action: {0}")]
+    #[error("duplicate action `{0}`")]
     DuplicateAction(String),
     /// Duplicate specification for a reusable type declaration.
-    #[error("duplicate common type: {0}")]
+    #[error("duplicate common type `{0}`")]
     DuplicateCommonType(String),
     /// Cycle in the schema's action hierarchy.
     #[error("cycle in action hierarchy")]

--- a/cedar-policy-validator/src/extensions/decimal.rs
+++ b/cedar-policy-validator/src/extensions/decimal.rs
@@ -88,9 +88,9 @@ fn validate_decimal_string(exprs: &[Expr]) -> Result<(), String> {
             match RestrictedExpr::from_str(&format!("decimal({arg})")) {
                 Ok(expr) => match evaluator.interpret(expr.as_borrowed()) {
                     Ok(_) => Ok(()),
-                    Err(_) => Err(format!("Failed to parse as a decimal value: {arg}")),
+                    Err(_) => Err(format!("Failed to parse as a decimal value: `{arg}`")),
                 },
-                Err(_) => Err(format!("Failed to parse as a decimal value: {arg}")),
+                Err(_) => Err(format!("Failed to parse as a decimal value: `{arg}`")),
             }
         }
         _ => Ok(()),

--- a/cedar-policy-validator/src/extensions/ipaddr.rs
+++ b/cedar-policy-validator/src/extensions/ipaddr.rs
@@ -88,9 +88,9 @@ fn validate_ip_string(exprs: &[Expr]) -> Result<(), String> {
             match RestrictedExpr::from_str(&format!("ip({arg})")) {
                 Ok(expr) => match evaluator.interpret(expr.as_borrowed()) {
                     Ok(_) => Ok(()),
-                    Err(_) => Err(format!("Failed to parse as IP address: {arg}")),
+                    Err(_) => Err(format!("Failed to parse as IP address: `{arg}`")),
                 },
-                Err(_) => Err(format!("Failed to parse as IP address: {arg}")),
+                Err(_) => Err(format!("Failed to parse as IP address: `{arg}`")),
             }
         }
         _ => Ok(()),

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -56,10 +56,10 @@ impl std::fmt::Display for ValidationWarning<'_> {
 #[derive(Debug, Clone, PartialEq, Error, Eq)]
 pub enum ValidationWarningKind {
     /// A string contains mixed scripts. Different scripts can contain visually similar characters which may be confused for each other.
-    #[error("string \"{0}\" contains mixed scripts")]
+    #[error("string `\"{0}\"` contains mixed scripts")]
     MixedScriptString(String),
     /// A string contains BIDI control characters. These can be used to create crafted pieces of code that obfuscate true control flow.
-    #[error("string \"{0}\" contains BIDI control characters")]
+    #[error("string `\"{0}\"` contains BIDI control characters")]
     BidiCharsInString(String),
     /// An id contains BIDI control characters. These can be used to create crafted pieces of code that obfuscate true control flow.
     #[error("identifier `{0}` contains BIDI control characters")]

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -47,8 +47,8 @@ impl std::fmt::Display for ValidationWarning<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "warning: {} in policy with id {}",
-            self.kind, self.location
+            "validation warning on policy `{}`: {}",
+            self.location, self.kind
         )
     }
 }
@@ -189,7 +189,7 @@ mod test {
         );
         assert_eq!(
             format!("{warning}"),
-            "warning: identifier `say_һello` contains mixed scripts in policy with id test"
+            "validation warning on policy `test`: identifier `say_һello` contains mixed scripts"
         );
         assert_eq!(location, &PolicyID::from_string("test"));
         assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
@@ -232,7 +232,7 @@ mod test {
         );
         assert_eq!(
             format!("{warning}"),
-            "warning: string `\"*_һello\"` contains mixed scripts in policy with id test"
+            "validation warning on policy `test`: string `\"*_һello\"` contains mixed scripts"
         );
         assert_eq!(location, &PolicyID::from_string("test"));
         assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
@@ -259,7 +259,7 @@ mod test {
             kind,
             ValidationWarningKind::BidiCharsInString(r#"user‮ ⁦&& principal.is_admin⁩ ⁦"#.to_string())
         );
-        assert_eq!(format!("{warning}"), "warning: string `\"user‮ ⁦&& principal.is_admin⁩ ⁦\"` contains BIDI control characters in policy with id test");
+        assert_eq!(format!("{warning}"), "validation warning on policy `test`: string `\"user‮ ⁦&& principal.is_admin⁩ ⁦\"` contains BIDI control characters");
         assert_eq!(location, &PolicyID::from_string("test"));
         assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
     }

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -232,7 +232,7 @@ mod test {
         );
         assert_eq!(
             format!("{warning}"),
-            "warning: string \"*_һello\" contains mixed scripts in policy with id test"
+            "warning: string `\"*_һello\"` contains mixed scripts in policy with id test"
         );
         assert_eq!(location, &PolicyID::from_string("test"));
         assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
@@ -259,7 +259,7 @@ mod test {
             kind,
             ValidationWarningKind::BidiCharsInString(r#"user‮ ⁦&& principal.is_admin⁩ ⁦"#.to_string())
         );
-        assert_eq!(format!("{warning}"), "warning: string \"user‮ ⁦&& principal.is_admin⁩ ⁦\" contains BIDI control characters in policy with id test");
+        assert_eq!(format!("{warning}"), "warning: string `\"user‮ ⁦&& principal.is_admin⁩ ⁦\"` contains BIDI control characters in policy with id test");
         assert_eq!(location, &PolicyID::from_string("test"));
         assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
     }

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -212,7 +212,7 @@ impl std::error::Error for TypeError {}
 pub enum TypeErrorKind {
     /// The typechecker expected to see a subtype of one of the types in
     /// `expected`, but saw `actual`.
-    #[error("Unexpected type. Expected {} but saw {}",
+    #[error("unexpected type: expected {} but saw {}",
         match .0.expected.iter().next() {
             Some(single) if .0.expected.len() == 1 => format!("{}", single),
             _ => .0.expected.iter().join(", or ")
@@ -221,19 +221,20 @@ pub enum TypeErrorKind {
     )]
     UnexpectedType(UnexpectedType),
     /// The typechecker could not compute a least upper bound for `types`.
-    #[error("Unable to find upper bound for types: [{}]", .0.types.iter().join(","))]
+    #[error("unable to find upper bound for types: [{}]", .0.types.iter().join(","))]
     IncompatibleTypes(IncompatibleTypes),
     /// The typechecker detected an access to a record or entity attribute
     /// that it could not statically guarantee would be present.
     #[error(
-        "attribute {} not found{}{}",
+        "attribute {} not found{}{}{}",
         .0.attribute_access,
         match &.0.suggestion {
-            Some(suggestion) => format!(", did you mean `{suggestion}`"),
+            Some(suggestion) => format!(", did you mean `{suggestion}`?"),
             None => "".to_string(),
         },
+        if .0.suggestion.is_none() && .0.may_exist { "." } else { "" },
         if .0.may_exist {
-            ". There may be additional attributes that the validator is not able to reason about."
+            " There may be additional attributes that the validator is not able to reason about"
         } else {
             ""
         }
@@ -245,23 +246,23 @@ pub enum TypeErrorKind {
     UnsafeOptionalAttributeAccess(UnsafeOptionalAttributeAccess),
     /// The typechecker found that a policy condition will always evaluate to false.
     #[error(
-        "Policy is impossible. The policy expression evaluates to false for all valid requests"
+        "policy is impossible. The policy expression evaluates to false for all valid requests"
     )]
     ImpossiblePolicy,
     /// Undefined extension function.
-    #[error("Undefined extension function: {}", .0.name)]
+    #[error("undefined extension function: {}", .0.name)]
     UndefinedFunction(UndefinedFunction),
     /// Multiply defined extension function.
-    #[error("Extension function defined multiple times: {}", .0.name)]
+    #[error("extension function defined multiple times: {}", .0.name)]
     MultiplyDefinedFunction(MultiplyDefinedFunction),
     /// Incorrect number of arguments in an extension function application.
-    #[error("Wrong number of arguments in extension function application. Expected {}, got {}", .0.expected, .0.actual)]
+    #[error("wrong number of arguments in extension function application. Expected {}, got {}", .0.expected, .0.actual)]
     WrongNumberArguments(WrongNumberArguments),
     /// Incorrect call style in an extension function application.
-    #[error("Wrong call style in extension function application. Expected {}, got {}", .0.expected, .0.actual)]
+    #[error("wrong call style in extension function application. Expected {}, got {}", .0.expected, .0.actual)]
     WrongCallStyle(WrongCallStyle),
     /// Error returned by custom extension function argument validation
-    #[error("Error during extension function argument validation: {}", .0.msg)]
+    #[error("error during extension function argument validation: {}", .0.msg)]
     FunctionArgumentValidationError(FunctionArgumentValidationError),
     #[error("empty set literals are forbidden in policies")]
     EmptySetForbidden,

--- a/cedar-policy-validator/src/typecheck/test_extensions.rs
+++ b/cedar-policy-validator/src/typecheck/test_extensions.rs
@@ -57,7 +57,7 @@ fn ip_extension_typecheck_fails() {
         Type::extension(ipaddr_name.clone()),
         vec![TypeError::arg_validation_error(
             expr,
-            "Failed to parse as IP address: \"foo\"".into(),
+            "Failed to parse as IP address: `\"foo\"`".into(),
         )],
     );
     let expr = Expr::from_str("ip(\"127.0.0.1\").isIpv4(3)").expect("parsing should succeed");
@@ -120,7 +120,7 @@ fn decimal_extension_typecheck_fails() {
         Type::extension(decimal_name.clone()),
         vec![TypeError::arg_validation_error(
             expr,
-            "Failed to parse as a decimal value: \"foo\"".into(),
+            "Failed to parse as a decimal value: `\"foo\"`".into(),
         )],
     );
     let expr = Expr::from_str("decimal(\"1.23\").lessThan(3, 4)").expect("parsing should succeed");

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Improved validation error messages for access to undeclared attributes and
   unsafe access to optional attributes to report the target of the access (fix #175).
 - Implements RFC #19, making validation slightly more strict, but more explainable.
+- Improved formatting for error messages.
 
 ## 2.4.0
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1060,14 +1060,14 @@ pub enum SchemaError {
     UndeclaredCommonTypes(HashSet<String>),
     /// Duplicate specifications for an entity type. Argument is the name of
     /// the duplicate entity type.
-    #[error("duplicate entity type: {0}")]
+    #[error("duplicate entity type `{0}`")]
     DuplicateEntityType(String),
     /// Duplicate specifications for an action. Argument is the name of the
     /// duplicate action.
-    #[error("duplicate action: {0}")]
+    #[error("duplicate action `{0}`")]
     DuplicateAction(String),
     /// Duplicate specification for a reusable type declaration.
-    #[error("duplicate common type: {0}")]
+    #[error("duplicate common type `{0}`")]
     DuplicateCommonType(String),
     /// Cycle in the schema's action hierarchy.
     #[error("cycle in action hierarchy")]
@@ -1092,7 +1092,7 @@ pub enum SchemaError {
     #[error("entity type `Action` declared in `entityTypes` list")]
     ActionEntityTypeDeclared,
     /// `context` or `shape` fields are not records
-    #[error("`{0}` is not a record")]
+    #[error("{0} is declared with a type other than `Record`")]
     ContextOrShapeNotRecord(ContextOrShape),
     /// An action entity (transitively) has an attribute that is an empty set.
     /// The validator cannot assign a type to an empty set.
@@ -1260,7 +1260,11 @@ impl<'a> From<cedar_policy_validator::ValidationError<'a>> for ValidationError<'
 
 impl<'a> std::fmt::Display for ValidationError<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Validation error on policy {}", self.location.policy_id)?;
+        write!(
+            f,
+            "validation error on policy `{}`",
+            self.location.policy_id
+        )?;
         if let (Some(range_start), Some(range_end)) =
             (self.location().range_start(), self.location().range_end())
         {
@@ -1316,7 +1320,7 @@ pub fn confusable_string_checker<'a>(
 }
 
 #[derive(Debug, Error)]
-#[error("Warning on policy {}: {}", .location.policy_id, .kind)]
+#[error("validation warning on policy `{}`: {}", .location.policy_id, .kind)]
 /// Warnings found in Cedar policies
 pub struct ValidationWarning<'a> {
     location: SourceLocation<'a>,
@@ -1573,7 +1577,7 @@ impl std::fmt::Display for EntityUid {
 pub enum PolicySetError {
     /// There was a duplicate [`PolicyId`] encountered in either the set of
     /// templates or the set of policies.
-    #[error("duplicate template or policy id: {id}")]
+    #[error("duplicate template or policy id `{id}`")]
     AlreadyDefined {
         /// [`PolicyId`] that was duplicate
         id: PolicyId,
@@ -2971,7 +2975,7 @@ pub enum ContextJsonError {
     #[error(transparent)]
     JsonDeserialization(#[from] JsonDeserializationError),
     /// The supplied action doesn't exist in the supplied schema
-    #[error("action `{action}` doesn't exist in the supplied schema")]
+    #[error("action `{action}` does not exist in the supplied schema")]
     MissingAction {
         /// UID of the action which doesn't exist
         action: EntityUid,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -4105,7 +4105,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
-            err.to_string().contains(r#"in attribute "numDirectReports" on Employee::"12UA45", type mismatch: attribute was expected to have type long, but actually has type string"#),
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but actually has type string"#),
             "actual error message was {err}"
         );
 
@@ -4141,7 +4141,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on manager");
         assert!(
             err.to_string()
-                .contains(r#"in attribute "manager" on Employee::"12UA45", expected a literal entity reference, but got: "34FB87""#),
+                .contains(r#"in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#),
             "actual error message was {err}"
         );
 
@@ -4173,7 +4173,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute "hr_contacts" on Employee::"12UA45", type mismatch: attribute was expected to have type (set of (entity of type HR)), but actually has type record with attributes: ("#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type HR)), but actually has type record with attributes: ("#),
             "actual error message was {err}"
         );
 
@@ -4208,7 +4208,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute "manager" on Employee::"12UA45", type mismatch: attribute was expected to have type (entity of type Employee), but actually has type (entity of type HR)"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type Employee), but actually has type (entity of type HR)"#),
             "actual error message was {err}"
         );
 
@@ -4244,7 +4244,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute "home_ip" on Employee::"12UA45", type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
             "actual error message was {err}"
         );
 
@@ -4278,7 +4278,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to missing attribute \"inner2\"");
         assert!(
-            err.to_string().contains(r#"in attribute "json_blob" on Employee::"12UA45", expected the record to have an attribute "inner2", but it doesn't"#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#),
             "actual error message was {err}"
         );
 
@@ -4313,7 +4313,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on attribute \"inner1\"");
         assert!(
-            err.to_string().contains(r#"in attribute "json_blob" on Employee::"12UA45", type mismatch: attribute was expected to have type record with attributes: "#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type record with attributes: "#),
             "actual error message was {err}"
         );
 
@@ -4427,7 +4427,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute "manager" on XYZCorp::Employee::"12UA45", type mismatch: attribute was expected to have type (entity of type XYZCorp::Employee), but actually has type (entity of type Employee)"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type XYZCorp::Employee), but actually has type (entity of type Employee)"#),
             "actual error message was {err}"
         );
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -4173,7 +4173,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type HR)), but actually has type record with attributes: ("#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but actually has type record with attributes: ("#),
             "actual error message was {err}"
         );
 
@@ -4208,7 +4208,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type Employee), but actually has type (entity of type HR)"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but actually has type (entity of type `HR`)"#),
             "actual error message was {err}"
         );
 
@@ -4427,7 +4427,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type XYZCorp::Employee), but actually has type (entity of type Employee)"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but actually has type (entity of type `Employee`)"#),
             "actual error message was {err}"
         );
     }

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -357,7 +357,7 @@ fn parse_policy_set_from_individual_policies(
                 }
             },
             Err(pes) => errs.extend(
-                std::iter::once(format!("couldn't parse policy with id {id}"))
+                std::iter::once(format!("couldn't parse policy with id `{id}`"))
                     .chain(pes.errors_as_strings().into_iter()),
             ),
         }
@@ -373,7 +373,7 @@ fn parse_policy_set_from_individual_policies(
                     }
                 },
                 Err(pes) => errs.extend(
-                    std::iter::once(format!("couldn't parse policy with id {id}"))
+                    std::iter::once(format!("couldn't parse policy with id `{id}`"))
                         .chain(pes.errors_as_strings().into_iter()),
                 ),
             }


### PR DESCRIPTION
## Description of changes

Another pass at standardizing error messages. My changes are meant to align with the following rules (loosely inspired by https://rustc-dev-guide.rust-lang.org/diagnostics.html#diagnostic-structure):
* Error messages should avoid capitalization and periods. If multiple sentences are needed then use grammatical capitalization and punctuation only on the message’s interior. Example: `wrong number of arguments in extension function application. Expected {}, got {}` (note the initial lowercase letter and lack of final period).
* Error messages should not include line breaks.
* User-provided input (e.g. attributes, entity uids, policy ids) should be surrounded with backticks or otherwise clearly separated from the rest of the message. Use of backticks is preferred. Examples: ``undeclared action `foo` ``,  `undeclared entity type(s): {"Foo"}`
* Related error messages should be concatenated with colons. Example: ``error occurred while evaluating policy `policy0`: `User::\"alive\"` does not have the attribute `foo` ``
* Error messages should not use contractions (e.g., “don’t”). (This last one isn't as important as the others -- just my mood today.)

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
