### PR TITLE
Add a new command to the CLI that creates dummy Cedar project

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -22,7 +22,7 @@
 mod err;
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use miette::{miette, NamedSource, Report, Result, WrapErr};
+use miette::{miette, IntoDiagnostic, NamedSource, Report, Result, WrapErr};
 use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
@@ -36,8 +36,6 @@ use std::{
 
 use cedar_policy::*;
 use cedar_policy_formatter::{policies_str_to_pretty, Config};
-
-use crate::err::IntoDiagnostic;
 
 /// Basic Cedar CLI for evaluating authorization queries
 #[derive(Parser)]
@@ -98,6 +96,8 @@ pub enum Commands {
     Link(LinkArgs),
     /// Format a policy set
     Format(FormatArgs),
+    /// Create a Cedar project
+    New(NewArgs),
 }
 
 #[derive(Args, Debug)]
@@ -289,6 +289,13 @@ pub struct FormatArgs {
     /// Custom indentation width (default: 2).
     #[arg(short, long, value_name = "INT", default_value_t = 2)]
     pub indent_width: isize,
+}
+
+#[derive(Args, Debug)]
+pub struct NewArgs {
+    /// Name of the Cedar project
+    #[arg(short, long, value_name = "DIR")]
+    pub name: String,
 }
 
 /// Wrapper struct
@@ -499,6 +506,104 @@ fn format_policies_inner(args: &FormatArgs) -> Result<()> {
 
 pub fn format_policies(args: &FormatArgs) -> CedarExitCode {
     if let Err(err) = format_policies_inner(args) {
+        println!("Error: {err:?}");
+        CedarExitCode::Failure
+    } else {
+        CedarExitCode::Success
+    }
+}
+
+fn generate_schema(path: &Path) -> Result<()> {
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&serde_json::json!(
+        {
+            "": {
+                "entityTypes": {
+                    "A": {
+                        "memberOfTypes": [
+                            "B"
+                        ]
+                    },
+                    "B": {
+                        "memberOfTypes": []
+                    },
+                    "C": {
+                        "memberOfTypes": []
+                    }
+                },
+                "actions": {
+                    "action": {
+                        "appliesTo": {
+                            "resourceTypes": [
+                                "C"
+                            ],
+                            "principalTypes": [
+                                "A",
+                                "B"
+                            ]
+                        }
+                    }
+                }
+            }
+        }))
+        .into_diagnostic()?,
+    )
+    .into_diagnostic()
+}
+
+fn generate_policy(path: &Path) -> Result<()> {
+    std::fs::write(
+        path,
+        r#"permit (
+  principal in A::"a",
+  action == Action::"action",
+  resource == C::"c"
+) when { true };
+"#,
+    )
+    .into_diagnostic()
+}
+
+fn generate_entities(path: &Path) -> Result<()> {
+    std::fs::write(
+        path,
+        serde_json::to_string_pretty(&serde_json::json!(
+        [
+            {
+                "uid": { "type": "A", "id": "a"} ,
+                "attrs": {},
+                "parents": [{"type": "B", "id": "b"}]
+            },
+            {
+                "uid": { "type": "B", "id": "b"} ,
+                "attrs": {},
+                "parents": []
+            },
+            {
+                "uid": { "type": "C", "id": "c"} ,
+                "attrs": {},
+                "parents": []
+            }
+        ]))
+        .into_diagnostic()?,
+    )
+    .into_diagnostic()
+}
+
+fn new_inner(args: &NewArgs) -> Result<()> {
+    let dir = &std::env::current_dir().into_diagnostic()?.join(&args.name);
+    std::fs::create_dir(dir).into_diagnostic()?;
+    let schema_path = dir.join("schema.cedarschema.json");
+    let policy_path = dir.join("policy.cedar");
+    let entities_path = dir.join("entities.jon");
+    generate_schema(&schema_path)?;
+    generate_policy(&policy_path)?;
+    generate_entities(&entities_path)
+}
+
+pub fn new(args: &NewArgs) -> CedarExitCode {
+    if let Err(err) = new_inner(args) {
         println!("Error: {err:?}");
         CedarExitCode::Failure
     } else {

--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 use miette::ErrorHook;
 
 use cedar_policy_cli::{
-    authorize, check_parse, evaluate, format_policies, link, validate, CedarExitCode, Cli,
+    authorize, check_parse, evaluate, format_policies, link, new, validate, CedarExitCode, Cli,
     Commands, ErrorFormat,
 };
 
@@ -47,5 +47,6 @@ fn main() -> CedarExitCode {
         Commands::Validate(args) => validate(&args),
         Commands::Format(args) => format_policies(&args),
         Commands::Link(args) => link(&args),
+        Commands::New(args) => new(&args),
     }
 }


### PR DESCRIPTION
## Description of changes
Now users should be able to create a Cedar project named `hello-world` by issuing `cedar new hello-world`. The dummy project contains a schema, a policy, and an entity store.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
