### PR TITLE
add doc string about stacker to is_authorized

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -397,6 +397,10 @@ impl Default for Authorizer {
 
 impl Authorizer {
     /// Create a new `Authorizer`
+    ///
+    /// The authorizer uses the `stacker` crate to manage stack size and tries to use a sane default.
+    /// If the default is not right for you, you can try wrapping the authorizer or individual calls
+    /// to `is_authorized` in `stacker::grow`.
     /// ```
     /// # use cedar_policy::{Authorizer, Context, Entities, EntityId, EntityTypeName,
     /// # EntityUid, Request,PolicySet};

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -35,6 +35,9 @@ thread_local!(
 );
 
 /// Construct and ask the authorizer the request.
+///
+/// The authorizer uses the `stacker` crate to manage stack size and tries to use a sane default.
+/// If the default is not right for you, you can try wrapping calls to `is_authorized` in `stacker::grow`.
 fn is_authorized(call: AuthorizationCall) -> Response {
     match call.get_components() {
         Ok((request, policies, entities)) => {
@@ -48,6 +51,9 @@ fn is_authorized(call: AuthorizationCall) -> Response {
 /// the `RecvdSlice`, you can either pass a `Map<String, String>` where the values are all single policies,
 /// or a single String which is a concatenation of multiple policies. If you choose the latter,
 /// policy id's will be auto-generated for you in the format `policyX` where X is a Whole Number (zero or a positive int)
+///
+/// The authorizer uses the `stacker` crate to manage stack size and tries to use a sane default.
+/// If the default is not right for you, you can try wrapping calls to `is_authorized` in `stacker::grow`.
 pub fn json_is_authorized(input: &str) -> InterfaceResult {
     serde_json::from_str::<AuthorizationCall>(input).map_or_else(
         |e| InterfaceResult::fail_internally(format!("error parsing call: {e:}")),

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -35,9 +35,6 @@ thread_local!(
 );
 
 /// Construct and ask the authorizer the request.
-///
-/// The authorizer uses the `stacker` crate to manage stack size and tries to use a sane default.
-/// If the default is not right for you, you can try wrapping calls to `is_authorized` in `stacker::grow`.
 fn is_authorized(call: AuthorizationCall) -> Response {
     match call.get_components() {
         Ok((request, policies, entities)) => {
@@ -51,9 +48,6 @@ fn is_authorized(call: AuthorizationCall) -> Response {
 /// the `RecvdSlice`, you can either pass a `Map<String, String>` where the values are all single policies,
 /// or a single String which is a concatenation of multiple policies. If you choose the latter,
 /// policy id's will be auto-generated for you in the format `policyX` where X is a Whole Number (zero or a positive int)
-///
-/// The authorizer uses the `stacker` crate to manage stack size and tries to use a sane default.
-/// If the default is not right for you, you can try wrapping calls to `is_authorized` in `stacker::grow`.
 pub fn json_is_authorized(input: &str) -> InterfaceResult {
     serde_json::from_str::<AuthorizationCall>(input).map_or_else(
         |e| InterfaceResult::fail_internally(format!("error parsing call: {e:}")),


### PR DESCRIPTION

## Description of changes
add doc strings about wrapping is_authorized inside stacker::grow if running into limits with stack size

## Issue #, if available
https://github.com/cedar-policy/cedar/issues/322

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
