### PR TITLE
Add apis to remove policies

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -67,10 +67,10 @@ impl TryFrom<LiteralPolicySet> for PolicySet {
         for template in &templates {
             template_to_links_map.insert(template.0.clone(), HashSet::new());
         }
-        for linked_policy in &links {
-            let template = linked_policy.1.template().id();
+        for (link_id, link) in &links {
+            let template = link.template().id();
             match template_to_links_map.entry(template.clone()) {
-                Entry::Occupied(t) => t.into_mut().insert(linked_policy.0.clone()),
+                Entry::Occupied(t) => t.into_mut().insert(link_id.clone()),
                 Entry::Vacant(_) => return Err(ReificationError::NoSuchTemplate(template.clone())),
             };
         }

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -339,7 +339,7 @@ impl PolicySet {
     /// Get the list of policies linked to `template_id`.
     /// Returns all p in `links` s.t. `p.template().id() == template_id`
     pub fn get_linked_policies(
-        &mut self,
+        &self,
         template_id: &PolicyID,
     ) -> Result<impl Iterator<Item = &PolicyID>, PolicySetGetLinksError> {
         match self.template_to_links_map.get(template_id) {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -138,9 +138,7 @@ pub enum PolicySetUnlinkError {
 #[derive(Error, Debug)]
 pub enum PolicySetTemplateRemovalError {
     /// There was no [`PolicyID`] template in the list of templates.
-    #[error(
-        "unable to remove static policy id `{0}` from template list because it does not exist"
-    )]
+    #[error("unable to remove template id `{0}` from template list because it does not exist")]
     RemovePolicyNoTemplateError(PolicyID),
     /// There are still active links to template [`PolicyID`].
     #[error(
@@ -343,9 +341,9 @@ impl PolicySet {
     pub fn get_linked_policies(
         &mut self,
         template_id: &PolicyID,
-    ) -> Result<Vec<&PolicyID>, PolicySetGetLinksError> {
+    ) -> Result<impl Iterator<Item = &PolicyID>, PolicySetGetLinksError> {
         match self.template_to_links_map.get(template_id) {
-            Some(s) => Ok(s.iter().collect_vec()),
+            Some(s) => Ok(s.iter()),
             None => Err(PolicySetGetLinksError::MissingTemplate(template_id.clone())),
         }
     }

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -40,7 +40,7 @@ pub struct PolicySet {
     /// A `Template` may have zero or many links
     links: HashMap<PolicyID, Policy>,
 
-    /// Map from a template `PolicyID`` to the set of `PolicyID`s in `links` that are linked to that template.
+    /// Map from a template `PolicyID` to the set of `PolicyID`s in `links` that are linked to that template.
     /// There is a key `t` iff `templates` contains the key `t`. The value of `t` will be a (possibly empty)
     /// set of every `p` in `links` s.t. `p.template().id() == t`.
     template_to_links_map: HashMap<PolicyID, HashSet<PolicyID>>,

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -227,8 +227,8 @@ impl PolicySet {
         Ok(())
     }
 
-    /// Remove a `Policy`` from the `PolicySet`.
-    pub fn remove(&mut self, policy_id: &PolicyID) -> Result<Policy, PolicySetPolicyRemovalError> {
+    /// Remove a static `Policy`` from the `PolicySet`.
+    pub fn remove_static(&mut self, policy_id: &PolicyID) -> Result<Policy, PolicySetPolicyRemovalError> {
         // Invariant: if `policy_id` is a key in both `self.links` and `self.templates`,
         // then self.templates[policy_id] has exactly one link: self.links[policy_id]
         let policy = match self.links.remove(policy_id) {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -228,7 +228,10 @@ impl PolicySet {
     }
 
     /// Remove a static `Policy`` from the `PolicySet`.
-    pub fn remove_static(&mut self, policy_id: &PolicyID) -> Result<Policy, PolicySetPolicyRemovalError> {
+    pub fn remove_static(
+        &mut self,
+        policy_id: &PolicyID,
+    ) -> Result<Policy, PolicySetPolicyRemovalError> {
         // Invariant: if `policy_id` is a key in both `self.links` and `self.templates`,
         // then self.templates[policy_id] has exactly one link: self.links[policy_id]
         let policy = match self.links.remove(policy_id) {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -96,6 +96,15 @@ pub enum PolicySetError {
     },
 }
 
+/// Potential errors when working with `PolicySet`s.
+#[derive(Error, Debug)]
+pub enum PolicySetRemovalError {
+    /// There was no [`PolicyID`] encountered in either the set of
+    /// templates or the set of policies.
+    #[error("unable to unlink policy id `{0}` because it does not exist")]
+    UnlinkingError(PolicyID),
+}
+
 // The public interface of `PolicySet` is intentionally narrow, to allow us
 // maximum flexibility to change the underlying implementation in the future
 impl PolicySet {
@@ -219,6 +228,14 @@ impl PolicySet {
             (_, Entry::Occupied(oentry)) => Err(LinkingError::PolicyIdConflict {
                 id: oentry.key().clone(),
             }),
+        }
+    }
+
+    /// Unlink `policy_id`
+    pub fn unlink(&mut self, policy_id: &PolicyID) -> Result<Policy, PolicySetRemovalError> {
+        match self.links.remove(policy_id) {
+            Some(p) => Ok(p),
+            None => Err(PolicySetRemovalError::UnlinkingError(policy_id.clone())),
         }
     }
 

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -228,6 +228,31 @@ impl PolicySet {
         }
     }
 
+    /// Remove a template from the policy set.
+    /// This involves an expensive scan over all linked policies to see if they are linked to the template
+    /// If any policy is linked to the template, this will error
+    pub fn remove_template(
+        &mut self,
+        policy_id: &PolicyID,
+    ) -> Result<Template, PolicySetRemovalError> {
+        if self
+            .links
+            .iter()
+            .any(|(_, p)| p.template().id().eq(policy_id))
+        {
+            return Err(PolicySetRemovalError::RemovePolicyNoTemplateError(
+                policy_id.clone(),
+            ));
+        }
+
+        match self.templates.remove(policy_id) {
+            Some(t) => Ok((*t).clone()),
+            None => Err(PolicySetRemovalError::RemovePolicyNoTemplateError(
+                policy_id.clone(),
+            )),
+        }
+    }
+
     /// Attempt to create a new template linked policy and add it to the policy
     /// set. Returns a references to the new template linked policy if
     /// successful.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added an API to `ParseError` to quickly get the primary source span
 - Added an API, `unknown_entities`, to `PolicySet` to collect unknown entity UIDs from `PartialResponse`.
 - Added APIs `remove`, `remove_template` and `unlink` to remove policies from the `PolicySet`
+- Added API `get_linked_policies` to get the policies linked to a `Template`
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -11,6 +11,7 @@
   `cedar_policy_core::authorizer::AuthorizationError` error types.
 - Added an API to `ParseError` to quickly get the primary source span
 - Added an API, `unknown_entities`, to `PolicySet` to collect unknown entity UIDs from `PartialResponse`.
+- Added APIs `remove`, `remove_template` and `unlink` to remove policies from the `PolicySet`
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1613,7 +1613,7 @@ pub enum PolicySetError {
     #[error("unable to remove policy template `{0}` because it does not exist")]
     TemplateNonexistentError(PolicyId),
     /// Error when removing a template with active links
-    #[error("unable to remove policy template: {0} because it has active links")]
+    #[error("unable to remove policy template `{0}` because it has active links")]
     RemoveTemplateWithActiveLinksError(PolicyId),
     /// Error when unlinking a template
     #[error("unable to unlink policy template: {0} because it does not exist")]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1607,7 +1607,7 @@ pub enum PolicySetError {
     #[error("expected a template, but a static policy was provided")]
     ExpectedTemplate,
     /// Error when removing a static policy
-    #[error("unable to remove static policy: {0} because it does not exist")]
+    #[error("unable to remove static policy `{0}` because it does not exist")]
     PolicyNonexistentError(PolicyId),
     /// Error when removing a template that doesn't exist
     #[error("unable to remove policy template: {0} because it does not exist")]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1787,7 +1787,7 @@ impl PolicySet {
             .ast
             .get_linked_policies(&ast::PolicyID::from_string(template_id.to_string()))
         {
-            Ok(v) => Ok(v.iter().map(|id| PolicyId((*id).clone())).collect()),
+            Ok(v) => Ok(v.map(|id| PolicyId((*id).clone())).collect()),
             Err(_) => Err(PolicySetError::TemplateNonexistentError(template_id)),
         }
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1722,6 +1722,14 @@ impl PolicySet {
     }
 
     /// Add a `Template` to the `PolicySet`
+    pub fn remove(&mut self, policy_id: PolicyId) -> Result<(), PolicySetError> {
+        match self.policies.remove(&policy_id) {
+            Some(_) => Ok(()),
+            None => Err(PolicySetError::RemovePolicyError(policy_id)),
+        }
+    }
+
+    /// Add a `Template` to the `PolicySet`
     pub fn add_template(&mut self, template: Template) -> Result<(), PolicySetError> {
         let id = PolicyId(template.ast.id().clone());
         self.ast.add_template(template.ast.clone())?;
@@ -3782,6 +3790,9 @@ mod policy_set_tests {
 
         pset.remove_template(PolicyId::from_str("t").unwrap())
             .expect("Failed to remove policy template");
+
+        pset.remove(PolicyId::from_str("id").unwrap())
+            .expect("Failed to remove static policy");
     }
 
     #[test]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1610,7 +1610,7 @@ pub enum PolicySetError {
     #[error("unable to remove static policy `{0}` because it does not exist")]
     PolicyNonexistentError(PolicyId),
     /// Error when removing a template that doesn't exist
-    #[error("unable to remove policy template: {0} because it does not exist")]
+    #[error("unable to remove policy template `{0}` because it does not exist")]
     TemplateNonexistentError(PolicyId),
     /// Error when removing a template with active links
     #[error("unable to remove policy template: {0} because it has active links")]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1723,9 +1723,21 @@ impl PolicySet {
 
     /// Remove a static `Policy` from the `PolicySet`
     pub fn remove(&mut self, policy_id: PolicyId) -> Result<Policy, PolicySetError> {
-        match self.policies.remove(&policy_id) {
-            Some(p) => Ok(p),
-            None => Err(PolicySetError::RemovePolicyError(policy_id)),
+        let policy = match self.policies.remove(&policy_id) {
+            Some(p) => p,
+            None => return Err(PolicySetError::RemovePolicyError(policy_id)),
+        };
+        match self
+            .ast
+            .remove(&ast::PolicyID::from_string(policy_id.to_string()))
+        {
+            Ok(_) => Ok(policy),
+            Err(_e) => {
+                //This should be unreachable.
+                debug_assert!(false);
+                self.policies.insert(policy_id.clone(), policy);
+                Err(PolicySetError::RemovePolicyError(policy_id))
+            }
         }
     }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1725,13 +1725,13 @@ impl PolicySet {
     }
 
     /// Remove a static `Policy` from the `PolicySet`
-    pub fn remove(&mut self, policy_id: PolicyId) -> Result<Policy, PolicySetError> {
+    pub fn remove_static(&mut self, policy_id: PolicyId) -> Result<Policy, PolicySetError> {
         let Some(policy) = self.policies.remove(&policy_id) else {
             return Err(PolicySetError::PolicyNonexistentError(policy_id));
         };
         match self
             .ast
-            .remove(&ast::PolicyID::from_string(policy_id.to_string()))
+            .remove_static(&ast::PolicyID::from_string(policy_id.to_string()))
         {
             Ok(_) => Ok(policy),
             Err(_) => {
@@ -3867,7 +3867,7 @@ mod policy_set_tests {
             }
         );
 
-        pset.remove(PolicyId::from_str("id").unwrap())
+        pset.remove_static(PolicyId::from_str("id").unwrap())
             .expect("Failed to remove static policy");
 
         //Deny
@@ -3908,7 +3908,7 @@ mod policy_set_tests {
         );
 
         assert_matches!(
-            pset.remove(PolicyId::from_str("t").unwrap()),
+            pset.remove_static(PolicyId::from_str("t").unwrap()),
             Err(PolicySetError::PolicyNonexistentError(_))
         );
 
@@ -3916,7 +3916,7 @@ mod policy_set_tests {
         assert_matches!(result, Ok(_));
 
         assert_matches!(
-            pset.remove(PolicyId::from_str("t").unwrap()),
+            pset.remove_static(PolicyId::from_str("t").unwrap()),
             Err(PolicySetError::PolicyNonexistentError(_))
         );
 
@@ -4296,18 +4296,18 @@ mod policy_set_tests {
         pset.add(static_policy).unwrap();
 
         //Can remove `policy`
-        pset.remove(PolicyId::from_str("policy").unwrap())
+        pset.remove_static(PolicyId::from_str("policy").unwrap())
             .expect("should be able to remove policy");
 
         //Cannot remove "linked"
         assert_matches!(
-            pset.remove(PolicyId::from_str("linked").unwrap()),
+            pset.remove_static(PolicyId::from_str("linked").unwrap()),
             Err(PolicySetError::PolicyNonexistentError(_))
         );
 
         //Cannot remove "template"
         assert_matches!(
-            pset.remove(PolicyId::from_str("template").unwrap()),
+            pset.remove_static(PolicyId::from_str("template").unwrap()),
             Err(PolicySetError::PolicyNonexistentError(_))
         );
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1721,7 +1721,7 @@ impl PolicySet {
         }
     }
 
-    /// Add a `Template` to the `PolicySet`
+    /// Remove a static `Policy` from the `PolicySet`
     pub fn remove(&mut self, policy_id: PolicyId) -> Result<(), PolicySetError> {
         match self.policies.remove(&policy_id) {
             Some(_) => Ok(()),
@@ -1737,7 +1737,7 @@ impl PolicySet {
         Ok(())
     }
 
-    /// Add a `Template` to the `PolicySet`
+    /// Remove a `Template` from the `PolicySet`
     pub fn remove_template(&mut self, template_id: PolicyId) -> Result<(), PolicySetError> {
         match self.templates.remove(&template_id) {
             Some(_) => Ok(()),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1616,7 +1616,7 @@ pub enum PolicySetError {
     #[error("unable to remove policy template `{0}` because it has active links")]
     RemoveTemplateWithActiveLinksError(PolicyId),
     /// Error when unlinking a template
-    #[error("unable to unlink policy template: {0} because it does not exist")]
+    #[error("unable to unlink policy template `{0}` because it does not exist")]
     LinkNonexistentError(PolicyId),
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1780,14 +1780,14 @@ impl PolicySet {
     /// Get policies linked to a `Template` in the `PolicySet`.
     /// If any policy is linked to the template, this will error
     pub fn get_linked_policies(
-        &mut self,
+        &self,
         template_id: PolicyId,
-    ) -> Result<Vec<PolicyId>, PolicySetError> {
+    ) -> Result<impl Iterator<Item = &PolicyId>, PolicySetError> {
         match self
             .ast
             .get_linked_policies(&ast::PolicyID::from_string(template_id.to_string()))
         {
-            Ok(v) => Ok(v.map(|id| PolicyId((*id).clone())).collect()),
+            Ok(v) => Ok(v.map(|id| PolicyId::ref_cast(id))),
             Err(_) => Err(PolicySetError::TemplateNonexistentError(template_id)),
         }
     }
@@ -4185,6 +4185,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             1
         );
@@ -4194,6 +4195,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             0
         );
@@ -4209,6 +4211,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             1
         );
@@ -4221,6 +4224,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             2
         );
@@ -4248,6 +4252,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template2").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             0
         );
@@ -4256,6 +4261,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             2
         );
@@ -4316,6 +4322,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             2
         );
@@ -4326,6 +4333,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             1
         );
@@ -4348,6 +4356,7 @@ mod policy_set_tests {
         assert_eq!(
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .unwrap()
+                .collect::<Vec<_>>()
                 .len(),
             0
         );
@@ -4360,8 +4369,10 @@ mod policy_set_tests {
 
         //can't get count for nonexistent template
         assert_matches!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap()),
-            Err(PolicySetError::TemplateNonexistentError(_))
+            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+                .err()
+                .unwrap(),
+            PolicySetError::TemplateNonexistentError(_)
         )
     }
 }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1923,7 +1923,8 @@ impl PolicySet {
         entity_uids
     }
 
-    /// Unlink a dynamic policy from the policy set
+    /// Unlink a template link from the policy set.
+    /// Returns the policy that was unlinked.
     pub fn unlink(&mut self, policy_id: PolicyId) -> Result<Policy, PolicySetError> {
         let Some(policy) = self.policies.remove(&policy_id) else {
             return Err(PolicySetError::LinkNonexistentError(policy_id));


### PR DESCRIPTION
## Description of changes
Add APIs for removing policies / policy templates and for unlinking templates.

## Issue #, if available
https://github.com/cedar-policy/cedar/issues/328

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
