### PR TITLE
remove naked should_panics

### DIFF
--- a/cedar-policy-cli/tests/integration_tests/example_use_cases_doc.rs
+++ b/cedar-policy-cli/tests/integration_tests/example_use_cases_doc.rs
@@ -68,7 +68,9 @@ fn scenario_4a() {
 // note: 4b currently omitted because it requires date/timestamp functionality
 
 /// currently failing, as the validator does not support action attributes
-#[should_panic]
+#[should_panic(
+    expected = "error occurred while evaluating policy `policy0`: `Action::\\\"view\\\"` does not have the attribute: readOnly"
+)]
 #[test]
 fn scenario_4c() {
     perform_integration_test_from_json(folder().join("4c.json"));

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -335,7 +335,7 @@ mod tests {
         assert!(policy.is_ok());
     }
 
-    #[test] // we no longer support structs
+    #[test] // we no longer support named structs
     fn member7() {
         let policy = parse_policy(
             r#"

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -335,8 +335,7 @@ mod tests {
         assert!(policy.is_ok());
     }
 
-    #[test]
-    #[should_panic] // we no longer support structs
+    #[test] // we no longer support structs
     fn member7() {
         let policy = parse_policy(
             r#"
@@ -346,7 +345,15 @@ mod tests {
                 };
             "#,
         );
-        assert!(policy.is_ok());
+        let errs = match policy.err() {
+            Some(pes) => pes,
+            _ => panic!("Expected parsing policy to error"),
+        };
+        assert!(errs.len() == 2);
+        assert!(format!("{:?}", errs[0])
+            .contains("ToCST(ToCSTError { err: UnrecognizedToken { token: (98, \"{\", 99)"));
+        assert!(format!("{:?}", errs[1])
+            .contains("ToCST(ToCSTError { err: UnrecognizedToken { token: (141, \"}\", 142)"));
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2617,7 +2617,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn cross_fragment_duplicate_type() {
         let fragment1: ValidatorSchemaFragment = serde_json::from_value::<SchemaFragment>(json!({
             "A": {
@@ -2643,12 +2642,13 @@ mod test {
         .unwrap()
         .try_into()
         .unwrap();
-        let schema = ValidatorSchema::from_schema_fragments([fragment1, fragment2]).unwrap();
 
-        assert_eq!(
-            schema.entity_types.iter().next().unwrap().1.attributes,
-            Attributes::with_required_attributes([("a".into(), Type::primitive_long())])
-        );
+        let schema = ValidatorSchema::from_schema_fragments([fragment1, fragment2]);
+
+        match schema {
+            Err(SchemaError::DuplicateCommonType(s)) if s.contains("A::MyLong") => (),
+            _ => panic!("should have errored because schema fragments have duplicate types"),
+        };
     }
 
     #[test]

--- a/cedar-policy/tests/example_use_cases_doc.rs
+++ b/cedar-policy/tests/example_use_cases_doc.rs
@@ -68,7 +68,9 @@ fn scenario_4a() {
 // note: 4b currently omitted because it requires date/timestamp functionality
 
 /// currently failing, as the validator does not support action attributes
-#[should_panic]
+#[should_panic(
+    expected = "error occurred while evaluating policy `policy0`: entity does not exist: Action::\\\"view\\\""
+)]
 #[test]
 fn scenario_4c() {
     perform_integration_test_from_json(folder().join("4c.json"));


### PR DESCRIPTION
## Description of changes
remove naked `should_panic`s. After this change, all `should_panic`s have an `expected = ...`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
