### PR TITLE
Accessing an unspecified entity should produce `None`

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,8 @@
   unsafe access to optional attributes to report the target of the access (fix #175).
 - Implements RFC #19, making validation slightly more strict, but more explainable.
 - Improved formatting for error messages.
+- Update the behavior of `Request::principal()`, `Request::action()`, and `Request::resource()` to
+  return `None` if the entities are unspecified.
 
 ## 2.4.0
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2713,43 +2713,40 @@ impl Request {
     }
 
     /// Get the principal component of the request. Returns `None` if the principal is
-    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or 
+    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or
     /// "unknown" (i.e., constructed using the partial evaluation APIs).
     pub fn principal(&self) -> Option<&EntityUid> {
         match self.0.principal() {
-            ast::EntityUIDEntry::Concrete(euid) => 
-                match euid.entity_type() {
-                    ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
-                    ast::EntityType::Unspecified => None,
-                }
+            ast::EntityUIDEntry::Concrete(euid) => match euid.entity_type() {
+                ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
+                ast::EntityType::Unspecified => None,
+            },
             ast::EntityUIDEntry::Unknown => None,
         }
     }
 
     /// Get the action component of the request. Returns `None` if the action is
-    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or 
+    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or
     /// "unknown" (i.e., constructed using the partial evaluation APIs).
     pub fn action(&self) -> Option<&EntityUid> {
         match self.0.action() {
-            ast::EntityUIDEntry::Concrete(euid) => 
-                match euid.entity_type() {
-                    ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
-                    ast::EntityType::Unspecified => None,
-                }
+            ast::EntityUIDEntry::Concrete(euid) => match euid.entity_type() {
+                ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
+                ast::EntityType::Unspecified => None,
+            },
             ast::EntityUIDEntry::Unknown => None,
         }
     }
 
     /// Get the resource component of the request. Returns `None` if the resource is
-    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or 
+    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or
     /// "unknown" (i.e., constructed using the partial evaluation APIs).
     pub fn resource(&self) -> Option<&EntityUid> {
         match self.0.resource() {
-            ast::EntityUIDEntry::Concrete(euid) => 
-                match euid.entity_type() {
-                    ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
-                    ast::EntityType::Unspecified => None,
-                }
+            ast::EntityUIDEntry::Concrete(euid) => match euid.entity_type() {
+                ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
+                ast::EntityType::Unspecified => None,
+            },
             ast::EntityUIDEntry::Unknown => None,
         }
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2712,26 +2712,44 @@ impl Request {
         Self(ast::Request::new(p, a, r, context.0))
     }
 
-    ///Get the principal component of the request
+    /// Get the principal component of the request. Returns `None` if the principal is
+    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or 
+    /// "unknown" (i.e., constructed using the partial evaluation APIs).
     pub fn principal(&self) -> Option<&EntityUid> {
         match self.0.principal() {
-            ast::EntityUIDEntry::Concrete(euid) => Some(EntityUid::ref_cast(euid.as_ref())),
+            ast::EntityUIDEntry::Concrete(euid) => 
+                match euid.entity_type() {
+                    ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
+                    ast::EntityType::Unspecified => None,
+                }
             ast::EntityUIDEntry::Unknown => None,
         }
     }
 
-    ///Get the action component of the request
+    /// Get the action component of the request. Returns `None` if the action is
+    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or 
+    /// "unknown" (i.e., constructed using the partial evaluation APIs).
     pub fn action(&self) -> Option<&EntityUid> {
         match self.0.action() {
-            ast::EntityUIDEntry::Concrete(euid) => Some(EntityUid::ref_cast(euid.as_ref())),
+            ast::EntityUIDEntry::Concrete(euid) => 
+                match euid.entity_type() {
+                    ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
+                    ast::EntityType::Unspecified => None,
+                }
             ast::EntityUIDEntry::Unknown => None,
         }
     }
 
-    ///Get the resource component of the request
+    /// Get the resource component of the request. Returns `None` if the resource is
+    /// "unspecified" (i.e., constructed by passing `None` into the constructor) or 
+    /// "unknown" (i.e., constructed using the partial evaluation APIs).
     pub fn resource(&self) -> Option<&EntityUid> {
         match self.0.resource() {
-            ast::EntityUIDEntry::Concrete(euid) => Some(EntityUid::ref_cast(euid.as_ref())),
+            ast::EntityUIDEntry::Concrete(euid) => 
+                match euid.entity_type() {
+                    ast::EntityType::Concrete(_) => Some(EntityUid::ref_cast(euid.as_ref())),
+                    ast::EntityType::Unspecified => None,
+                }
             ast::EntityUIDEntry::Unknown => None,
         }
     }
@@ -3899,6 +3917,14 @@ mod schema_based_parsing_tests {
     use super::*;
     use cool_asserts::assert_matches;
     use serde_json::json;
+
+    #[test]
+    fn accessing_unspecified_entity_returns_none() {
+        let c = Context::empty();
+        let request: Request = Request::new(None, None, None, c);
+        let p = request.principal();
+        assert!(p.is_none());
+    }
 
     /// Simple test that exercises a variety of attribute types.
     #[test]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3385,6 +3385,18 @@ permit(principal ==  A :: B
             .expect("failed to roundtrip");
         assert_eq!(reparsed.id().as_ref(), r#"b'ob"#);
     }
+
+    #[test]
+    fn accessing_unspecified_entity_returns_none() {
+        let c = Context::empty();
+        let request: Request = Request::new(None, None, None, c);
+        let p = request.principal();
+        let a = request.action();
+        let r = request.resource();
+        assert!(p.is_none());
+        assert!(a.is_none());
+        assert!(r.is_none());
+    }
 }
 
 #[cfg(test)]
@@ -3914,14 +3926,6 @@ mod schema_based_parsing_tests {
     use super::*;
     use cool_asserts::assert_matches;
     use serde_json::json;
-
-    #[test]
-    fn accessing_unspecified_entity_returns_none() {
-        let c = Context::empty();
-        let request: Request = Request::new(None, None, None, c);
-        let p = request.principal();
-        assert!(p.is_none());
-    }
 
     /// Simple test that exercises a variety of attribute types.
     #[test]


### PR DESCRIPTION
## Description of changes

When you construct a `Request` by passing in `None`, then you should get back `None` when you try to access that component of the request.

Example:
```
let c = Context::empty();
let request: Request = Request::new(None, None, None, c);
let p = request.principal(); // <-- should be None
```

This PR fixes the currently broken behavior and adds additional documentation.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
