### PR TITLE
fix clippy

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -403,7 +403,7 @@ impl Eq for ExtensionValueWithArgs {}
 
 impl PartialOrd for ExtensionValueWithArgs {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.value.partial_cmp(&other.value)
+        Some(self.cmp(other))
     }
 }
 

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -70,7 +70,7 @@ impl EntityUIDEntry {
     /// Get the UID of the entry, or `None` if it is unknown (partial evaluation)
     pub fn uid(&self) -> Option<&EntityUID> {
         match self {
-            Self::Concrete(euid) => Some(&euid),
+            Self::Concrete(euid) => Some(euid),
             Self::Unknown => None,
         }
     }

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -296,9 +296,7 @@ impl Eq for Set {}
 // HashSet doesn't implement PartialOrd
 impl PartialOrd<Set> for Set {
     fn partial_cmp(&self, other: &Set) -> Option<std::cmp::Ordering> {
-        self.authoritative
-            .as_ref()
-            .partial_cmp(other.authoritative.as_ref())
+        Some(self.cmp(other))
     }
 }
 

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -114,14 +114,14 @@ impl Authorizer {
                     ErrorHandling::Deny => Response::new(
                         Decision::Deny,
                         idset
-                            .chain(partial.diagnostics.reason.into_iter())
+                            .chain(partial.diagnostics.reason)
                             .collect(),
                         errors,
                     ),
                     ErrorHandling::Forbid => Response::new(
                         Decision::Deny,
                         idset
-                            .chain(partial.diagnostics.reason.into_iter())
+                            .chain(partial.diagnostics.reason)
                             .collect(),
                         errors,
                     ),
@@ -149,7 +149,7 @@ impl Authorizer {
                             Response::new(
                                 Decision::Deny,
                                 idset
-                                    .chain(partial.diagnostics.reason.into_iter())
+                                    .chain(partial.diagnostics.reason)
                                     .collect(),
                                 errors,
                             )

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -113,16 +113,12 @@ impl Authorizer {
                 match self.error_handling {
                     ErrorHandling::Deny => Response::new(
                         Decision::Deny,
-                        idset
-                            .chain(partial.diagnostics.reason)
-                            .collect(),
+                        idset.chain(partial.diagnostics.reason).collect(),
                         errors,
                     ),
                     ErrorHandling::Forbid => Response::new(
                         Decision::Deny,
-                        idset
-                            .chain(partial.diagnostics.reason)
-                            .collect(),
+                        idset.chain(partial.diagnostics.reason).collect(),
                         errors,
                     ),
                     ErrorHandling::Skip => {
@@ -148,9 +144,7 @@ impl Authorizer {
                         } else {
                             Response::new(
                                 Decision::Deny,
-                                idset
-                                    .chain(partial.diagnostics.reason)
-                                    .collect(),
+                                idset.chain(partial.diagnostics.reason).collect(),
                                 errors,
                             )
                         }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -159,7 +159,7 @@ impl TryFrom<cst::Cond> for Clause {
         let expr = match expr {
             Ok(expr) => Some(expr),
             Err(expr_errs) => {
-                errs.extend(expr_errs.0.into_iter());
+                errs.extend(expr_errs.0);
                 None
             }
         };

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -98,7 +98,7 @@ impl Decimal {
         // check that the string matches the regex
         // PANIC SAFETY: This regex does parse
         #[allow(clippy::unwrap_used)]
-        let re = Regex::new(r#"^(-?\d+)\.(\d+)$"#).unwrap();
+        let re = Regex::new(r"^(-?\d+)\.(\d+)$").unwrap();
         if !re.is_match(str.as_ref()) {
             return Err(Error::FailedParse(str.as_ref().to_owned()));
         }

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -50,7 +50,7 @@ pub(crate) fn to_pattern(s: &str) -> Result<Vec<PatternElem>, Vec<UnescapeError>
         Err(EscapeError::InvalidEscape)
         // note that the range argument refers to the *byte* offset into the string.
         // so we can compare the byte slice against the bytes of the ``star'' escape sequence.
-        if &bytes[range.start..range.end] == r#"\*"#.as_bytes()
+        if &bytes[range.start..range.end] == r"\*".as_bytes()
             =>
         {
             unescaped_str.push(PatternElem::Char('*'))


### PR DESCRIPTION
## Description of changes
Fix clippy errs for not using `cmp` in `partial_cmp` if the type also implements `Ord`. Also fix some warnings.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
