### PR TITLE
Return `Err` from `Context::from_expr` on non-record expr

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -164,11 +164,16 @@ impl Context {
         Self::from_pairs([])
     }
 
-    /// Create a `Context` from a `RestrictedExpr`, which must be a `Record`
-    /// INVARIANT: `from_expr` must only be called with an `expr` that is a `Record`
-    pub fn from_expr(expr: RestrictedExpr) -> Self {
-        debug_assert!(matches!(expr.expr_kind(), ExprKind::Record { .. }));
-        Self { context: expr }
+    /// Create a `Context` from a `RestrictedExpr`, which must be a `Record`.
+    /// If it is not a `Record`, then this function returns `Err` (returning
+    /// ownership of the non-record expression), otherwise it returns `Ok` of
+    /// a context for that record.
+    pub fn from_expr(expr: RestrictedExpr) -> Result<Self, RestrictedExpr> {
+        match expr.expr_kind() {
+            // INVARIANT: `context` must be a `Record`, which is guaranteed by the match case.
+            ExprKind::Record { .. } => Ok(Self { context: expr }),
+            _ => Err(expr),
+        }
     }
 
     /// Create a `Context` from a map of key to `RestrictedExpr`, or a Vec of

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -523,7 +523,8 @@ mod test {
         let context = Context::from_expr(RestrictedExpr::record([(
             "test".into(),
             RestrictedExpr::new(Expr::unknown("name")).unwrap(),
-        )]));
+        )]))
+        .unwrap();
         let a = Authorizer::new();
         let q = Request::new(
             EntityUID::with_eid("p"),

--- a/cedar-policy-core/src/entities/json/context.rs
+++ b/cedar-policy-core/src/entities/json/context.rs
@@ -15,7 +15,7 @@
  */
 
 use super::{JsonDeserializationError, JsonDeserializationErrorContext, SchemaType, ValueParser};
-use crate::ast::{Context, ExprKind};
+use crate::ast::Context;
 use crate::extensions::Extensions;
 use std::collections::HashMap;
 
@@ -80,14 +80,11 @@ impl<'e, 's, S: ContextSchema> ContextJsonParser<'e, 's, S> {
         let rexpr = vparser.val_into_rexpr(json, expected_ty.as_ref(), || {
             JsonDeserializationErrorContext::Context
         })?;
-        // INVARIANT `Context::from_exprs` requires that `rexpr` is a `Record`.
-        // This is checked by the `match` expression
-        match rexpr.expr_kind() {
-            ExprKind::Record { .. } => Ok(Context::from_expr(rexpr)),
-            _ => Err(JsonDeserializationError::ExpectedContextToBeRecord {
+        Context::from_expr(rexpr).map_err(|rexpr| {
+            JsonDeserializationError::ExpectedContextToBeRecord {
                 got: Box::new(rexpr),
-            }),
-        }
+            }
+        })
     }
 
     /// Parse context JSON (in `std::io::Read` form) into a `Context` object

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -3866,7 +3866,7 @@ pub mod test {
         let euid: EntityUID = r#"Test::"test""#.parse().unwrap();
         let rexpr = RestrictedExpr::new(context_expr)
             .expect("Context Expression was not a restricted expression");
-        let context = Context::from_expr(rexpr);
+        let context = Context::from_expr(rexpr).unwrap();
         let q = Request::new(euid.clone(), euid.clone(), euid, context);
         let es = Entities::new();
         let exts = Extensions::none();
@@ -3989,7 +3989,8 @@ pub mod test {
         let context = Context::from_expr(RestrictedExpr::new_unchecked(Expr::record([
             ("a".into(), Expr::val(3)),
             ("b".into(), Expr::unknown("b".to_string())),
-        ])));
+        ])))
+        .unwrap();
         let euid: EntityUID = r#"Test::"test""#.parse().unwrap();
         let q = Request::new(euid.clone(), euid.clone(), euid, context);
         let es = Entities::new();
@@ -4028,7 +4029,7 @@ pub mod test {
             Expr::unknown("cell".to_string()),
         )]))
         .expect("should qualify as restricted");
-        let context = Context::from_expr(c_expr);
+        let context = Context::from_expr(c_expr).unwrap();
 
         let q = Request::new(p, a, r, context);
         let exts = Extensions::none();
@@ -4101,7 +4102,8 @@ pub mod test {
             Context::from_expr(RestrictedExpr::new_unchecked(Expr::record([(
                 "condition".into(),
                 Expr::unknown("unknown_condition"),
-            )]))),
+            )])))
+            .unwrap(),
         );
         let eval = Evaluator::new(&q, &es, &exts).unwrap();
 


### PR DESCRIPTION
## Description of changes

A small change to make an invariant more robust.

The `Context` struct requires as an invariant that it may only contain a record expression, but `Context::from_expr` could construct contexts violating the invariant (although this fail a debug assertion).

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
