### PR TITLE
Add `PolicySet::unknown_entities`

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -473,12 +473,9 @@ impl Expr {
     }
 
     /// Get all unknowns in an expression
-    pub fn unknowns(&self) -> impl Iterator<Item = &str> {
+    pub fn unknowns(&self) -> impl Iterator<Item = &Expr> {
         self.subexpressions()
-            .filter_map(|subexpr| match subexpr.expr_kind() {
-                ExprKind::Unknown { name, .. } => Some(name.as_str()),
-                _ => None,
-            })
+            .filter(|subexpr| matches!(subexpr.expr_kind(), ExprKind::Unknown { .. }))
     }
 
     /// Substitute unknowns with values
@@ -1596,9 +1593,9 @@ mod test {
         );
         let unknowns = e.unknowns().collect_vec();
         assert_eq!(unknowns.len(), 3);
-        assert!(unknowns.contains(&"a"));
-        assert!(unknowns.contains(&"b"));
-        assert!(unknowns.contains(&"c"));
+        assert!(unknowns.contains(&&Expr::unknown("a".to_string())));
+        assert!(unknowns.contains(&&Expr::unknown("b".to_string())));
+        assert!(unknowns.contains(&&Expr::unknown("c".to_string())));
     }
 
     #[test]

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -94,7 +94,12 @@ impl Entities {
             None => match self.mode {
                 Mode::Concrete => Dereference::NoSuchEntity,
                 #[cfg(feature = "partial-eval")]
-                Mode::Partial => Dereference::Residual(Expr::unknown(format!("{uid}"))),
+                Mode::Partial => Dereference::Residual(Expr::unknown_with_type(
+                    format!("{uid}"),
+                    Some(Type::Entity {
+                        ty: uid.entity_type().clone(),
+                    }),
+                )),
             },
         }
     }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -947,12 +947,22 @@ pub mod test {
         let r = eval.partial_eval_expr(&e).unwrap();
         let expected_residual = Expr::binary_app(
             BinaryOp::In,
-            Expr::unknown(format!("{missing}")),
+            Expr::unknown_with_type(
+                format!("{missing}"),
+                Some(Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                }),
+            ),
             Expr::set([Expr::val(parent.clone()), Expr::val(second.clone())]),
         );
         let expected_residual2 = Expr::binary_app(
             BinaryOp::In,
-            Expr::unknown(format!("{missing}")),
+            Expr::unknown_with_type(
+                format!("{missing}"),
+                Some(Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                }),
+            ),
             Expr::set([Expr::val(second), Expr::val(parent)]),
         );
 
@@ -983,7 +993,12 @@ pub mod test {
         let r = eval.partial_eval_expr(&e).unwrap();
         let expected_residual = Expr::binary_app(
             BinaryOp::In,
-            Expr::unknown(format!("{missing}")),
+            Expr::unknown_with_type(
+                format!("{missing}"),
+                Some(Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                }),
+            ),
             Expr::val(parent),
         );
         assert_eq!(r, Either::Right(expected_residual));
@@ -1005,7 +1020,15 @@ pub mod test {
 
         let e = Expr::has_attr(Expr::val(missing.clone()), "spoon".into());
         let r = eval.partial_eval_expr(&e).unwrap();
-        let expected_residual = Expr::has_attr(Expr::unknown(format!("{missing}")), "spoon".into());
+        let expected_residual = Expr::has_attr(
+            Expr::unknown_with_type(
+                format!("{missing}"),
+                Some(Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                }),
+            ),
+            "spoon".into(),
+        );
         assert_eq!(r, Either::Right(expected_residual));
     }
 
@@ -1025,7 +1048,15 @@ pub mod test {
 
         let e = Expr::get_attr(Expr::val(missing.clone()), "spoon".into());
         let r = eval.partial_eval_expr(&e).unwrap();
-        let expected_residual = Expr::get_attr(Expr::unknown(format!("{missing}")), "spoon".into());
+        let expected_residual = Expr::get_attr(
+            Expr::unknown_with_type(
+                format!("{missing}"),
+                Some(Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                }),
+            ),
+            "spoon".into(),
+        );
         assert_eq!(r, Either::Right(expected_residual));
     }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Export the `cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind}` and
   `cedar_policy_core::authorizer::AuthorizationError` error types.
 - Added an API to `ParseError` to quickly get the primary source span
+- Added an API, `unknown_entities`, to `PolicySet` to collect unknown entity UIDs from `PartialResponse`.
 
 ### Changed
 


### PR DESCRIPTION
## Description of changes

Add an `unknown_entities` under `PolicySet` so that users can get all unknown entity UIDs from a `PartialResponse`.

## Issue #, if available

#321 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
