### PR TITLE
Add tests for duplicates in frontend JSON formats 

### DIFF
--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -392,7 +392,7 @@ fn parse_policy_set_from_individual_policies(
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::EntityUid;
+    use crate::{frontend::utils::assert_is_failure, EntityUid};
     use std::collections::HashMap;
 
     #[test]
@@ -440,7 +440,11 @@ mod test {
 
     #[test]
     fn test_failure_on_invalid_syntax() {
-        assert_is_failure(&json_is_authorized("iefjieoafiaeosij"));
+        assert_is_failure(
+            &json_is_authorized("iefjieoafiaeosij"),
+            true,
+            "expected value",
+        );
     }
 
     #[test]
@@ -693,6 +697,133 @@ mod test {
         assert_is_authorized(json_is_authorized(call));
     }
 
+    #[test]
+    fn test_authorized_fails_on_policy_collision_with_template() {
+        let call = r#"{
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : { "ID0": "permit(principal, action, resource);" },
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "template_instantiations" : []
+            }
+        }"#;
+        assert_is_failure(
+            &json_is_authorized(call),
+            false,
+            "couldn't add policy to set due to error: duplicate template or policy id `ID0`",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_instantiations_ids() {
+        let call = r#"{
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "template_instantiations" : [
+                    {
+                        "template_id" : "ID0",
+                        "result_policy_id" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    },
+                    {
+                        "template_id" : "ID0",
+                        "result_policy_id" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+        assert_is_failure(
+            &json_is_authorized(call),
+            false,
+            "Error instantiating template: unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_template_instantiation_collision_with_template() {
+        let call = r#"{
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "template_instantiations" : [
+                    {
+                        "template_id" : "ID0",
+                        "result_policy_id" : "ID0",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+        assert_is_failure(
+            &json_is_authorized(call),
+            false,
+            "Error instantiating template: unable to link template: template-linked policy id `ID0` conflicts with an existing policy id",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_template_instantiation_collision_with_policy() {
+        let call = r#"{
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : { "ID1": "permit(principal, action, resource);" },
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "template_instantiations" : [
+                    {
+                        "template_id" : "ID0",
+                        "result_policy_id" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        }"#;
+        assert_is_failure(
+            &json_is_authorized(call),
+            false,
+            "Error instantiating template: unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
+        );
+    }
+
     fn assert_is_authorized(result: InterfaceResult) {
         match result {
             InterfaceResult::Success { result } => {
@@ -732,15 +863,6 @@ mod test {
             InterfaceResult::Failure { .. } => {
                 panic!("Expected a successful response, not {result:?}");
             }
-        }
-    }
-
-    fn assert_is_failure(result: &InterfaceResult) {
-        match result {
-            InterfaceResult::Success { .. } => {
-                panic!("Expected a failing response, not {result:?}")
-            }
-            InterfaceResult::Failure { .. } => {}
         }
     }
 }

--- a/cedar-policy/src/frontend/utils.rs
+++ b/cedar-policy/src/frontend/utils.rs
@@ -84,3 +84,16 @@ impl InterfaceResult {
         }
     }
 }
+
+#[cfg(test)]
+pub(crate) fn assert_is_failure(result: &InterfaceResult, internal: bool, err: &str) {
+    use cool_asserts::assert_matches;
+    use itertools::Itertools;
+
+    assert_matches!(result, InterfaceResult::Failure { is_internal, errors } => {
+        assert!(
+            errors.iter().exactly_one().unwrap().contains(err),
+            "Expected to see error containing `{}`, but saw {:?}", err, errors);
+        assert_eq!(is_internal, &internal, "Unexpected value for `is_internal`");
+    });
+}

--- a/cedar-policy/src/frontend/validate.rs
+++ b/cedar-policy/src/frontend/validate.rs
@@ -145,6 +145,8 @@ enum ValidateAnswer {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod test {
+    use crate::frontend::utils::assert_is_failure;
+
     use super::*;
     use std::collections::HashMap;
 
@@ -246,7 +248,11 @@ mod test {
         .to_string();
 
         let result = json_validate(&call_json);
-        assert_fails_with_user_errors(result);
+        assert_is_failure(
+            &result,
+            false,
+            "parse error in policy policy0: unexpected end of input",
+        );
     }
 
     #[test]
@@ -349,7 +355,11 @@ mod test {
         .to_string();
 
         let result = json_validate(&call_json);
-        assert_fails_with_user_errors(result);
+        assert_is_failure(
+            &result,
+            false,
+            "parse error in policy: unexpected end of input",
+        );
     }
 
     #[test]
@@ -391,24 +401,36 @@ mod test {
             "policySet": "permit(principal, action, resource);forbid"
         }"#
         .to_string();
-
         let result = json_validate(&call_json);
-        assert_fails_with_user_errors(result);
+        assert_is_failure(
+            &result,
+            false,
+            "parse error in policy: unexpected end of input",
+        );
     }
 
     #[test]
     fn test_bad_call_format_fails() {
         let result = json_validate("uerfheriufheiurfghtrg");
-        assert_fails(result);
+        assert_is_failure(&result, true, "error parsing call: expected value");
     }
 
-    fn assert_fails(result: InterfaceResult) {
-        match result {
-            InterfaceResult::Success { result } => {
-                panic!("expected call to fail but got {:?}", &result)
-            }
-            InterfaceResult::Failure { .. } => {}
-        }
+    #[test]
+    fn test_validate_fails_on_duplicate_namespace() {
+        let call_json = r#"{
+            "schema": {
+              "foo": { "entityTypes": {}, "actions": {} },
+              "foo": { "entityTypes": {}, "actions": {} }
+            },
+            "policySet": ""
+        }"#
+        .to_string();
+        let result = json_validate(&call_json);
+        assert_is_failure(
+            &result,
+            true,
+            "error parsing call: invalid entry: found duplicate key",
+        );
     }
 
     fn assert_validates_without_notes(result: InterfaceResult) {
@@ -445,22 +467,6 @@ mod test {
             }
             InterfaceResult::Failure { .. } => {
                 panic!("expected call to succeed but got {:?}", &result)
-            }
-        }
-    }
-
-    fn assert_fails_with_user_errors(result: InterfaceResult) {
-        dbg!(&result);
-        match result {
-            InterfaceResult::Success { result } => {
-                panic!("expected call to fail but got {:?}", &result)
-            }
-            InterfaceResult::Failure {
-                is_internal,
-                errors,
-            } => {
-                assert!(!is_internal);
-                assert_ne!(errors.len(), 0);
             }
         }
     }


### PR DESCRIPTION
## Description of changes

The json frontend API detects and reports duplicates in some cases that weren't explicitly tested. This PR also includes a small improvement to a few existing test cases.

There are some other cases where duplicates are not detected that I'll report in an Issue.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
