### PR TITLE
Automatically add action entities to `Entities`; validate entities against schema

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -280,10 +280,11 @@ impl Entity {
         &self.attrs
     }
 
-    /// Read-only access the internal `ancestors` hashset.
-    /// This function is available only inside Core.
-    pub(crate) fn ancestors_set(&self) -> &HashSet<EntityUID> {
-        &self.ancestors
+    /// Test if two `Entity` objects are deep/structurally equal.
+    /// That is, not only do they have the same UID, but also the same
+    /// attributes, attribute values, and ancestors.
+    pub(crate) fn deep_eq(&self, other: &Self) -> bool {
+        self.uid == other.uid && self.attrs == other.attrs && self.ancestors == other.ancestors
     }
 
     /// Set the given attribute to the given value.

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -515,7 +515,7 @@ mod json_parsing_tests {
 
     #[test]
     fn enforces_tc_fail_cycle_almost() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"george\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"george\"", "Test::\"janet\""]}]);
@@ -542,7 +542,7 @@ mod json_parsing_tests {
 
     #[test]
     fn enforces_tc_fail_connecting() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"george\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"henry\""]}]);
@@ -568,7 +568,7 @@ mod json_parsing_tests {
 
     #[test]
     fn enforces_tc_fail_missing_edge() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"alice\""]}]);
@@ -594,7 +594,7 @@ mod json_parsing_tests {
 
     #[test]
     fn enforces_tc_success() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"alice\"", "Test::\"bob\""]}]);
@@ -618,7 +618,7 @@ mod json_parsing_tests {
 
     #[test]
     fn adds_extends_tc_connecting() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"george\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"henry\""] }]);
@@ -642,7 +642,7 @@ mod json_parsing_tests {
 
     #[test]
     fn adds_extends_tc() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"alice\""]}]);
@@ -665,7 +665,7 @@ mod json_parsing_tests {
 
     #[test]
     fn adds_works() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : { "foo" : 3 }, "parents" : ["Test::\"susan\""]}]);
@@ -690,7 +690,7 @@ mod json_parsing_tests {
 
     #[test]
     fn add_duplicates_fail2() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([
             {"uid":{"__expr":"Test::\"jeff\""}, "attrs" : {}, "parents" : []},
@@ -715,7 +715,7 @@ mod json_parsing_tests {
 
     #[test]
     fn add_duplicates_fail1() {
-        let parser: EntityJsonParser<'_> =
+        let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new =
             serde_json::json!([{"uid":{"__expr":"Test::\"alice\""}, "attrs" : {}, "parents" : []}]);
@@ -734,7 +734,7 @@ mod json_parsing_tests {
         }
     }
 
-    fn simple_entities(parser: &EntityJsonParser<'_>) -> Entities {
+    fn simple_entities(parser: &EntityJsonParser<'_, '_>) -> Entities {
         let json = serde_json::json!(
             [
                 {
@@ -802,7 +802,7 @@ mod json_parsing_tests {
             ]
         );
 
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let es = eparser
             .from_json_value(json)
@@ -845,7 +845,7 @@ mod json_parsing_tests {
             ]
         );
 
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let es = eparser.from_json_value(json).expect("JSON is correct");
 
@@ -899,7 +899,7 @@ mod json_parsing_tests {
             ]
         );
 
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let es = eparser.from_json_value(json).expect("JSON is correct");
 
@@ -978,7 +978,7 @@ mod json_parsing_tests {
             ]
         );
 
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let es = eparser.from_json_value(json).expect("JSON is correct");
 
@@ -1004,7 +1004,7 @@ mod json_parsing_tests {
     #[test]
     fn uid_failures() {
         // various JSON constructs that are invalid in `uid` and `parents` fields
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
 
         let json = serde_json::json!(
@@ -1119,7 +1119,7 @@ mod json_parsing_tests {
     fn roundtrip(entities: &Entities) -> Result<Entities> {
         let mut buf = Vec::new();
         entities.write_to_json(&mut buf)?;
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         eparser.from_json_str(&String::from_utf8(buf).expect("should be valid UTF-8"))
     }
@@ -1265,7 +1265,7 @@ mod json_parsing_tests {
                 }
             ]
         );
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let err = eparser
             .from_json_value(json)
@@ -1546,7 +1546,7 @@ mod schema_based_parsing_tests {
         // without schema-based parsing, `home_ip` and `trust_score` are
         // strings, `manager` and `work_ip` are Records, `hr_contacts` contains
         // Records, and `json_blob.inner3.innerinner` is a Record
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let parsed = eparser
             .from_json_value(entitiesjson.clone())
@@ -1612,7 +1612,7 @@ mod schema_based_parsing_tests {
 
         // but with schema-based parsing, we get these other types
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -1751,7 +1751,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -1797,7 +1797,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -1841,7 +1841,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -1887,7 +1887,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -1934,7 +1934,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -1979,7 +1979,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2025,7 +2025,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2103,7 +2103,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2147,7 +2147,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2194,7 +2194,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2244,7 +2244,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2273,7 +2273,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2302,7 +2302,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2335,7 +2335,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2368,7 +2368,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2401,7 +2401,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2432,7 +2432,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2466,7 +2466,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2497,7 +2497,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2531,7 +2531,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );
@@ -2626,7 +2626,7 @@ mod schema_based_parsing_tests {
             ]
         );
         let eparser = EntityJsonParser::new(
-            Some(MockSchema),
+            Some(&MockSchema),
             Extensions::all_available(),
             TCComputation::ComputeNow,
         );

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -27,6 +27,8 @@ use std::fmt::Write;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 
+mod conformance;
+pub use conformance::EntitySchemaConformanceError;
 mod err;
 pub use err::*;
 mod json;

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -1,0 +1,66 @@
+use super::SchemaType;
+use crate::ast::{EntityType, EntityUID};
+use smol_str::SmolStr;
+use thiserror::Error;
+
+/// Errors raised when (non-action) entities do not conform to the schema.
+#[derive(Debug, Error)]
+pub enum EntitySchemaConformanceError {
+    /// Encountered this attribute on this entity, but that attribute shouldn't
+    /// exist on entities of this type
+    #[error("attribute `{attr}` on `{uid}` should not exist according to the schema")]
+    UnexpectedEntityAttr {
+        /// Entity that had the unexpected attribute
+        uid: EntityUID,
+        /// Name of the attribute that was unexpected
+        attr: SmolStr,
+    },
+    /// Didn't encounter this attribute of an entity, but that attribute should
+    /// have existed
+    #[error("expected entity `{uid}` to have an attribute `{attr}`, but it does not")]
+    MissingRequiredEntityAttr {
+        /// Entity that is missing a required attribute
+        uid: EntityUID,
+        /// Name of the attribute which was expected
+        attr: SmolStr,
+    },
+    /// The given attribute on the given entity had a different type than the
+    /// schema indicated to expect
+    #[error("in attribute `{attr}` on `{uid}`, type mismatch: attribute was expected to have type {expected}, but actually has type {actual}")]
+    TypeMismatch {
+        /// Entity where the type mismatch occurred
+        uid: EntityUID,
+        /// Name of the attribute where the type mismatch occurred
+        attr: SmolStr,
+        /// Type which was expected
+        expected: Box<SchemaType>,
+        /// Type which was encountered instead
+        actual: Box<SchemaType>,
+    },
+    /// During schema-based parsing, found a set whose elements don't all have the
+    /// same type.  This doesn't match any possible schema.
+    #[error(
+        "in attribute `{attr}` on `{uid}`, set elements have different types: {ty1} and {ty2}"
+    )]
+    HeterogeneousSet {
+        /// Entity where the error occurred
+        uid: EntityUID,
+        /// Name of the attribute where the error occurred
+        attr: SmolStr,
+        /// First element type which was found
+        ty1: Box<SchemaType>,
+        /// Second element type which was found
+        ty2: Box<SchemaType>,
+    },
+    /// During schema-based parsing, found a parent of a type that's not allowed
+    /// for that entity
+    #[error(
+        "`{uid}` is not allowed to have a parent of type `{parent_ty}` according to the schema"
+    )]
+    InvalidParentType {
+        /// Entity that has an invalid parent type
+        uid: EntityUID,
+        /// Parent type which was invalid
+        parent_ty: Box<EntityType>, // boxed to avoid this variant being very large (and thus all EntitySchemaConformanceErrors being large)
+    },
+}

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -1,9 +1,11 @@
-use super::SchemaType;
-use crate::ast::{EntityType, EntityUID};
+use super::{AttributeType, EntityTypeDescription, Schema, SchemaType};
+use crate::ast::{BorrowedRestrictedExpr, Entity, EntityType, EntityUID, ExprKind, Literal};
+use crate::extensions::{ExtensionFunctionLookupError, Extensions};
 use smol_str::SmolStr;
+use std::collections::HashMap;
 use thiserror::Error;
 
-/// Errors raised when (non-action) entities do not conform to the schema.
+/// Errors raised when entities do not conform to the schema
 #[derive(Debug, Error)]
 pub enum EntitySchemaConformanceError {
     /// Encountered this attribute on this entity, but that attribute shouldn't
@@ -37,30 +39,271 @@ pub enum EntitySchemaConformanceError {
         /// Type which was encountered instead
         actual: Box<SchemaType>,
     },
-    /// During schema-based parsing, found a set whose elements don't all have the
-    /// same type.  This doesn't match any possible schema.
-    #[error(
-        "in attribute `{attr}` on `{uid}`, set elements have different types: {ty1} and {ty2}"
-    )]
+    /// Found a set whose elements don't all have the same type. This doesn't match
+    /// any possible schema.
+    #[error("in attribute `{attr}` on `{uid}`, {err}")]
     HeterogeneousSet {
         /// Entity where the error occurred
         uid: EntityUID,
         /// Name of the attribute where the error occurred
         attr: SmolStr,
-        /// First element type which was found
-        ty1: Box<SchemaType>,
-        /// Second element type which was found
-        ty2: Box<SchemaType>,
+        /// Underlying error
+        err: HeterogeneousSetError,
     },
-    /// During schema-based parsing, found a parent of a type that's not allowed
-    /// for that entity
+    /// Found an ancestor of a type that's not allowed for that entity
     #[error(
-        "`{uid}` is not allowed to have a parent of type `{parent_ty}` according to the schema"
+        "`{uid}` is not allowed to have an ancestor of type `{ancestor_ty}` according to the schema"
     )]
-    InvalidParentType {
-        /// Entity that has an invalid parent type
+    InvalidAncestorType {
+        /// Entity that has an invalid ancestor type
         uid: EntityUID,
-        /// Parent type which was invalid
-        parent_ty: Box<EntityType>, // boxed to avoid this variant being very large (and thus all EntitySchemaConformanceErrors being large)
+        /// Ancestor type which was invalid
+        ancestor_ty: Box<EntityType>, // boxed to avoid this variant being very large (and thus all EntitySchemaConformanceErrors being large)
     },
+    /// Encountered an entity of a type which is not declared in the schema.
+    /// Note that this error is only used for non-Action entity types.
+    #[error("entity `{uid}` has type `{}` which is not declared in the schema{}",
+        &.uid.entity_type(),
+        match .suggested_types.as_slice() {
+            [] => String::new(),
+            [ty] => format!(". Did you mean `{ty}`?"),
+            tys => format!(". Did you mean one of {:?}?", tys.iter().map(ToString::to_string).collect::<Vec<String>>())
+        }
+    )]
+    UnexpectedEntityType {
+        /// Entity that had the unexpected type
+        uid: EntityUID,
+        /// Suggested similar entity types that actually are declared in the schema (if any)
+        suggested_types: Vec<EntityType>,
+    },
+    /// Encountered an action which was not declared in the schema
+    #[error("found action entity `{uid}`, but it was not declared as an action in the schema")]
+    UndeclaredAction {
+        /// Action which was not declared in the schema
+        uid: EntityUID,
+    },
+    /// Encountered an action whose definition doesn't precisely match the
+    /// schema's declaration of that action
+    #[error("definition of action `{uid}` does not match its schema declaration")]
+    ActionDeclarationMismatch {
+        /// Action whose definition mismatched between entity data and schema
+        uid: EntityUID,
+    },
+    /// Error looking up an extension function. This error can occur when
+    /// checking entity conformance because that may require getting information
+    /// about any extension functions referenced in entity attribute values.
+    #[error("in attribute `{attr}` on `{uid}`, {err}")]
+    Extension {
+        /// Entity where the error occurred
+        uid: EntityUID,
+        /// Name of the attribute where the error occurred
+        attr: SmolStr,
+        /// Underlying error
+        err: ExtensionFunctionLookupError,
+    },
+}
+
+/// Found a set whose elements don't all have the same type.  This doesn't match
+/// any possible schema.
+#[derive(Debug, Error)]
+#[error("set elements have different types: {ty1} and {ty2}")]
+pub struct HeterogeneousSetError {
+    /// First element type which was found
+    ty1: Box<SchemaType>,
+    /// Second element type which was found
+    ty2: Box<SchemaType>,
+}
+
+/// Struct used to check whether entities conform to a schema
+#[derive(Debug, Clone)]
+pub struct EntitySchemaConformanceChecker<'a, S: Schema> {
+    /// Schema to check conformance with
+    schema: &'a S,
+    /// Extensions which are active for the conformance checks
+    extensions: Extensions<'a>,
+}
+
+impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
+    /// Create a new checker
+    pub fn new(schema: &'a S, extensions: Extensions<'a>) -> Self {
+        Self { schema, extensions }
+    }
+
+    /// Validate an entity against the schema, returning an
+    /// [`EntitySchemaConformanceError`] if it does not comply.
+    pub fn validate_entity(&self, entity: &Entity) -> Result<(), EntitySchemaConformanceError> {
+        let uid = entity.uid();
+        let etype = uid.entity_type();
+        if etype.is_action() {
+            let schema_action = self
+                .schema
+                .action(&uid)
+                .ok_or(EntitySchemaConformanceError::UndeclaredAction { uid: uid.clone() })?;
+            // check that the action exactly matches the schema's definition
+            if !entity.deep_eq(&schema_action) {
+                return Err(EntitySchemaConformanceError::ActionDeclarationMismatch {
+                    uid: uid.clone(),
+                });
+            }
+        } else {
+            let schema_etype = self.schema.entity_type(etype).ok_or_else(|| {
+                let suggested_types = match etype {
+                    EntityType::Concrete(name) => self
+                        .schema
+                        .entity_types_with_basename(name.basename())
+                        .collect(),
+                    EntityType::Unspecified => vec![],
+                };
+                EntitySchemaConformanceError::UnexpectedEntityType {
+                    uid: uid.clone(),
+                    suggested_types,
+                }
+            })?;
+            // Ensure that all required attributes for `etype` are actually
+            // included in `entity`
+            for required_attr in schema_etype.required_attrs() {
+                if entity.get(&required_attr).is_none() {
+                    return Err(EntitySchemaConformanceError::MissingRequiredEntityAttr {
+                        uid: uid.clone(),
+                        attr: required_attr,
+                    });
+                }
+            }
+            // For each attribute that actually appears in `entity`, ensure it
+            // complies with the schema
+            for (attr, val) in entity.attrs() {
+                match schema_etype.attr_type(attr) {
+                    None => {
+                        // `None` indicates the attribute shouldn't exist -- see
+                        // docs on the `attr_type()` trait method
+                        return Err(EntitySchemaConformanceError::UnexpectedEntityAttr {
+                            uid: uid.clone(),
+                            attr: attr.into(),
+                        });
+                    }
+                    Some(expected_ty) => {
+                        // typecheck: ensure that the entity attribute value matches
+                        // the expected type
+                        match type_of_rexpr(val, self.extensions) {
+                            Ok(actual_ty) => {
+                                if actual_ty.is_consistent_with(&expected_ty) {
+                                    // typecheck passes
+                                } else {
+                                    return Err(EntitySchemaConformanceError::TypeMismatch {
+                                        uid: uid.clone(),
+                                        attr: attr.into(),
+                                        expected: Box::new(expected_ty),
+                                        actual: Box::new(actual_ty),
+                                    });
+                                }
+                            }
+                            Err(TypeOfRexprError::HeterogeneousSet(err)) => {
+                                return Err(EntitySchemaConformanceError::HeterogeneousSet {
+                                    uid: uid.clone(),
+                                    attr: attr.into(),
+                                    err,
+                                });
+                            }
+                            Err(TypeOfRexprError::Extension(err)) => {
+                                return Err(EntitySchemaConformanceError::Extension {
+                                    uid: uid.clone(),
+                                    attr: attr.into(),
+                                    err,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            // For each ancestor that actually appears in `entity`, ensure the
+            // ancestor type is allowed by the schema
+            for ancestor_euid in entity.ancestors() {
+                let ancestor_type = ancestor_euid.entity_type();
+                if schema_etype.allowed_parent_types().contains(ancestor_type) {
+                    // note that `allowed_parent_types()` was transitively
+                    // closed, so it's actually `allowed_ancestor_types()`
+                    //
+                    // thus, the check passes in this case
+                } else {
+                    return Err(EntitySchemaConformanceError::InvalidAncestorType {
+                        uid: uid.clone(),
+                        ancestor_ty: Box::new(ancestor_type.clone()),
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Errors thrown by [`type_of_rexpr()`]
+#[derive(Debug, Error)]
+pub enum TypeOfRexprError {
+    /// Encountered a heterogeneous set
+    #[error(transparent)]
+    HeterogeneousSet(#[from] HeterogeneousSetError),
+    /// Error looking up an extension function
+    #[error(transparent)]
+    Extension(#[from] ExtensionFunctionLookupError),
+}
+
+/// Get the [`SchemaType`] of a restricted expression.
+///
+/// This isn't possible for general `Expr`s (without a Request, full schema,
+/// etc), but is possible for restricted expressions, given the information in
+/// `Extensions`.
+pub fn type_of_rexpr(
+    rexpr: BorrowedRestrictedExpr<'_>,
+    extensions: Extensions<'_>,
+) -> Result<SchemaType, TypeOfRexprError> {
+    match rexpr.expr_kind() {
+        ExprKind::Lit(Literal::Bool(_)) => Ok(SchemaType::Bool),
+        ExprKind::Lit(Literal::Long(_)) => Ok(SchemaType::Long),
+        ExprKind::Lit(Literal::String(_)) => Ok(SchemaType::String),
+        ExprKind::Lit(Literal::EntityUID(uid)) => Ok(SchemaType::Entity { ty: uid.entity_type().clone() }),
+        ExprKind::Set(elements) => {
+            let mut element_types = elements.iter().map(|el| {
+                type_of_rexpr(BorrowedRestrictedExpr::new_unchecked(el), extensions) // assuming the invariant holds for the set as a whole, it will also hold for each element
+            });
+            match element_types.next() {
+                None => Ok(SchemaType::EmptySet),
+                Some(Err(e)) => Err(e),
+                Some(Ok(element_ty)) => {
+                    let matches_element_ty = |ty: &Result<SchemaType, TypeOfRexprError>| matches!(ty, Ok(ty) if ty.is_consistent_with(&element_ty));
+                    let conflicting_ty = element_types.find(|ty| !matches_element_ty(ty));
+                    match conflicting_ty {
+                        None => Ok(SchemaType::Set { element_ty: Box::new(element_ty) }),
+                        Some(Ok(conflicting_ty)) => Err(HeterogeneousSetError {
+                                ty1: Box::new(element_ty),
+                                ty2: Box::new(conflicting_ty),
+                        }.into()),
+                        Some(Err(e)) => Err(e),
+                    }
+                }
+            }
+        }
+        ExprKind::Record { pairs } => {
+            Ok(SchemaType::Record { attrs: {
+                pairs.iter().map(|(k, v)| {
+                    let attr_type = type_of_rexpr(
+                        BorrowedRestrictedExpr::new_unchecked(v), // assuming the invariant holds for the record as a whole, it will also hold for each attribute value
+                        extensions,
+                    )?;
+                    // we can't know if the attribute is required or optional,
+                    // but marking it optional is more flexible -- allows the
+                    // attribute type to `is_consistent_with()` more types
+                    Ok((k.clone(), AttributeType::optional(attr_type)))
+                }).collect::<Result<HashMap<_,_>, TypeOfRexprError>>()?
+            }})
+        }
+        ExprKind::ExtensionFunctionApp { fn_name, .. } => {
+            let efunc = extensions.func(fn_name)?;
+            Ok(efunc.return_type().cloned().ok_or_else(|| ExtensionFunctionLookupError::HasNoType {
+                name: efunc.name().clone()
+            })?)
+        }
+        // PANIC SAFETY. Unreachable by invariant on restricted expressions
+        #[allow(clippy::unreachable)]
+        expr => unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
+    }
 }

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::{EntitySchemaConformanceError, EntityUID};
+use super::EntityUID;
 use crate::transitive_closure;
 use thiserror::Error;
 
@@ -34,6 +34,9 @@ pub enum EntitiesError {
     /// entity hierarchy.
     #[error("transitive closure computation/enforcement error: {0}")]
     TransitiveClosureError(#[from] Box<transitive_closure::TcError<EntityUID>>),
+    /// Error because an entity doesn't conform to the schema
+    #[error("entity does not conform to the schema: {0}")]
+    InvalidEntity(#[from] crate::entities::EntitySchemaConformanceError),
 }
 
 /// Type alias for convenience

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::EntityUID;
+use super::{EntitySchemaConformanceError, EntityUID};
 use crate::transitive_closure;
 use thiserror::Error;
 

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -206,14 +206,11 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
         &self,
         ejsons: impl IntoIterator<Item = EntityJSON>,
     ) -> Result<Entities, EntitiesError> {
-        let mut entities: Vec<Entity> = ejsons
+        let entities: Vec<Entity> = ejsons
             .into_iter()
             .map(|ejson| self.parse_ejson(ejson))
             .collect::<Result<_, _>>()?;
-        if let Some(schema) = &self.schema {
-            entities.extend(schema.action_entities().into_iter().map(unwrap_or_clone));
-        }
-        Entities::from_entities(entities, self.tc_computation)
+        Entities::from_entities(entities, self.schema.as_ref(), self.tc_computation)
     }
 
     /// internal function that parses an `EntityJSON` into an `Entity`

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -46,7 +46,7 @@ pub struct EntityJSON {
 
 /// Struct used to parse entities from JSON.
 #[derive(Debug, Clone)]
-pub struct EntityJsonParser<'e, S: Schema = NoEntitiesSchema> {
+pub struct EntityJsonParser<'e, 's, S: Schema = NoEntitiesSchema> {
     /// `schema` represents a source of `Action` entities, which will be added
     /// to the entities parsed from JSON.
     /// (If any `Action` entities are present in the JSON, and a `schema` is
@@ -61,7 +61,7 @@ pub struct EntityJsonParser<'e, S: Schema = NoEntitiesSchema> {
     /// instance, it will error if attributes have the wrong types (e.g., string
     /// instead of integer), or if required attributes are missing or
     /// superfluous attributes are provided.
-    schema: Option<S>,
+    schema: Option<&'s S>,
 
     /// Extensions which are active for the JSON parsing.
     extensions: Extensions<'e>,
@@ -83,7 +83,7 @@ enum EntitySchemaInfo<E: EntityTypeDescription> {
     NonAction(E),
 }
 
-impl<'e, S: Schema> EntityJsonParser<'e, S> {
+impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
     /// Create a new `EntityJsonParser`.
     ///
     /// `schema` represents a source of `Action` entities, which will be added
@@ -104,7 +104,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
     /// If you pass `TCComputation::AssumeAlreadyComputed`, then the caller is
     /// responsible for ensuring that TC holds before calling this method.
     pub fn new(
-        schema: Option<S>,
+        schema: Option<&'s S>,
         extensions: Extensions<'e>,
         tc_computation: TCComputation,
     ) -> Self {
@@ -216,7 +216,7 @@ impl<'e, S: Schema> EntityJsonParser<'e, S> {
             .collect::<Result<_, _>>()?;
         Entities::from_entities(
             entities,
-            self.schema.as_ref(),
+            self.schema,
             self.tc_computation,
             self.extensions,
         )

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -9,6 +9,9 @@ pub trait Schema {
     /// Type returned by `entity_type()`. Must implement the `EntityTypeDescription` trait
     type EntityTypeDescription: EntityTypeDescription;
 
+    /// Type returned by `action_entities()`
+    type ActionEntityIterator: IntoIterator<Item = Arc<Entity>>;
+
     /// Get an `EntityTypeDescription` for the given entity type, or `None` if that
     /// entity type is not declared in the schema (in which case entities of that
     /// type should not appear in the JSON data).
@@ -25,6 +28,9 @@ pub trait Schema {
         &'a self,
         basename: &'a Id,
     ) -> Box<dyn Iterator<Item = EntityType> + 'a>;
+
+    /// Get all the actions declared in the schema
+    fn action_entities(&self) -> Self::ActionEntityIterator;
 }
 
 /// Simple type that implements `Schema` by expecting no entities to exist at all
@@ -32,6 +38,7 @@ pub trait Schema {
 pub struct NoEntitiesSchema;
 impl Schema for NoEntitiesSchema {
     type EntityTypeDescription = NullEntityTypeDescription;
+    type ActionEntityIterator = std::iter::Empty<Arc<Entity>>;
     fn entity_type(&self, _entity_type: &EntityType) -> Option<NullEntityTypeDescription> {
         None
     }
@@ -44,15 +51,25 @@ impl Schema for NoEntitiesSchema {
     ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
         Box::new(std::iter::empty())
     }
+    fn action_entities(&self) -> std::iter::Empty<Arc<Entity>> {
+        std::iter::empty()
+    }
 }
 
 /// Simple type that implements `Schema` by allowing entities of all types to
 /// exist, and allowing all actions to exist, but expecting no attributes or
-/// parents on any entity (action or otherwise)
+/// parents on any entity (action or otherwise).
+///
+/// This type returns an empty iterator for `action_entities()`, which is kind
+/// of inconsistent with its behavior on `action()`. But it works out -- the
+/// result is that, in `EntityJsonParser`, all actions encountered in JSON data
+/// are allowed to exist without error, but no additional actions from the
+/// schema are added.
 #[derive(Debug, Clone)]
 pub struct AllEntitiesNoAttrsSchema;
 impl Schema for AllEntitiesNoAttrsSchema {
     type EntityTypeDescription = NullEntityTypeDescription;
+    type ActionEntityIterator = std::iter::Empty<Arc<Entity>>;
     fn entity_type(&self, entity_type: &EntityType) -> Option<NullEntityTypeDescription> {
         Some(NullEntityTypeDescription {
             ty: entity_type.clone(),
@@ -72,6 +89,9 @@ impl Schema for AllEntitiesNoAttrsSchema {
         Box::new(std::iter::once(EntityType::Concrete(
             Name::unqualified_name(basename.clone()),
         )))
+    }
+    fn action_entities(&self) -> std::iter::Empty<Arc<Entity>> {
+        std::iter::empty()
     }
 }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -3506,7 +3506,7 @@ pub mod test {
     fn eval_and_or() -> Result<()> {
         use crate::parser;
         let request = basic_request();
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
@@ -3619,7 +3619,7 @@ pub mod test {
     #[test]
     fn template_env_tests() {
         let request = basic_request();
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
@@ -3676,7 +3676,7 @@ pub mod test {
             EntityUID::with_eid("r"),
             Context::empty(),
         );
-        let eparser: EntityJsonParser<'_> =
+        let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -864,6 +864,7 @@ pub mod test {
             ],
             None::<&NoEntitiesSchema>,
             TCComputation::ComputeNow,
+            Extensions::none(),
         )
         .expect("failed to create basic entities")
     }
@@ -917,6 +918,7 @@ pub mod test {
             ],
             None::<&NoEntitiesSchema>,
             TCComputation::ComputeNow,
+            Extensions::all_available(),
         )
         .expect("Failed to create rich entities")
     }
@@ -3003,6 +3005,7 @@ pub mod test {
             vec![alice],
             None::<&NoEntitiesSchema>,
             TCComputation::AssumeAlreadyComputed,
+            Extensions::all_available(),
         )
         .expect("failed to create basic entities");
         let exts = Extensions::none();

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -827,7 +827,7 @@ pub mod test {
     use super::*;
 
     use crate::{
-        entities::{EntityJsonParser, TCComputation},
+        entities::{EntityJsonParser, NoEntitiesSchema, TCComputation},
         parser::{self, parse_policyset},
         parser::{parse_expr, parse_policy_template},
     };
@@ -862,6 +862,7 @@ pub mod test {
                 Entity::with_uid(EntityUID::with_eid("test_action")),
                 Entity::with_uid(EntityUID::with_eid("test_resource")),
             ],
+            None::<&NoEntitiesSchema>,
             TCComputation::ComputeNow,
         )
         .expect("failed to create basic entities")
@@ -914,6 +915,7 @@ pub mod test {
                 sibling,
                 unrelated,
             ],
+            None::<&NoEntitiesSchema>,
             TCComputation::ComputeNow,
         )
         .expect("Failed to create rich entities")
@@ -2997,8 +2999,12 @@ pub mod test {
         let mut alice = Entity::with_uid(EntityUID::with_eid("Alice"));
         let parent = Entity::with_uid(EntityUID::with_eid("Friends"));
         alice.add_ancestor(parent.uid());
-        let entities = Entities::from_entities(vec![alice], TCComputation::AssumeAlreadyComputed)
-            .expect("failed to create basic entities");
+        let entities = Entities::from_entities(
+            vec![alice],
+            None::<&NoEntitiesSchema>,
+            TCComputation::AssumeAlreadyComputed,
+        )
+        .expect("failed to create basic entities");
         let exts = Extensions::none();
         let eval = Evaluator::new(&request, &entities, &exts).expect("failed to create evaluator");
         assert_eq!(

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -39,8 +39,8 @@ lazy_static::lazy_static! {
 
 /// Holds data on all the Extensions which are active for a given evaluation.
 ///
-/// Clone is cheap for this type.
-#[derive(Debug, Clone)]
+/// Clone is cheap for this type, and in fact we commit to this by marking it Copy
+#[derive(Debug, Clone, Copy)]
 pub struct Extensions<'a> {
     /// the actual extensions
     extensions: &'a [Extension],

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1277,6 +1277,7 @@ impl<'a> CoreSchema<'a> {
 
 impl<'a> cedar_policy_core::entities::Schema for CoreSchema<'a> {
     type EntityTypeDescription = EntityTypeDescription;
+    type ActionEntityIterator = Vec<Arc<Entity>>;
 
     fn entity_type(
         &self,
@@ -1305,6 +1306,10 @@ impl<'a> cedar_policy_core::entities::Schema for CoreSchema<'a> {
                 None
             }
         }))
+    }
+
+    fn action_entities(&self) -> Self::ActionEntityIterator {
+        self.actions.values().map(Arc::clone).collect()
     }
 }
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1216,7 +1216,8 @@ impl ValidatorSchema {
         })
     }
 
-    /// Construct an `Entity` object for each action in the schema
+    /// Invert the action hierarchy to get the ancestor relation expected for
+    /// the `Entity` datatype instead of descendant as stored by the schema.
     fn action_entities_iter(&self) -> impl Iterator<Item = cedar_policy_core::ast::Entity> + '_ {
         // We could store the un-inverted `memberOf` relation for each action,
         // but I [john-h-kastner-aws] judge that the current implementation is
@@ -1241,11 +1242,11 @@ impl ValidatorSchema {
         })
     }
 
-    /// Invert the action hierarchy to get the ancestor relation expected for
-    /// the `Entity` datatype instead of descendant as stored by the schema.
+    /// Construct an `Entity` object for each action in the schema
     pub fn action_entities(&self) -> cedar_policy_core::entities::Result<Entities> {
         Entities::from_entities(
             self.action_entities_iter(),
+            None::<&cedar_policy_core::entities::NoEntitiesSchema>, // we don't want to tell `Entities::from_entities()` to add the schema's action entities, that would infinitely recurse
             TCComputation::AssumeAlreadyComputed,
         )
     }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -26,6 +26,7 @@ use std::sync::Arc;
 use cedar_policy_core::{
     ast::{Eid, Entity, EntityType, EntityUID, Id, Name, RestrictedExpr},
     entities::{Entities, JSONValue, TCComputation},
+    extensions::Extensions,
     parser::err::ParseErrors,
     transitive_closure::{compute_tc, TCNode},
     FromNormalizedStr,
@@ -1248,6 +1249,7 @@ impl ValidatorSchema {
             self.action_entities_iter(),
             None::<&cedar_policy_core::entities::NoEntitiesSchema>, // we don't want to tell `Entities::from_entities()` to add the schema's action entities, that would infinitely recurse
             TCComputation::AssumeAlreadyComputed,
+            Extensions::all_available(),
         )
     }
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added an API, `unknown_entities`, to `PolicySet` to collect unknown entity UIDs from `PartialResponse`.
 - Added APIs `remove`, `remove_template` and `unlink` to remove policies from the `PolicySet`
 - Added API `get_linked_policies` to get the policies linked to a `Template`
+- Added `Entity::validate()` to validate an entity against a `Schema`
 
 ### Changed
 
@@ -22,6 +23,10 @@
 - The `Response::new()` constructor now expects a `Vec<AuthorizationError>` as its third argument.
 - Implements RFC #19, making validation slightly more strict, but more explainable.
 - Improved formatting for error messages.
+- `Entities::from_*()` methods now automatically add action entities present in the `schema`
+  to the constructed `Entities`, if a `schema` is provided
+- `Entities::from_*()` methods now validate the entities against the `schema`, if a `schema`
+  is provided
 
 ## 2.4.1
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -283,9 +283,7 @@ impl Entities {
             Extensions::all_available(),
             entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser
-            .iter_from_json_str(json)?
-            .collect::<Result<Vec<_>, _>>()?;
+        let new_entities = eparser.iter_from_json_str(json)?;
         Ok(Self(self.0.add_entities(
             new_entities,
             entities::TCComputation::ComputeNow,
@@ -309,9 +307,7 @@ impl Entities {
             Extensions::all_available(),
             entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser
-            .iter_from_json_value(json)?
-            .collect::<Result<Vec<_>, _>>()?;
+        let new_entities = eparser.iter_from_json_value(json)?;
         Ok(Self(self.0.add_entities(
             new_entities,
             entities::TCComputation::ComputeNow,
@@ -335,9 +331,7 @@ impl Entities {
             Extensions::all_available(),
             entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser
-            .iter_from_json_file(json)?
-            .collect::<Result<Vec<_>, _>>()?;
+        let new_entities = eparser.iter_from_json_file(json)?;
         Ok(Self(self.0.add_entities(
             new_entities,
             entities::TCComputation::ComputeNow,
@@ -4651,7 +4645,8 @@ mod schema_based_parsing_tests {
         // but with schema-based parsing, we get these other types
         let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect("Should parse without error");
-        assert_eq!(parsed.iter().count(), 1);
+        assert_eq!(parsed.iter().count(), 2); // Employee::"12UA45" and the one action
+        assert_eq!(parsed.iter().filter(|e| e.0.uid().is_action()).count(), 1);
         let parsed = parsed
             .get(&EntityUid::from_strs("Employee", "12UA45"))
             .expect("that should be the employee id");
@@ -5023,7 +5018,8 @@ mod schema_based_parsing_tests {
         );
         let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect("Should parse without error");
-        assert_eq!(parsed.iter().count(), 1);
+        assert_eq!(parsed.iter().count(), 2); // XYZCorp::Employee::"12UA45" and one action
+        assert_eq!(parsed.iter().filter(|e| e.0.uid().is_action()).count(), 1);
         let parsed = parsed
             .get(&EntityUid::from_strs("XYZCorp::Employee", "12UA45"))
             .expect("that should be the employee type and id");
@@ -5104,7 +5100,8 @@ mod schema_based_parsing_tests {
         );
         let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect("Should parse without error");
-        assert_eq!(parsed.iter().count(), 1);
+        assert_eq!(parsed.iter().count(), 2); // Employee::"12UA45" and one action
+        assert_eq!(parsed.iter().filter(|e| e.0.uid().is_action()).count(), 1);
 
         // "department" shouldn't be required
         let entitiesjson = json!(
@@ -5121,7 +5118,8 @@ mod schema_based_parsing_tests {
         );
         let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect("Should parse without error");
-        assert_eq!(parsed.iter().count(), 1);
+        assert_eq!(parsed.iter().count(), 2); // Employee::"12UA45" and the one action
+        assert_eq!(parsed.iter().filter(|e| e.0.uid().is_action()).count(), 1);
     }
 
     /// Test that involves open entities

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -262,6 +262,7 @@ impl Entities {
                 .map(|s| cedar_policy_validator::CoreSchema::new(&s.0))
                 .as_ref(),
             entities::TCComputation::ComputeNow,
+            Extensions::all_available(),
         )
         .map(Entities)
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -26,7 +26,7 @@ use cedar_policy_core::ast;
 use cedar_policy_core::ast::RestrictedExprError;
 use cedar_policy_core::authorizer;
 pub use cedar_policy_core::authorizer::AuthorizationError;
-use cedar_policy_core::entities;
+use cedar_policy_core::entities::{self, EntitySchemaConformanceChecker};
 use cedar_policy_core::entities::JsonDeserializationErrorContext;
 use cedar_policy_core::entities::{ContextSchema, Dereference, JsonDeserializationError};
 use cedar_policy_core::est;
@@ -187,6 +187,15 @@ impl Entity {
                 .interpret(expr.as_borrowed())
                 .map(EvalResult::from),
         )
+    }
+
+    /// Validate this `Entity` against the given `schema`.
+    ///
+    /// If the entity does not conform to the `schema`, an error is returned.
+    pub fn validate(&self, schema: &Schema) -> Result<(), impl std::error::Error> {
+        let schema = cedar_policy_validator::CoreSchema::new(&schema.0);
+        let checker = EntitySchemaConformanceChecker::new(&schema, Extensions::all_available());
+        checker.validate_entity(&self.0)
     }
 }
 


### PR DESCRIPTION
## Description of changes

- `Entities::from_*()` now automatically adds action entities from the `schema`, if a `schema` is provided
- `Entities::from_*()` now validates entities against the `schema`, if a `schema` is provided
- `Entities::add_*()` now validates entities against the `schema`, if a `schema` is provided
- Adds `Entity::validate()` to the public API, which validates a single entity against a schema
- Significant refactoring of entity-validation code in Core to facilitate all of the above changes
- includes refactoring of some errors and tweaks to some error messages
- some small refactors are also included in this PR that could technically be independent, e.g. passing schemas by reference to `EntityJsonParser`. If folks feel it's important, I can split those into a separate PR to declutter this one slightly.  But this one is probably going to be a big PR regardless

As of this writing, I have not written tests for these changes. Marking as draft to get reviews while I work on tests.

## Issue #, if available

Fixes #286

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
