### PR TITLE
Improvement/aaronjeline/infallible parsing

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -32,6 +32,7 @@
 	+ Template instantiation records
 	+ Entity slice JSONs
 	+ Context JSONs
+- `EntityId::FromStr::Error` is now `Infallible` instead of `ParseErrors`
 
 ## 2.4.1
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -45,6 +45,7 @@ use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::convert::Infallible;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -1368,7 +1369,7 @@ impl<'a> From<cedar_policy_validator::ValidationWarning<'a>> for ValidationWarni
 pub struct EntityId(ast::Eid);
 
 impl FromStr for EntityId {
-    type Err = ParseErrors;
+    type Err = Infallible;
     fn from_str(eid_str: &str) -> Result<Self, Self::Err> {
         Ok(Self(ast::Eid::new(eid_str)))
     }

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -288,17 +288,16 @@ fn parse_instantiation(v: &Link) -> Result<(SlotId, EntityUid), Vec<String>> {
         }
     };
     let type_name = EntityTypeName::from_str(v.value.ty.as_str());
-    let eid = EntityId::from_str(v.value.eid.as_str());
-    match (type_name, eid) {
-        (Ok(type_name), Ok(eid)) => {
+    let eid = match EntityId::from_str(v.value.eid.as_str()) {
+        Ok(eid) => eid,
+        Err(err) => match err {},
+    };
+    match type_name {
+        Ok(type_name) => {
             let entity_uid = EntityUid::from_type_name_and_id(type_name, eid);
             Ok((slot, entity_uid))
         }
-        (Ok(_), Err(e)) | (Err(e), Ok(_)) => Err(e.errors_as_strings()),
-        (Err(mut e1), Err(mut e2)) => {
-            e1.0.append(&mut e2.0);
-            Err(ParseErrors(e1.0).errors_as_strings())
-        }
+        Err(e) => Err(e.errors_as_strings()),
     }
 }
 


### PR DESCRIPTION
## Description of changes
Parsing eids always suceeds, so it's `Error` type should be `Infallible`, not `ParseErrors`
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
