### PR TITLE
Implement RFC 20

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -416,6 +416,12 @@ impl Expr {
     }
 
     /// Create an `Expr` which evaluates to a Record with the given key-value mapping.
+    ///
+    /// If you have an iterator of pairs, generally prefer calling
+    /// `Expr::record()` instead of `.collect()`-ing yourself and calling this,
+    /// potentially for efficiency reasons but also because `Expr::record()`
+    /// will properly handle duplicate keys but your own `.collect()` will not
+    /// (by default).
     pub fn record_arc(map: Arc<BTreeMap<SmolStr, Expr>>) -> Self {
         ExprBuilder::new().record_arc(map)
     }
@@ -1070,6 +1076,11 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an `Expr` which evalutes to a Record with the given key-value mapping.
+    ///
+    /// If you have an iterator of pairs, generally prefer calling `.record()`
+    /// instead of `.collect()`-ing yourself and calling this, potentially for
+    /// efficiency reasons but also because `.record()` will properly handle
+    /// duplicate keys but your own `.collect()` will not (by default).
     pub fn record_arc(self, map: Arc<BTreeMap<SmolStr, Expr<T>>>) -> Expr<T> {
         self.with_expr_kind(ExprKind::Record(map))
     }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -23,8 +23,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::{
-    collections::HashMap,
-    collections::HashSet,
+    collections::{BTreeMap, HashMap},
     hash::{Hash, Hasher},
     mem,
     sync::Arc,
@@ -155,11 +154,7 @@ pub enum ExprKind<T = ()> {
     // evaluated into `Value`s
     Set(Arc<Vec<Expr<T>>>),
     /// Anonymous record (whose elements may be arbitrary expressions)
-    /// This is a `Vec` for the same reason as above.
-    Record {
-        /// key/value pairs
-        pairs: Arc<Vec<(SmolStr, Expr<T>)>>,
-    },
+    Record(Arc<BTreeMap<SmolStr, Expr<T>>>),
 }
 
 impl From<Value> for Expr {
@@ -276,15 +271,7 @@ impl<T> Expr<T> {
             ExprKind::Unknown { .. } => true,
             ExprKind::Set(_) => true,
             ExprKind::Var(_) => true,
-            ExprKind::Record { pairs } => {
-                // We need to ensure there are no duplicate keys in the expression
-                let uniq_keys = pairs
-                    .as_ref()
-                    .iter()
-                    .map(|(key, _)| key)
-                    .collect::<HashSet<_>>();
-                pairs.len() == uniq_keys.len()
-            }
+            ExprKind::Record(_) => true,
             _ => false,
         })
     }
@@ -425,6 +412,11 @@ impl Expr {
         ExprBuilder::new().record(pairs)
     }
 
+    /// Create an `Expr` which evaluates to a Record with the given key-value mapping.
+    pub fn record_arc(map: Arc<BTreeMap<SmolStr, Expr>>) -> Self {
+        ExprBuilder::new().record_arc(map)
+    }
+
     /// Create an `Expr` which calls the extension function with the given
     /// `Name` on `args`
     pub fn call_extension_fn(fn_name: Name, args: Vec<Expr>) -> Self {
@@ -556,12 +548,12 @@ impl Expr {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Expr::set(members))
             }
-            ExprKind::Record { pairs } => {
-                let pairs = pairs
+            ExprKind::Record(map) => {
+                let map = map
                     .iter()
                     .map(|(name, e)| Ok((name.clone(), e.substitute(definitions)?)))
-                    .collect::<Result<Vec<_>, _>>()?;
-                Ok(Expr::record(pairs))
+                    .collect::<Result<BTreeMap<_, _>, _>>()?;
+                Ok(Expr::record(map))
             }
             ExprKind::MulByConst { arg, constant } => {
                 Ok(Expr::mul(arg.substitute(definitions)?, *constant))
@@ -717,11 +709,10 @@ impl std::fmt::Display for Expr {
                 write!(f, "{} like \"{}\"", maybe_with_parens(expr), pattern,)
             }
             ExprKind::Set(v) => write!(f, "[{}]", v.iter().join(", ")),
-            ExprKind::Record { pairs } => write!(
+            ExprKind::Record(m) => write!(
                 f,
                 "{{{}}}",
-                pairs
-                    .iter()
+                m.iter()
                     .map(|(k, v)| format!("\"{}\": {}", k.escape_debug(), v))
                     .join(", ")
             ),
@@ -1053,9 +1044,12 @@ impl<T> ExprBuilder<T> {
 
     /// Create an `Expr` which evaluates to a Record with the given (key, value) pairs.
     pub fn record(self, pairs: impl IntoIterator<Item = (SmolStr, Expr<T>)>) -> Expr<T> {
-        self.with_expr_kind(ExprKind::Record {
-            pairs: Arc::new(pairs.into_iter().collect()),
-        })
+        self.with_expr_kind(ExprKind::Record(Arc::new(pairs.into_iter().collect())))
+    }
+
+    /// Create an `Expr` which evalutes to a Record with the given key-value mapping.
+    pub fn record_arc(self, map: Arc<BTreeMap<SmolStr, Expr<T>>>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Record(map))
     }
 
     /// Create an `Expr` which calls the extension function with the given
@@ -1281,10 +1275,13 @@ impl<T> Expr<T> {
                 .iter()
                 .zip(elems1.iter())
                 .all(|(e, e1)| e.eq_shape(e1)),
-            (Record { pairs }, Record { pairs: pairs1 }) => pairs
-                .iter()
-                .zip(pairs1.iter())
-                .all(|((a, e), (a1, e1))| a == a1 && e.eq_shape(e1)),
+            (Record(map), Record(map1)) => {
+                map.len() == map1.len()
+                    && map
+                        .iter()
+                        .zip(map1.iter()) // relying on BTreeMap producing an iterator sorted by key
+                        .all(|((a, e), (a1, e1))| a == a1 && e.eq_shape(e1))
+            }
             _ => false,
         }
     }
@@ -1363,9 +1360,9 @@ impl<T> Expr<T> {
                     e.hash_shape(state);
                 })
             }
-            ExprKind::Record { pairs } => {
-                state.write_usize(pairs.len());
-                pairs.iter().for_each(|(s, a)| {
+            ExprKind::Record(map) => {
+                state.write_usize(map.len());
+                map.iter().for_each(|(s, a)| {
                     s.hash(state);
                     a.hash_shape(state);
                 });

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -89,14 +89,10 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
                 self.expression_stack.push(expr);
             }
             ExprKind::Set(elems) => {
-                for expr in elems.as_ref() {
-                    self.expression_stack.push(expr);
-                }
+                self.expression_stack.extend(elems.as_ref());
             }
-            ExprKind::Record { pairs } => {
-                for (_, val_expr) in pairs.as_ref() {
-                    self.expression_stack.push(val_expr);
-                }
+            ExprKind::Record(map) => {
+                self.expression_stack.extend(map.values());
             }
         }
         Some(next_expr)

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -229,7 +229,8 @@ mod test {
         let e = Expr::record(vec![
             ("test".into(), Expr::val(true)),
             ("another".into(), Expr::val(false)),
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             e.subexpressions().collect::<HashSet<_>>(),
             HashSet::from([&e, &Expr::val(false), &Expr::val(true)])

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -226,7 +226,7 @@ impl Context {
         // PANIC SAFETY invariant on `self.context` ensures that it is a Record
         #[allow(clippy::panic)]
         match self.context.as_ref().expr_kind() {
-            ExprKind::Record { pairs } => pairs
+            ExprKind::Record(map) => map
                 .iter()
                 .map(|(k, v)| (k.as_str(), BorrowedRestrictedExpr::new_unchecked(v))), // given that the invariant holds for `self.context`, it will hold here
             e => panic!("internal invariant violation: expected Expr::Record, got {e:?}"),

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::{Expr, ExprKind, Literal, Name};
+use super::{Expr, ExprConstructionError, ExprKind, Literal, Name};
 use crate::entities::JsonSerializationError;
 use crate::parser;
 use crate::parser::err::ParseErrors;
@@ -98,12 +98,19 @@ impl RestrictedExpr {
         Self::new_unchecked(Expr::set(exprs.into_iter().map(Into::into)))
     }
 
-    /// Create a `RestrictedExpr` which evaluates to a Record with the given (key, value) pairs.
-    pub fn record(pairs: impl IntoIterator<Item = (SmolStr, RestrictedExpr)>) -> Self {
+    /// Create a `RestrictedExpr` which evaluates to a Record with the given
+    /// (key, value) pairs.
+    ///
+    /// Throws an error if any key occurs two or more times.
+    pub fn record(
+        pairs: impl IntoIterator<Item = (SmolStr, RestrictedExpr)>,
+    ) -> Result<Self, ExprConstructionError> {
         // Record expressions are valid restricted-exprs if their elements are;
         // and we know the elements are because we require `RestrictedExpr`s in
         // the parameter
-        Self::new_unchecked(Expr::record(pairs.into_iter().map(|(k, v)| (k, v.into()))))
+        Ok(Self::new_unchecked(Expr::record(
+            pairs.into_iter().map(|(k, v)| (k, v.into())),
+        )?))
     }
 
     /// Create a `RestrictedExpr` which calls the given extension function
@@ -340,4 +347,61 @@ pub enum RestrictedExprError {
     /// Failed to parse the expression that the restricted expression wraps.
     #[error("failed to parse restricted expression: {0}")]
     Parse(#[from] ParseErrors),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::parser::err::{ParseError, ToASTError};
+    use std::str::FromStr;
+
+    #[test]
+    fn duplicate_key() {
+        // duplicate key is an error when mapped to values of different types
+        assert_eq!(
+            RestrictedExpr::record([
+                ("foo".into(), RestrictedExpr::val(37),),
+                ("foo".into(), RestrictedExpr::val("hello"),),
+            ]),
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "foo".into() })
+        );
+
+        // duplicate key is an error when mapped to different values of same type
+        assert_eq!(
+            RestrictedExpr::record([
+                ("foo".into(), RestrictedExpr::val(37),),
+                ("foo".into(), RestrictedExpr::val(101),),
+            ]),
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "foo".into() })
+        );
+
+        // duplicate key is an error when mapped to the same value multiple times
+        assert_eq!(
+            RestrictedExpr::record([
+                ("foo".into(), RestrictedExpr::val(37),),
+                ("foo".into(), RestrictedExpr::val(37),),
+            ]),
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "foo".into() })
+        );
+
+        // duplicate key is an error even when other keys appear in between
+        assert_eq!(
+            RestrictedExpr::record([
+                ("bar".into(), RestrictedExpr::val(-3),),
+                ("foo".into(), RestrictedExpr::val(37),),
+                ("spam".into(), RestrictedExpr::val("eggs"),),
+                ("foo".into(), RestrictedExpr::val(37),),
+                ("eggs".into(), RestrictedExpr::val("spam"),),
+            ]),
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "foo".into() })
+        );
+
+        // duplicate key is also an error when parsing from string
+        assert_eq!(
+            RestrictedExpr::from_str(r#"{ foo: 37, bar: "hi", foo: 101 }"#),
+            Err(RestrictedExprError::Parse(ParseErrors(vec![
+                ParseError::ToAST(ToASTError::DuplicateKeyInRecordLiteral { key: "foo".into() })
+            ]))),
+        )
+    }
 }

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -227,7 +227,7 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExprError> {
         }),
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
-        ExprKind::Record { pairs } => pairs.iter().map(|(_, v)| v).try_for_each(is_restricted),
+        ExprKind::Record(map) => map.values().try_for_each(is_restricted),
     }
 }
 

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -72,7 +72,7 @@ impl TryFrom<Expr> for Value {
                 .map(|e| e.clone().try_into())
                 .collect::<Result<Set, _>>()
                 .map(Value::Set),
-            ExprKind::Record { pairs } => pairs
+            ExprKind::Record(map) => map
                 .iter()
                 .map(|(k, v)| v.clone().try_into().map(|v: Value| (k.clone(), v)))
                 .collect::<Result<BTreeMap<SmolStr, Value>, _>>()

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -520,10 +520,13 @@ mod test {
 
     #[test]
     fn authorizer_sanity_check_partial_deny() {
-        let context = Context::from_expr(RestrictedExpr::record([(
-            "test".into(),
-            RestrictedExpr::new(Expr::unknown("name")).unwrap(),
-        )]))
+        let context = Context::from_expr(
+            RestrictedExpr::record([(
+                "test".into(),
+                RestrictedExpr::new(Expr::unknown("name")).unwrap(),
+            )])
+            .unwrap(),
+        )
         .unwrap();
         let a = Authorizer::new();
         let q = Request::new(

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1294,7 +1294,8 @@ mod json_parsing_tests {
             .from_json_str(json)
             .expect_err("should fail due to duplicate key in record");
         assert!(
-            err.to_string().contains(r#"duplicate key error for `bar`"#),
+            err.to_string()
+                .contains(r#"the key `bar` occurs two or more times in the same JSON object"#),
             "actual error message was {err}"
         );
     }

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1534,28 +1534,28 @@ mod schema_based_parsing_tests {
         let json_blob = parsed
             .get("json_blob")
             .expect("json_blob attr should exist");
-        let ExprKind::Record { pairs } = json_blob.expr_kind() else {
+        let ExprKind::Record(map) = json_blob.expr_kind() else {
             panic!("expected json_blob to be a Record")
         };
-        let (_, inner1) = pairs
+        let (_, inner1) = map
             .iter()
-            .find(|(k, _)| k == "inner1")
+            .find(|(k, _)| *k == "inner1")
             .expect("inner1 attr should exist");
         assert!(matches!(
             inner1.expr_kind(),
             &ExprKind::Lit(Literal::Bool(_))
         ));
-        let (_, inner3) = pairs
+        let (_, inner3) = map
             .iter()
-            .find(|(k, _)| k == "inner3")
+            .find(|(k, _)| *k == "inner3")
             .expect("inner3 attr should exist");
         assert!(matches!(inner3.expr_kind(), &ExprKind::Record { .. }));
-        let ExprKind::Record { pairs: innerpairs } = inner3.expr_kind() else {
+        let ExprKind::Record(innermap) = inner3.expr_kind() else {
             panic!("already checked it was Record")
         };
-        let (_, innerinner) = innerpairs
+        let (_, innerinner) = innermap
             .iter()
-            .find(|(k, _)| k == "innerinner")
+            .find(|(k, _)| *k == "innerinner")
             .expect("innerinner attr should exist");
         assert!(matches!(innerinner.expr_kind(), &ExprKind::Record { .. }));
 
@@ -1618,28 +1618,28 @@ mod schema_based_parsing_tests {
         let json_blob = parsed
             .get("json_blob")
             .expect("json_blob attr should exist");
-        let ExprKind::Record { pairs } = json_blob.expr_kind() else {
+        let ExprKind::Record(map) = json_blob.expr_kind() else {
             panic!("expected json_blob to be a Record")
         };
-        let (_, inner1) = pairs
+        let (_, inner1) = map
             .iter()
-            .find(|(k, _)| k == "inner1")
+            .find(|(k, _)| *k == "inner1")
             .expect("inner1 attr should exist");
         assert!(matches!(
             inner1.expr_kind(),
             &ExprKind::Lit(Literal::Bool(_))
         ));
-        let (_, inner3) = pairs
+        let (_, inner3) = map
             .iter()
-            .find(|(k, _)| k == "inner3")
+            .find(|(k, _)| *k == "inner3")
             .expect("inner3 attr should exist");
         assert!(matches!(inner3.expr_kind(), &ExprKind::Record { .. }));
-        let ExprKind::Record { pairs: innerpairs } = inner3.expr_kind() else {
+        let ExprKind::Record(innermap) = inner3.expr_kind() else {
             panic!("already checked it was Record")
         };
-        let (_, innerinner) = innerpairs
+        let (_, innerinner) = innermap
             .iter()
-            .find(|(k, _)| k == "innerinner")
+            .find(|(k, _)| *k == "innerinner")
             .expect("innerinner attr should exist");
         assert!(matches!(
             innerinner.expr_kind(),

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -487,6 +487,7 @@ pub enum TCComputation {
 mod json_parsing_tests {
     use super::*;
     use crate::{extensions::Extensions, transitive_closure::TcError};
+    use cool_asserts::assert_matches;
 
     #[test]
     fn enforces_tc_fail_cycle_almost() {
@@ -892,7 +893,7 @@ mod json_parsing_tests {
         );
         assert_attr_vals_are_shape_equal(
             alice.get("waffles"),
-            &RestrictedExpr::record([("key".into(), RestrictedExpr::val("value"))]),
+            &RestrictedExpr::record([("key".into(), RestrictedExpr::val("value"))]).unwrap(),
         );
         assert_attr_vals_are_shape_equal(
             alice.get("toast"),
@@ -1002,8 +1003,7 @@ mod json_parsing_tests {
                     err.to_string().contains(
                         r#"in uid field of <unknown entity>, expected a literal entity reference, but got `"hello"`"#
                     ),
-                    "actual error message was {}",
-                    err
+                    "actual error message was {err}"
                 )
             }
             _ => panic!("expected deserialization error, got a different error: {err}"),
@@ -1025,8 +1025,7 @@ mod json_parsing_tests {
             EntitiesError::Deserialization(err) => assert!(
                 err.to_string()
                     .contains(r#"expected a literal entity reference, but got `"hello"`"#),
-                "actual error message was {}",
-                err
+                "actual error message was {err}"
             ),
             _ => panic!("expected deserialization error, got a different error: {err}"),
         }
@@ -1155,7 +1154,8 @@ mod json_parsing_tests {
                             "another".into(),
                             RestrictedExpr::val(EntityUID::with_eid("foo")),
                         ),
-                    ]),
+                    ])
+                    .unwrap(),
                 ),
                 (
                     "src_ip".into(),
@@ -1193,7 +1193,7 @@ mod json_parsing_tests {
             [(
                 // record literal that happens to look like an escape
                 "oops".into(),
-                RestrictedExpr::record([("__entity".into(), RestrictedExpr::val("hi"))]),
+                RestrictedExpr::record([("__entity".into(), RestrictedExpr::val("hi"))]).unwrap(),
             )]
             .into_iter()
             .collect(),
@@ -1242,8 +1242,60 @@ mod json_parsing_tests {
             err.to_string().contains(
                 r#"action `XYZ::Action::"view"` has a non-action parent `User::"alice"`"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
+        );
+    }
+
+    /// test that non-Action having an Action parent is not an error
+    /// (not sure if this was intentional? but it's the current behavior, and if
+    /// that behavior changes, we want to know)
+    #[test]
+    fn not_bad_action_parent() {
+        let json = serde_json::json!(
+            [
+                {
+                    "uid": { "type": "User", "id": "alice" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "XYZ::Action", "id": "view" },
+                    ]
+                }
+            ]
+        );
+        let eparser: EntityJsonParser<'_> =
+            EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
+        assert_matches!(eparser.from_json_value(json), Ok(_));
+    }
+
+    /// test that duplicate keys in a record is an error
+    #[test]
+    fn duplicate_keys() {
+        // this test uses string JSON because it needs to specify JSON containing duplicate
+        // keys, and the `json!` macro would already eliminate the duplicate keys
+        let json = r#"
+            [
+                {
+                    "uid": { "type": "User", "id": "alice "},
+                    "attrs": {
+                        "foo": {
+                            "hello": "goodbye",
+                            "bar": 2,
+                            "spam": "eggs",
+                            "bar": 3
+                        }
+                    },
+                    "parents": []
+                }
+            ]
+        "#;
+        let eparser: EntityJsonParser<'_> =
+            EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
+        let err = eparser
+            .from_json_str(json)
+            .expect_err("should fail due to duplicate key in record");
+        assert!(
+            err.to_string().contains(r#"duplicate key error for `bar`"#),
+            "actual error message was {err}"
         );
     }
 }
@@ -1709,8 +1761,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
             err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but actually has type string"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -1756,8 +1807,7 @@ mod schema_based_parsing_tests {
         assert!(
             err.to_string()
                 .contains(r#"in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -1799,8 +1849,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
             err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but actually has type record"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -1845,8 +1894,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on manager");
         assert!(
             err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but actually has type (entity of type `HR`)"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -1892,8 +1940,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
             err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -1937,8 +1984,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to missing attribute \"inner2\"");
         assert!(
             err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -1983,8 +2029,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to type mismatch on attribute \"inner1\"");
         assert!(
             err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type record with attributes: "#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
 
         let entitiesjson = json!(
@@ -2061,8 +2106,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to unexpected attribute \"inner4\"");
         assert!(
             err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, record attribute `inner4` should not exist"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2105,8 +2149,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to missing attribute \"numDirectReports\"");
         assert!(
             err.to_string().contains(r#"expected entity `Employee::"12UA45"` to have an attribute `numDirectReports`, but it does not"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2154,8 +2197,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"attribute `wat` on `Employee::"12UA45"` should not exist according to the schema"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2204,8 +2246,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"`Employee::"12UA45"` is not allowed to have a parent of type `Employee` according to the schema"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2233,8 +2274,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"entity `CEO::"abcdef"` has type `CEO` which is not declared in the schema"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2262,8 +2302,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"found action entity `Action::"update"`, but it was not declared as an action in the schema"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2328,8 +2367,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"definition of action `Action::"view"` does not match its schema declaration"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2361,8 +2399,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"definition of action `Action::"view"` does not match its schema declaration"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2392,8 +2429,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"definition of action `Action::"view"` does not match its schema declaration"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2426,8 +2462,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"definition of action `Action::"view"` does not match its schema declaration"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2457,8 +2492,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"definition of action `Action::"view"` does not match its schema declaration"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2491,8 +2525,7 @@ mod schema_based_parsing_tests {
             err.to_string().contains(
                 r#"definition of action `Action::"view"` does not match its schema declaration"#
             ),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 
@@ -2628,8 +2661,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
             err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but actually has type (entity of type `Employee`)"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
 
         let entitiesjson = json!(
@@ -2651,8 +2683,7 @@ mod schema_based_parsing_tests {
             .expect_err("should fail due to employee being wrong entity type (missing namespace)");
         assert!(
             err.to_string().contains(r#"`Employee::"12UA45"` has type `Employee` which is not declared in the schema. Did you mean `XYZCorp::Employee`?"#),
-            "actual error message was {}",
-            err
+            "actual error message was {err}"
         );
     }
 }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -18,7 +18,7 @@ use std::fmt::Display;
 
 use super::SchemaType;
 use crate::ast::{
-    EntityType, EntityUID, Expr, ExprKind, Name, RestrictedExpr, RestrictedExprError,
+    EntityType, EntityUID, Expr, ExprKind, Name, PolicyID, RestrictedExpr, RestrictedExprError,
 };
 use crate::extensions::ExtensionFunctionLookupError;
 use crate::parser::err::ParseErrors;
@@ -201,6 +201,14 @@ pub enum JsonDeserializationError {
         /// Second element type which was found
         ty2: Box<SchemaType>,
     },
+    /// The same key appears two or more times in a single record literal
+    #[error("{ctx}, duplicate key `{key}` in record literal")]
+    DuplicateKeyInRecordLiteral {
+        /// Context of this error
+        ctx: Box<JsonDeserializationErrorContext>,
+        /// The key that appeared two or more times
+        key: SmolStr,
+    },
     /// During schema-based parsing, found a parent of a type that's not allowed
     /// for that entity
     #[error(
@@ -273,6 +281,11 @@ pub enum JsonDeserializationErrorContext {
     EntityUid,
     /// The error occurred while deserializing the `Context`.
     Context,
+    /// The error occurred while deserializing a policy in JSON (EST) form.
+    Policy {
+        /// ID of the policy we were deserializing
+        id: PolicyID,
+    },
 }
 
 impl std::fmt::Display for JsonDeserializationErrorContext {
@@ -282,6 +295,7 @@ impl std::fmt::Display for JsonDeserializationErrorContext {
             Self::EntityParents { uid } => write!(f, "in parents field of `{uid}`"),
             Self::EntityUid => write!(f, "in uid field of <unknown entity>"),
             Self::Context => write!(f, "while parsing context"),
+            Self::Policy { id } => write!(f, "while parsing JSON policy `{id}`"),
         }
     }
 }

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -19,14 +19,16 @@ use super::{
     JsonSerializationError, SchemaType,
 };
 use crate::ast::{
-    BorrowedRestrictedExpr, Eid, EntityUID, Expr, ExprKind, Literal, Name, RestrictedExpr,
+    BorrowedRestrictedExpr, Eid, EntityUID, Expr, ExprConstructionError, ExprKind, Literal, Name,
+    RestrictedExpr,
 };
 use crate::entities::EscapeKind;
 use crate::extensions::{ExtensionFunctionLookupError, Extensions};
 use crate::FromNormalizedStr;
 use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
 use smol_str::SmolStr;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// The canonical JSON representation of a Cedar value.
 /// Many Cedar values have a natural one-to-one mapping to and from JSON values.
@@ -92,8 +94,49 @@ pub enum CedarValueJson {
     /// heterogeneously
     Set(Vec<CedarValueJson>),
     /// JSON object => Cedar record; must have string keys, but values
-    /// can be any `CedarValueJson`s, even heterogeneously
-    Record(HashMap<SmolStr, CedarValueJson>),
+    /// can be any JSONValues, even heterogeneously
+    Record(JsonRecord),
+}
+
+/// Structure representing a Cedar record in JSON
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct JsonRecord {
+    /// Cedar records must have string keys, but values can be any
+    /// `CedarValueJson`s, even heterogeneously
+    #[serde_as(as = "serde_with::MapPreventDuplicates<_, _>")]
+    #[serde(flatten)]
+    values: BTreeMap<SmolStr, CedarValueJson>,
+}
+
+impl IntoIterator for JsonRecord {
+    type Item = (SmolStr, CedarValueJson);
+    type IntoIter = <BTreeMap<SmolStr, CedarValueJson> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a JsonRecord {
+    type Item = (&'a SmolStr, &'a CedarValueJson);
+    type IntoIter = <&'a BTreeMap<SmolStr, CedarValueJson> as IntoIterator>::IntoIter;
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.iter()
+    }
+}
+
+// At this time, this doesn't check for duplicate keys upon constructing a
+// `JsonRecord` from an iterator.
+// As of this writing, we only construct `JsonRecord` from an iterator during
+// _serialization_, not _deserialization_, and we can assume that values being
+// serialized (i.e., coming from the Cedar engine itself) are already free of
+// duplicate keys.
+impl FromIterator<(SmolStr, CedarValueJson)> for JsonRecord {
+    fn from_iter<T: IntoIterator<Item = (SmolStr, CedarValueJson)>>(iter: T) -> Self {
+        Self {
+            values: BTreeMap::from_iter(iter),
+        }
+    }
 }
 
 /// Structure expected by the `__entity` escape
@@ -155,21 +198,32 @@ impl CedarValueJson {
     }
 
     /// Convert this `CedarValueJson` into a Cedar "restricted expression"
-    pub fn into_expr(self) -> Result<RestrictedExpr, JsonDeserializationError> {
+    pub fn into_expr(
+        self,
+        ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
+    ) -> Result<RestrictedExpr, JsonDeserializationError> {
         match self {
             Self::Bool(b) => Ok(RestrictedExpr::val(b)),
             Self::Long(i) => Ok(RestrictedExpr::val(i)),
             Self::String(s) => Ok(RestrictedExpr::val(s)),
             Self::Set(vals) => Ok(RestrictedExpr::set(
                 vals.into_iter()
-                    .map(CedarValueJson::into_expr)
+                    .map(|v| v.into_expr(ctx.clone()))
                     .collect::<Result<Vec<_>, _>>()?,
             )),
             Self::Record(map) => Ok(RestrictedExpr::record(
                 map.into_iter()
-                    .map(|(k, v)| Ok((k, v.into_expr()?)))
+                    .map(|(k, v)| Ok((k, v.into_expr(ctx.clone())?)))
                     .collect::<Result<Vec<_>, JsonDeserializationError>>()?,
-            )),
+            )
+            .map_err(|e| match e {
+                ExprConstructionError::DuplicateKeyInRecordLiteral { key } => {
+                    JsonDeserializationError::DuplicateKeyInRecordLiteral {
+                        ctx: Box::new(ctx()),
+                        key,
+                    }
+                }
+            })?),
             Self::ExprEscape { __expr: expr } => {
                 use crate::parser;
                 let expr: Expr = parser::parse_expr(&expr).map_err(|errs| {
@@ -191,7 +245,7 @@ impl CedarValueJson {
                     }
                 })?,
             )),
-            Self::ExtnEscape { __extn: extn } => extn.into_expr(),
+            Self::ExtnEscape { __extn: extn } => extn.into_expr(ctx),
         }
     }
 
@@ -280,7 +334,10 @@ impl CedarValueJson {
 
 impl FnAndArg {
     /// Convert this `FnAndArg` into a Cedar "restricted expression" (which will be a call to an extension constructor)
-    pub fn into_expr(self) -> Result<RestrictedExpr, JsonDeserializationError> {
+    pub fn into_expr(
+        self,
+        ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
+    ) -> Result<RestrictedExpr, JsonDeserializationError> {
         Ok(RestrictedExpr::call_extension_fn(
             Name::from_normalized_str(&self.ext_fn).map_err(|errs| {
                 JsonDeserializationError::ParseEscape {
@@ -289,7 +346,7 @@ impl FnAndArg {
                     errs,
                 }
             })?,
-            vec![CedarValueJson::into_expr(*self.arg)?],
+            vec![CedarValueJson::into_expr(*self.arg, ctx)?],
         ))
     }
 }
@@ -317,12 +374,6 @@ impl<'e> ValueParser<'e> {
         ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
     ) -> Result<RestrictedExpr, JsonDeserializationError> {
         match expected_ty {
-            None => {
-                // ordinary, non-schema-based parsing. Everything is parsed as
-                // `CedarValueJson`, and converted into `RestrictedExpr` from that.
-                let jvalue: CedarValueJson = serde_json::from_value(val)?;
-                jvalue.into_expr()
-            }
             // The expected type is an entity reference. Special parsing rules
             // apply: for instance, the `__entity` escape can optionally be omitted.
             // What this means is that we parse the contents as `EntityUidJson`, and
@@ -353,7 +404,9 @@ impl<'e> ValueParser<'e> {
                     expected: Box::new(expected_ty.clone()),
                     actual: {
                         let jvalue: CedarValueJson = serde_json::from_value(val)?;
-                        Box::new(self.type_of_rexpr(jvalue.into_expr()?.as_borrowed(), ctx)?)
+                        Box::new(
+                            self.type_of_rexpr(jvalue.into_expr(ctx.clone())?.as_borrowed(), ctx)?,
+                        )
                     },
                 }),
             },
@@ -394,22 +447,37 @@ impl<'e> ValueParser<'e> {
                             record_attr: record_attr.into(),
                         });
                     }
-                    Ok(RestrictedExpr::record(rexpr_pairs))
+                    // having duplicate keys should be impossible here (because
+                    // neither `actual_attrs` nor `expected_attrs` can have
+                    // duplicate keys; they're both maps), but we can still throw
+                    // the error properly in the case that it somehow happens
+                    RestrictedExpr::record(rexpr_pairs).map_err(|e| match e {
+                        ExprConstructionError::DuplicateKeyInRecordLiteral { key } => {
+                            JsonDeserializationError::DuplicateKeyInRecordLiteral {
+                                ctx: Box::new(ctx2()),
+                                key,
+                            }
+                        }
+                    })
                 }
                 _ => Err(JsonDeserializationError::TypeMismatch {
                     ctx: Box::new(ctx()),
                     expected: Box::new(expected_ty.clone()),
                     actual: {
                         let jvalue: CedarValueJson = serde_json::from_value(val)?;
-                        Box::new(self.type_of_rexpr(jvalue.into_expr()?.as_borrowed(), ctx)?)
+                        Box::new(
+                            self.type_of_rexpr(jvalue.into_expr(ctx.clone())?.as_borrowed(), ctx)?,
+                        )
                     },
                 }),
             },
-            // The expected type is any other type. No special parsing rules apply,
-            // and we treat this exactly as the non-schema-based-parsing case.
-            Some(_) => {
+            // The expected type is any other type, or we don't have an expected type.
+            // No special parsing rules apply; we do ordinary, non-schema-based parsing.
+            Some(_) | None => {
+                // Everything is parsed as `CedarValueJson`, and converted into
+                // `RestrictedExpr` from that.
                 let jvalue: CedarValueJson = serde_json::from_value(val)?;
-                jvalue.into_expr()
+                Ok(jvalue.into_expr(ctx)?)
             }
         }
     }
@@ -428,7 +496,7 @@ impl<'e> ValueParser<'e> {
             ExtnValueJson::ExplicitExprEscape { __expr } => {
                 // reuse the same logic that parses CedarValueJson
                 let jvalue = CedarValueJson::ExprEscape { __expr };
-                let expr = jvalue.into_expr()?;
+                let expr = jvalue.into_expr(ctx.clone())?;
                 match expr.expr_kind() {
                     ExprKind::ExtensionFunctionApp { .. } => Ok(expr),
                     _ => Err(JsonDeserializationError::ExpectedExtnValue {
@@ -441,7 +509,7 @@ impl<'e> ValueParser<'e> {
             | ExtnValueJson::ImplicitExtnEscape(__extn) => {
                 // reuse the same logic that parses CedarValueJson
                 let jvalue = CedarValueJson::ExtnEscape { __extn };
-                let expr = jvalue.into_expr()?;
+                let expr = jvalue.into_expr(ctx.clone())?;
                 match expr.expr_kind() {
                     ExprKind::ExtensionFunctionApp { .. } => Ok(expr),
                     _ => Err(JsonDeserializationError::ExpectedExtnValue {
@@ -451,7 +519,7 @@ impl<'e> ValueParser<'e> {
                 }
             }
             ExtnValueJson::ImplicitConstructor(val) => {
-                let arg = val.into_expr()?;
+                let arg = val.into_expr(ctx.clone())?;
                 let argty = self.type_of_rexpr(arg.as_borrowed(), ctx.clone())?;
                 let func = self
                     .extensions
@@ -614,7 +682,7 @@ impl EntityUidJson {
     /// Convert this `EntityUidJson` into an `EntityUID`
     pub fn into_euid(
         self,
-        ctx: impl Fn() -> JsonDeserializationErrorContext,
+        ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
     ) -> Result<EntityUID, JsonDeserializationError> {
         let is_implicit_expr = matches!(self, Self::ImplicitExprEscape(_));
         match self {
@@ -623,7 +691,7 @@ impl EntityUidJson {
                 let jvalue = CedarValueJson::ExprEscape {
                     __expr: __expr.clone(),
                 };
-                let expr = jvalue.into_expr().map_err(|e| {
+                let expr = jvalue.into_expr(ctx.clone()).map_err(|e| {
                     if is_implicit_expr {
                         // in this case, the user provided a string that wasn't
                         // an appropriate entity reference.
@@ -638,7 +706,10 @@ impl EntityUidJson {
                         JsonDeserializationError::ExpectedLiteralEntityRef {
                             ctx: Box::new(ctx()),
                             got: Box::new(
-                                CedarValueJson::String(__expr).into_expr().unwrap().into(),
+                                CedarValueJson::String(__expr)
+                                    .into_expr(ctx.clone())
+                                    .unwrap()
+                                    .into(),
                             ),
                         }
                     } else {
@@ -656,7 +727,7 @@ impl EntityUidJson {
             Self::ExplicitEntityEscape { __entity } | Self::ImplicitEntityEscape(__entity) => {
                 // reuse the same logic that parses CedarValueJson
                 let jvalue = CedarValueJson::EntityEscape { __entity };
-                let expr = jvalue.into_expr()?;
+                let expr = jvalue.into_expr(ctx.clone())?;
                 match expr.expr_kind() {
                     ExprKind::Lit(Literal::EntityUID(euid)) => Ok((**euid).clone()),
                     _ => Err(JsonDeserializationError::ExpectedLiteralEntityRef {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -683,8 +683,8 @@ impl From<ast::Expr> for Expr {
             ast::ExprKind::Set(set) => {
                 Expr::set(unwrap_or_clone(set).into_iter().map(Into::into).collect())
             }
-            ast::ExprKind::Record { pairs } => Expr::record(
-                unwrap_or_clone(pairs)
+            ast::ExprKind::Record(map) => Expr::record(
+                unwrap_or_clone(map)
                     .into_iter()
                     .map(|(k, v)| (k, v.into()))
                     .collect(),

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -17,7 +17,10 @@
 use super::utils::unwrap_or_clone;
 use super::FromJsonError;
 use crate::ast;
-use crate::entities::{CedarValueJson, EscapeKind, JsonDeserializationError, TypeAndId};
+use crate::entities::{
+    CedarValueJson, EscapeKind, JsonDeserializationError, JsonDeserializationErrorContext,
+    TypeAndId,
+};
 use crate::parser::cst::{self, Ident};
 use crate::parser::err::{ParseError, ParseErrors, ToASTError};
 use crate::parser::unescape;
@@ -462,69 +465,72 @@ impl Expr {
     }
 }
 
-impl TryFrom<Expr> for ast::Expr {
-    type Error = FromJsonError;
-    fn try_from(expr: Expr) -> Result<ast::Expr, Self::Error> {
-        match expr {
-            Expr::ExprNoExt(ExprNoExt::Value(jsonvalue)) => {
-                jsonvalue.into_expr().map(Into::into).map_err(Into::into)
-            }
+impl Expr {
+    /// Attempt to convert this `est::Expr` into an `ast::Expr`
+    ///
+    /// `id`: the ID of the policy this `Expr` belongs to, used only for reporting errors
+    pub fn try_into_ast(self, id: ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
+        match self {
+            Expr::ExprNoExt(ExprNoExt::Value(jsonvalue)) => jsonvalue
+                .into_expr(|| JsonDeserializationErrorContext::Policy { id: id.clone() })
+                .map(Into::into)
+                .map_err(Into::into),
             Expr::ExprNoExt(ExprNoExt::Var(var)) => Ok(ast::Expr::var(var)),
             Expr::ExprNoExt(ExprNoExt::Slot(slot)) => Ok(ast::Expr::slot(slot)),
             Expr::ExprNoExt(ExprNoExt::Unknown { name }) => Ok(ast::Expr::unknown(name)),
             Expr::ExprNoExt(ExprNoExt::Not { arg }) => {
-                Ok(ast::Expr::not((*arg).clone().try_into()?))
+                Ok(ast::Expr::not((*arg).clone().try_into_ast(id)?))
             }
             Expr::ExprNoExt(ExprNoExt::Neg { arg }) => {
-                Ok(ast::Expr::neg((*arg).clone().try_into()?))
+                Ok(ast::Expr::neg((*arg).clone().try_into_ast(id)?))
             }
             Expr::ExprNoExt(ExprNoExt::Eq { left, right }) => Ok(ast::Expr::is_eq(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::NotEq { left, right }) => Ok(ast::Expr::noteq(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::In { left, right }) => Ok(ast::Expr::is_in(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Less { left, right }) => Ok(ast::Expr::less(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::LessEq { left, right }) => Ok(ast::Expr::lesseq(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Greater { left, right }) => Ok(ast::Expr::greater(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GreaterEq { left, right }) => Ok(ast::Expr::greatereq(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::And { left, right }) => Ok(ast::Expr::and(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Or { left, right }) => Ok(ast::Expr::or(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Add { left, right }) => Ok(ast::Expr::add(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Sub { left, right }) => Ok(ast::Expr::sub(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Mul { left, right }) => {
-                let left: ast::Expr = (*left).clone().try_into()?;
-                let right: ast::Expr = (*right).clone().try_into()?;
+                let left: ast::Expr = (*left).clone().try_into_ast(id.clone())?;
+                let right: ast::Expr = (*right).clone().try_into_ast(id)?;
                 let left_c = match left.expr_kind() {
                     ast::ExprKind::Lit(ast::Literal::Long(c)) => Some(c),
                     _ => None,
@@ -536,34 +542,34 @@ impl TryFrom<Expr> for ast::Expr {
                 match (left_c, right_c) {
                     (_, Some(c)) => Ok(ast::Expr::mul(left, *c)),
                     (Some(c), _) => Ok(ast::Expr::mul(right, *c)),
-                    (None, None) => Err(Self::Error::MultiplicationByNonConstant {
+                    (None, None) => Err(FromJsonError::MultiplicationByNonConstant {
                         arg1: left,
                         arg2: right,
                     })?,
                 }
             }
             Expr::ExprNoExt(ExprNoExt::Contains { left, right }) => Ok(ast::Expr::contains(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::ContainsAll { left, right }) => Ok(ast::Expr::contains_all(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::ContainsAny { left, right }) => Ok(ast::Expr::contains_any(
-                (*left).clone().try_into()?,
-                (*right).clone().try_into()?,
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GetAttr { left, attr }) => {
-                Ok(ast::Expr::get_attr((*left).clone().try_into()?, attr))
+                Ok(ast::Expr::get_attr((*left).clone().try_into_ast(id)?, attr))
             }
             Expr::ExprNoExt(ExprNoExt::HasAttr { left, attr }) => {
-                Ok(ast::Expr::has_attr((*left).clone().try_into()?, attr))
+                Ok(ast::Expr::has_attr((*left).clone().try_into_ast(id)?, attr))
             }
             Expr::ExprNoExt(ExprNoExt::Like { left, pattern }) => {
                 match unescape::to_pattern(&pattern) {
-                    Ok(pattern) => Ok(ast::Expr::like((*left).clone().try_into()?, pattern)),
-                    Err(errs) => Err(Self::Error::UnescapeError(errs)),
+                    Ok(pattern) => Ok(ast::Expr::like((*left).clone().try_into_ast(id)?, pattern)),
+                    Err(errs) => Err(FromJsonError::UnescapeError(errs)),
                 }
             }
             Expr::ExprNoExt(ExprNoExt::If {
@@ -571,24 +577,29 @@ impl TryFrom<Expr> for ast::Expr {
                 then_expr,
                 else_expr,
             }) => Ok(ast::Expr::ite(
-                (*cond_expr).clone().try_into()?,
-                (*then_expr).clone().try_into()?,
-                (*else_expr).clone().try_into()?,
+                (*cond_expr).clone().try_into_ast(id.clone())?,
+                (*then_expr).clone().try_into_ast(id.clone())?,
+                (*else_expr).clone().try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Set(elements)) => Ok(ast::Expr::set(
                 elements
                     .into_iter()
-                    .map(|el| el.try_into())
-                    .collect::<Result<Vec<_>, Self::Error>>()?,
+                    .map(|el| el.try_into_ast(id.clone()))
+                    .collect::<Result<Vec<_>, FromJsonError>>()?,
             )),
-            Expr::ExprNoExt(ExprNoExt::Record(map)) => Ok(ast::Expr::record(
-                map.into_iter()
-                    .map(|(k, v)| Ok((k, v.try_into()?)))
-                    .collect::<Result<HashMap<SmolStr, _>, Self::Error>>()?,
-            )),
+            Expr::ExprNoExt(ExprNoExt::Record(map)) => {
+                // PANIC SAFETY: can't have duplicate keys here because the input was already a HashMap
+                #[allow(clippy::expect_used)]
+                Ok(ast::Expr::record(
+                    map.into_iter()
+                        .map(|(k, v)| Ok((k, v.try_into_ast(id.clone())?)))
+                        .collect::<Result<HashMap<SmolStr, _>, FromJsonError>>()?,
+                )
+                .expect("can't have duplicate keys here because the input was already a HashMap"))
+            }
             Expr::ExtFuncCall(ExtFuncCall { call }) => {
                 match call.len() {
-                    0 => Err(Self::Error::MissingOperator),
+                    0 => Err(FromJsonError::MissingOperator),
                     1 => {
                         // PANIC SAFETY checked that `call.len() == 1`
                         #[allow(clippy::expect_used)]
@@ -606,11 +617,11 @@ impl TryFrom<Expr> for ast::Expr {
                         Ok(ast::Expr::call_extension_fn(
                             fn_name,
                             args.into_iter()
-                                .map(TryInto::try_into)
+                                .map(|arg| arg.try_into_ast(id.clone()))
                                 .collect::<Result<_, _>>()?,
                         ))
                     }
-                    _ => Err(Self::Error::MultipleOperators {
+                    _ => Err(FromJsonError::MultipleOperators {
                         ops: call.into_keys().collect(),
                     }),
                 }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -118,7 +118,15 @@ impl<'e> RestrictedEvaluator<'e> {
                 let (names, attrs) : (Vec<_>, Vec<_>) = map.into_iter().unzip();
                 match split(attrs) {
                     Either::Left(values) => Ok(Value::Record(Arc::new(names.into_iter().zip(values).collect())).into()),
-                    Either::Right(residuals) => Ok(Expr::record(names.into_iter().zip(residuals)).into()),
+                    Either::Right(residuals) => {
+                        // PANIC SAFETY: can't have a duplicate key here because `names` is the set of keys of the input `BTreeMap`
+                        #[allow(clippy::expect_used)]
+                        Ok(
+                            Expr::record(names.into_iter().zip(residuals))
+                                .expect("can't have a duplicate key here because `names` is the set of keys of the input `BTreeMap`")
+                                .into()
+                        )
+                    }
                 }
             }
             ExprKind::ExtensionFunctionApp { fn_name, args } => {
@@ -559,7 +567,15 @@ impl<'q, 'e> Evaluator<'e> {
                     Either::Left(vals) => {
                         Ok(Value::Record(Arc::new(names.into_iter().zip(vals).collect())).into())
                     }
-                    Either::Right(rs) => Ok(Expr::record(names.into_iter().zip(rs)).into()),
+                    Either::Right(rs) => {
+                        // PANIC SAFETY: can't have a duplicate key here because `names` is the set of keys of the input `BTreeMap`
+                        #[allow(clippy::expect_used)]
+                        Ok(
+                            Expr::record(names.into_iter().zip(rs))
+                                .expect("can't have a duplicate key here because `names` is the set of keys of the input `BTreeMap`")
+                                .into()
+                        )
+                    }
                 }
             }
         }
@@ -846,9 +862,11 @@ pub mod test {
                     RestrictedExpr::record(vec![
                         ("os_name".into(), RestrictedExpr::val("Windows")),
                         ("manufacturer".into(), RestrictedExpr::val("ACME Corp")),
-                    ]),
+                    ])
+                    .unwrap(),
                 ),
-            ]),
+            ])
+            .unwrap(),
         )
     }
 
@@ -886,7 +904,8 @@ pub mod test {
                 ("street".into(), RestrictedExpr::val("234 magnolia")),
                 ("town".into(), RestrictedExpr::val("barmstadt")),
                 ("country".into(), RestrictedExpr::val("amazonia")),
-            ]),
+            ])
+            .unwrap(),
         );
         let mut child = Entity::with_uid(EntityUID::with_eid("child"));
         let mut parent = Entity::with_uid(EntityUID::with_eid("parent"));
@@ -1378,7 +1397,7 @@ pub mod test {
             eval.interpret_inline_policy(&Expr::ite(
                 Expr::val(true),
                 Expr::val(3),
-                Expr::get_attr(Expr::record(vec![]), "foo".into()),
+                Expr::get_attr(Expr::record(vec![]).unwrap(), "foo".into()),
             )),
             Ok(Value::Lit(Literal::Long(3)))
         );
@@ -1387,7 +1406,7 @@ pub mod test {
             eval.interpret_inline_policy(&Expr::ite(
                 Expr::val(false),
                 Expr::val(3),
-                Expr::get_attr(Expr::record(vec![]), "foo".into()),
+                Expr::get_attr(Expr::record(vec![]).unwrap(), "foo".into()),
             )),
             Err(EvaluationError::record_attr_does_not_exist(
                 "foo".into(),
@@ -1398,7 +1417,7 @@ pub mod test {
         assert_eq!(
             eval.interpret_inline_policy(&Expr::ite(
                 Expr::val(true),
-                Expr::get_attr(Expr::record(vec![]), "foo".into()),
+                Expr::get_attr(Expr::record(vec![]).unwrap(), "foo".into()),
                 Expr::val(3),
             )),
             Err(EvaluationError::record_attr_does_not_exist(
@@ -1410,7 +1429,7 @@ pub mod test {
         assert_eq!(
             eval.interpret_inline_policy(&Expr::ite(
                 Expr::val(false),
-                Expr::get_attr(Expr::record(vec![]), "foo".into()),
+                Expr::get_attr(Expr::record(vec![]).unwrap(), "foo".into()),
                 Expr::val(3),
             )),
             Ok(Value::Lit(Literal::Long(3)))
@@ -1571,7 +1590,7 @@ pub mod test {
         let exts = Extensions::none();
         let eval = Evaluator::new(&request, &entities, &exts).expect("failed to create evaluator");
         // {"key": 3}["key"] or {"key": 3}.key
-        let string_key = Expr::record(vec![("key".into(), Expr::val(3))]);
+        let string_key = Expr::record(vec![("key".into(), Expr::val(3))]).unwrap();
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(string_key, "key".into())),
             Ok(Value::Lit(Literal::Long(3)))
@@ -1580,7 +1599,8 @@ pub mod test {
         let ham_and_eggs = Expr::record(vec![
             ("ham".into(), Expr::val(3)),
             ("eggs".into(), Expr::val(7)),
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(ham_and_eggs.clone(), "ham".into())),
             Ok(Value::Lit(Literal::Long(3)))
@@ -1603,7 +1623,8 @@ pub mod test {
         let ham_and_eggs_2 = Expr::record(vec![
             ("ham".into(), Expr::val(3)),
             ("eggs".into(), Expr::val("why")),
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(ham_and_eggs_2.clone(), "ham".into())),
             Ok(Value::Lit(Literal::Long(3)))
@@ -1618,7 +1639,8 @@ pub mod test {
             ("ham".into(), Expr::val(3)),
             ("eggs".into(), Expr::val("why")),
             ("else".into(), Expr::val(EntityUID::with_eid("foo"))),
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(ham_and_eggs_3, "else".into())),
             Ok(Value::from(EntityUID::with_eid("foo")))
@@ -1630,10 +1652,12 @@ pub mod test {
                 Expr::record(vec![
                     ("some".into(), Expr::val(1)),
                     ("more".into(), Expr::val(2)),
-                ]),
+                ])
+                .unwrap(),
             ),
             ("eggs".into(), Expr::val("why")),
-        ]);
+        ])
+        .unwrap();
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(
                 Expr::get_attr(hams_and_eggs, "hams".into()),
@@ -1645,7 +1669,8 @@ pub mod test {
         let weird_key = Expr::record(vec![(
             "this is a valid map key+.-_%() ".into(),
             Expr::val(7),
-        )]);
+        )])
+        .unwrap();
         assert_eq!(
             eval.interpret_inline_policy(&Expr::get_attr(
                 weird_key,
@@ -1662,7 +1687,8 @@ pub mod test {
                         "bar".into(),
                         Expr::set(vec!(Expr::val(3), Expr::val(33), Expr::val(333)))
                     )
-                ]),
+                ])
+                .unwrap(),
                 "bar".into()
             )),
             Ok(Value::set(vec![
@@ -1683,8 +1709,10 @@ pub mod test {
                                 ("a+b".into(), Expr::val(5)),
                                 ("jkl;".into(), Expr::val(10)),
                             ])
+                            .unwrap()
                         ),
-                    ]),
+                    ])
+                    .unwrap(),
                     "bar".into()
                 ),
                 "a+b".into()
@@ -1703,13 +1731,25 @@ pub mod test {
                                 ("foo".into(), Expr::val(4)),
                                 ("cake".into(), Expr::val(77)),
                             ])
+                            .unwrap()
                         ),
-                    ]),
+                    ])
+                    .unwrap(),
                     "bar".into(),
                 ),
                 "foo".into(),
             )),
             Ok(Value::Lit(Literal::Long(4)))
+        );
+        // duplicate record key
+        // { foo: 2, bar: 4, foo: "hi" }.bar
+        assert_eq!(
+            Expr::record(vec![
+                ("foo".into(), Expr::val(2)),
+                ("bar".into(), Expr::val(4)),
+                ("foo".into(), Expr::val("hi")),
+            ]),
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "foo".into() })
         );
         // entity_with_attrs.address.street
         assert_eq!(
@@ -1745,32 +1785,34 @@ pub mod test {
                 Expr::record(vec![
                     ("foo".into(), Expr::val(77)),
                     ("bar".into(), Expr::val("pancakes")),
-                ]),
+                ])
+                .unwrap(),
                 "foo".into()
             )),
             Ok(Value::Lit(Literal::Bool(true)))
         );
         // using has() to test for existence of a record field (which doesn't exist)
-        // has({"foo": 77, "bar" : "pancakes"}.pancakes)
+        // {"foo": 77, "bar" : "pancakes"} has pancakes
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(
                 Expr::record(vec![
                     ("foo".into(), Expr::val(77)),
                     ("bar".into(), Expr::val("pancakes")),
-                ]),
+                ])
+                .unwrap(),
                 "pancakes".into()
             )),
             Ok(Value::Lit(Literal::Bool(false)))
         );
-        // has({"2": "ham"}["2"])
+        // {"2": "ham"} has "2"
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(
-                Expr::record(vec![("2".into(), Expr::val("ham"))]),
+                Expr::record(vec![("2".into(), Expr::val("ham"))]).unwrap(),
                 "2".into()
             )),
             Ok(Value::Lit(Literal::Bool(true)))
         );
-        // has({"ham": 17, "eggs": if has(foo.spaghetti) then 3 else 7}.ham)
+        // {"ham": 17, "eggs": if foo has spaghetti then 3 else 7} has ham
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(
                 Expr::record(vec![
@@ -1786,7 +1828,8 @@ pub mod test {
                             Expr::val(7)
                         )
                     ),
-                ]),
+                ])
+                .unwrap(),
                 "ham".into()
             )),
             Ok(Value::Lit(Literal::Bool(true)))
@@ -1819,7 +1862,7 @@ pub mod test {
                 Type::String,
             ))
         );
-        // has_attr on something that's not a record, has(1010122.hello)
+        // has_attr on something that's not a record, 1010122 has hello
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(Expr::val(1010122), "hello".into())),
             Err(EvaluationError::type_error(
@@ -1833,7 +1876,7 @@ pub mod test {
                 Type::Long,
             ))
         );
-        // has_attr on something that's not a record, has("hello".eggs)
+        // has_attr on something that's not a record, "hello" has eggs
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(Expr::val("hello"), "eggs".into())),
             Err(EvaluationError::type_error(
@@ -2088,6 +2131,7 @@ pub mod test {
                     ("os_name".into(), Expr::val("Windows")),
                     ("manufacturer".into(), Expr::val("ACME Corp")),
                 ])
+                .unwrap()
             )),
             Ok(Value::Lit(Literal::Bool(true)))
         );
@@ -2095,7 +2139,7 @@ pub mod test {
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_eq(
                 Expr::get_attr(Expr::var(Var::Context), "device_properties".into()),
-                Expr::record(vec![("os_name".into(), Expr::val("Windows")),])
+                Expr::record(vec![("os_name".into(), Expr::val("Windows"))]).unwrap()
             )),
             Ok(Value::Lit(Literal::Bool(false)))
         );
@@ -2108,6 +2152,7 @@ pub mod test {
                     ("manufacturer".into(), Expr::val("ACME Corp")),
                     ("extrafield".into(), Expr::val(true)),
                 ])
+                .unwrap()
             )),
             Ok(Value::Lit(Literal::Bool(false)))
         );
@@ -2119,6 +2164,7 @@ pub mod test {
                     ("os_name".into(), Expr::val("Windows")),
                     ("manufacturer".into(), Expr::val("ACME Corp")),
                 ])
+                .unwrap()
             )),
             Ok(Value::Lit(Literal::Bool(true)))
         );
@@ -2644,7 +2690,7 @@ pub mod test {
         // { ham: "eggs" } contains "ham"
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains(
-                Expr::record(vec![("ham".into(), Expr::val("eggs"))]),
+                Expr::record(vec![("ham".into(), Expr::val("eggs"))]).unwrap(),
                 Expr::val("ham")
             )),
             Err(EvaluationError::type_error(vec![Type::Set], Type::Record))
@@ -2946,7 +2992,7 @@ pub mod test {
                 Expr::record(vec![
                     ("foo".into(), Expr::val(2)),
                     ("bar".into(), Expr::val(true)),
-                ])
+                ]).unwrap()
             )),
             Err(EvaluationError::type_error_with_advice(
                 vec![Type::entity_type(
@@ -2965,6 +3011,7 @@ pub mod test {
                     ("foo".into(), Expr::val(2)),
                     ("bar".into(), Expr::val(true)),
                 ])
+                .unwrap()
             )),
             Err(EvaluationError::type_error(
                 vec![
@@ -3350,11 +3397,11 @@ pub mod test {
                     Expr::val(false),
                     Expr::val(3),
                     Expr::set(vec![Expr::val(47), Expr::val(0)]),
-                    Expr::record(vec![("2".into(), Expr::val("ham"))])
+                    Expr::record(vec![("2".into(), Expr::val("ham"))]).unwrap()
                 ]),
                 Expr::set(vec![
                     Expr::val(3),
-                    Expr::record(vec![("2".into(), Expr::val("ham"))])
+                    Expr::record(vec![("2".into(), Expr::val("ham"))]).unwrap()
                 ])
             )),
             Ok(Value::Lit(Literal::Bool(true)))
@@ -3370,11 +3417,12 @@ pub mod test {
         // {"2": "ham", "3": "eggs"} containsall {"2": "ham"} ?
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains_all(
-                Expr::record(vec![("2".into(), Expr::val("ham"))]),
+                Expr::record(vec![("2".into(), Expr::val("ham"))]).unwrap(),
                 Expr::record(vec![
                     ("2".into(), Expr::val("ham")),
                     ("3".into(), Expr::val("eggs"))
                 ])
+                .unwrap()
             )),
             Err(EvaluationError::type_error(vec![Type::Set], Type::Record))
         );
@@ -3457,6 +3505,7 @@ pub mod test {
                         ("2".into(), Expr::val("ham")),
                         ("1".into(), Expr::val("eggs"))
                     ])
+                    .unwrap()
                 ]),
                 Expr::set(vec![
                     Expr::val(7),
@@ -3466,6 +3515,7 @@ pub mod test {
                         ("1".into(), Expr::val("eggs")),
                         ("2".into(), Expr::val("ham"))
                     ])
+                    .unwrap()
                 ])
             )),
             Ok(Value::Lit(Literal::Bool(true)))
@@ -3481,11 +3531,12 @@ pub mod test {
         // test for {"2": "ham"} contains_any of {"2": "ham", "3": "eggs"}
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains_any(
-                Expr::record(vec![("2".into(), Expr::val("ham"))]),
+                Expr::record(vec![("2".into(), Expr::val("ham"))]).unwrap(),
                 Expr::record(vec![
                     ("2".into(), Expr::val("ham")),
                     ("3".into(), Expr::val("eggs"))
                 ])
+                .unwrap()
             )),
             Err(EvaluationError::type_error(vec![Type::Set], Type::Record))
         );
@@ -3824,10 +3875,13 @@ pub mod test {
             Ok(PartialValue::Value(Value::Set(_)))
         );
         assert_matches!(
-            BorrowedRestrictedExpr::new(&Expr::record([
-                ("hi".into(), Expr::val(1001)),
-                ("foo".into(), Expr::val("bar"))
-            ]),)
+            BorrowedRestrictedExpr::new(
+                &Expr::record([
+                    ("hi".into(), Expr::val(1001)),
+                    ("foo".into(), Expr::val("bar"))
+                ])
+                .unwrap()
+            )
             .map_err(Into::into)
             .and_then(|e| evaluator.partial_interpret(e)),
             Ok(PartialValue::Value(Value::Record(_)))
@@ -3907,7 +3961,7 @@ pub mod test {
     #[test]
     fn partial_contexts1() {
         // { "cell" : <unknown> }
-        let c_expr = Expr::record([("cell".into(), Expr::unknown("cell"))]);
+        let c_expr = Expr::record([("cell".into(), Expr::unknown("cell"))]).unwrap();
         let expr = Expr::binary_app(
             BinaryOp::Eq,
             Expr::get_attr(Expr::var(Var::Context), "cell".into()),
@@ -3930,7 +3984,8 @@ pub mod test {
         let c_expr = Expr::record([
             ("loc".into(), Expr::val("test")),
             ("cell".into(), Expr::unknown("cell")),
-        ]);
+        ])
+        .unwrap();
         // context["cell"] == 2
         let expr = Expr::binary_app(
             BinaryOp::Eq,
@@ -3958,9 +4013,10 @@ pub mod test {
     #[test]
     fn partial_contexts3() {
         // { "loc" : "test", "cell" : { "row" : <unknown> } }
-        let row = Expr::record([("row".into(), Expr::unknown("row"))]);
+        let row = Expr::record([("row".into(), Expr::unknown("row"))]).unwrap();
         //assert!(row.is_partially_projectable());
-        let c_expr = Expr::record([("loc".into(), Expr::val("test")), ("cell".into(), row)]);
+        let c_expr =
+            Expr::record([("loc".into(), Expr::val("test")), ("cell".into(), row)]).unwrap();
         //assert!(c_expr.is_partially_projectable());
         // context["cell"]["row"] == 2
         let expr = Expr::binary_app(
@@ -3983,9 +4039,11 @@ pub mod test {
         let row = Expr::record([
             ("row".into(), Expr::unknown("row")),
             ("col".into(), Expr::unknown("col")),
-        ]);
+        ])
+        .unwrap();
         //assert!(row.is_partially_projectable());
-        let c_expr = Expr::record([("loc".into(), Expr::val("test")), ("cell".into(), row)]);
+        let c_expr =
+            Expr::record([("loc".into(), Expr::val("test")), ("cell".into(), row)]).unwrap();
         //assert!(c_expr.is_partially_projectable());
         // context["cell"]["row"] == 2
         let expr = Expr::binary_app(
@@ -4016,10 +4074,13 @@ pub mod test {
 
     #[test]
     fn partial_context_fail() {
-        let context = Context::from_expr(RestrictedExpr::new_unchecked(Expr::record([
-            ("a".into(), Expr::val(3)),
-            ("b".into(), Expr::unknown("b".to_string())),
-        ])))
+        let context = Context::from_expr(RestrictedExpr::new_unchecked(
+            Expr::record([
+                ("a".into(), Expr::val(3)),
+                ("b".into(), Expr::unknown("b".to_string())),
+            ])
+            .unwrap(),
+        ))
         .unwrap();
         let euid: EntityUID = r#"Test::"test""#.parse().unwrap();
         let q = Request::new(euid.clone(), euid.clone(), euid, context);
@@ -4054,10 +4115,9 @@ pub mod test {
         let a: EntityUID = r#"Action::"a""#.parse().expect("Failed to parse");
         let r: EntityUID = r#"Table::"t""#.parse().expect("Failed to parse");
 
-        let c_expr = RestrictedExpr::new(Expr::record([(
-            "cell".into(),
-            Expr::unknown("cell".to_string()),
-        )]))
+        let c_expr = RestrictedExpr::new(
+            Expr::record([("cell".into(), Expr::unknown("cell".to_string()))]).unwrap(),
+        )
         .expect("should qualify as restricted");
         let context = Context::from_expr(c_expr).unwrap();
 
@@ -4129,10 +4189,9 @@ pub mod test {
             EntityUID::with_eid("p"),
             EntityUID::with_eid("a"),
             EntityUID::with_eid("r"),
-            Context::from_expr(RestrictedExpr::new_unchecked(Expr::record([(
-                "condition".into(),
-                Expr::unknown("unknown_condition"),
-            )])))
+            Context::from_expr(RestrictedExpr::new_unchecked(
+                Expr::record([("condition".into(), Expr::unknown("unknown_condition"))]).unwrap(),
+            ))
             .unwrap(),
         );
         let eval = Evaluator::new(&q, &es, &exts).unwrap();
@@ -4313,7 +4372,7 @@ pub mod test {
     #[test]
     fn record_semantics_err() {
         let a = Expr::get_attr(
-            Expr::record([("value".into(), Expr::unknown("test".to_string()))]),
+            Expr::record([("value".into(), Expr::unknown("test".to_string()))]).unwrap(),
             "notpresent".into(),
         );
 
@@ -4327,7 +4386,7 @@ pub mod test {
     #[test]
     fn record_semantics_key_present() {
         let a = Expr::get_attr(
-            Expr::record([("value".into(), Expr::unknown("test".to_string()))]),
+            Expr::record([("value".into(), Expr::unknown("test".to_string()))]).unwrap(),
             "value".into(),
         );
 
@@ -4348,7 +4407,8 @@ pub mod test {
             Expr::record([
                 ("a".into(), Expr::unknown("a")),
                 ("b".into(), Expr::unknown("c")),
-            ]),
+            ])
+            .unwrap(),
             "c".into(),
         );
 
@@ -4365,7 +4425,8 @@ pub mod test {
             Expr::record([
                 ("a".into(), Expr::unknown("a")),
                 ("b".into(), Expr::unknown("b")),
-            ]),
+            ])
+            .unwrap(),
             "b".into(),
         );
 
@@ -4885,26 +4946,21 @@ pub mod test {
             ("a".into(), Expr::val(1)),
             ("b".into(), Expr::unknown("a")),
             ("c".into(), Expr::val(2)),
-        ]);
+        ])
+        .unwrap();
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(r, PartialValue::Residual(e));
 
         let e = Expr::record([("a".into(), Expr::val(1)), ("a".into(), Expr::unknown("a"))]);
-        let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(
-            r,
-            // last value wins for the same key
-            PartialValue::Residual(Expr::record([("a".into(), Expr::unknown("a"))]))
+            e,
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "a".into() })
         );
 
         let e = Expr::record([("a".into(), Expr::unknown("a")), ("a".into(), Expr::val(1))]);
-        let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(
-            r,
-            // last value wins for the same key
-            PartialValue::Value(Value::Record(Arc::new(
-                [("a".into(), Value::from(1))].into_iter().collect()
-            )))
+            e,
+            Err(ExprConstructionError::DuplicateKeyInRecordLiteral { key: "a".into() })
         );
 
         let e = Expr::record([
@@ -4914,15 +4970,19 @@ pub mod test {
                 "c".into(),
                 Expr::binary_app(BinaryOp::Add, Expr::val(1), Expr::val(2)),
             ),
-        ]);
+        ])
+        .unwrap();
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(
             r,
-            PartialValue::Residual(Expr::record([
-                ("a".into(), Expr::val(1)),
-                ("b".into(), Expr::unknown("a")),
-                ("c".into(), Expr::val(3))
-            ]))
+            PartialValue::Residual(
+                Expr::record([
+                    ("a".into(), Expr::val(1)),
+                    ("b".into(), Expr::unknown("a")),
+                    ("c".into(), Expr::val(3))
+                ])
+                .unwrap()
+            )
         );
 
         let e = Expr::record([
@@ -4932,7 +4992,8 @@ pub mod test {
                 "c".into(),
                 Expr::binary_app(BinaryOp::Add, Expr::val(1), Expr::val("hello")),
             ),
-        ]);
+        ])
+        .unwrap();
         assert!(eval.partial_interpret(&e, &HashMap::new()).is_err());
     }
 
@@ -4964,7 +5025,8 @@ pub mod test {
                     Expr::binary_app(BinaryOp::Add, Expr::unknown("a"), Expr::val(3)),
                 ),
                 ("b".into(), Expr::val(83)),
-            ]),
+            ])
+            .unwrap(),
             "b".into(),
         );
         let r = eval.partial_eval_expr(&e).unwrap();
@@ -4974,7 +5036,8 @@ pub mod test {
             Expr::record([(
                 "a".into(),
                 Expr::binary_app(BinaryOp::Add, Expr::unknown("a"), Expr::val(3)),
-            )]),
+            )])
+            .unwrap(),
             "b".into(),
         );
         assert!(eval.partial_eval_expr(&e).is_err());

--- a/cedar-policy-core/src/jsonvalue.rs
+++ b/cedar-policy-core/src/jsonvalue.rs
@@ -1,0 +1,151 @@
+//! This module provides general-purpose JSON utilities not specific to Cedar.
+
+use serde::de::{MapAccess, SeqAccess, Visitor};
+use serde::{Deserialize, Serialize};
+
+/// Wrapper around `serde_json::Value`, with a different `Deserialize`
+/// implementation, such that duplicate keys in JSON objects (maps/records) are
+/// not allowed (result in an error).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct JsonValueWithNoDuplicateKeys(serde_json::Value);
+
+impl std::ops::Deref for JsonValueWithNoDuplicateKeys {
+    type Target = serde_json::Value;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+// this implementation heavily borrows from the `Deserialize` implementation
+// for `serde_json::Value`
+impl<'de> Deserialize<'de> for JsonValueWithNoDuplicateKeys {
+    fn deserialize<D>(deserializer: D) -> Result<JsonValueWithNoDuplicateKeys, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ValueVisitor;
+
+        impl<'de> Visitor<'de> for ValueVisitor {
+            type Value = JsonValueWithNoDuplicateKeys;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("any valid JSON value")
+            }
+
+            fn visit_bool<E>(self, value: bool) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Bool(value)))
+            }
+
+            fn visit_i64<E>(self, value: i64) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Number(
+                    value.into(),
+                )))
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Number(
+                    value.into(),
+                )))
+            }
+
+            fn visit_f64<E>(self, value: f64) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(
+                    serde_json::Number::from_f64(value)
+                        .map_or(serde_json::Value::Null, serde_json::Value::Number),
+                ))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<JsonValueWithNoDuplicateKeys, E>
+            where
+                E: serde::de::Error,
+            {
+                self.visit_string(String::from(value))
+            }
+
+            fn visit_string<E>(self, value: String) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::String(
+                    value,
+                )))
+            }
+
+            fn visit_none<E>(self) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Null))
+            }
+
+            fn visit_some<D>(
+                self,
+                deserializer: D,
+            ) -> Result<JsonValueWithNoDuplicateKeys, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                Deserialize::deserialize(deserializer)
+            }
+
+            fn visit_unit<E>(self) -> Result<JsonValueWithNoDuplicateKeys, E> {
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Null))
+            }
+
+            fn visit_seq<A>(self, mut access: A) -> Result<JsonValueWithNoDuplicateKeys, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let mut vec: Vec<serde_json::Value> = Vec::new();
+
+                while let Some(elem) = access.next_element::<JsonValueWithNoDuplicateKeys>()? {
+                    vec.push(elem.0);
+                }
+
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Array(vec)))
+            }
+
+            fn visit_map<A>(self, mut access: A) -> Result<JsonValueWithNoDuplicateKeys, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let mut map: serde_json::Map<String, serde_json::Value> = serde_json::Map::new();
+
+                while let Some((k, v)) =
+                    access.next_entry::<String, JsonValueWithNoDuplicateKeys>()?
+                {
+                    match map.entry(k) {
+                        serde_json::map::Entry::Vacant(ventry) => {
+                            ventry.insert(v.0);
+                        }
+                        serde_json::map::Entry::Occupied(oentry) => {
+                            return Err(serde::de::Error::custom(format!(
+                                "the key `{}` occurs two or more times in the same JSON object",
+                                oentry.key()
+                            )));
+                        }
+                    }
+                }
+
+                Ok(JsonValueWithNoDuplicateKeys(serde_json::Value::Object(map)))
+            }
+        }
+
+        deserializer.deserialize_any(ValueVisitor)
+    }
+}
+
+impl std::str::FromStr for JsonValueWithNoDuplicateKeys {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl From<serde_json::Value> for JsonValueWithNoDuplicateKeys {
+    fn from(value: serde_json::Value) -> Self {
+        // the `serde_json::Value` representation cannot represent duplicate keys, so we can just wrap.
+        // If there were any duplicate keys, they're already gone as a result of creating the `serde_json::Value`.
+        Self(value)
+    }
+}
+
+impl From<JsonValueWithNoDuplicateKeys> for serde_json::Value {
+    fn from(value: JsonValueWithNoDuplicateKeys) -> Self {
+        value.0
+    }
+}

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -29,5 +29,6 @@ pub mod entities;
 pub mod est;
 pub mod evaluator;
 pub mod extensions;
+pub mod jsonvalue;
 pub mod parser;
 pub mod transitive_closure;

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -40,8 +40,9 @@ use super::node::{ASTNode, SourceInfo};
 use super::unescape::{to_pattern, to_unescaped_string};
 use super::{cst, err};
 use crate::ast::{
-    self, ActionConstraint, CallStyle, EntityReference, EntityType, EntityUID, PatternElem,
-    PolicySetError, PrincipalConstraint, PrincipalOrResourceConstraint, ResourceConstraint,
+    self, ActionConstraint, CallStyle, EntityReference, EntityType, EntityUID,
+    ExprConstructionError, PatternElem, PolicySetError, PrincipalConstraint,
+    PrincipalOrResourceConstraint, ResourceConstraint,
 };
 use itertools::Either;
 use smol_str::SmolStr;
@@ -1654,7 +1655,13 @@ impl ASTNode<Option<cst::Primary>> {
             cst::Primary::RInits(is) => {
                 let rec: Vec<_> = is.iter().filter_map(|i| i.to_init(errs)).collect();
                 if rec.len() == is.len() {
-                    Some(ExprOrSpecial::Expr(construct_expr_record(rec, src.clone())))
+                    match construct_expr_record(rec, src.clone()) {
+                        Ok(rec) => Some(ExprOrSpecial::Expr(rec)),
+                        Err(e) => {
+                            errs.push(e.into());
+                            None
+                        }
+                    }
                 } else {
                     errs.push(ToASTError::InvalidAttributesInRecordLiteral.into());
                     None
@@ -2068,8 +2075,18 @@ fn construct_ext_meth(n: String, args: Vec<ast::Expr>, l: SourceInfo) -> ast::Ex
 fn construct_expr_set(s: Vec<ast::Expr>, l: SourceInfo) -> ast::Expr {
     ast::ExprBuilder::new().with_source_info(l).set(s)
 }
-fn construct_expr_record(kvs: Vec<(SmolStr, ast::Expr)>, l: SourceInfo) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_info(l).record(kvs)
+fn construct_expr_record(
+    kvs: Vec<(SmolStr, ast::Expr)>,
+    l: SourceInfo,
+) -> Result<ast::Expr, ToASTError> {
+    ast::ExprBuilder::new()
+        .with_source_info(l)
+        .record(kvs)
+        .map_err(|e| match e {
+            ExprConstructionError::DuplicateKeyInRecordLiteral { key } => {
+                ToASTError::DuplicateKeyInRecordLiteral { key }
+            }
+        })
 }
 
 // PANIC SAFETY: Unit Test Code

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -246,6 +246,12 @@ pub enum ToASTError {
     /// Returned when the contents of an indexing expression is not a string literal
     #[error("the contents of an index expression must be a string literal")]
     NonStringIndex,
+    /// Returned when the same key appears two or more times in a single record literal
+    #[error("duplicate key `{key}` in record literal")]
+    DuplicateKeyInRecordLiteral {
+        /// The key that appeared two or more times
+        key: SmolStr,
+    },
     /// Returned when a user attempts to use type-constraint syntax. This is not currently supported
     #[error("type constraints are not currently supported")]
     TypeConstraints,

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -63,10 +63,7 @@ fn text_in_expr(e: &'_ Expr) -> impl IntoIterator<Item = TextKind<'_>> {
         ExprKind::GetAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::HasAttr { attr, .. } => vec![TextKind::Identifier(attr)],
         ExprKind::Like { pattern, .. } => vec![TextKind::Pattern(pattern.get_elems())],
-        ExprKind::Record { pairs } => pairs
-            .iter()
-            .map(|(attr, _)| TextKind::Identifier(attr))
-            .collect(),
+        ExprKind::Record(map) => map.keys().map(|attr| TextKind::Identifier(attr)).collect(),
         _ => vec![],
     }
 }

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -221,7 +221,7 @@ mod tests {
         let euid_foo =
             EntityUID::with_eid_and_type("test_entity_type", "foo").expect("valid identifier");
         let entity_get_elem = Expr::get_attr(
-            Expr::record(vec![("bar".into(), Expr::val(euid_foo.clone()))]),
+            Expr::record(vec![("bar".into(), Expr::val(euid_foo.clone()))]).unwrap(),
             "bar".into(),
         );
 
@@ -233,7 +233,8 @@ mod tests {
     fn entity_record() {
         let euid_foo =
             EntityUID::with_eid_and_type("test_entity_type", "foo").expect("valid identifier");
-        let entity_record = Expr::record(vec![("bar".into(), Expr::val(euid_foo.clone()))]);
+        let entity_record =
+            Expr::record(vec![("bar".into(), Expr::val(euid_foo.clone()))]).unwrap();
 
         let entities: Vec<EntityUID> = expr_entity_uids(&entity_record).cloned().collect();
         assert_eq!(vec![euid_foo], entities);
@@ -317,7 +318,8 @@ mod tests {
         let r = Expr::record([
             ("a1".into(), Expr::val(true)),
             ("a2".into(), Expr::val(false)),
-        ]);
+        ])
+        .unwrap();
         let e = Expr::ite(
             Expr::get_attr(
                 Expr::val(EntityUID::from_str("another::\"euid\"").unwrap()),

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -23,6 +23,7 @@
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::sync::Arc;
 
+use cedar_policy_core::entities::JsonDeserializationErrorContext;
 use cedar_policy_core::{
     ast::{Eid, Entity, EntityType, EntityUID, Id, Name, RestrictedExpr},
     entities::{CedarValueJson, Entities, TCComputation},
@@ -422,7 +423,7 @@ impl ValidatorNamespaceDef {
             // `non_exhaustive`, so any new variants are a breaking change.
             // PANIC SAFETY: see above
             #[allow(clippy::expect_used)]
-            let e = v.into_expr().expect("`Self::jsonval_to_type_helper` will always return `Err` for a `CedarValueJson` that might make `into_expr` return `Err`");
+            let e = v.into_expr(|| JsonDeserializationErrorContext::EntityAttribute { uid: action_id.clone(), attr: k.clone() }).expect("`Self::jsonval_to_type_helper` will always return `Err` for a `CedarValueJson` that might make `into_expr` return `Err`");
             attr_values.insert(k.clone(), e);
         }
         Ok((

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1174,31 +1174,28 @@ impl<'a> Typechecker<'a> {
                             .iter()
                             .map(|e| e.data().clone())
                             .collect::<Option<Vec<_>>>();
-                        let t = map.keys().cloned().zip(record_attr_expr_tys);
-                        match record_attr_tys {
-                            Some(record_attr_tys) => {
-                                // Given the attribute types which we know know
-                                // exist, we pair them with the corresponding
-                                // attribute names to get a record type.
-                                let record_attrs = map.keys().cloned();
-                                let record_type_entries =
-                                    std::iter::zip(record_attrs, record_attr_tys);
-                                TypecheckAnswer::success(
-                                    ExprBuilder::with_data(Some(
-                                        Type::record_with_required_attributes(
-                                            record_type_entries,
-                                            OpenTag::ClosedAttributes,
-                                        ),
-                                    ))
-                                    .with_same_source_info(e)
-                                    .record(t),
-                                )
-                            }
-                            None => TypecheckAnswer::fail(
-                                ExprBuilder::with_data(None)
-                                    .with_same_source_info(e)
-                                    .record(t),
-                            ),
+                        let ty = record_attr_tys.map(|record_attr_tys| {
+                            // Given the attribute types which we know know
+                            // exist, we pair them with the corresponding
+                            // attribute names to get a record type.
+                            let record_attrs = map.keys().cloned();
+                            let record_type_entries = std::iter::zip(record_attrs, record_attr_tys);
+                            Type::record_with_required_attributes(
+                                record_type_entries,
+                                OpenTag::ClosedAttributes,
+                            )
+                        });
+                        let is_success = ty.is_some();
+                        // PANIC SAFETY: can't have duplicate keys because the keys are the same as those in `map` which was already a BTreeMap
+                        #[allow(clippy::expect_used)]
+                        let expr = ExprBuilder::with_data(ty)
+                            .with_same_source_info(e)
+                            .record(map.keys().cloned().zip(record_attr_expr_tys))
+                            .expect("this can't have duplicate keys because the keys are the same as those in `map` which was already a BTreeMap");
+                        if is_success {
+                            TypecheckAnswer::success(expr)
+                        } else {
+                            TypecheckAnswer::fail(expr)
                         }
                     },
                 )

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -150,7 +150,7 @@ fn heterogeneous_set() {
 #[test]
 fn record_typechecks() {
     assert_typechecks_empty_schema(
-        Expr::record([("foo".into(), Expr::val(1))]),
+        Expr::record([("foo".into(), Expr::val(1))]).unwrap(),
         Type::closed_record_with_required_attributes([("foo".into(), Type::primitive_long())]),
     )
 }
@@ -515,7 +515,7 @@ fn record_has_typechecks() {
         Type::singleton_boolean(false),
     );
     assert_typechecks_empty_schema(
-        Expr::has_attr(Expr::record([]), "attr".into()),
+        Expr::has_attr(Expr::record([]).unwrap(), "attr".into()),
         Type::singleton_boolean(false),
     );
     assert_typechecks_empty_schema(
@@ -599,7 +599,7 @@ fn has_typecheck_fails() {
 fn record_get_attr_typechecks() {
     let attr: SmolStr = "foo".into();
     assert_typechecks_empty_schema(
-        Expr::get_attr(Expr::record([(attr.clone(), Expr::val(1))]), attr),
+        Expr::get_attr(Expr::record([(attr.clone(), Expr::val(1))]).unwrap(), attr),
         Type::primitive_long(),
     );
 }
@@ -609,8 +609,8 @@ fn record_get_attr_incompatible() {
     let attr: SmolStr = "foo".into();
     let if_expr = Expr::ite(
         Expr::less(Expr::val(1), Expr::val(0)),
-        Expr::record([(attr.clone(), Expr::val(true))]),
-        Expr::record([(attr.clone(), Expr::val(1))]),
+        Expr::record([(attr.clone(), Expr::val(true))]).unwrap(),
+        Expr::record([(attr.clone(), Expr::val(1))]).unwrap(),
     );
 
     assert_typecheck_fails_for_mode(
@@ -644,7 +644,7 @@ fn record_get_attr_lub_typecheck_fails() {
     let attr: SmolStr = "foo".into();
     let if_expr = Expr::ite(
         Expr::less(Expr::val(0), Expr::val(1)),
-        Expr::record([(attr.clone(), Expr::val(true))]),
+        Expr::record([(attr.clone(), Expr::val(true))]).unwrap(),
         Expr::val(1),
     );
     assert_typecheck_fails_empty_schema_without_type(
@@ -666,9 +666,9 @@ fn record_get_attr_lub_typecheck_fails() {
 fn record_get_attr_does_not_exist() {
     let attr: SmolStr = "foo".into();
     assert_typecheck_fails_empty_schema_without_type(
-        Expr::get_attr(Expr::record([]), attr.clone()),
+        Expr::get_attr(Expr::record([]).unwrap(), attr.clone()),
         vec![TypeError::unsafe_attribute_access(
-            Expr::get_attr(Expr::record([]), attr.clone()),
+            Expr::get_attr(Expr::record([]).unwrap(), attr.clone()),
             AttributeAccess::Other(vec![attr]),
             None,
             false,
@@ -681,8 +681,8 @@ fn record_get_attr_lub_does_not_exist() {
     let attr: SmolStr = "foo".into();
     let if_expr = Expr::ite(
         Expr::val(true),
-        Expr::record([]),
-        Expr::record([(attr.clone(), Expr::val(1))]),
+        Expr::record([]).unwrap(),
+        Expr::record([(attr.clone(), Expr::val(1))]).unwrap(),
     );
     assert_typecheck_fails_empty_schema_without_type(
         Expr::get_attr(if_expr.clone(), attr.clone()),
@@ -787,12 +787,12 @@ fn contains_typecheck_fails() {
     );
     assert_typecheck_fails_empty_schema(
         Expr::contains(
-            Expr::record([("foo".into(), Expr::val(1))]),
+            Expr::record([("foo".into(), Expr::val(1))]).unwrap(),
             Expr::val("foo"),
         ),
         Type::primitive_boolean(),
         vec![TypeError::expected_type(
-            Expr::record([("foo".into(), Expr::val(1))]),
+            Expr::record([("foo".into(), Expr::val(1))]).unwrap(),
             Type::any_set(),
             Type::closed_record_with_attributes([(
                 "foo".into(),

--- a/cedar-policy-validator/src/typecheck/test_type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test_type_annotation.rs
@@ -121,7 +121,8 @@ fn expr_typechecks_with_correct_annotation() {
         &Expr::record([
             ("foo".into(), Expr::val(1)),
             ("bar".into(), Expr::val(false)),
-        ]),
+        ])
+        .unwrap(),
         &ExprBuilder::with_data(Some(Type::closed_record_with_required_attributes([
             ("foo".into(), Type::primitive_long()),
             ("bar".into(), Type::singleton_boolean(false)),
@@ -135,7 +136,8 @@ fn expr_typechecks_with_correct_annotation() {
                 "bar".into(),
                 ExprBuilder::with_data(Some(Type::singleton_boolean(false))).val(false),
             ),
-        ]),
+        ])
+        .unwrap(),
     );
     with_typechecker_from_schema(
         serde_json::from_value::<SchemaFragment>(

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -21,6 +21,8 @@
 - The `Diagnostics::errors()` function now returns an iterator over `AuthorizationError`s.
 - The `Response::new()` constructor now expects a `Vec<AuthorizationError>` as its third argument.
 - Implements RFC #19, making validation slightly more strict, but more explainable.
+- Implemented RFC #20, disallowing duplicate keys in record values (including
+  record literals in policies, request `context`, and records in entity attributes).
 - Improved formatting for error messages.
 - Changed the semantics of equality for IP ranges. For example,
   `ip("192.168.0.1/24") == ip("192.168.0.3/24")` was previously `true` and is now

--- a/cedar-policy/benches/cedar_benchmarks.rs
+++ b/cedar-policy/benches/cedar_benchmarks.rs
@@ -121,7 +121,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         Some(principal.clone()),
         Some(action.clone()),
         Some(resource.clone()),
-        Context::from_pairs(context.clone()),
+        Context::from_pairs(context.clone()).expect("no duplicate keys in this context"),
     );
 
     c.bench_function("request_new", |b| {
@@ -130,7 +130,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 Some(black_box(principal.clone())),
                 Some(black_box(action.clone())),
                 Some(black_box(resource.clone())),
-                black_box(Context::from_pairs(context.clone())),
+                black_box(
+                    Context::from_pairs(context.clone())
+                        .expect("no duplicate keys in this context"),
+                ),
             )
         })
     });

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -111,7 +111,8 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
             "suspicion".to_string(),
             RestrictedExpression::from_str("4")?,
         ),
-    ]);
+    ])
+    .unwrap();
 
     // Combine into request
     let request = Request::new(
@@ -299,7 +300,8 @@ fn expression_eval_context() -> Result<(), Box<dyn Error>> {
             "suspicion".to_string(),
             RestrictedExpression::from_str("4")?,
         ),
-    ]);
+    ])
+    .unwrap();
 
     // Combine into request
     let request = Request::new(Some(principal), Some(action), Some(resource), context);


### PR DESCRIPTION
## Description of changes

Disallows duplicate keys in record values (including record literals in policies, request `context`, and records in entity attributes).

Includes the changes in #169 (and thus subsumes #169) -- it is now both possible and desirable to store records as maps in the AST, and internally expresses the no-duplicate-keys invariant.  (The EST already stored records as maps, which was a discrepancy between EST and AST semantics noted in #167.)

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
