### PR TITLE
Use cedar-policy `README.md` as crate top-level documentation

### DIFF
--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -39,3 +39,10 @@ pub mod frontend;
 
 #[cfg(feature = "integration_testing")]
 pub mod integration_testing;
+
+/// Includes README.md as the documentation for this unused empty function so
+/// that the example usage in the README is executed as a doctest,
+/// protecting against accidental breakage of the example.
+#[doc = include_str!("../README.md")]
+#[allow(dead_code)]
+fn readme_as_doc_test() {}

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -20,7 +20,6 @@
 // to add a separate test specifically for README examples by introducing a
 // private, empty, and unused function with `#[doc = include_str!("../README.md")]`.
 #![doc = include_str!("../README.md")]
-
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, clippy::pedantic, clippy::nursery)]
 #![deny(

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-//! Public Rust interface for Cedar
+// Includes the cedar-policy README as the top-level documentation for this
+// crate. This also acts as a test that the example code in the README
+// compiles. If changing the docs away from using the readme verbatim, be sure
+// to add a separate test specifically for README examples by introducing a
+// private, empty, and unused function with `#[doc = include_str!("../README.md")]`.
+#![doc = include_str!("../README.md")]
+
 #![forbid(unsafe_code)]
 #![warn(rust_2018_idioms, clippy::pedantic, clippy::nursery)]
 #![deny(
@@ -39,10 +45,3 @@ pub mod frontend;
 
 #[cfg(feature = "integration_testing")]
 pub mod integration_testing;
-
-/// Includes README.md as the documentation for this unused empty function so
-/// that the example usage in the README is executed as a doctest,
-/// protecting against accidental breakage of the example.
-#[doc = include_str!("../README.md")]
-#[allow(dead_code)]
-fn readme_as_doc_test() {}


### PR DESCRIPTION

Edit: updated to make it top level docs.

---

It's a little bit hacky, but this is the simplest way I found to run the actual code that's in the readme. ([See the test execute here](https://github.com/cedar-policy/cedar/actions/runs/6655106480/job/18084606177?pr=386#step:7:1502))


A nicer option that avoids adding the dummy function could be running `rustdoc --test README.md` in CI, but `rustdoc` doesn't resolve the `cedar_policy::*` import, and `cargo doc --test` doesn't exist.

Another alternative could be using `#![doc = include_str!("../README.md")]` as the top level crate documentation. This would resolve the docs issue #362 and test the example at the same time, if were happy to use the exact same text in the README and crate docs.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
