### PR TITLE
refactor RequestBuilder

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2863,7 +2863,12 @@ impl RequestBuilder {
 
     /// Create the [`Request`]
     pub fn build(self) -> Request {
-        Request(ast::Request::new_with_unknowns(self.principal, self.action, self.resource, self.context))
+        Request(ast::Request::new_with_unknowns(
+            self.principal,
+            self.action,
+            self.resource,
+            self.context,
+        ))
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2764,66 +2764,96 @@ impl FromStr for RestrictedExpression {
 
 /// Builder for a [`Request`]
 ///
-/// Note that you can create the `EntityUid`s using `.parse()` on any
-/// string (via the `FromStr` implementation for `EntityUid`).
-/// The principal, action, and resource fields are optional to support
-/// the case where these fields do not contribute to authorization
-/// decisions (e.g., because they are not used in your policies).
-/// If any of the fields are `None`, we will automatically generate
-/// a unique entity UID that is not equal to any UID in the store.
-///
-/// The default for principal, action and resource fields is Unknown.
+/// The default for principal, action, resource, and context fields is Unknown
+/// for partial evaluation.
 #[cfg(feature = "partial-eval")]
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct RequestBuilder {
-    principal: Option<ast::EntityUIDEntry>,
-    action: Option<ast::EntityUIDEntry>,
-    resource: Option<ast::EntityUIDEntry>,
+    principal: ast::EntityUIDEntry,
+    action: ast::EntityUIDEntry,
+    resource: ast::EntityUIDEntry,
+    /// Here, `None` means unknown
     context: Option<ast::Context>,
 }
 
 #[cfg(feature = "partial-eval")]
+impl Default for RequestBuilder {
+    fn default() -> Self {
+        Self {
+            principal: ast::EntityUIDEntry::Unknown,
+            action: ast::EntityUIDEntry::Unknown,
+            resource: ast::EntityUIDEntry::Unknown,
+            context: None,
+        }
+    }
+}
+
+#[cfg(feature = "partial-eval")]
 impl RequestBuilder {
-    /// Set the principal
+    /// Set the principal.
+    ///
+    /// Note that you can create the `EntityUid` using `.parse()` on any
+    /// string (via the `FromStr` implementation for `EntityUid`).
+    ///
+    /// Here, passing `None` for `principal` indicates that `principal` does
+    /// not contribute to authorization decisions (e.g., because it is not
+    /// used in your policies).
+    /// This is different than Unknown for partial-evaluation purposes.
     pub fn principal(self, principal: Option<EntityUid>) -> Self {
         Self {
-            principal: Some(match principal {
+            principal: match principal {
                 Some(p) => ast::EntityUIDEntry::concrete(p.0),
                 None => ast::EntityUIDEntry::concrete(ast::EntityUID::unspecified_from_eid(
                     ast::Eid::new("principal"),
                 )),
-            }),
+            },
             ..self
         }
     }
 
-    /// Set the action
+    /// Set the action.
+    ///
+    /// Note that you can create the `EntityUid` using `.parse()` on any
+    /// string (via the `FromStr` implementation for `EntityUid`).
+    ///
+    /// Here, passing `None` for `action` indicates that `action` does
+    /// not contribute to authorization decisions (e.g., because it is not
+    /// used in your policies).
+    /// This is different than Unknown for partial-evaluation purposes.
     pub fn action(self, action: Option<EntityUid>) -> Self {
         Self {
-            action: Some(match action {
+            action: match action {
                 Some(a) => ast::EntityUIDEntry::concrete(a.0),
                 None => ast::EntityUIDEntry::concrete(ast::EntityUID::unspecified_from_eid(
                     ast::Eid::new("action"),
                 )),
-            }),
+            },
             ..self
         }
     }
 
-    /// Set the resource
+    /// Set the resource.
+    ///
+    /// Note that you can create the `EntityUid` using `.parse()` on any
+    /// string (via the `FromStr` implementation for `EntityUid`).
+    ///
+    /// Here, passing `None` for `resource` indicates that `resource` does
+    /// not contribute to authorization decisions (e.g., because it is not
+    /// used in your policies).
+    /// This is different than Unknown for partial-evaluation purposes.
     pub fn resource(self, resource: Option<EntityUid>) -> Self {
         Self {
-            resource: Some(match resource {
+            resource: match resource {
                 Some(r) => ast::EntityUIDEntry::concrete(r.0),
                 None => ast::EntityUIDEntry::concrete(ast::EntityUID::unspecified_from_eid(
                     ast::Eid::new("resource"),
                 )),
-            }),
+            },
             ..self
         }
     }
 
-    /// Set the context
+    /// Set the context.
     pub fn context(self, context: Context) -> Self {
         Self {
             context: Some(context.0),
@@ -2833,19 +2863,7 @@ impl RequestBuilder {
 
     /// Create the [`Request`]
     pub fn build(self) -> Request {
-        let p = match self.principal {
-            Some(p) => p,
-            None => ast::EntityUIDEntry::Unknown,
-        };
-        let a = match self.action {
-            Some(a) => a,
-            None => ast::EntityUIDEntry::Unknown,
-        };
-        let r = match self.resource {
-            Some(r) => r,
-            None => ast::EntityUIDEntry::Unknown,
-        };
-        Request(ast::Request::new_with_unknowns(p, a, r, self.context))
+        Request(ast::Request::new_with_unknowns(self.principal, self.action, self.resource, self.context))
     }
 }
 


### PR DESCRIPTION
## Description of changes

User-invisible change, pure refactor, except docs are affected (hopefully improved).

RequestBuilder was storing `Option<EntityUIDEntry>`, which is needlessly confusing, because `EntityUIDEntry` is already capable of expressing both Unknown and Unspecified.  This PR refactors to just store `EntityUIDEntry`s directly.  No behavior is changed for existing APIs.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
