### PR TITLE
Nits in CI

### DIFF
--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -79,6 +79,7 @@ jobs:
   cedar-examples:
     name: CedarExamples
     runs-on: ubuntu-latest
+    needs: get-branch-name
     strategy:
       matrix:
         toolchain:
@@ -89,7 +90,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: cedar-policy/cedar-examples
-          ref: main
+          ref: ${{ needs.get-branch-name.outputs.branch_name }}
           path: ./cedar-examples
       - name: checkout cedar
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Crates.io](https://img.shields.io/crates/v/cedar-policy.svg)](https://crates.io/crates/cedar-policy)
 [![docs.rs](https://img.shields.io/docsrs/cedar-policy)](https://docs.rs/cedar-policy/latest/cedar_policy/)
 ![nightly](https://github.com/cedar-policy/cedar/actions/workflows/nightly_build.yml/badge.svg)
+![audit](https://github.com/cedar-policy/cedar/actions/workflows/cargo_audit.yml/badge.svg)
 
 This repository contains source code of the Rust crates that implement the [Cedar](https://www.cedarpolicy.com/) policy language.
 


### PR DESCRIPTION
## Description of changes

* Build the relevant `cedar-examples` branch during testing (`cedar-examples` release branch added in [cedar-examples#68](https://github.com/cedar-policy/cedar-examples/pull/68))
* Add a README badge for the nightly `cargo audit`

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
