### PR TITLE
Avoid duplicating build_and_test workflow

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,4 @@ rustflags = [
     "-Dclippy::unreachable",
     "-Dclippy::indexing_slicing",
     "-Dclippy::panic",
-    "-Dwarnings",
-    "-Funsafe-code"
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,4 +6,6 @@ rustflags = [
     "-Dclippy::unreachable",
     "-Dclippy::indexing_slicing",
     "-Dclippy::panic",
+    "-Dwarnings",
+    "-Funsafe-code"
 ]

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,9 +15,9 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: ./panic_safety.sh
       - run: cargo fmt --all --check
-      - run: cargo build --verbose --features "experimental"
-      - run: cargo build --verbose
-      - run: cargo doc --all-features
+      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose --features "experimental"
+      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+      - run: cargo doc --all-features --no-deps
       - run: cargo clippy --all-features
       - run: cargo test --verbose --features "experimental"
       - run: cargo test --verbose

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,0 +1,27 @@
+name: Build and Test
+on:
+    workflow_call:
+
+jobs:
+  build_and_test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: ./panic_safety.sh
+      - run: cargo fmt --all --check
+      - run: cargo build --verbose --features "experimental"
+      - run: cargo build --verbose
+      - run: cargo doc --all-features
+      - run: cargo clippy --all-features
+      - run: cargo test --verbose --features "experimental"
+      - run: cargo test --verbose
+      - run: cargo test --verbose --no-default-features
+      - run: cargo test --verbose -- --ignored
+      - run: cargo bench --no-run
+      - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,31 +7,7 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   build_and_test:
-    name: Rust project - latest
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-    steps:
-      - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo fmt --all --check
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose --features "experimental"
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
-      - run: cargo test --verbose --features "experimental"
-      - run: cargo test --verbose
-      - run: cargo doc --all-features
-      - run: cargo clippy --all-features
-      - run: ./panic_safety.sh
-      - run: cargo test --verbose -- --ignored
-      - run: cargo bench --no-run
-      - run: cd cedar-policy ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-cli ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-core ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-formatter ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-validator ; cargo test --no-default-features --verbose
-      - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
+    uses: ./.github/workflows/build_and_test.yml
 
   cargo_semver_checks:
     name: Cargo SemVer Checks

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -7,27 +7,4 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   build_and_test:
-    name: Rust project - latest
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-    steps:
-      - uses: actions/checkout@v3
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo fmt --all --check
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose --features "experimental"
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
-      - run: cargo test --verbose --features "experimental"
-      - run: cargo test --verbose
-      - run: cargo doc --all-features
-      - run: cargo clippy
-      - run: ./panic_safety.sh
-      - run: cargo test --verbose -- --ignored
-      - run: cargo bench --no-run
-      - run: cd cedar-policy ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-cli ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-core ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-formatter ; cargo test --no-default-features --verbose
-      - run: cd cedar-policy-validator ; cargo test --no-default-features --verbose
+    uses: ./.github/workflows/build_and_test.yml


### PR DESCRIPTION
Extract `build_and_test` into a [re-usable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows)run for both PRs and nightly build. This also re-orders the steps a bit to run faster steps before some of the slower steps.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
