### PR TITLE
Fix benchmark using old entity format

### DIFF
--- a/cedar-policy/benches/cedar_benchmarks.rs
+++ b/cedar-policy/benches/cedar_benchmarks.rs
@@ -58,32 +58,32 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     let entity_json = r#"
     [
         {
-            "uid": { "__expr" : "User::\"alice\"" },
+            "uid": { "type" : "User", "id": "alice"},
             "attrs": {},
-            "parents": [ { "__expr" : "UserGroup::\"jane_friends\"" } ]
+            "parents": [ { "__entity" : {"type": "UserGroup", "id": "jane_friends"}} ]
         },
         {
-            "uid": { "__expr" : "UserGroup::\"jane_friends\"" },
-            "attrs": {},
-            "parents": []
-        },
-        {
-            "uid": { "__expr" : "Action::\"view\"" },
+            "uid": {"type": "UserGroup", "id": "jane_friends"},
             "attrs": {},
             "parents": []
         },
         {
-            "uid": { "__expr" : "Photo::\"VacationPhoto94.jpg\"" },
+            "uid": {"type": "Action", "id": "view"},
             "attrs": {},
-            "parents": [ { "__expr" : "Album::\"jane_vacation\"" } ]
+            "parents": []
         },
         {
-            "uid": { "__expr" : "Album::\"jane_vacation\"" },
+            "uid": {"type": "Photo", "id": "VacationPhoto94.jpg"},
             "attrs": {},
-            "parents": [ { "__expr" : "Account::\"jane\"" } ]
+            "parents": [ { "__entity": {"type": "Album", "id": "jane_vacation"}} ]
         },
         {
-            "uid": { "__expr" : "Account::\"jane\"" },
+            "uid": {"type": "Album", "id": "jane_vacation"},
+            "attrs": {},
+            "parents": [ { "__entity" : {"type": "Account", "id": "jane"}} ]
+        },
+        {
+            "uid": {"type": "Account", "id": "jane"},
             "attrs": {},
             "parents": []
         }


### PR DESCRIPTION
Fixes benchmark that panicked when run due to outdated entity data format.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
