### PR TITLE
Fix/jkastner/112

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -781,16 +781,6 @@ impl<T> ExprBuilder<T> {
         })
     }
 
-    /// Create a '>' expression. Arguments must evaluate to Long type
-    pub fn greater(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
-        self.less(e2, e1)
-    }
-
-    /// Create a '>=' expression. Arguments must evaluate to Long type
-    pub fn greatereq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
-        self.lesseq(e2, e1)
-    }
-
     /// Create an 'add' expression. Arguments must evaluate to Long type
     pub fn add(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
@@ -990,6 +980,24 @@ impl<T: Clone> ExprBuilder<T> {
                 .with_maybe_source_info(self.source_info.clone())
                 .or(acc, next)
         })
+    }
+
+    /// Create a '>' expression. Arguments must evaluate to Long type
+    pub fn greater(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        // e1 > e2 is defined as !(e1 <= e2)
+        let leq = Self::with_data(self.data.clone())
+            .with_maybe_source_info(self.source_info.clone())
+            .lesseq(e1, e2);
+        self.not(leq)
+    }
+
+    /// Create a '>=' expression. Arguments must evaluate to Long type
+    pub fn greatereq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        // e1 >= e2 is defined as !(e1 < e2)
+        let leq = Self::with_data(self.data.clone())
+            .with_maybe_source_info(self.source_info.clone())
+            .less(e1, e2);
+        self.not(leq)
     }
 }
 

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -1757,23 +1757,27 @@ mod test {
                                             }
                                         },
                                         "right": {
-                                            "<": {
-                                                "left": {
-                                                    "neg": {
-                                                        "arg": {
-                                                            "-": {
-                                                                "left": {
-                                                                    "Value": 23
-                                                                },
-                                                                "right": {
-                                                                    "Value": 1
+                                            "!": {
+                                                "arg":{
+                                                    "<=": {
+                                                        "left": {
+                                                            "Value": 4
+                                                        },
+                                                        "right": {
+                                                            "neg": {
+                                                                "arg": {
+                                                                    "-": {
+                                                                        "left": {
+                                                                            "Value": 23
+                                                                        },
+                                                                        "right": {
+                                                                            "Value": 1
+                                                                        }
+                                                                    }
                                                                 }
                                                             }
                                                         }
                                                     }
-                                                },
-                                                "right": {
-                                                    "Value": 4
                                                 }
                                             }
                                         }
@@ -1792,12 +1796,16 @@ mod test {
                                             }
                                         },
                                         "right": {
-                                            "<=": {
-                                                "left": {
-                                                    "Value": 1
-                                                },
-                                                "right": {
-                                                    "Value": 7
+                                            "!": {
+                                                "arg": {
+                                                    "<": {
+                                                        "left": {
+                                                            "Value": 7
+                                                        },
+                                                        "right": {
+                                                            "Value": 1
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -2458,6 +2458,49 @@ pub mod test {
     }
 
     #[test]
+    fn interpret_comparison_err_order() {
+        // Expressions are evaluated left to right, so the unexpected-string
+        // type error should be reported for all of the following. This tests a
+        // fix for incorrect evaluation order in `>` and `>=`.
+        let request = basic_request();
+        let entities = basic_entities();
+        let exts = Extensions::none();
+        let eval = Evaluator::new(&request, &entities, &exts).expect("failed to create evaluator");
+
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::greatereq(
+                Expr::add(Expr::val("a"), Expr::val("b")),
+                Expr::add(Expr::val(false), Expr::val(true))
+            )),
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
+        );
+
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::greater(
+                Expr::add(Expr::val("a"), Expr::val("b")),
+                Expr::add(Expr::val(false), Expr::val(true))
+            )),
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
+        );
+
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::lesseq(
+                Expr::add(Expr::val("a"), Expr::val("b")),
+                Expr::add(Expr::val(false), Expr::val(true))
+            )),
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
+        );
+
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::less(
+                Expr::add(Expr::val("a"), Expr::val("b")),
+                Expr::add(Expr::val(false), Expr::val(true))
+            )),
+            Err(EvaluationError::type_error(vec![Type::Long], Type::String))
+        );
+    }
+
+    #[test]
     fn interpret_arithmetic() {
         let request = basic_request();
         let entities = basic_entities();

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -47,6 +47,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   impl for `Template`.  The displayed representations now more closely match the
   original input, whether the input was in string or JSON form.
 
+### Fixed
+
+* Evaluation order of operand to `>` and `>=` (#112). They now evaluate left to right,
+  matching all other operators. This effects what error is reported when there is
+  an evaluation error in both operands, but does not otherwise change the result
+  of evaluation.
+
 ## [2.4.2] - 2023-10-23
 Cedar Language Version: 2.1.2
 


### PR DESCRIPTION
Fix #112. The evaluation order of operands to `>` and `>=` so that an error in the left operand will always be reported instead of any error which may exist in the right operand.

`a > b` is defined as `!(a <= b)` instead of `b < a` and `a >= b` is defined as `!(a > b)` instead of `b <= a`.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
