### PR TITLE
Record source location with offset for validation warnings

### DIFF
--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -14,31 +14,32 @@
  * limitations under the License.
  */
 
-use cedar_policy_core::ast::{Pattern, PolicyID, Template};
+use cedar_policy_core::ast::{Pattern, Template};
 use thiserror::Error;
 
 use crate::expr_iterator::expr_text;
 use crate::expr_iterator::TextKind;
+use crate::SourceLocation;
 use unicode_security::GeneralSecurityProfile;
 use unicode_security::MixedScript;
 
 /// Returned by the standalone `confusable_string_checker` function, which checks a policy set for potentially confusing/obfuscating text.
 #[derive(Debug, Clone)]
 pub struct ValidationWarning<'a> {
-    location: &'a PolicyID,
+    location: SourceLocation<'a>,
     kind: ValidationWarningKind,
 }
 
 impl<'a> ValidationWarning<'a> {
-    pub fn location(&self) -> &'a PolicyID {
-        self.location
+    pub fn location(&self) -> &SourceLocation<'a> {
+        &self.location
     }
 
     pub fn kind(&self) -> &ValidationWarningKind {
         &self.kind
     }
 
-    pub fn to_kind_and_location(self) -> (&'a PolicyID, ValidationWarningKind) {
+    pub fn to_kind_and_location(self) -> (SourceLocation<'a>, ValidationWarningKind) {
         (self.location, self.kind)
     }
 }
@@ -48,7 +49,8 @@ impl std::fmt::Display for ValidationWarning<'_> {
         write!(
             f,
             "validation warning on policy `{}`: {}",
-            self.location, self.kind
+            self.location.policy_id(),
+            self.kind
         )
     }
 }
@@ -81,19 +83,19 @@ pub fn confusable_string_checks<'a>(
     for policy in p {
         let e = policy.condition();
         for str in expr_text(&e) {
-            let warning = match str {
-                TextKind::String(s) => permissable_str(s),
-                TextKind::Identifier(i) => permissable_ident(i),
-                TextKind::Pattern(p) => {
+            let (loc, warning) = match str {
+                TextKind::String(l, s) => (l, permissable_str(s)),
+                TextKind::Identifier(l, i) => (l, permissable_ident(i)),
+                TextKind::Pattern(l, p) => {
                     let pat = Pattern::new(p.iter().copied());
                     let as_str = format!("{pat}");
-                    permissable_str(&as_str)
+                    (l, permissable_str(&as_str))
                 }
             };
 
             if let Some(w) = warning {
                 warnings.push(ValidationWarning {
-                    location: policy.id(),
+                    location: SourceLocation::new(policy.id(), loc.clone()),
                     kind: w,
                 })
             }
@@ -146,7 +148,10 @@ const BIDI_CHARS: [char; 9] = [
 mod test {
 
     use super::*;
-    use cedar_policy_core::{ast::PolicySet, parser::parse_policy};
+    use cedar_policy_core::{
+        ast::{PolicyID, PolicySet},
+        parser::{parse_policy, SourceInfo},
+    };
 
     #[test]
     fn strs() {
@@ -195,8 +200,10 @@ mod test {
             format!("{warning}"),
             "validation warning on policy `test`: identifier `say_һello` contains mixed scripts"
         );
-        assert_eq!(location, &PolicyID::from_string("test"));
-        assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
+        assert_eq!(
+            location,
+            &SourceLocation::new(&PolicyID::from_string("test"), None)
+        );
     }
 
     #[test]
@@ -238,8 +245,10 @@ mod test {
             format!("{warning}"),
             "validation warning on policy `test`: string `\"*_һello\"` contains mixed scripts"
         );
-        assert_eq!(location, &PolicyID::from_string("test"));
-        assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
+        assert_eq!(
+            location,
+            &SourceLocation::new(&PolicyID::from_string("test"), Some(SourceInfo(64..94))),
+        );
     }
 
     #[test]
@@ -264,7 +273,9 @@ mod test {
             ValidationWarningKind::BidiCharsInString(r#"user‮ ⁦&& principal.is_admin⁩ ⁦"#.to_string())
         );
         assert_eq!(format!("{warning}"), "validation warning on policy `test`: string `\"user‮ ⁦&& principal.is_admin⁩ ⁦\"` contains BIDI control characters");
-        assert_eq!(location, &PolicyID::from_string("test"));
-        assert_eq!(warning.clone().to_kind_and_location(), (location, kind));
+        assert_eq!(
+            location,
+            &SourceLocation::new(&PolicyID::from_string("test"), Some(SourceInfo(90..131)))
+        );
     }
 }

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -91,14 +91,14 @@ impl<'a> ValidationError<'a> {
 }
 
 /// Represents a location in Cedar policy source.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct SourceLocation<'a> {
     policy_id: &'a PolicyID,
     source_info: Option<SourceInfo>,
 }
 
 impl<'a> SourceLocation<'a> {
-    fn new(policy_id: &'a PolicyID, source_info: Option<SourceInfo>) -> Self {
+    pub(crate) fn new(policy_id: &'a PolicyID, source_info: Option<SourceInfo>) -> Self {
         Self {
             policy_id,
             source_info,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -46,6 +46,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve the `Display` impls for `Policy` and `PolicySet`, and add a `Display`
   impl for `Template`.  The displayed representations now more closely match the
   original input, whether the input was in string or JSON form.
+- `ValidationWarning::location` and `ValidationWarning::to_kind_and_location`
+  now return `&SourceLocation<'a>` instead of `&'a PolicyID`, matching
+  `ValidationError::location`.
 
 ### Fixed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1340,6 +1340,7 @@ impl<'a> From<cedar_policy_validator::ValidationResult<'a>> for ValidationResult
 /// and provides details specific to that kind of problem. The error also records
 /// where the problem was encountered.
 #[derive(Debug, Error)]
+#[error("validation error on `{}`: {}", self.location, self.error_kind())]
 pub struct ValidationError<'a> {
     location: SourceLocation<'a>,
     error_kind: ValidationErrorKind,
@@ -1364,22 +1365,6 @@ impl<'a> From<cedar_policy_validator::ValidationError<'a>> for ValidationError<'
             location: SourceLocation::from(location),
             error_kind,
         }
-    }
-}
-
-impl<'a> std::fmt::Display for ValidationError<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "validation error on policy `{}`",
-            self.location.policy_id
-        )?;
-        if let (Some(range_start), Some(range_end)) =
-            (self.location().range_start(), self.location().range_end())
-        {
-            write!(f, " at offset {range_start}-{range_end}")?;
-        }
-        write!(f, ": {}", self.error_kind())
     }
 }
 
@@ -1409,6 +1394,21 @@ impl<'a> SourceLocation<'a> {
     }
 }
 
+impl<'a> std::fmt::Display for SourceLocation<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "policy `{}`", self.policy_id)?;
+        if let Some(source_range) = &self.source_range {
+            write!(
+                f,
+                " at offset {}-{}",
+                source_range.range_start(),
+                source_range.range_end()
+            )?;
+        }
+        Ok(())
+    }
+}
+
 impl<'a> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation<'a> {
     fn from(loc: cedar_policy_validator::SourceLocation<'a>) -> SourceLocation<'a> {
         let policy_id: &'a PolicyId = PolicyId::ref_cast(loc.policy_id());
@@ -1429,7 +1429,7 @@ pub fn confusable_string_checker<'a>(
 }
 
 #[derive(Debug, Error)]
-#[error("validation warning on policy `{}`: {}", .location.policy_id, .kind)]
+#[error("validation warning on `{}`: {}", .location, .kind)]
 /// Warnings found in Cedar policies
 pub struct ValidationWarning<'a> {
     location: SourceLocation<'a>,
@@ -1453,10 +1453,7 @@ impl<'a> From<cedar_policy_validator::ValidationWarning<'a>> for ValidationWarni
     fn from(w: cedar_policy_validator::ValidationWarning<'a>) -> Self {
         let (loc, kind) = w.to_kind_and_location();
         ValidationWarning {
-            location: SourceLocation {
-                policy_id: PolicyId::ref_cast(loc),
-                source_range: None,
-            },
+            location: loc.into(),
             kind,
         }
     }


### PR DESCRIPTION
## Description of changes

Validation warnings only recorded the policy id where the warning was found and not the source offset of the particular expression. This PR update warnings to provide the same source location information as errors.

This changes the return type of a function in the public api, so it is a breaking change.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
