### PR TITLE
Make format and check-parse CLI subcommands consistent

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -14,6 +14,7 @@
   subcommands, while `-l` refers to `--principal`. Relatedly, the `--policies`
   long form of the flag is also now accepted across all subcommands.
 - The short form of `--template-linked` was changed from `-t` to `-k`.
+- The `format` subcommand no longer takes a positional file argument.
 
 ## 2.4.2
 

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -112,8 +112,8 @@ pub struct ValidateArgs {
 
 #[derive(Args, Debug)]
 pub struct CheckParseArgs {
-    /// File containing the policy set
-    #[clap(short, long = "policies", value_name = "FILE")]
+    /// Optional policy file name. If none is provided, read input from stdin.
+    #[arg(short, long = "policies", value_name = "FILE")]
     pub policies_file: Option<String>,
 }
 
@@ -310,8 +310,8 @@ pub struct LinkArgs {
 #[derive(Args, Debug)]
 pub struct FormatArgs {
     /// Optional policy file name. If none is provided, read input from stdin.
-    #[arg(value_name = "FILE")]
-    pub file_name: Option<String>,
+    #[arg(short, long = "policies", value_name = "FILE")]
+    pub policy_file: Option<String>,
 
     /// Custom line width (default: 80).
     #[arg(short, long, value_name = "UINT", default_value_t = 80)]
@@ -519,7 +519,7 @@ pub fn link(args: &LinkArgs) -> CedarExitCode {
 }
 
 fn format_policies_inner(args: &FormatArgs) -> Result<()> {
-    let policies_str = read_from_file_or_stdin(args.file_name.as_ref(), "policy set")?;
+    let policies_str = read_from_file_or_stdin(args.policy_file.as_ref(), "policy set")?;
     let config = Config {
         line_width: args.line_width,
         indent_width: args.indent_width,

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -111,6 +111,7 @@ fn run_format_test(policies_file: &str) {
     let format_cmd = assert_cmd::Command::cargo_bin("cedar")
         .expect("bin exists")
         .arg("format")
+        .arg("-p")
         .arg(policies_file)
         .assert();
     assert_eq!(


### PR DESCRIPTION
## Description of changes

## Issue #403

Based on discussion of format and check-parse in linked issue, specifically:

> If we make format use -p and --policies instead of a positional argument, then I think we can call it good.

This should close that issue out by making the two subcommands consistent. It only requires a small renaming change for format in the code. I updated the changelog to note the removal of the positional argument for format.

## Checklist for requesting a review

The change in this PR is:

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR:

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
