### PR TITLE
Improve error message for template slot mismatch

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3775,6 +3775,14 @@ mod tests {
     fn is_err() {
         let invalid_is_policies = [
             (
+                r#"permit(principal == ?resource, action, resource);"#,
+                "?resource instead of ?principal",
+            ),
+            (
+                r#"permit(principal, action, resource == ?principal);"#,
+                "?principal instead of ?resource",
+            ),
+            (
                 r#"permit(principal in Group::"friends" is User, action, resource);"#,
                 "expected a entity uid or matching template slot",
             ),

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3776,11 +3776,11 @@ mod tests {
         let invalid_is_policies = [
             (
                 r#"permit(principal in Group::"friends" is User, action, resource);"#,
-                "expected a entity uid or template slot",
+                "expected a entity uid or matching template slot",
             ),
             (
                 r#"permit(principal, action, resource in Folder::"folder" is File);"#,
-                "expected a entity uid or template slot",
+                "expected a entity uid or matching template slot",
             ),
             (
                 r#"permit(principal is User == User::"Alice", action, resource);"#,
@@ -3800,11 +3800,11 @@ mod tests {
             ),
             (
                 r#"permit(principal is User in 1, action, resource);"#,
-                "expected a entity uid or template slot, found a `literal` statement",
+                "expected a entity uid or matching template slot, found a `literal` statement",
             ),
             (
                 r#"permit(principal, action, resource is File in 1);"#,
-                "expected a entity uid or template slot, found a `literal` statement",
+                "expected a entity uid or matching template slot, found a `literal` statement",
             ),
             (
                 r#"permit(principal is 1, action, resource);"#,
@@ -3824,11 +3824,11 @@ mod tests {
             ),
             (
                 r#"permit(principal is User in ?resource, action, resource);"#,
-                "expected a entity uid or template slot",
+                "expected a entity uid or matching template slot",
             ),
             (
                 r#"permit(principal, action, resource is Folder in ?principal);"#,
-                "expected a entity uid or template slot",
+                "expected a entity uid or matching template slot",
             ),
             (
                 r#"permit(principal, action, resource) when { principal is 1 };"#,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -915,7 +915,7 @@ impl RefKind for SingleEntity {
 
 impl RefKind for EntityReference {
     fn err_str() -> &'static str {
-        "entity uid or template slot"
+        "entity uid or matching template slot"
     }
 
     fn create_slot(_: &mut ParseErrors) -> Option<Self> {
@@ -1639,7 +1639,7 @@ impl ASTNode<Option<cst::Primary>> {
                 if slot.matches(var) {
                     Ok(T::create_slot(errs))
                 } else {
-                    Err(format!("?{slot}"))
+                    Err(format!("{slot} instead of ?{var}"))
                 }
             }
             cst::Primary::Literal(_) => Err("literal".to_string()),


### PR DESCRIPTION
## Description of changes

Improve error message when there is a template slot mismatch such as `principal = ?resource` instead of `principal = ?principal`.

## Issue #391 

## Checklist for requesting a review

The change in this PR is:

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR:

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
