### PR TITLE
Fix `PolicySet::link` to avoid mutating policy set on link fail

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -64,6 +64,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching all other operators. This affects what error is reported when there is
   an evaluation error in both operands, but does not otherwise change the result
   of evaluation.
+- `PolicySet::link` to not mutate internal state when failing to link a static
+  policy. With this fix it is be possible to create a link with a policy id
+  after previously failing to create that link with the same id from a static
+  policy.
 
 ## [2.4.2] - 2023-10-23
 Cedar Language Version: 2.1.2

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -64,8 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   matching all other operators. This affects what error is reported when there is
   an evaluation error in both operands, but does not otherwise change the result
   of evaluation.
-- `PolicySet::link` to not mutate internal state when failing to link a static
-  policy. With this fix it is be possible to create a link with a policy id
+- Updated `PolicySet::link` to not mutate internal state when failing to link a static
+  policy. With this fix it is possible to create a link with a policy id
   after previously failing to create that link with the same id from a static
   policy.
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1972,6 +1972,24 @@ impl PolicySet {
             .into_iter()
             .map(|(key, value)| (key.into(), value.0))
             .collect();
+
+        // Try to get the template with the id we're linking from.  We do this
+        // _before_ calling `self.ast.link` because `link` mutates the policy
+        // set by creating a new link entry in a hashmap. This happens even when
+        // trying to link a static policy, which we want to error on here.
+        let template = match self.templates.get(&template_id) {
+            Some(template) => template,
+            None => {
+                return Err(if self.policies.contains_key(&template_id) {
+                    PolicySetError::ExpectedTemplate
+                } else {
+                    PolicySetError::LinkingError(ast::LinkingError::NoSuchTemplate {
+                        id: template_id.0,
+                    })
+                });
+            }
+        };
+
         let linked_ast = self
             .ast
             .link(
@@ -1980,17 +1998,10 @@ impl PolicySet {
                 unwrapped_vals.clone(),
             )
             .map_err(PolicySetError::LinkingError)?;
+
         // PANIC SAFETY: `lossless.link()` will not fail after `ast.link()` succeeds
         #[allow(clippy::expect_used)]
-        let linked_lossless = self
-            .templates
-            .get(&template_id)
-            // We know `template_id` exists in the policy set as either a
-            // template or a static policy because otherwise `ast.link()` would
-            // have errored. If `ast.link()` did not error, then it could still
-            // be that the id corresponds to a static policy. This function
-            // should only be used to link templates, so this is an error.
-            .ok_or(PolicySetError::ExpectedTemplate)?
+        let linked_lossless = template
             .lossless
             .clone()
             .link(unwrapped_vals.iter().map(|(k, v)| (*k, v)))
@@ -4073,19 +4084,23 @@ mod policy_set_tests {
         let env: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
 
+        let before_link = pset.clone();
         let r = pset.link(
             PolicyId::from_str("t").unwrap(),
             PolicyId::from_str("id").unwrap(),
             env,
         );
 
-        match r {
-            Ok(_) => panic!("Should have failed due to conflict"),
-            Err(PolicySetError::LinkingError(LinkingError::PolicyIdConflict { id })) => {
+        assert_matches!(
+            r,
+            Err(PolicySetError::LinkingError(LinkingError::PolicyIdConflict { id })) =>{
                 assert_eq!(id, ast::PolicyID::from_string("id"));
             }
-            Err(e) => panic!("Incorrect error: {e}"),
-        };
+        );
+        assert_eq!(
+            pset, before_link,
+            "A failed link shouldn't mutate the policy set"
+        );
     }
 
     #[test]
@@ -4374,12 +4389,17 @@ mod policy_set_tests {
         let mut pset = PolicySet::new();
         pset.add(static_policy).unwrap();
 
+        let before_link = pset.clone();
         let result = pset.link(
             PolicyId::from_str("static").unwrap(),
             PolicyId::from_str("linked").unwrap(),
             HashMap::new(),
         );
         assert_matches!(result, Err(PolicySetError::ExpectedTemplate));
+        assert_eq!(
+            pset, before_link,
+            "A failed link shouldn't mutate the policy set"
+        );
     }
 
     #[test]
@@ -4399,16 +4419,16 @@ mod policy_set_tests {
         )
         .unwrap();
 
+        let before_link = pset.clone();
         let result = pset.link(
             PolicyId::from_str("linked").unwrap(),
             PolicyId::from_str("linked2").unwrap(),
             HashMap::new(),
         );
-        assert_matches!(
-            result,
-            Err(PolicySetError::LinkingError(
-                LinkingError::NoSuchTemplate { .. }
-            ))
+        assert_matches!(result, Err(PolicySetError::ExpectedTemplate));
+        assert_eq!(
+            pset, before_link,
+            "A failed link shouldn't mutate the policy set"
         );
     }
 


### PR DESCRIPTION
If linking failed because the template id corresponded to a static policy, `PolicySet::link` would correctly return an error, but the error was returned after calling `ast::PolicySet::link`. When given a static policy id, this function updated the links HashMap to add an entry for the target policy id which was not removed when returning an error.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
