### PR TITLE
Refactor AST Unknowns

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -630,6 +630,15 @@ impl Unknown {
             type_annotation: None,
         }
     }
+
+    /// Create a new `Unknown` with type annotation. (Only values of the given
+    /// type can be substituted.)
+    pub fn new_with_type(name: impl Into<SmolStr>, ty: Type) -> Self {
+        Self {
+            name: name.into(),
+            type_annotation: Some(ty),
+        }
+    }
 }
 
 /// Builder for constructing `Expr` objects annotated with some `data`

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-use smol_str::SmolStr;
-
 use crate::ast::*;
 use crate::entities::SchemaType;
 use crate::evaluator;
@@ -76,7 +74,7 @@ pub enum ExtensionOutputValue {
     /// A concrete value from an extension call
     Concrete(Value),
     /// An unknown returned from an extension call
-    Unknown(SmolStr),
+    Unknown(Unknown),
 }
 
 impl<T> From<T> for ExtensionOutputValue
@@ -313,7 +311,7 @@ impl ExtensionFunction {
     pub fn call(&self, args: &[Value]) -> evaluator::Result<PartialValue> {
         match (self.func)(args)? {
             ExtensionOutputValue::Concrete(v) => Ok(PartialValue::Value(v)),
-            ExtensionOutputValue::Unknown(name) => Ok(PartialValue::Residual(Expr::unknown(name))),
+            ExtensionOutputValue::Unknown(u) => Ok(PartialValue::Residual(Expr::unknown(u))),
         }
     }
 }

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use super::{
     BorrowedRestrictedExpr, EntityUID, Expr, ExprConstructionError, ExprKind, Literal,
-    PartialValue, RestrictedExpr, Value, Var,
+    PartialValue, RestrictedExpr, Unknown, Value, Var,
 };
 
 /// Represents the request tuple <P, A, R, C> (see the Cedar design doc).
@@ -60,7 +60,7 @@ impl EntityUIDEntry {
     pub fn evaluate(&self, var: Var) -> PartialValue {
         match self {
             EntityUIDEntry::Concrete(euid) => Value::Lit(Literal::EntityUID(euid.clone())).into(),
-            EntityUIDEntry::Unknown => Expr::unknown(var.to_string()).into(),
+            EntityUIDEntry::Unknown => Expr::unknown(Unknown::new_untyped(var.to_string())).into(),
         }
     }
 

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -54,7 +54,7 @@ impl TryFrom<Expr> for Value {
     fn try_from(value: Expr) -> Result<Self, Self::Error> {
         match value.into_expr_kind() {
             ExprKind::Lit(l) => Ok(Value::Lit(l)),
-            ExprKind::Unknown { .. } => Err(NotValue::NotValue),
+            ExprKind::Unknown(_) => Err(NotValue::NotValue),
             ExprKind::Var(_) => Err(NotValue::NotValue),
             ExprKind::Slot(_) => Err(NotValue::NotValue),
             ExprKind::If { .. } => Err(NotValue::NotValue),
@@ -452,6 +452,13 @@ impl Value {
             authoritative: Arc::new(authoritative),
             fast: Some(Arc::new(fast)),
         })
+    }
+}
+
+impl PartialValue {
+    /// Create a new `PartialValue` consisting of just this single `Unknown`
+    pub fn unknown(u: Unknown) -> Self {
+        Self::Residual(Expr::unknown(u))
     }
 }
 

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -532,7 +532,7 @@ mod test {
         let context = Context::from_expr(
             RestrictedExpr::record([(
                 "test".into(),
-                RestrictedExpr::new(Expr::unknown("name")).unwrap(),
+                RestrictedExpr::unknown(Unknown::new_untyped("name")),
             )])
             .unwrap(),
         )

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -96,12 +96,12 @@ impl Entities {
             None => match self.mode {
                 Mode::Concrete => Dereference::NoSuchEntity,
                 #[cfg(feature = "partial-eval")]
-                Mode::Partial => Dereference::Residual(Expr::unknown_with_type(
-                    format!("{uid}"),
-                    Some(Type::Entity {
+                Mode::Partial => Dereference::Residual(Expr::unknown(Unknown {
+                    name: format!("{uid}").into(),
+                    type_annotation: Some(Type::Entity {
                         ty: uid.entity_type().clone(),
                     }),
-                )),
+                })),
             },
         }
     }
@@ -817,8 +817,7 @@ mod json_parsing_tests {
         let euid = r#"Test::"jeff""#.parse().unwrap();
         let jeff = es.entity(&euid).unwrap();
         let rexpr = jeff.get("foo").unwrap();
-        let expected_rexpr = RestrictedExpr::new(Expr::val(3)).unwrap();
-        assert_eq!(rexpr, &expected_rexpr);
+        assert_eq!(rexpr, &RestrictedExpr::val(3));
         assert!(jeff.is_descendant_of(&r#"Test::"susan""#.parse().unwrap()));
         simple_entities_still_sane(&es);
     }
@@ -918,8 +917,7 @@ mod json_parsing_tests {
         let bob = r#"Test::"bob""#.parse().unwrap();
         let alice = e.entity(&r#"Test::"alice""#.parse().unwrap()).unwrap();
         let bar = alice.get("bar").unwrap();
-        let two = RestrictedExpr::new(Expr::val(2)).unwrap();
-        assert_eq!(bar, &two);
+        assert_eq!(bar, &RestrictedExpr::val(2));
         assert!(alice.is_descendant_of(&bob));
         let bob = e.entity(&bob).unwrap();
         assert!(bob.ancestors().collect::<Vec<_>>().is_empty());

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -96,12 +96,12 @@ impl Entities {
             None => match self.mode {
                 Mode::Concrete => Dereference::NoSuchEntity,
                 #[cfg(feature = "partial-eval")]
-                Mode::Partial => Dereference::Residual(Expr::unknown(Unknown {
-                    name: format!("{uid}").into(),
-                    type_annotation: Some(Type::Entity {
+                Mode::Partial => Dereference::Residual(Expr::unknown(Unknown::new_with_type(
+                    format!("{uid}"),
+                    Type::Entity {
                         ty: uid.entity_type().clone(),
-                    }),
-                })),
+                    },
+                ))),
             },
         }
     }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -514,7 +514,9 @@ impl Expr {
                 .map_err(Into::into),
             Expr::ExprNoExt(ExprNoExt::Var(var)) => Ok(ast::Expr::var(var)),
             Expr::ExprNoExt(ExprNoExt::Slot(slot)) => Ok(ast::Expr::slot(slot)),
-            Expr::ExprNoExt(ExprNoExt::Unknown { name }) => Ok(ast::Expr::unknown(name)),
+            Expr::ExprNoExt(ExprNoExt::Unknown { name }) => {
+                Ok(ast::Expr::unknown(ast::Unknown::new_untyped(name)))
+            }
             Expr::ExprNoExt(ExprNoExt::Not { arg }) => {
                 Ok(ast::Expr::not((*arg).clone().try_into_ast(id)?))
             }
@@ -692,7 +694,7 @@ impl From<ast::Expr> for Expr {
             ast::ExprKind::Lit(lit) => lit.into(),
             ast::ExprKind::Var(var) => var.into(),
             ast::ExprKind::Slot(slot) => slot.into(),
-            ast::ExprKind::Unknown { name, .. } => Expr::unknown(name),
+            ast::ExprKind::Unknown(ast::Unknown { name, .. }) => Expr::unknown(name),
             ast::ExprKind::If {
                 test_expr,
                 then_expr,

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -985,22 +985,22 @@ pub mod test {
         let r = eval.partial_eval_expr(&e).unwrap();
         let expected_residual = Expr::binary_app(
             BinaryOp::In,
-            Expr::unknown(Unknown {
-                name: format!("{missing}").into(),
-                type_annotation: Some(Type::Entity {
+            Expr::unknown(Unknown::new_with_type(
+                format!("{missing}"),
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
-                }),
-            }),
+                },
+            )),
             Expr::set([Expr::val(parent.clone()), Expr::val(second.clone())]),
         );
         let expected_residual2 = Expr::binary_app(
             BinaryOp::In,
-            Expr::unknown(Unknown {
-                name: format!("{missing}").into(),
-                type_annotation: Some(Type::Entity {
+            Expr::unknown(Unknown::new_with_type(
+                format!("{missing}"),
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
-                }),
-            }),
+                },
+            )),
             Expr::set([Expr::val(second), Expr::val(parent)]),
         );
 
@@ -1031,12 +1031,12 @@ pub mod test {
         let r = eval.partial_eval_expr(&e).unwrap();
         let expected_residual = Expr::binary_app(
             BinaryOp::In,
-            Expr::unknown(Unknown {
-                name: format!("{missing}").into(),
-                type_annotation: Some(Type::Entity {
+            Expr::unknown(Unknown::new_with_type(
+                format!("{missing}"),
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
-                }),
-            }),
+                },
+            )),
             Expr::val(parent),
         );
         assert_eq!(r, Either::Right(expected_residual));
@@ -1059,12 +1059,12 @@ pub mod test {
         let e = Expr::has_attr(Expr::val(missing.clone()), "spoon".into());
         let r = eval.partial_eval_expr(&e).unwrap();
         let expected_residual = Expr::has_attr(
-            Expr::unknown(Unknown {
-                name: format!("{missing}").into(),
-                type_annotation: Some(Type::Entity {
+            Expr::unknown(Unknown::new_with_type(
+                format!("{missing}"),
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
-                }),
-            }),
+                },
+            )),
             "spoon".into(),
         );
         assert_eq!(r, Either::Right(expected_residual));
@@ -1087,12 +1087,12 @@ pub mod test {
         let e = Expr::get_attr(Expr::val(missing.clone()), "spoon".into());
         let r = eval.partial_eval_expr(&e).unwrap();
         let expected_residual = Expr::get_attr(
-            Expr::unknown(Unknown {
-                name: format!("{missing}").into(),
-                type_annotation: Some(Type::Entity {
+            Expr::unknown(Unknown::new_with_type(
+                format!("{missing}"),
+                Type::Entity {
                     ty: EntityUID::test_entity_type(),
-                }),
-            }),
+                },
+            )),
             "spoon".into(),
         );
         assert_eq!(r, Either::Right(expected_residual));

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -23,10 +23,9 @@ use crate::{
 
 /// Create a new untyped `Unknown`
 fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
-    Ok(ExtensionOutputValue::Unknown(Unknown {
-        name: v.get_as_string()?.clone(),
-        type_annotation: None,
-    }))
+    Ok(ExtensionOutputValue::Unknown(Unknown::new_untyped(
+        v.get_as_string()?.clone(),
+    )))
 }
 
 fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -16,13 +16,17 @@
 
 //! This module contains the extension for including unknown values
 use crate::{
-    ast::{CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, Value},
+    ast::{CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, Unknown, Value},
     entities::SchemaType,
     evaluator::{self, EvaluationError},
 };
 
+/// Create a new untyped `Unknown`
 fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
-    Ok(ExtensionOutputValue::Unknown(v.get_as_string()?.clone()))
+    Ok(ExtensionOutputValue::Unknown(Unknown {
+        name: v.get_as_string()?.clone(),
+        type_annotation: None,
+    }))
 }
 
 fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -570,12 +570,9 @@ impl<'a> Typechecker<'a> {
                 .with_same_source_info(e)
                 .var(Var::Context),
             ),
-            ExprKind::Unknown {
-                name,
-                type_annotation,
-            } => TypecheckAnswer::fail(
-                ExprBuilder::with_data(None).unknown(name.clone(), type_annotation.clone()),
-            ),
+            ExprKind::Unknown(u) => {
+                TypecheckAnswer::fail(ExprBuilder::with_data(None).unknown(u.clone()))
+            }
             // Template Slots, always has to be an entity.
             ExprKind::Slot(slotid) => TypecheckAnswer::success(
                 ExprBuilder::with_data(Some(if slotid.is_principal() {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -4436,12 +4436,12 @@ mod policy_set_tests {
     fn unknown_entities() {
         let ast = ast::Policy::from_when_clause(
             ast::Effect::Permit,
-            ast::Expr::unknown_with_type(
+            ast::Expr::unknown(ast::Unknown::new_with_type(
                 "test_entity_type::\"unknown\"",
-                Some(ast::Type::Entity {
+                ast::Type::Entity {
                     ty: ast::EntityType::Concrete("test_entity_type".parse().unwrap()),
-                }),
-            ),
+                },
+            )),
             ast::PolicyID::from_smolstr("static".into()),
         );
         let static_policy = Policy::from_ast(ast);

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2029,19 +2029,18 @@ impl PolicySet {
                 .ast
                 .condition()
                 .unknowns()
-                .filter_map(|expr| match expr.expr_kind() {
-                    ast::ExprKind::Unknown {
-                        name,
-                        type_annotation,
-                    } => {
+                .filter_map(
+                    |ast::Unknown {
+                         name,
+                         type_annotation,
+                     }| {
                         if matches!(type_annotation, Some(ast::Type::Entity { .. })) {
                             EntityUid::from_str(name.as_str()).ok()
                         } else {
                             None
                         }
-                    }
-                    _ => None,
-                })
+                    },
+                )
                 .collect();
             entity_uids.extend(ids);
         }


### PR DESCRIPTION
## Description of changes

A refactoring that will be useful for implementing [RFC 34](https://github.com/cedar-policy/rfcs/pull/34), but also in my opinion independently valuable.  Makes some things easier, other things more explicit, and theoretically paves the way for Unknown type annotations to be handled/provided in more places.

No change to public API, just Core's.

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
