### PR TITLE
fix for 418; some associated refactoring

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -641,6 +641,14 @@ impl Unknown {
     }
 }
 
+impl std::fmt::Display for Unknown {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Like the Display impl for Expr, we delegate to the EST
+        // pretty-printer, to avoid code duplication
+        write!(f, "{}", crate::est::Expr::from(Expr::unknown(self.clone())))
+    }
+}
+
 /// Builder for constructing `Expr` objects annotated with some `data`
 /// (possibly taking default value) and optional some `source_info`.
 #[derive(Debug)]

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2175,7 +2175,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
-            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but actually has type string"#),
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but it does not: `"3"`"#),
             "actual error message was {err}"
         );
     }
@@ -2263,7 +2263,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but actually has type record"#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but it does not: `{"id": "aaaaa", "type": "HR"}`"#),
             "actual error message was {err}"
         );
     }
@@ -2308,7 +2308,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but actually has type (entity of type `HR`)"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but it does not: `HR::"34FB87"`"#),
             "actual error message was {err}"
         );
     }
@@ -2354,7 +2354,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but it does not: `decimal("3.33")`"#),
             "actual error message was {err}"
         );
     }
@@ -3080,7 +3080,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but actually has type (entity of type `Employee`)"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but it does not: `Employee::"34FB87"`"#),
             "actual error message was {err}"
         );
 

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2175,7 +2175,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
-            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but it does not: `"3"`"#),
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: value was expected to have type long, but actually has type string: `"3"`"#),
             "actual error message was {err}"
         );
     }
@@ -2263,7 +2263,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but it does not: `{"id": "aaaaa", "type": "HR"}`"#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: value was expected to have type (set of `HR`), but actually has type record with attributes: {"id" => (optional) string, "type" => (optional) string}: `{"id": "aaaaa", "type": "HR"}`"#),
             "actual error message was {err}"
         );
     }
@@ -2308,7 +2308,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but it does not: `HR::"34FB87"`"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: value was expected to have type `Employee`, but actually has type `HR`: `HR::"34FB87"`"#),
             "actual error message was {err}"
         );
     }
@@ -2354,7 +2354,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but it does not: `decimal("3.33")`"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#),
             "actual error message was {err}"
         );
     }
@@ -2443,7 +2443,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on attribute \"inner1\"");
         assert!(
-            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type record with attributes: "#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: value was expected to have type record with attributes: "#),
             "actual error message was {err}"
         );
 
@@ -3080,7 +3080,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but it does not: `Employee::"34FB87"`"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: value was expected to have type `XYZCorp::Employee`, but actually has type `Employee`: `Employee::"34FB87"`"#),
             "actual error message was {err}"
         );
 

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -263,7 +263,7 @@ pub enum TypeOfRestrictedExprError {
     /// Trying to compute the type of a restricted expression which contains
     /// an [`Unknown`] that has insufficient type information associated in
     /// order to compute the `SchemaType`
-    #[error("can't compute SchemaType because of insufficient type information for `{unknown}`")]
+    #[error("cannot compute type because of insufficient type information for `{unknown}`")]
     UnknownInsufficientTypeInfo {
         /// `Unknown` which has insufficient type information
         unknown: Unknown,

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -143,7 +143,9 @@ pub enum JsonDeserializationError {
     /// entity attributes are reported as `Self::EntitySchemaConformance`. As of
     /// this writing, that means this should only be used for schema-based
     /// parsing of the `Context`.)
-    #[error("{ctx}, type mismatch: expected type {expected}, but actually has type {actual}")]
+    #[error(
+        "{ctx}, type mismatch: expected value to have type {expected}, but it does not: `{actual}`"
+    )]
     TypeMismatch {
         /// Context of this error, which will be something other than `EntityAttribute`.
         /// (Type mismatches in entity attributes are reported as
@@ -151,8 +153,8 @@ pub enum JsonDeserializationError {
         ctx: Box<JsonDeserializationErrorContext>,
         /// Type which was expected
         expected: Box<SchemaType>,
-        /// Type which was encountered instead
-        actual: Box<SchemaType>,
+        /// Value which doesn't have the expected type
+        actual: Box<RestrictedExpr>,
     },
     /// During schema-based parsing, found a set whose elements don't all have
     /// the same type.  This doesn't match any possible schema.
@@ -189,6 +191,18 @@ pub enum JsonDeserializationError {
         ctx: Box<JsonDeserializationErrorContext>,
         /// Underlying error
         err: ExtensionFunctionLookupError,
+    },
+    /// During schema-based parsing, found an unknown in an _argument_ to an
+    /// extension function being processed in implicit-constructor form. This is
+    /// not currently supported.
+    /// To pass an unknown to an extension function, use the
+    /// explicit-constructor form.
+    #[error("{ctx}, argument `{arg}` to implicit constructor is an unknown; this is not currently supported. To pass an unknown to an extension function, use the explicit constructor form")]
+    UnknownInImplicitConstructorArg {
+        /// Context of this error
+        ctx: Box<JsonDeserializationErrorContext>,
+        /// Argument which was encountered
+        arg: Box<RestrictedExpr>,
     },
     /// Raised when a JsonValue contains the no longer supported `__expr` escape
     #[error("{0}, invalid escape. The `__expr` escape is no longer supported")]

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -64,6 +64,22 @@ pub struct AttributeType {
 }
 
 impl SchemaType {
+    /// Return the `SchemaType` corresponding to the given `Type`, if possible.
+    ///
+    /// Some `Type`s do not contain enough information to construct a full
+    /// `SchemaType`.  In those cases, this function returns `None`.
+    pub fn from_ty(ty: Type) -> Option<Self> {
+        match ty {
+            Type::Bool => Some(SchemaType::Bool),
+            Type::Long => Some(SchemaType::Long),
+            Type::String => Some(SchemaType::String),
+            Type::Entity { ty } => Some(SchemaType::Entity { ty }),
+            Type::Set => None,
+            Type::Record => None,
+            Type::Extension { name } => Some(SchemaType::Extension { name }),
+        }
+    }
+
     /// Does this SchemaType match the given Type.
     /// I.e., are they compatible, in the sense that there exist some concrete
     /// values that have the given SchemaType and the given Type.

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast::{EntityType, Name, Type};
+use itertools::Itertools;
 use smol_str::SmolStr;
 use std::collections::HashMap;
 
@@ -190,17 +191,27 @@ impl std::fmt::Display for SchemaType {
                 if attrs.is_empty() {
                     write!(f, "empty record")
                 } else {
-                    write!(f, "record with attributes: (")?;
-                    for (k, v) in attrs.iter() {
-                        write!(f, "{k:?} => {v}, ")?;
+                    write!(f, "record with attributes: {{")?;
+                    // sorting attributes ensures that there is a single, deterministic
+                    // Display output for each `SchemaType`, which is important for
+                    // tests that check equality of error messages
+                    for (i, (k, v)) in attrs
+                        .iter()
+                        .sorted_unstable_by_key(|(k, _)| SmolStr::clone(k))
+                        .enumerate()
+                    {
+                        write!(f, "{k:?} => {v}")?;
+                        if i < (attrs.len() - 1) {
+                            write!(f, ", ")?;
+                        }
                     }
-                    write!(f, ")")?;
+                    write!(f, "}}")?;
                     Ok(())
                 }
             }
             Self::Entity { ty } => match ty {
                 EntityType::Unspecified => write!(f, "(entity of unspecified type)"),
-                EntityType::Concrete(name) => write!(f, "(entity of type `{}`)", name),
+                EntityType::Concrete(name) => write!(f, "`{}`", name),
             },
             Self::Extension { name } => write!(f, "{}", name),
         }

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -19,7 +19,7 @@ use super::{
 };
 use crate::ast::{
     BorrowedRestrictedExpr, Eid, EntityUID, ExprConstructionError, ExprKind, Literal, Name,
-    RestrictedExpr,
+    RestrictedExpr, Unknown,
 };
 use crate::entities::{
     type_of_restricted_expr, EntitySchemaConformanceError, EscapeKind, TypeOfRestrictedExprError,
@@ -366,6 +366,25 @@ impl<'e> ValueParser<'e> {
         expected_ty: Option<&SchemaType>,
         ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
     ) -> Result<RestrictedExpr, JsonDeserializationError> {
+        // First we have to check if we've been given an Unknown. This is valid
+        // regardless of the expected type (see #418).
+        let parse_as_unknown = |val: serde_json::Value| {
+            let extjson: ExtnValueJson = serde_json::from_value(val).ok()?;
+            match extjson {
+                ExtnValueJson::ExplicitExtnEscape {
+                    __extn: FnAndArg { ext_fn, arg },
+                } if ext_fn == "unknown" => {
+                    let arg = arg.into_expr(ctx.clone()).ok()?;
+                    let name = arg.as_string()?;
+                    Some(RestrictedExpr::unknown(Unknown::new_untyped(name.clone())))
+                }
+                _ => None, // only explicit `__extn` escape is valid for this purpose. For instance, if we allowed `ImplicitConstructor` here, then all strings would parse as calls to `unknown()`, which is clearly not what we want.
+            }
+        };
+        if let Some(rexpr) = parse_as_unknown(val.clone()) {
+            return Ok(rexpr);
+        }
+        // otherwise, we do normal schema-based parsing based on the expected type.
         match expected_ty {
             // The expected type is an entity reference. Special parsing rules
             // apply: for instance, the `__entity` escape can optionally be omitted.
@@ -398,14 +417,7 @@ impl<'e> ValueParser<'e> {
                     let expected = Box::new(expected_ty.clone());
                     let actual = {
                         let jvalue: CedarValueJson = serde_json::from_value(val)?;
-                        let ty = type_of_restricted_expr(
-                            jvalue.into_expr(ctx.clone())?.as_borrowed(),
-                            self.extensions,
-                        )
-                        .map_err(|e| {
-                            type_of_restricted_expr_error_to_json_deserialization_error(e, ctx())
-                        })?;
-                        Box::new(ty)
+                        Box::new(jvalue.into_expr(ctx.clone())?)
                     };
                     match ctx() {
                         JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
@@ -480,14 +492,7 @@ impl<'e> ValueParser<'e> {
                     let expected = Box::new(expected_ty.clone());
                     let actual = {
                         let jvalue: CedarValueJson = serde_json::from_value(val)?;
-                        let ty = type_of_restricted_expr(
-                            jvalue.into_expr(ctx.clone())?.as_borrowed(),
-                            self.extensions,
-                        )
-                        .map_err(|e| {
-                            type_of_restricted_expr_error_to_json_deserialization_error(e, ctx())
-                        })?;
-                        Box::new(ty)
+                        Box::new(jvalue.into_expr(ctx.clone())?)
                     };
                     match ctx() {
                         JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
@@ -548,10 +553,46 @@ impl<'e> ValueParser<'e> {
             }
             ExtnValueJson::ImplicitConstructor(val) => {
                 let arg = val.into_expr(ctx.clone())?;
-                let argty =
-                    type_of_restricted_expr(arg.as_borrowed(), self.extensions).map_err(|e| {
-                        type_of_restricted_expr_error_to_json_deserialization_error(e, ctx())
-                    })?;
+                let argty = type_of_restricted_expr(arg.as_borrowed(), self.extensions).map_err(
+                    |e| match e {
+                        TypeOfRestrictedExprError::HeterogeneousSet(err) => match ctx() {
+                            JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
+                                JsonDeserializationError::EntitySchemaConformance(
+                                    EntitySchemaConformanceError::HeterogeneousSet {
+                                        uid,
+                                        attr,
+                                        err,
+                                    },
+                                )
+                            }
+                            ctx => JsonDeserializationError::HeterogeneousSet {
+                                ctx: Box::new(ctx),
+                                err,
+                            },
+                        },
+                        TypeOfRestrictedExprError::ExtensionFunctionLookup(err) => match ctx() {
+                            JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
+                                JsonDeserializationError::EntitySchemaConformance(
+                                    EntitySchemaConformanceError::ExtensionFunctionLookup {
+                                        uid,
+                                        attr,
+                                        err,
+                                    },
+                                )
+                            }
+                            ctx => JsonDeserializationError::ExtensionFunctionLookup {
+                                ctx: Box::new(ctx),
+                                err,
+                            },
+                        },
+                        TypeOfRestrictedExprError::UnknownInsufficientTypeInfo { .. } => {
+                            JsonDeserializationError::UnknownInImplicitConstructorArg {
+                                ctx: Box::new(ctx()),
+                                arg: Box::new(arg.clone()),
+                            }
+                        }
+                    },
+                )?;
                 let func = self
                     .extensions
                     .lookup_single_arg_constructor(
@@ -577,36 +618,6 @@ impl<'e> ValueParser<'e> {
                 ))
             }
         }
-    }
-}
-
-fn type_of_restricted_expr_error_to_json_deserialization_error(
-    torerr: TypeOfRestrictedExprError,
-    ctx: JsonDeserializationErrorContext,
-) -> JsonDeserializationError {
-    match torerr {
-        TypeOfRestrictedExprError::HeterogeneousSet(err) => match ctx {
-            JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
-                JsonDeserializationError::EntitySchemaConformance(
-                    EntitySchemaConformanceError::HeterogeneousSet { uid, attr, err },
-                )
-            }
-            ctx => JsonDeserializationError::HeterogeneousSet {
-                ctx: Box::new(ctx),
-                err,
-            },
-        },
-        TypeOfRestrictedExprError::ExtensionFunctionLookup(err) => match ctx {
-            JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
-                JsonDeserializationError::EntitySchemaConformance(
-                    EntitySchemaConformanceError::ExtensionFunctionLookup { uid, attr, err },
-                )
-            }
-            ctx => JsonDeserializationError::ExtensionFunctionLookup {
-                ctx: Box::new(ctx),
-                err,
-            },
-        },
     }
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   policy. With this fix it is possible to create a link with a policy id
   after previously failing to create that link with the same id from a static
   policy.
+- Fixed schema-based parsing of entity data that includes unknowns (for the
+  `partial-eval` experimental feature). (#418)
 
 ## [2.4.2] - 2023-10-23
 Cedar Language Version: 2.1.2

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -5410,7 +5410,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
-            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but actually has type string"#),
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but it does not: `"3"`"#),
             "actual error message was {err}"
         );
 
@@ -5478,7 +5478,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but actually has type record with attributes: ("#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but it does not: `{"id": "aaaaa", "type": "HR"}`"#),
             "actual error message was {err}"
         );
 
@@ -5513,7 +5513,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but actually has type (entity of type `HR`)"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but it does not: `HR::"34FB87"`"#),
             "actual error message was {err}"
         );
 
@@ -5549,7 +5549,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but actually has type decimal"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but it does not: `decimal("3.33")`"#),
             "actual error message was {err}"
         );
 
@@ -5733,7 +5733,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but actually has type (entity of type `Employee`)"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but it does not: `Employee::"34FB87"`"#),
             "actual error message was {err}"
         );
     }
@@ -6225,5 +6225,140 @@ mod schema_based_parsing_tests {
             EntitiesError::Duplicate(euid) => assert_eq!(euid, expected_euid),
             e => panic!("Wrong error. Expected `Duplicate`, got: {e:?}"),
         }
+    }
+
+    /// Test that schema-based parsing accepts unknowns in any position where any type is expected
+    #[test]
+    fn issue_418() {
+        let schema = Schema::from_json_value(json!(
+        {"": {
+            "entityTypes": {
+                "Employee": {
+                    "memberOfTypes": [],
+                    "shape": {
+                        "type": "Record",
+                        "attributes": {
+                            "isFullTime": { "type": "Boolean" },
+                            "numDirectReports": { "type": "Long" },
+                            "department": { "type": "String" },
+                            "manager": { "type": "Entity", "name": "Employee" },
+                            "hr_contacts": { "type": "Set", "element": {
+                                "type": "Entity", "name": "HR" } },
+                            "sales_contacts": { "type": "Set", "element": {
+                                "type": "Entity", "name": "Employee" } },
+                            "json_blob": { "type": "Record", "attributes": {
+                                "inner1": { "type": "Boolean" },
+                                "inner2": { "type": "String" },
+                                "inner3": { "type": "Record", "attributes": {
+                                    "innerinner": { "type": "Entity", "name": "Employee" }
+                                }}
+                            }},
+                            "home_ip": { "type": "Extension", "name": "ipaddr" },
+                            "work_ip": { "type": "Extension", "name": "ipaddr" },
+                            "trust_score": { "type": "Extension", "name": "decimal" },
+                            "tricky": { "type": "Record", "attributes": {
+                                "type": { "type": "String" },
+                                "id": { "type": "String" }
+                            }}
+                        }
+                    }
+                },
+                "HR": {
+                    "memberOfTypes": []
+                }
+            },
+            "actions": {
+                "view": { }
+            }
+        }}
+        ))
+        .expect("should be a valid schema");
+
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": { "__extn": { "fn": "unknown", "arg": "abc" }},
+                        "numDirectReports": { "__extn": { "fn": "unknown", "arg": "def" }},
+                        "department": { "__extn": { "fn": "unknown", "arg": "zxy" }},
+                        "manager": { "__extn": { "fn": "unknown", "arg": "www" }},
+                        "hr_contacts": { "__extn": { "fn": "unknown", "arg": "yyy" }},
+                        "sales_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "__extn": { "fn": "unknown", "arg": "123" }}
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": { "__extn": { "fn": "unknown", "arg": "hhh" }},
+                            "inner3": { "innerinner": { "__extn": { "fn": "unknown", "arg": "bbb" }}},
+                        },
+                        "home_ip": { "__extn": { "fn": "unknown", "arg": "uuu" }},
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": { "__extn": { "fn": "unknown", "arg": "dec" }},
+                        "tricky": { "__extn": { "fn": "unknown", "arg": "ttt" }}
+                    },
+                    "parents": []
+                }
+            ]
+        );
+
+        let parsed = Entities::from_json_value(entitiesjson.clone(), Some(&schema))
+            .expect("Should parse without error");
+        let parsed = parsed
+            .get(&EntityUid::from_strs("Employee", "12UA45"))
+            .expect("that should be the employee id");
+        let assert_contains_unknown = |err: EvaluationError, unk_name: &str| {
+            assert!(
+                err.to_string()
+                    .contains("the expression contains unknown(s)"),
+                "actual error message was {err}"
+            );
+            assert!(
+                err.to_string().contains(unk_name),
+                "actual error message was {err}"
+            );
+        };
+        assert_matches!(
+            parsed.attr("isFullTime"),
+            Some(Err(e)) => assert_contains_unknown(e, "abc")
+        );
+        assert_matches!(
+            parsed.attr("numDirectReports"),
+            Some(Err(e)) => assert_contains_unknown(e, "def")
+        );
+        assert_matches!(
+            parsed.attr("department"),
+            Some(Err(e)) => assert_contains_unknown(e, "zxy")
+        );
+        assert_matches!(
+            parsed.attr("manager"),
+            Some(Err(e)) => assert_contains_unknown(e, "www")
+        );
+        assert_matches!(
+            parsed.attr("hr_contacts"),
+            Some(Err(e)) => assert_contains_unknown(e, "yyy")
+        );
+        assert_matches!(
+            parsed.attr("sales_contacts"),
+            Some(Err(e)) => assert_contains_unknown(e, "123")
+        );
+        assert_matches!(
+            parsed.attr("json_blob"),
+            Some(Err(e)) => assert_contains_unknown(e, "bbb")
+        );
+        assert_matches!(
+            parsed.attr("home_ip"),
+            Some(Err(e)) => assert_contains_unknown(e, "uuu")
+        );
+        assert_matches!(parsed.attr("work_ip"), Some(Ok(_)));
+        assert_matches!(
+            parsed.attr("trust_score"),
+            Some(Err(e)) => assert_contains_unknown(e, "dec")
+        );
+        assert_matches!(
+            parsed.attr("tricky"),
+            Some(Err(e)) => assert_contains_unknown(e, "ttt")
+        );
     }
 }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -5410,7 +5410,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on numDirectReports");
         assert!(
-            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type long, but it does not: `"3"`"#),
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: value was expected to have type long, but actually has type string: `"3"`"#),
             "actual error message was {err}"
         );
 
@@ -5478,7 +5478,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on hr_contacts");
         assert!(
-            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (set of (entity of type `HR`)), but it does not: `{"id": "aaaaa", "type": "HR"}`"#),
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: value was expected to have type (set of `HR`), but actually has type record with attributes: {"id" => (optional) string, "type" => (optional) string}: `{"id": "aaaaa", "type": "HR"}`"#),
             "actual error message was {err}"
         );
 
@@ -5513,7 +5513,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on manager");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `Employee`), but it does not: `HR::"34FB87"`"#),
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: value was expected to have type `Employee`, but actually has type `HR`: `HR::"34FB87"`"#),
             "actual error message was {err}"
         );
 
@@ -5549,7 +5549,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type ipaddr, but it does not: `decimal("3.33")`"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#),
             "actual error message was {err}"
         );
 
@@ -5618,7 +5618,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to type mismatch on attribute \"inner1\"");
         assert!(
-            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: attribute was expected to have type record with attributes: "#),
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: value was expected to have type record with attributes: "#),
             "actual error message was {err}"
         );
 
@@ -5733,7 +5733,7 @@ mod schema_based_parsing_tests {
         let err = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect_err("should fail due to manager being wrong entity type (missing namespace)");
         assert!(
-            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: attribute was expected to have type (entity of type `XYZCorp::Employee`), but it does not: `Employee::"34FB87"`"#),
+            err.to_string().contains(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: value was expected to have type `XYZCorp::Employee`, but actually has type `Employee`: `Employee::"34FB87"`"#),
             "actual error message was {err}"
         );
     }


### PR DESCRIPTION
## Description of changes

Fixes #418 and does a bit of associated refactoring.

One consequence of #418 is that computing the type of a `RestrictedExpr` is no longer always possible, due to `Unknown`s.  This affects error messages for some type mismatches, which used to report the expected and actual types, but now the actual type of the `RestrictedExpr` can't always be computed.  Rather than provide a different error message when the actual value is an unknown with no type, I have instead adjusted the error messages for these type mismatches to report the _expected type_ and _actual value_.  In my judgment, the resulting messages are clearer in some cases and less clear in others; see for yourself in the adjusted test expectations and let's discuss.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
