### PR TITLE
Reorganizing `SchemaType`, and add some helpers

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -231,7 +231,10 @@ impl std::str::FromStr for RestrictedExpr {
 
 /// While `RestrictedExpr` wraps an _owned_ `Expr`, `BorrowedRestrictedExpr`
 /// wraps a _borrowed_ `Expr`, with the same invariants.
-#[derive(Serialize, Hash, Debug, Clone, PartialEq, Eq)]
+///
+/// We derive `Copy` for this type because it's just a single reference, and
+/// `&T` is `Copy` for all `T`.
+#[derive(Serialize, Hash, Debug, Clone, PartialEq, Eq, Copy)]
 pub struct BorrowedRestrictedExpr<'a>(&'a Expr);
 
 impl<'a> BorrowedRestrictedExpr<'a> {

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -259,13 +259,10 @@ pub fn typecheck_restricted_expr_against_schematype(
             Ok(())
         }
         Err(GetSchemaTypeError::NontrivialResidual { .. }) => {
-            // this case should be unreachable for the case of `PartialValue`s
-            // which are entity attributes, because a `PartialValue` computed
-            // from a `RestrictedExpr` should only have trivial residuals.  And
-            // as of this writing, there are no callers of this function that
-            // pass anything other than entity attributes.  Nonetheless, rather
-            // than relying on these delicate invariants, it's safe to treat
-            // this case like the case above and consider this as passing.
+            // this case is unreachable according to the invariant in the comments
+            // on `schematype_of_restricted_expr()`.
+            // Nonetheless, rather than relying on that invariant, it's safe to
+            // treat this case like the case above and consider this as passing.
             Ok(())
         }
         Err(GetSchemaTypeError::HeterogeneousSet(err)) => {

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -1,10 +1,10 @@
-use super::{AttributeType, EntityTypeDescription, Schema, SchemaType, TypeMismatchError};
-use crate::ast::{
-    BorrowedRestrictedExpr, Entity, EntityType, EntityUID, ExprKind, Literal, Unknown,
+use super::{
+    schematype_of_restricted_expr, EntityTypeDescription, GetSchemaTypeError,
+    HeterogeneousSetError, Schema, SchemaType, TypeMismatchError,
 };
+use crate::ast::{BorrowedRestrictedExpr, Entity, EntityType, EntityUID};
 use crate::extensions::{ExtensionFunctionLookupError, Extensions};
 use smol_str::SmolStr;
-use std::collections::HashMap;
 use thiserror::Error;
 
 /// Errors raised when entities do not conform to the schema
@@ -101,17 +101,6 @@ pub enum EntitySchemaConformanceError {
     },
 }
 
-/// Found a set whose elements don't all have the same type.  This doesn't match
-/// any possible schema.
-#[derive(Debug, Error)]
-#[error("set elements have different types: {ty1} and {ty2}")]
-pub struct HeterogeneousSetError {
-    /// First element type which was found
-    ty1: Box<SchemaType>,
-    /// Second element type which was found
-    ty2: Box<SchemaType>,
-}
-
 /// Struct used to check whether entities conform to a schema
 #[derive(Debug, Clone)]
 pub struct EntitySchemaConformanceChecker<'a, S: Schema> {
@@ -182,38 +171,27 @@ impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
                     Some(expected_ty) => {
                         // typecheck: ensure that the entity attribute value matches
                         // the expected type
-                        match type_of_restricted_expr(val.clone(), self.extensions) {
-                            Ok(actual_ty) => {
-                                if actual_ty.is_consistent_with(&expected_ty) {
-                                    // typecheck passes
-                                } else {
-                                    return Err(EntitySchemaConformanceError::TypeMismatch {
-                                        uid: uid.clone(),
-                                        attr: attr.into(),
-                                        err: TypeMismatchError {
-                                            expected: Box::new(expected_ty),
-                                            actual_ty: Some(Box::new(actual_ty)),
-                                            actual_val: Box::new(val.to_owned()),
-                                        },
-                                    });
-                                }
+                        match typecheck_restricted_expr_against_schematype(
+                            val,
+                            &expected_ty,
+                            self.extensions,
+                        ) {
+                            Ok(()) => {} // typecheck passes
+                            Err(RestrictedExprTypecheckError::TypeMismatch(err)) => {
+                                return Err(EntitySchemaConformanceError::TypeMismatch {
+                                    uid: uid.clone(),
+                                    attr: attr.into(),
+                                    err,
+                                });
                             }
-                            Err(TypeOfRestrictedExprError::UnknownInsufficientTypeInfo {
-                                ..
-                            }) => {
-                                // in this case we just don't have the information to know whether
-                                // the attribute value (an unknown) matches the expected type.
-                                // For now we consider this as passing -- we can't really report a
-                                // type error.
-                            }
-                            Err(TypeOfRestrictedExprError::HeterogeneousSet(err)) => {
+                            Err(RestrictedExprTypecheckError::HeterogeneousSet(err)) => {
                                 return Err(EntitySchemaConformanceError::HeterogeneousSet {
                                     uid: uid.clone(),
                                     attr: attr.into(),
                                     err,
                                 });
                             }
-                            Err(TypeOfRestrictedExprError::ExtensionFunctionLookup(err)) => {
+                            Err(RestrictedExprTypecheckError::ExtensionFunctionLookup(err)) => {
                                 return Err(
                                     EntitySchemaConformanceError::ExtensionFunctionLookup {
                                         uid: uid.clone(),
@@ -247,102 +225,73 @@ impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
     }
 }
 
-/// Errors thrown by [`type_of_restricted_expr()`]
-#[derive(Debug, Error)]
-pub enum TypeOfRestrictedExprError {
-    /// Encountered a heterogeneous set. Heterogeneous sets do not have a valid
-    /// `SchemaType`.
-    #[error(transparent)]
-    HeterogeneousSet(#[from] HeterogeneousSetError),
-    /// Error looking up an extension function, which may be necessary for
-    /// expressions that contain extension function calls -- not to actually
-    /// call the extension function, but to get metadata about it
-    #[error(transparent)]
-    ExtensionFunctionLookup(#[from] ExtensionFunctionLookupError),
-    /// Trying to compute the type of a restricted expression which contains
-    /// an [`Unknown`] that has insufficient type information associated in
-    /// order to compute the `SchemaType`
-    #[error("cannot compute type because of insufficient type information for `{unknown}`")]
-    UnknownInsufficientTypeInfo {
-        /// `Unknown` which has insufficient type information
-        unknown: Unknown,
-    },
+/// Check whether the given `RestrictedExpr` typechecks with the given `SchemaType`.
+/// If the typecheck passes, return `Ok(())`.
+/// If the typecheck fails, return an appropriate `Err`.
+pub fn typecheck_restricted_expr_against_schematype(
+    expr: BorrowedRestrictedExpr<'_>,
+    expected_ty: &SchemaType,
+    extensions: Extensions<'_>,
+) -> Result<(), RestrictedExprTypecheckError> {
+    // TODO: instead of computing the `SchemaType` of `value` and then checking
+    // whether the schematypes are "consistent", wouldn't it be less confusing,
+    // more efficient, and maybe even more precise to just typecheck directly?
+    match schematype_of_restricted_expr(expr, extensions) {
+        Ok(actual_ty) => {
+            if actual_ty.is_consistent_with(expected_ty) {
+                // typecheck passes
+                Ok(())
+            } else {
+                Err(RestrictedExprTypecheckError::TypeMismatch(
+                    TypeMismatchError {
+                        expected: Box::new(expected_ty.clone()),
+                        actual_ty: Some(Box::new(actual_ty)),
+                        actual_val: Box::new(expr.to_owned()),
+                    },
+                ))
+            }
+        }
+        Err(GetSchemaTypeError::UnknownInsufficientTypeInfo { .. }) => {
+            // in this case we just don't have the information to know whether
+            // the attribute value (an unknown) matches the expected type.
+            // For now we consider this as passing -- we can't really report a
+            // type error.
+            Ok(())
+        }
+        Err(GetSchemaTypeError::NontrivialResidual { .. }) => {
+            // this case should be unreachable for the case of `PartialValue`s
+            // which are entity attributes, because a `PartialValue` computed
+            // from a `RestrictedExpr` should only have trivial residuals.  And
+            // as of this writing, there are no callers of this function that
+            // pass anything other than entity attributes.  Nonetheless, rather
+            // than relying on these delicate invariants, it's safe to treat
+            // this case like the case above and consider this as passing.
+            Ok(())
+        }
+        Err(GetSchemaTypeError::HeterogeneousSet(err)) => {
+            Err(RestrictedExprTypecheckError::HeterogeneousSet(err))
+        }
+        Err(GetSchemaTypeError::ExtensionFunctionLookup(err)) => {
+            Err(RestrictedExprTypecheckError::ExtensionFunctionLookup(err))
+        }
+    }
 }
 
-/// Get the [`SchemaType`] of a restricted expression.
-///
-/// This isn't possible for general `Expr`s (without a request, full schema,
-/// etc), but is possible for restricted expressions, given the information in
-/// `Extensions`.
-///
-/// For records, we can't know whether the attributes in the given record are
-/// required or optional.
-/// This function, when given a record that has keys A, B, and C, will return a
-/// `SchemaType` where A, B, and C are all marked as optional attributes, but no
-/// other attributes are possible.
-/// That is, this assumes that all existing attributes are optional, but that no
-/// other optional attributes are possible.
-/// Compared to marking A, B, and C as required, this allows the returned
-/// `SchemaType` to `is_consistent_with()` more types.
-pub fn type_of_restricted_expr(
-    rexpr: BorrowedRestrictedExpr<'_>,
-    extensions: Extensions<'_>,
-) -> Result<SchemaType, TypeOfRestrictedExprError> {
-    match rexpr.expr_kind() {
-        ExprKind::Lit(Literal::Bool(_)) => Ok(SchemaType::Bool),
-        ExprKind::Lit(Literal::Long(_)) => Ok(SchemaType::Long),
-        ExprKind::Lit(Literal::String(_)) => Ok(SchemaType::String),
-        ExprKind::Lit(Literal::EntityUID(uid)) => Ok(SchemaType::Entity { ty: uid.entity_type().clone() }),
-        ExprKind::Set(elements) => {
-            let mut element_types = elements.iter().map(|el| {
-                type_of_restricted_expr(BorrowedRestrictedExpr::new_unchecked(el), extensions) // assuming the invariant holds for the set as a whole, it will also hold for each element
-            });
-            match element_types.next() {
-                None => Ok(SchemaType::EmptySet),
-                Some(Err(e)) => Err(e),
-                Some(Ok(element_ty)) => {
-                    let matches_element_ty = |ty: &Result<SchemaType, TypeOfRestrictedExprError>| matches!(ty, Ok(ty) if ty.is_consistent_with(&element_ty));
-                    let conflicting_ty = element_types.find(|ty| !matches_element_ty(ty));
-                    match conflicting_ty {
-                        None => Ok(SchemaType::Set { element_ty: Box::new(element_ty) }),
-                        Some(Ok(conflicting_ty)) => Err(HeterogeneousSetError {
-                                ty1: Box::new(element_ty),
-                                ty2: Box::new(conflicting_ty),
-                        }.into()),
-                        Some(Err(e)) => Err(e),
-                    }
-                }
-            }
-        }
-        ExprKind::Record(map) => {
-            Ok(SchemaType::Record { attrs: {
-                map.iter().map(|(k, v)| {
-                    let attr_type = type_of_restricted_expr(
-                        BorrowedRestrictedExpr::new_unchecked(v), // assuming the invariant holds for the record as a whole, it will also hold for each attribute value
-                        extensions,
-                    )?;
-                    // we can't know if the attribute is required or optional,
-                    // but marking it optional is more flexible -- allows the
-                    // attribute type to `is_consistent_with()` more types
-                    Ok((k.clone(), AttributeType::optional(attr_type)))
-                }).collect::<Result<HashMap<_,_>, TypeOfRestrictedExprError>>()?
-            }})
-        }
-        ExprKind::ExtensionFunctionApp { fn_name, .. } => {
-            let efunc = extensions.func(fn_name)?;
-            Ok(efunc.return_type().cloned().ok_or_else(|| ExtensionFunctionLookupError::HasNoType {
-                name: efunc.name().clone()
-            })?)
-        }
-        ExprKind::Unknown(u @ Unknown { type_annotation, .. }) => match type_annotation {
-            None => Err(TypeOfRestrictedExprError::UnknownInsufficientTypeInfo { unknown: u.clone() }),
-            Some(ty) => match SchemaType::from_ty(ty.clone()) {
-                Some(ty) => Ok(ty),
-                None => Err(TypeOfRestrictedExprError::UnknownInsufficientTypeInfo { unknown: u.clone() }),
-            }
-        }
-        // PANIC SAFETY. Unreachable by invariant on restricted expressions
-        #[allow(clippy::unreachable)]
-        expr => unreachable!("internal invariant violation: BorrowedRestrictedExpr somehow contained this expr case: {expr:?}"),
-    }
+/// Errors returned by
+/// [`typecheck_restricted_expr_against_schematype()`]
+#[derive(Debug, Error)]
+pub enum RestrictedExprTypecheckError {
+    /// The given value had a type different than what was expected
+    #[error(transparent)]
+    TypeMismatch(#[from] TypeMismatchError),
+    /// The given value contained a heterogeneous set, which doesn't conform to
+    /// any possible `SchemaType`
+    #[error(transparent)]
+    HeterogeneousSet(#[from] HeterogeneousSetError),
+    /// Error looking up an extension function. This error can occur when
+    /// typechecking a `RestrictedExpr` because that may require getting
+    /// information about any extension functions referenced in the
+    /// `RestrictedExpr`.
+    #[error(transparent)]
+    ExtensionFunctionLookup(#[from] ExtensionFunctionLookupError),
 }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -16,12 +16,12 @@
 
 use std::fmt::Display;
 
-use super::SchemaType;
+use super::{HeterogeneousSetError, SchemaType};
 use crate::ast::{
     BorrowedRestrictedExpr, EntityUID, Expr, ExprKind, Name, PolicyID, RestrictedExpr,
     RestrictedExprError,
 };
-use crate::entities::conformance::{EntitySchemaConformanceError, HeterogeneousSetError};
+use crate::entities::conformance::EntitySchemaConformanceError;
 use crate::extensions::ExtensionFunctionLookupError;
 use crate::parser::err::ParseErrors;
 use either::Either;
@@ -196,11 +196,11 @@ pub enum JsonDeserializationError {
     /// not currently supported.
     /// To pass an unknown to an extension function, use the
     /// explicit-constructor form.
-    #[error("{ctx}, argument `{arg}` to implicit constructor is an unknown; this is not currently supported. To pass an unknown to an extension function, use the explicit constructor form")]
+    #[error("{ctx}, argument `{arg}` to implicit constructor contains an unknown; this is not currently supported. To pass an unknown to an extension function, use the explicit constructor form")]
     UnknownInImplicitConstructorArg {
         /// Context of this error
         ctx: Box<JsonDeserializationErrorContext>,
-        /// Argument which was encountered
+        /// Argument which contains an unknown
         arg: Box<RestrictedExpr>,
     },
     /// Raised when a JsonValue contains the no longer supported `__expr` escape

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -1,5 +1,5 @@
 use crate::{ValidatorEntityType, ValidatorSchema};
-use cedar_policy_core::entities::TypeOfRestrictedExprError;
+use cedar_policy_core::entities::GetSchemaTypeError;
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::{ast, entities};
 use smol_str::SmolStr;
@@ -282,7 +282,7 @@ pub enum RequestValidationError {
     /// Error computing the type of the `Context`; see the contained error type
     /// for details about the kinds of errors that can occur
     #[error("context is not valid: {0}")]
-    TypeOfContext(TypeOfRestrictedExprError),
+    TypeOfContext(GetSchemaTypeError),
 }
 
 /// Struct which carries enough information that it can impl Core's


### PR DESCRIPTION
## Description of changes

This is also part of the run-up to implementing [RFC 34](https://github.com/cedar-policy/rfcs/pull/34).

@khieta and @andrewmwells-amazon reviewed the previous PR (#419), so I requested @aaronjeline and @john-h-kastner-aws for this one, but anyone can feel free to review.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
