### PR TITLE
Move permissive validation option behind feature flag

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -69,6 +69,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   after previously failing to create that link with the same id from a static
   policy.
 
+### Removed
+
+- Move `ValidationMode::Permissive` behind an experimental feature flag.
+  To continue using this feature you must enable the `permissive-validate` feature
+  flag.
+
 ## [2.4.2] - 2023-10-23
 Cedar Language Version: 2.1.2
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -40,8 +40,9 @@ integration_testing = []
 
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
-experimental = ["partial-eval"]
+experimental = ["partial-eval", "permissive-validate"]
 partial-eval = ["cedar-policy-core/partial-eval"]
+permissive-validate = []
 
 [lib]
 crate_type = ["rlib"]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -976,6 +976,7 @@ pub enum ValidationMode {
     /// have a restricted form which is amenable for analysis.
     #[default]
     Strict,
+    #[cfg(feature = "permissive-validate")]
     /// Validate that policies do not contain any type errors.
     Permissive,
 }
@@ -984,6 +985,7 @@ impl From<ValidationMode> for cedar_policy_validator::ValidationMode {
     fn from(mode: ValidationMode) -> Self {
         match mode {
             ValidationMode::Strict => Self::Strict,
+            #[cfg(feature = "permissive-validate")]
             ValidationMode::Permissive => Self::Permissive,
         }
     }


### PR DESCRIPTION
## Description of changes

We don't have a lean model for permissive validation, so we probably want to make it experimental after the 3.0 release. I don't think this is fully decided yet, so we can let this PR sit for a couple days before merging

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
