### PR TITLE
remove Deserialize for Core's Entity and Entities

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -208,7 +208,7 @@ impl std::fmt::Display for Eid {
 }
 
 /// Entity datatype
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Entity {
     /// UID
     uid: EntityUID,

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -24,7 +24,7 @@ use std::borrow::Cow;
 use std::collections::{hash_map, HashMap};
 use std::fmt::Write;
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_with::serde_as;
 
 mod conformance;
@@ -38,11 +38,11 @@ use smol_str::SmolStr;
 /// Represents an entity hierarchy, and allows looking up `Entity` objects by
 /// UID.
 //
-/// Note that `Entities` is `Serialize` and `Deserialize`, but currently this is
-/// only used for the Dafny-FFI layer in DRT. All others use (and should use) the
-/// `from_json_*()` and `write_to_json()` methods as necessary.
+/// Note that `Entities` is `Serialize`, but currently this is only used for the
+/// FFI layer in DRT. All others use (and should use) the `from_json_*()` and
+/// `write_to_json()` methods as necessary.
 #[serde_as]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 pub struct Entities {
     /// Serde cannot serialize a HashMap to JSON when the key to the map cannot
     /// be serialized to a JSON string. This is a limitation of the JSON format.


### PR DESCRIPTION
## Description of changes

The `Serialize` and `Deserialize` on Core's `Entity` and `Entities` are already documented to only be used for DRT FFI.  It turns out that only the `Serialize` is used by DRT FFI, not `Deserialize`.  This PR removes the `Deserialize`, because (1) it is unused, (2) it nudges future users towards `from_json_*()` which is preferred, and (3) it will make implementing [RFC 34](https://github.com/cedar-policy/rfcs/pull/34) easier.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
