### PR TITLE
Implementation of RFC 34

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -446,7 +446,7 @@ impl std::fmt::Display for PartialValueSerializedAsExpr {
 /// Contains some extra contextual information and the underlying
 /// `EvaluationError`.
 #[derive(Debug, Error)]
-#[error("failed to evaluate attribute `{attr}` of entity `{uid}`: {err}")]
+#[error("failed to evaluate attribute `{attr}` of `{uid}`: {err}")]
 pub struct EntityAttrEvaluationError {
     /// UID of the entity where the error was encountered
     pub uid: EntityUID,

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -15,13 +15,17 @@
  */
 
 use crate::ast::*;
+use crate::evaluator::{EvaluationError, RestrictedEvaluator};
+use crate::extensions::Extensions;
 use crate::parser::err::ParseErrors;
 use crate::transitive_closure::TCNode;
 use crate::FromNormalizedStr;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, TryFromInto};
 use smol_str::SmolStr;
 use std::collections::{HashMap, HashSet};
+use thiserror::Error;
 
 /// We support two types of entities. The first is a nominal type (e.g., User, Action)
 /// and the second is an unspecified type, which is used (internally) to represent cases
@@ -216,8 +220,8 @@ pub struct Entity {
     /// Internal HashMap of attributes.
     ///
     /// In the serialized form of `Entity`, attribute values appear as
-    /// `RestrictedExpr`s.
-    attrs: HashMap<SmolStr, RestrictedExpr>,
+    /// `RestrictedExpr`s, for mostly historical reasons.
+    attrs: HashMap<SmolStr, PartialValueSerializedAsExpr>,
 
     /// Set of ancestors of this `Entity` (i.e., all direct and transitive
     /// parents), as UIDs
@@ -229,6 +233,53 @@ impl Entity {
     pub fn new(
         uid: EntityUID,
         attrs: HashMap<SmolStr, RestrictedExpr>,
+        ancestors: HashSet<EntityUID>,
+        extensions: &Extensions<'_>,
+    ) -> Result<Self, EntityAttrEvaluationError> {
+        let evaluator = RestrictedEvaluator::new(extensions);
+        let evaluated_attrs = attrs
+            .into_iter()
+            .map(|(k, v)| {
+                let attr_val = evaluator
+                    .partial_interpret(v.as_borrowed())
+                    .map_err(|err| EntityAttrEvaluationError {
+                        uid: uid.clone(),
+                        attr: k.clone(),
+                        err,
+                    })?;
+                Ok((k, attr_val.into()))
+            })
+            .collect::<Result<_, EntityAttrEvaluationError>>()?;
+        Ok(Entity {
+            uid,
+            attrs: evaluated_attrs,
+            ancestors,
+        })
+    }
+
+    /// Create a new `Entity` with this UID, attributes, and ancestors.
+    ///
+    /// Unlike in `Entity::new()`, in this constructor, attributes are expressed
+    /// as `PartialValue`.
+    pub fn new_with_attr_partialvalues(
+        uid: EntityUID,
+        attrs: HashMap<SmolStr, PartialValue>,
+        ancestors: HashSet<EntityUID>,
+    ) -> Self {
+        Entity {
+            uid,
+            attrs: attrs.into_iter().map(|(k, v)| (k, v.into())).collect(), // TODO: can we do this without disassembling and reassembling the HashMap
+            ancestors,
+        }
+    }
+
+    /// Create a new `Entity` with this UID, attributes, and ancestors.
+    ///
+    /// Unlike in `Entity::new()`, in this constructor, attributes are expressed
+    /// as `PartialValueSerializedAsExpr`.
+    pub fn new_with_attr_partialvalueserializedasexpr(
+        uid: EntityUID,
+        attrs: HashMap<SmolStr, PartialValueSerializedAsExpr>,
         ancestors: HashSet<EntityUID>,
     ) -> Self {
         Entity {
@@ -244,8 +295,8 @@ impl Entity {
     }
 
     /// Get the value for the given attribute, or `None` if not present
-    pub fn get(&self, attr: &str) -> Option<&RestrictedExpr> {
-        self.attrs.get(attr)
+    pub fn get(&self, attr: &str) -> Option<&PartialValue> {
+        self.attrs.get(attr).map(|v| v.as_ref())
     }
 
     /// Is this `Entity` a descendant of `e` in the entity hierarchy?
@@ -259,10 +310,8 @@ impl Entity {
     }
 
     /// Iterate over this entity's attributes
-    pub fn attrs(&self) -> impl Iterator<Item = (&str, BorrowedRestrictedExpr<'_>)> {
-        self.attrs
-            .iter()
-            .map(|(k, v)| (k.as_str(), v.as_borrowed()))
+    pub fn attrs(&self) -> impl Iterator<Item = (&SmolStr, &PartialValue)> {
+        self.attrs.iter().map(|(k, v)| (k, v.as_ref()))
     }
 
     /// Create an `Entity` with the given UID, no attributes, and no parents.
@@ -272,12 +321,6 @@ impl Entity {
             attrs: HashMap::new(),
             ancestors: HashSet::new(),
         }
-    }
-
-    /// Read-only access the internal `attrs` map of String to RestrictedExpr.
-    /// This function is available only inside Core.
-    pub(crate) fn attrs_map(&self) -> &HashMap<SmolStr, RestrictedExpr> {
-        &self.attrs
     }
 
     /// Test if two `Entity` objects are deep/structurally equal.
@@ -290,8 +333,15 @@ impl Entity {
     /// Set the given attribute to the given value.
     // Only used for convenience in some tests and when fuzzing
     #[cfg(any(test, fuzzing))]
-    pub fn set_attr(&mut self, attr: SmolStr, val: RestrictedExpr) {
-        self.attrs.insert(attr, val);
+    pub fn set_attr(
+        &mut self,
+        attr: SmolStr,
+        val: RestrictedExpr,
+        extensions: &Extensions<'_>,
+    ) -> Result<(), EvaluationError> {
+        let val = RestrictedEvaluator::new(extensions).partial_interpret(val.as_borrowed())?;
+        self.attrs.insert(attr, val.into());
+        Ok(())
     }
 
     /// Mark the given `UID` as an ancestor of this `Entity`.
@@ -352,6 +402,58 @@ impl std::fmt::Display for Entity {
             self.ancestors.iter().join(", ")
         )
     }
+}
+
+/// `PartialValue`, but serialized as a RestrictedExpr, for historical reasons
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PartialValueSerializedAsExpr(
+    #[serde_as(as = "TryFromInto<RestrictedExpr>")] PartialValue,
+);
+
+impl AsRef<PartialValue> for PartialValueSerializedAsExpr {
+    fn as_ref(&self) -> &PartialValue {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for PartialValueSerializedAsExpr {
+    type Target = PartialValue;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<PartialValue> for PartialValueSerializedAsExpr {
+    fn from(value: PartialValue) -> PartialValueSerializedAsExpr {
+        PartialValueSerializedAsExpr(value)
+    }
+}
+
+impl From<PartialValueSerializedAsExpr> for PartialValue {
+    fn from(value: PartialValueSerializedAsExpr) -> PartialValue {
+        value.0
+    }
+}
+
+impl std::fmt::Display for PartialValueSerializedAsExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Error type for evaluation errors when evaluating an entity attribute.
+/// Contains some extra contextual information and the underlying
+/// `EvaluationError`.
+#[derive(Debug, Error)]
+#[error("failed to evaluate attribute `{attr}` of entity `{uid}`: {err}")]
+pub struct EntityAttrEvaluationError {
+    /// UID of the entity where the error was encountered
+    pub uid: EntityUID,
+    /// Attribute of the entity where the error was encountered
+    pub attr: SmolStr,
+    /// Underlying evaluation error
+    pub err: EvaluationError,
 }
 
 #[cfg(test)]

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -175,6 +175,15 @@ impl From<Value> for Expr {
     }
 }
 
+impl From<PartialValue> for Expr {
+    fn from(pv: PartialValue) -> Self {
+        match pv {
+            PartialValue::Value(v) => Expr::from(v),
+            PartialValue::Residual(expr) => expr,
+        }
+    }
+}
+
 impl<T> Expr<T> {
     fn new(expr_kind: ExprKind<T>, source_info: Option<SourceInfo>, data: T) -> Self {
         Self {
@@ -643,8 +652,8 @@ impl Unknown {
 
 impl std::fmt::Display for Unknown {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Like the Display impl for Expr, we delegate to the EST
-        // pretty-printer, to avoid code duplication
+        // Like the Display impl for Expr, we delegate to the EST pretty-printer,
+        // to avoid code duplication
         write!(f, "{}", crate::est::Expr::from(Expr::unknown(self.clone())))
     }
 }
@@ -936,10 +945,14 @@ impl<T> ExprBuilder<T> {
 
     /// Create an `Expr` which calls the extension function with the given
     /// `Name` on `args`
-    pub fn call_extension_fn(self, fn_name: Name, args: Vec<Expr<T>>) -> Expr<T> {
+    pub fn call_extension_fn(
+        self,
+        fn_name: Name,
+        args: impl IntoIterator<Item = Expr<T>>,
+    ) -> Expr<T> {
         self.with_expr_kind(ExprKind::ExtensionFunctionApp {
             fn_name,
-            args: Arc::new(args),
+            args: Arc::new(args.into_iter().collect()),
         })
     }
 

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -44,7 +44,7 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
         let next_expr = self.expression_stack.pop()?;
         match next_expr.expr_kind() {
             ExprKind::Lit(_) => (),
-            ExprKind::Unknown { .. } => (),
+            ExprKind::Unknown(_) => (),
             ExprKind::Slot(_) => (),
             ExprKind::Var(_) => (),
             ExprKind::If {

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -611,8 +611,6 @@ pub enum RestrictedExprParseError {
     RestrictedExpr(#[from] RestrictedExprError),
 }
 
-///
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2908,7 +2908,7 @@ mod schema_based_parsing_tests {
         let is_full_time = parsed
             .get("isFullTime")
             .expect("isFullTime attr should exist");
-        assert_eq!(is_full_time, &PartialValue::from(true),);
+        assert_eq!(is_full_time, &PartialValue::from(true));
         let department = parsed
             .get("department")
             .expect("department attr should exist");

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -17,10 +17,8 @@
 //! This module contains the `Entities` type and related functionality.
 
 use crate::ast::*;
-use crate::evaluator::{EvaluationError, RestrictedEvaluator};
 use crate::extensions::Extensions;
 use crate::transitive_closure::{compute_tc, enforce_tc_and_dag};
-use std::borrow::Cow;
 use std::collections::{hash_map, HashMap};
 use std::fmt::Write;
 
@@ -33,7 +31,6 @@ mod err;
 pub use err::*;
 mod json;
 pub use json::*;
-use smol_str::SmolStr;
 
 /// Represents an entity hierarchy, and allows looking up `Entity` objects by
 /// UID.
@@ -54,9 +51,6 @@ pub struct Entities {
     #[serde_as(as = "Vec<(_, _)>")]
     entities: HashMap<EntityUID, Entity>,
 
-    #[serde(skip)]
-    evaluated_entities: Option<EvaluatedEntities>,
-
     /// The mode flag determines whether this store functions as a partial store or
     /// as a fully concrete store.
     /// Mode::Concrete means that the store is fully concrete, and failed dereferences are an error.
@@ -73,7 +67,6 @@ impl Entities {
         Self {
             entities: HashMap::new(),
             mode: Mode::default(),
-            evaluated_entities: None,
         }
     }
 
@@ -85,7 +78,6 @@ impl Entities {
         Self {
             entities: self.entities,
             mode: Mode::Partial,
-            evaluated_entities: self.evaluated_entities,
         }
     }
 
@@ -148,7 +140,6 @@ impl Entities {
             }
             TCComputation::ComputeNow => compute_tc(&mut self.entities, true).map_err(Box::new)?,
         };
-        self.evaluated_entities = None;
         Ok(self)
     }
 
@@ -197,7 +188,6 @@ impl Entities {
         Ok(Self {
             entities: entity_map,
             mode: Mode::default(),
-            evaluated_entities: None,
         })
     }
 
@@ -298,37 +288,6 @@ impl Entities {
         dot_str.write_str("}\n")?;
         Ok(dot_str)
     }
-
-    /// Attempt to eagerly compute the values of attributes for all entities in the slice.
-    /// This can fail if evaluation of the [`RestrictedExpr`] fails.
-    /// In a future major version, we will likely make this function automatically called via the constructor.
-    pub fn evaluate(self) -> std::result::Result<Self, EvaluationError> {
-        if self.evaluated_entities.is_some() {
-            Ok(self)
-        } else {
-            let r = self.compute_entities_values()?;
-            Ok(Self {
-                entities: self.entities,
-                evaluated_entities: Some(r),
-                mode: self.mode,
-            })
-        }
-    }
-
-    fn compute_entities_values(&self) -> std::result::Result<EvaluatedEntities, EvaluationError> {
-        build_evaluated_entities(self, &Extensions::all_available())
-    }
-
-    /// Extracts the [`EntityAttrValues`] for this entity slice.
-    /// If the entity values have already been computed via [`Self::evaluate`], then that will be re-used.
-    /// Otherwise, the attributes will be evaluated.
-    pub fn get_attr_values(&self) -> std::result::Result<EntityAttrValues<'_>, EvaluationError> {
-        let map = match &self.evaluated_entities {
-            Some(cached) => Cow::Borrowed(cached),
-            None => Cow::Owned(self.compute_entities_values()?),
-        };
-        Ok(EntityAttrValues::new(map, self))
-    }
 }
 
 /// Create a map from EntityUids to Entities, erroring if there are any duplicates
@@ -343,73 +302,6 @@ fn create_entity_map(es: impl Iterator<Item = Entity>) -> Result<HashMap<EntityU
         };
     }
     Ok(map)
-}
-
-type EvaluatedEntities = HashMap<EntityUID, HashMap<SmolStr, PartialValue>>;
-
-/// Structure of borrowed entity information that is used in the evaluator
-#[derive(Debug)]
-pub struct EntityAttrValues<'a> {
-    /// The evaluated entity attributes. The attributes may either be owner or borrowed.
-    attrs: Cow<'a, EvaluatedEntities>,
-    /// The original entity slice, which contains hierarchy information.
-    entities: &'a Entities,
-}
-
-fn build_evaluated_entities(
-    entities: &Entities,
-    extensions: &'_ Extensions<'_>,
-) -> std::result::Result<EvaluatedEntities, EvaluationError> {
-    let restricted_eval = RestrictedEvaluator::new(extensions);
-    // Eagerly evaluate each attribute expression in the entities.
-    let attrs =
-        entities
-            .iter()
-            .map(|entity| {
-                Ok(
-                        (
-                            entity.uid(),
-                            entity
-                                .attrs_map()
-                                .iter()
-                                .map(|(attr, v)| {
-                                    Ok((
-                                        attr.to_owned(),
-                                        restricted_eval.partial_interpret(v.as_borrowed())?,
-                                    ))
-                                })
-                                .collect::<std::result::Result<
-                                    HashMap<SmolStr, PartialValue>,
-                                    EvaluationError,
-                                >>()?,
-                        ),
-                    )
-            })
-            .collect::<std::result::Result<
-                HashMap<EntityUID, HashMap<SmolStr, PartialValue>>,
-                EvaluationError,
-            >>()?;
-    Ok(attrs)
-}
-
-impl<'a> EntityAttrValues<'a> {
-    /// Construct an [`EntityAttrValues`] with either an owned or borrowed set of evaluated attributes.
-    pub fn new(attrs: Cow<'a, EvaluatedEntities>, entities: &'a Entities) -> Self {
-        Self { attrs, entities }
-    }
-
-    /// Get an entity's attribute map by its EntityUID.
-    pub fn get(&self, uid: &EntityUID) -> Dereference<'_, HashMap<SmolStr, PartialValue>> {
-        match self.entities.entity(uid) {
-            Dereference::NoSuchEntity => Dereference::NoSuchEntity,
-            Dereference::Residual(r) => Dereference::Residual(r),
-            Dereference::Data(_) => self
-                .attrs
-                .get(uid)
-                .map(Dereference::Data)
-                .unwrap_or_else(|| Dereference::NoSuchEntity),
-        }
-    }
 }
 
 impl IntoIterator for Entities {
@@ -816,8 +708,8 @@ mod json_parsing_tests {
             .unwrap();
         let euid = r#"Test::"jeff""#.parse().unwrap();
         let jeff = es.entity(&euid).unwrap();
-        let rexpr = jeff.get("foo").unwrap();
-        assert_eq!(rexpr, &RestrictedExpr::val(3));
+        let value = jeff.get("foo").unwrap();
+        assert_eq!(value, &PartialValue::from(3));
         assert!(jeff.is_descendant_of(&r#"Test::"susan""#.parse().unwrap()));
         simple_entities_still_sane(&es);
     }
@@ -917,7 +809,7 @@ mod json_parsing_tests {
         let bob = r#"Test::"bob""#.parse().unwrap();
         let alice = e.entity(&r#"Test::"alice""#.parse().unwrap()).unwrap();
         let bar = alice.get("bar").unwrap();
-        assert_eq!(bar, &RestrictedExpr::val(2));
+        assert_eq!(bar, &PartialValue::from(2));
         assert!(alice.is_descendant_of(&bob));
         let bob = e.entity(&bob).unwrap();
         assert!(bob.ancestors().collect::<Vec<_>>().is_empty());
@@ -979,7 +871,7 @@ mod json_parsing_tests {
 
         let janice = es.entity(&EntityUID::with_eid("janice"));
 
-        assert!(matches!(janice, Dereference::Residual(_)));
+        assert_matches!(janice, Dereference::Residual(_));
     }
 
     #[test]
@@ -1030,17 +922,6 @@ mod json_parsing_tests {
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
         // Double check transitive closure computation
         assert!(alice.is_descendant_of(&EntityUID::with_eid("bob")));
-    }
-
-    /// helper function which tests whether attribute values are shape-equal
-    fn assert_attr_vals_are_shape_equal(
-        actual: Option<&RestrictedExpr>,
-        expected: &RestrictedExpr,
-    ) {
-        assert_eq!(
-            actual.map(|re| RestrictedExprShapeOnly::new(re.as_borrowed())),
-            Some(RestrictedExprShapeOnly::new(expected.as_borrowed()))
-        )
     }
 
     #[test]
@@ -1249,36 +1130,39 @@ mod json_parsing_tests {
         let es = eparser.from_json_value(json).expect("JSON is correct");
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
-        assert_attr_vals_are_shape_equal(alice.get("bacon"), &RestrictedExpr::val("eggs"));
-        assert_attr_vals_are_shape_equal(
+        assert_eq!(alice.get("bacon"), Some(&PartialValue::from("eggs")));
+        assert_eq!(
             alice.get("pancakes"),
-            &RestrictedExpr::set([
-                RestrictedExpr::val(1),
-                RestrictedExpr::val(2),
-                RestrictedExpr::val(3),
-            ]),
+            Some(&PartialValue::from(vec![
+                Value::from(1),
+                Value::from(2),
+                Value::from(3),
+            ])),
         );
-        assert_attr_vals_are_shape_equal(
+        assert_eq!(
             alice.get("waffles"),
-            &RestrictedExpr::record([("key".into(), RestrictedExpr::val("value"))]).unwrap(),
+            Some(&PartialValue::from(vec![(
+                "key".into(),
+                Value::from("value")
+            )])),
         );
-        assert_attr_vals_are_shape_equal(
-            alice.get("toast"),
-            &RestrictedExpr::call_extension_fn(
+        assert_eq!(
+            alice.get("toast").cloned().map(RestrictedExpr::try_from),
+            Some(Ok(RestrictedExpr::call_extension_fn(
                 "decimal".parse().expect("should be a valid Name"),
                 vec![RestrictedExpr::val("33.47")],
-            ),
+            ))),
         );
-        assert_attr_vals_are_shape_equal(
+        assert_eq!(
             alice.get("12345"),
-            &RestrictedExpr::val(EntityUID::with_eid("bob")),
+            Some(&PartialValue::from(EntityUID::with_eid("bob"))),
         );
-        assert_attr_vals_are_shape_equal(
-            alice.get("a b c"),
-            &RestrictedExpr::call_extension_fn(
+        assert_eq!(
+            alice.get("a b c").cloned().map(RestrictedExpr::try_from),
+            Some(Ok(RestrictedExpr::call_extension_fn(
                 "ip".parse().expect("should be a valid Name"),
                 vec![RestrictedExpr::val("222.222.222.0/24")],
-            ),
+            ))),
         );
         assert!(alice.is_descendant_of(&EntityUID::with_eid("bob")));
         assert!(alice.is_descendant_of(&EntityUID::with_eid("catherine")));
@@ -1560,7 +1444,9 @@ mod json_parsing_tests {
             ]
             .into_iter()
             .collect(),
-        );
+            &Extensions::all_available(),
+        )
+        .unwrap();
         let entities = Entities::from_entities(
             [
                 complicated_entity,
@@ -1592,7 +1478,9 @@ mod json_parsing_tests {
             ]
             .into_iter()
             .collect(),
-        );
+            &Extensions::all_available(),
+        )
+        .unwrap();
         let entities = Entities::from_entities(
             [
                 oops_entity,
@@ -1604,10 +1492,10 @@ mod json_parsing_tests {
             Extensions::all_available(),
         )
         .expect("Failed to construct entities");
-        assert!(matches!(
+        assert_matches!(
             roundtrip(&entities),
             Err(EntitiesError::Serialization(JsonSerializationError::ReservedKey { key })) if key.as_str() == "__entity"
-        ));
+        );
     }
 
     /// test that an Action having a non-Action parent is an error
@@ -1791,6 +1679,7 @@ mod entities_tests {
 mod schema_based_parsing_tests {
     use super::*;
     use crate::extensions::Extensions;
+    use cool_asserts::assert_matches;
     use serde_json::json;
     use smol_str::SmolStr;
     use std::collections::HashSet;
@@ -1809,9 +1698,9 @@ mod schema_based_parsing_tests {
         }
         fn action(&self, action: &EntityUID) -> Option<Arc<Entity>> {
             match action.to_string().as_str() {
-                r#"Action::"view""# => Some(Arc::new(Entity::new(
+                r#"Action::"view""# => Some(Arc::new(Entity::new_with_attr_partialvalues(
                     action.clone(),
-                    [(SmolStr::from("foo"), RestrictedExpr::val(34))]
+                    [(SmolStr::from("foo"), PartialValue::from(34))]
                         .into_iter()
                         .collect(),
                     [r#"Action::"readOnly""#.parse().expect("valid uid")]
@@ -1972,59 +1861,56 @@ mod schema_based_parsing_tests {
             .entity(&r#"Employee::"12UA45""#.parse().unwrap())
             .expect("that should be the employee id");
         let home_ip = parsed.get("home_ip").expect("home_ip attr should exist");
-        assert!(matches!(
-            home_ip.expr_kind(),
-            &ExprKind::Lit(Literal::String(_)),
-        ));
+        assert_matches!(
+            home_ip,
+            &PartialValue::Value(Value::Lit(Literal::String(_))),
+        );
         let trust_score = parsed
             .get("trust_score")
             .expect("trust_score attr should exist");
-        assert!(matches!(
-            trust_score.expr_kind(),
-            &ExprKind::Lit(Literal::String(_)),
-        ));
+        assert_matches!(
+            trust_score,
+            &PartialValue::Value(Value::Lit(Literal::String(_))),
+        );
         let manager = parsed.get("manager").expect("manager attr should exist");
-        assert!(matches!(manager.expr_kind(), &ExprKind::Record { .. }));
+        assert_matches!(manager, &PartialValue::Value(Value::Record { .. }));
         let work_ip = parsed.get("work_ip").expect("work_ip attr should exist");
-        assert!(matches!(work_ip.expr_kind(), &ExprKind::Record { .. }));
+        assert_matches!(work_ip, &PartialValue::Value(Value::Record { .. }));
         let hr_contacts = parsed
             .get("hr_contacts")
             .expect("hr_contacts attr should exist");
-        assert!(matches!(hr_contacts.expr_kind(), &ExprKind::Set(_)));
+        assert_matches!(hr_contacts, &PartialValue::Value(Value::Set(_)));
         let contact = {
-            let ExprKind::Set(set) = hr_contacts.expr_kind() else {
+            let PartialValue::Value(Value::Set(set)) = hr_contacts else {
                 panic!("already checked it was Set")
             };
             set.iter().next().expect("should be at least one contact")
         };
-        assert!(matches!(contact.expr_kind(), &ExprKind::Record { .. }));
+        assert_matches!(contact, &Value::Record(_));
         let json_blob = parsed
             .get("json_blob")
             .expect("json_blob attr should exist");
-        let ExprKind::Record(map) = json_blob.expr_kind() else {
+        let PartialValue::Value(Value::Record(map)) = json_blob else {
             panic!("expected json_blob to be a Record")
         };
         let (_, inner1) = map
             .iter()
             .find(|(k, _)| *k == "inner1")
             .expect("inner1 attr should exist");
-        assert!(matches!(
-            inner1.expr_kind(),
-            &ExprKind::Lit(Literal::Bool(_))
-        ));
+        assert_matches!(inner1, &Value::Lit(Literal::Bool(_)));
         let (_, inner3) = map
             .iter()
             .find(|(k, _)| *k == "inner3")
             .expect("inner3 attr should exist");
-        assert!(matches!(inner3.expr_kind(), &ExprKind::Record { .. }));
-        let ExprKind::Record(innermap) = inner3.expr_kind() else {
+        assert_matches!(inner3, &Value::Record(_));
+        let Value::Record(innermap) = inner3 else {
             panic!("already checked it was Record")
         };
         let (_, innerinner) = innermap
             .iter()
             .find(|(k, _)| *k == "innerinner")
             .expect("innerinner attr should exist");
-        assert!(matches!(innerinner.expr_kind(), &ExprKind::Record { .. }));
+        assert_matches!(innerinner, &Value::Record(_));
 
         // but with schema-based parsing, we get these other types
         let eparser = EntityJsonParser::new(
@@ -2042,96 +1928,80 @@ mod schema_based_parsing_tests {
         let is_full_time = parsed
             .get("isFullTime")
             .expect("isFullTime attr should exist");
-        assert_eq!(
-            RestrictedExprShapeOnly::new(is_full_time.as_borrowed()),
-            RestrictedExprShapeOnly::new(RestrictedExpr::val(true).as_borrowed())
-        );
+        assert_eq!(is_full_time, &PartialValue::Value(Value::from(true)),);
         let num_direct_reports = parsed
             .get("numDirectReports")
             .expect("numDirectReports attr should exist");
-        assert_eq!(
-            RestrictedExprShapeOnly::new(num_direct_reports.as_borrowed()),
-            RestrictedExprShapeOnly::new(RestrictedExpr::val(3).as_borrowed())
-        );
+        assert_eq!(num_direct_reports, &PartialValue::Value(Value::from(3)),);
         let department = parsed
             .get("department")
             .expect("department attr should exist");
-        assert_eq!(
-            RestrictedExprShapeOnly::new(department.as_borrowed()),
-            RestrictedExprShapeOnly::new(RestrictedExpr::val("Sales").as_borrowed())
-        );
+        assert_eq!(department, &PartialValue::Value(Value::from("Sales")),);
         let manager = parsed.get("manager").expect("manager attr should exist");
         assert_eq!(
-            RestrictedExprShapeOnly::new(manager.as_borrowed()),
-            RestrictedExprShapeOnly::new(
-                RestrictedExpr::val("Employee::\"34FB87\"".parse::<EntityUID>().expect("valid"))
-                    .as_borrowed()
-            )
+            manager,
+            &PartialValue::Value(Value::from(
+                "Employee::\"34FB87\"".parse::<EntityUID>().expect("valid")
+            )),
         );
         let hr_contacts = parsed
             .get("hr_contacts")
             .expect("hr_contacts attr should exist");
-        assert!(matches!(hr_contacts.expr_kind(), &ExprKind::Set(_)));
+        assert_matches!(hr_contacts, &PartialValue::Value(Value::Set(_)));
         let contact = {
-            let ExprKind::Set(set) = hr_contacts.expr_kind() else {
+            let PartialValue::Value(Value::Set(set)) = hr_contacts else {
                 panic!("already checked it was Set")
             };
             set.iter().next().expect("should be at least one contact")
         };
-        assert!(matches!(
-            contact.expr_kind(),
-            &ExprKind::Lit(Literal::EntityUID(_))
-        ));
+        assert_matches!(contact, &Value::Lit(Literal::EntityUID(_)));
         let json_blob = parsed
             .get("json_blob")
             .expect("json_blob attr should exist");
-        let ExprKind::Record(map) = json_blob.expr_kind() else {
+        let PartialValue::Value(Value::Record(map)) = json_blob else {
             panic!("expected json_blob to be a Record")
         };
         let (_, inner1) = map
             .iter()
             .find(|(k, _)| *k == "inner1")
             .expect("inner1 attr should exist");
-        assert!(matches!(
-            inner1.expr_kind(),
-            &ExprKind::Lit(Literal::Bool(_))
-        ));
+        assert_matches!(inner1, &Value::Lit(Literal::Bool(_)));
         let (_, inner3) = map
             .iter()
             .find(|(k, _)| *k == "inner3")
             .expect("inner3 attr should exist");
-        assert!(matches!(inner3.expr_kind(), &ExprKind::Record { .. }));
-        let ExprKind::Record(innermap) = inner3.expr_kind() else {
+        assert_matches!(inner3, &Value::Record(_));
+        let Value::Record(innermap) = inner3 else {
             panic!("already checked it was Record")
         };
         let (_, innerinner) = innermap
             .iter()
             .find(|(k, _)| *k == "innerinner")
             .expect("innerinner attr should exist");
-        assert!(matches!(
-            innerinner.expr_kind(),
-            &ExprKind::Lit(Literal::EntityUID(_))
-        ));
+        assert_matches!(innerinner, &Value::Lit(Literal::EntityUID(_)));
         assert_eq!(
-            parsed.get("home_ip"),
-            Some(&RestrictedExpr::call_extension_fn(
+            parsed.get("home_ip").cloned().map(RestrictedExpr::try_from),
+            Some(Ok(RestrictedExpr::call_extension_fn(
                 Name::parse_unqualified_name("ip").expect("valid"),
                 vec![RestrictedExpr::val("222.222.222.101")]
-            )),
+            ))),
         );
         assert_eq!(
-            parsed.get("work_ip"),
-            Some(&RestrictedExpr::call_extension_fn(
+            parsed.get("work_ip").cloned().map(RestrictedExpr::try_from),
+            Some(Ok(RestrictedExpr::call_extension_fn(
                 Name::parse_unqualified_name("ip").expect("valid"),
                 vec![RestrictedExpr::val("2.2.2.0/24")]
-            )),
+            ))),
         );
         assert_eq!(
-            parsed.get("trust_score"),
-            Some(&RestrictedExpr::call_extension_fn(
+            parsed
+                .get("trust_score")
+                .cloned()
+                .map(RestrictedExpr::try_from),
+            Some(Ok(RestrictedExpr::call_extension_fn(
                 Name::parse_unqualified_name("decimal").expect("valid"),
                 vec![RestrictedExpr::val("5.7")]
-            )),
+            ))),
         );
     }
 
@@ -2354,7 +2224,7 @@ mod schema_based_parsing_tests {
             .from_json_value(entitiesjson)
             .expect_err("should fail due to type mismatch on home_ip");
         assert!(
-            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#),
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `3.3300`"#),
             "actual error message was {err}"
         );
     }
@@ -3038,28 +2908,19 @@ mod schema_based_parsing_tests {
         let is_full_time = parsed
             .get("isFullTime")
             .expect("isFullTime attr should exist");
-        assert_eq!(
-            RestrictedExprShapeOnly::new(is_full_time.as_borrowed()),
-            RestrictedExprShapeOnly::new(RestrictedExpr::val(true).as_borrowed())
-        );
+        assert_eq!(is_full_time, &PartialValue::from(true),);
         let department = parsed
             .get("department")
             .expect("department attr should exist");
-        assert_eq!(
-            RestrictedExprShapeOnly::new(department.as_borrowed()),
-            RestrictedExprShapeOnly::new(RestrictedExpr::val("Sales").as_borrowed())
-        );
+        assert_eq!(department, &PartialValue::from("Sales"),);
         let manager = parsed.get("manager").expect("manager attr should exist");
         assert_eq!(
-            RestrictedExprShapeOnly::new(manager.as_borrowed()),
-            RestrictedExprShapeOnly::new(
-                RestrictedExpr::val(
-                    "XYZCorp::Employee::\"34FB87\""
-                        .parse::<EntityUID>()
-                        .expect("valid")
-                )
-                .as_borrowed()
-            )
+            manager,
+            &PartialValue::from(
+                "XYZCorp::Employee::\"34FB87\""
+                    .parse::<EntityUID>()
+                    .expect("valid")
+            ),
         );
 
         let entitiesjson = json!(

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -15,13 +15,16 @@
  */
 
 use super::{
-    schematype_of_restricted_expr, CedarValueJson, EntityTypeDescription, EntityUidJson,
-    GetSchemaTypeError, JsonDeserializationError, JsonDeserializationErrorContext,
-    JsonSerializationError, NoEntitiesSchema, Schema, TypeAndId, ValueParser,
+    CedarValueJson, EntityTypeDescription, EntityUidJson, JsonDeserializationError,
+    JsonDeserializationErrorContext, JsonSerializationError, NoEntitiesSchema, Schema, TypeAndId,
+    ValueParser,
 };
-use crate::ast::{Entity, EntityType, EntityUID, RestrictedExpr};
+use crate::ast::{
+    BorrowedRestrictedExpr, Entity, EntityType, EntityUID, PartialValue, RestrictedExpr,
+};
 use crate::entities::{
-    unwrap_or_clone, Entities, EntitiesError, EntitySchemaConformanceError, TCComputation,
+    schematype_of_partialvalue, unwrap_or_clone, Entities, EntitiesError,
+    EntitySchemaConformanceError, GetSchemaTypeError, TCComputation,
 };
 use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
@@ -294,7 +297,7 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                     // the type in the JSON is the same as the type in the schema.
                     // (As of this writing, the schema doesn't actually tell us
                     // what type each action attribute is supposed to be)
-                    let expected_rexpr = match action.get(&k) {
+                    let expected_val = match action.get(&k) {
                         // `None` indicates the attribute isn't in the schema's
                         // copy of the action entity
                         None => {
@@ -304,53 +307,43 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                                 },
                             ))
                         }
-                        Some(rexpr) => rexpr,
+                        Some(v) => v,
                     };
-                    let expected_ty = match schematype_of_restricted_expr(
-                        expected_rexpr.as_borrowed(),
-                        self.extensions,
-                    ) {
-                        Ok(ty) => Ok(Some(ty)),
-                        Err(GetSchemaTypeError::HeterogeneousSet(err)) => {
-                            Err(JsonDeserializationError::EntitySchemaConformance(
-                                EntitySchemaConformanceError::HeterogeneousSet {
-                                    uid: uid.clone(),
-                                    attr: k.clone(),
-                                    err,
-                                },
-                            ))
-                        }
-                        Err(GetSchemaTypeError::ExtensionFunctionLookup(err)) => {
-                            Err(JsonDeserializationError::EntitySchemaConformance(
-                                EntitySchemaConformanceError::ExtensionFunctionLookup {
-                                    uid: uid.clone(),
-                                    attr: k.clone(),
-                                    err,
-                                },
-                            ))
-                        }
-                        Err(GetSchemaTypeError::UnknownInsufficientTypeInfo { .. })
-                        | Err(GetSchemaTypeError::NontrivialResidual { .. }) => {
-                            // In these cases, we'll just do ordinary non-schema-based parsing.
-                            Ok(None)
-                        }
-                    }?;
-                    let actual_rexpr =
+                    let expected_ty =
+                        match schematype_of_partialvalue(expected_val, self.extensions) {
+                            Ok(ty) => Ok(Some(ty)),
+                            Err(GetSchemaTypeError::HeterogeneousSet(err)) => {
+                                Err(JsonDeserializationError::EntitySchemaConformance(
+                                    EntitySchemaConformanceError::HeterogeneousSet {
+                                        uid: uid.clone(),
+                                        attr: k.clone(),
+                                        err,
+                                    },
+                                ))
+                            }
+                            Err(GetSchemaTypeError::ExtensionFunctionLookup(err)) => {
+                                Err(JsonDeserializationError::EntitySchemaConformance(
+                                    EntitySchemaConformanceError::ExtensionFunctionLookup {
+                                        uid: uid.clone(),
+                                        attr: k.clone(),
+                                        err,
+                                    },
+                                ))
+                            }
+                            Err(GetSchemaTypeError::UnknownInsufficientTypeInfo { .. })
+                            | Err(GetSchemaTypeError::NontrivialResidual { .. }) => {
+                                // In these cases, we'll just do ordinary non-schema-based parsing.
+                                Ok(None)
+                            }
+                        }?;
+                    let rexpr =
                         vparser.val_into_restricted_expr(v.into(), expected_ty.as_ref(), || {
                             JsonDeserializationErrorContext::EntityAttribute {
                                 uid: uid.clone(),
                                 attr: k.clone(),
                             }
                         })?;
-                    if actual_rexpr == *expected_rexpr {
-                        Ok((k, actual_rexpr))
-                    } else {
-                        Err(JsonDeserializationError::EntitySchemaConformance(
-                            EntitySchemaConformanceError::ActionDeclarationMismatch {
-                                uid: uid.clone(),
-                            },
-                        ))
-                    }
+                    Ok((k, rexpr))
                 }
             })
             .collect::<Result<_, JsonDeserializationError>>()?;
@@ -386,7 +379,7 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                 })
             })
             .collect::<Result<_, JsonDeserializationError>>()?;
-        Ok(Entity::new(uid, attrs, parents))
+        Ok(Entity::new(uid, attrs, parents, &self.extensions)?)
     }
 }
 
@@ -400,11 +393,20 @@ impl EntityJson {
             uid: EntityUidJson::ImplicitEntityEscape(TypeAndId::from(entity.uid())),
             attrs: entity
                 .attrs()
-                .map(|(k, expr)| {
-                    Ok((
-                        k.into(),
-                        serde_json::to_value(CedarValueJson::from_expr(expr)?)?.into(),
-                    ))
+                .map(|(k, pvalue)| match pvalue {
+                    PartialValue::Value(value) => {
+                        let cedarvaluejson = CedarValueJson::from_value(value.clone())?;
+                        Ok((k.clone(), serde_json::to_value(cedarvaluejson)?.into()))
+                    }
+                    PartialValue::Residual(expr) => match BorrowedRestrictedExpr::new(expr) {
+                        Ok(expr) => {
+                            let cedarvaluejson = CedarValueJson::from_expr(expr)?;
+                            Ok((k.clone(), serde_json::to_value(cedarvaluejson)?.into()))
+                        }
+                        Err(_) => Err(JsonSerializationError::Residual {
+                            residual: expr.clone(),
+                        }),
+                    },
                 })
                 .collect::<Result<_, JsonSerializationError>>()?,
             parents: entity

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -76,7 +76,7 @@ impl Schema for AllEntitiesNoAttrsSchema {
         })
     }
     fn action(&self, action: &EntityUID) -> Option<Arc<Entity>> {
-        Some(Arc::new(Entity::new(
+        Some(Arc::new(Entity::new_with_attr_partialvalues(
             action.clone(),
             HashMap::new(),
             HashSet::new(),

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -19,11 +19,11 @@ use super::{
 };
 use crate::ast::{
     BorrowedRestrictedExpr, Eid, EntityUID, ExprConstructionError, ExprKind, Literal, Name,
-    RestrictedExpr, Unknown,
+    RestrictedExpr, Unknown, Value,
 };
 use crate::entities::{
-    schematype_of_restricted_expr, EntitySchemaConformanceError, EscapeKind, GetSchemaTypeError,
-    TypeMismatchError,
+    schematype_of_restricted_expr, unwrap_or_clone, EntitySchemaConformanceError, EscapeKind,
+    GetSchemaTypeError, TypeMismatchError,
 };
 use crate::extensions::Extensions;
 use crate::FromNormalizedStr;
@@ -283,36 +283,77 @@ impl CedarValueJson {
                 // if `map` contains a key which collides with one of our JSON
                 // escapes, then we have a problem because it would be interpreted
                 // as an escape when being read back in.
-                // We could be a little more permissive here, but to be
-                // conservative, we throw an error for any record that contains
-                // any key with a reserved name, not just single-key records
-                // with the reserved names.
-                let reserved_keys: HashSet<&str> =
-                    HashSet::from_iter(["__entity", "__extn", "__expr"]);
-                let collision = map.keys().find(|k| reserved_keys.contains(k.as_str()));
-                if let Some(collision) = collision {
-                    Err(JsonSerializationError::ReservedKey {
-                        key: collision.clone(),
-                    })
-                } else {
-                    // the common case: the record doesn't use any reserved keys
-                    Ok(Self::Record(
-                        map.iter()
-                            .map(|(k, v)| {
-                                Ok((
-                                    k.clone(),
-                                    CedarValueJson::from_expr(
-                                        // assuming the invariant holds for `expr`, it must also hold here
-                                        BorrowedRestrictedExpr::new_unchecked(v),
-                                    )?,
-                                ))
-                            })
-                            .collect::<Result<_, JsonSerializationError>>()?,
-                    ))
-                }
+                check_for_reserved_keys(map.keys())?;
+                Ok(Self::Record(
+                    map.iter()
+                        .map(|(k, v)| {
+                            Ok((
+                                k.clone(),
+                                CedarValueJson::from_expr(
+                                    // assuming the invariant holds for `expr`, it must also hold here
+                                    BorrowedRestrictedExpr::new_unchecked(v),
+                                )?,
+                            ))
+                        })
+                        .collect::<Result<_, JsonSerializationError>>()?,
+                ))
             }
             kind => {
                 Err(JsonSerializationError::UnexpectedRestrictedExprKind { kind: kind.clone() })
+            }
+        }
+    }
+
+    /// Convert a Cedar value into a `CedarValueJson`.
+    ///
+    /// Only throws errors in two cases:
+    /// 1. `value` is (or contains) a record with a reserved key such as
+    ///     "__entity"
+    /// 2. `value` is (or contains) an extension value, and the argument to the
+    ///     extension constructor that produced that extension value can't
+    ///     itself be converted to `CedarJsonValue`. (Either because that
+    ///     argument falls into one of these two cases itself, or because the
+    ///     argument is a nontrivial residual.)
+    pub fn from_value(value: Value) -> Result<Self, JsonSerializationError> {
+        match value {
+            Value::Lit(lit) => Ok(Self::from_lit(lit)),
+            Value::Set(set) => Ok(Self::Set(
+                set.iter()
+                    .cloned()
+                    .map(Self::from_value)
+                    .collect::<Result<_, _>>()?,
+            )),
+            Value::Record(map) => {
+                // if `map` contains a key which collides with one of our JSON
+                // escapes, then we have a problem because it would be interpreted
+                // as an escape when being read back in.
+                check_for_reserved_keys(map.keys())?;
+                Ok(Self::Record(
+                    map.iter()
+                        .map(|(k, v)| Ok((k.clone(), Self::from_value(v.clone())?)))
+                        .collect::<Result<JsonRecord, JsonSerializationError>>()?,
+                ))
+            }
+            Value::ExtensionValue(ev) => {
+                let ext_fn: &Name = &ev.constructor;
+                Ok(Self::ExtnEscape {
+                    __extn: FnAndArg {
+                        ext_fn: ext_fn.to_string().into(),
+                        arg: match ev.args.as_slice() {
+                            [ref expr] => Box::new(Self::from_expr(expr.as_borrowed())?),
+                            [] => {
+                                return Err(JsonSerializationError::ExtnCall0Arguments {
+                                    func: ext_fn.clone(),
+                                })
+                            }
+                            _ => {
+                                return Err(JsonSerializationError::ExtnCall2OrMoreArguments {
+                                    func: ext_fn.clone(),
+                                })
+                            }
+                        },
+                    },
+                })
             }
         }
     }
@@ -324,9 +365,28 @@ impl CedarValueJson {
             Literal::Long(i) => Self::Long(i),
             Literal::String(s) => Self::String(s),
             Literal::EntityUID(euid) => Self::EntityEscape {
-                __entity: (*euid).clone().into(),
+                __entity: unwrap_or_clone(euid).into(),
             },
         }
+    }
+}
+
+/// helper function to check if the given keys contain any reserved keys,
+/// throwing an appropriate `JsonSerializationError` if so
+fn check_for_reserved_keys<'a>(
+    mut keys: impl Iterator<Item = &'a SmolStr>,
+) -> Result<(), JsonSerializationError> {
+    // We could be a little more permissive here, but to be
+    // conservative, we throw an error for any record that contains
+    // any key with a reserved name, not just single-key records
+    // with the reserved names.
+    let reserved_keys: HashSet<&str> = HashSet::from_iter(["__entity", "__extn", "__expr"]);
+    let collision = keys.find(|k| reserved_keys.contains(k.as_str()));
+    match collision {
+        Some(collision) => Err(JsonSerializationError::ReservedKey {
+            key: collision.clone(),
+        }),
+        None => Ok(()),
     }
 }
 
@@ -419,7 +479,7 @@ impl<'e> ValueParser<'e> {
                         })
                         .collect::<Result<Vec<RestrictedExpr>, JsonDeserializationError>>()?,
                 )),
-                _ => {
+                val => {
                     let actual_val = {
                         let jvalue: CedarValueJson = serde_json::from_value(val)?;
                         jvalue.into_expr(ctx.clone())?
@@ -433,7 +493,7 @@ impl<'e> ValueParser<'e> {
                             Ok(actual_ty) => Some(Box::new(actual_ty)),
                             Err(_) => None, // just don't report the type if there was an error computing it
                         },
-                        actual_val: Box::new(actual_val),
+                        actual_val: Either::Right(Box::new(actual_val)),
                     };
                     match ctx() {
                         JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {
@@ -498,7 +558,7 @@ impl<'e> ValueParser<'e> {
                         }
                     })
                 }
-                _ => {
+                val => {
                     let actual_val = {
                         let jvalue: CedarValueJson = serde_json::from_value(val)?;
                         jvalue.into_expr(ctx.clone())?
@@ -512,7 +572,7 @@ impl<'e> ValueParser<'e> {
                             Ok(actual_ty) => Some(Box::new(actual_ty)),
                             Err(_) => None, // just don't report the type if there was an error computing it
                         },
-                        actual_val: Box::new(actual_val),
+                        actual_val: Either::Right(Box::new(actual_val)),
                     };
                     match ctx() {
                         JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -177,7 +177,7 @@ fn decimal_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
     let decimal = Decimal::from_str(str.as_str()).map_err(|e| extension_err(e.to_string()))?;
     let function_name = names::DECIMAL_FROM_STR_NAME.clone();
-    let e = ExtensionValueWithArgs::new(Arc::new(decimal), vec![arg.into()], function_name);
+    let e = ExtensionValueWithArgs::new(Arc::new(decimal), function_name, vec![arg.into()]);
     Ok(Value::ExtensionValue(Arc::new(e)).into())
 }
 

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -271,8 +271,8 @@ fn ip_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     let function_name = names::IP_FROM_STR_NAME.clone();
     let ipaddr = ExtensionValueWithArgs::new(
         Arc::new(IPAddr::from_str(str.as_str()).map_err(extension_err)?),
-        vec![arg.into()],
         function_name,
+        vec![arg.into()],
     );
     Ok(Value::ExtensionValue(Arc::new(ipaddr)).into())
 }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -36,7 +36,7 @@ use smol_str::SmolStr;
 use std::collections::HashMap;
 
 use crate::ast;
-use crate::ast::RestrictedExprError;
+use crate::ast::RestrictedExprParseError;
 use crate::est;
 
 /// simple main function for parsing policies
@@ -239,9 +239,9 @@ pub(crate) fn parse_expr(ptext: &str) -> Result<ast::Expr, err::ParseErrors> {
 /// `FromStr` impl or its constructors
 pub(crate) fn parse_restrictedexpr(
     ptext: &str,
-) -> Result<ast::RestrictedExpr, RestrictedExprError> {
+) -> Result<ast::RestrictedExpr, RestrictedExprParseError> {
     let expr = parse_expr(ptext)?;
-    ast::RestrictedExpr::new(expr)
+    Ok(ast::RestrictedExpr::new(expr)?)
 }
 
 /// parse an EntityUID

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -71,9 +71,6 @@ impl ParseError {
             ParseError::ToCST(to_cst_err) => Some(to_cst_err.primary_source_span()),
             ParseError::RestrictedExpr(restricted_expr_err) => match restricted_expr_err {
                 RestrictedExprError::InvalidRestrictedExpression { .. } => None,
-                RestrictedExprError::Parse(ParseErrors(parse_errs)) => {
-                    parse_errs.first().and_then(ParseError::primary_source_span)
-                }
             },
             ParseError::ToAST(_) | ParseError::ParseLiteral(_) => None,
         }

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -369,7 +369,8 @@ mod test {
                 }
             }
         }});
-        ValidatorSchema::from_json_value(src).expect("failed to create ValidatorSchema")
+        ValidatorSchema::from_json_value(src, Extensions::all_available())
+            .expect("failed to create ValidatorSchema")
     }
 
     /// basic success with concrete request and no context

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -17,7 +17,7 @@
 use std::collections::HashSet;
 
 use cedar_policy_core::{
-    ast::{EntityUID, Name},
+    ast::{EntityAttrEvaluationError, EntityUID, Name},
     parser::err::{ParseError, ParseErrors},
     transitive_closure,
 };
@@ -97,6 +97,11 @@ pub enum SchemaError {
     /// This error variant should only be used when `PermitAttributes` is enabled.
     #[error("action `{0}` has an attribute with unsupported JSON representation: {1}")]
     UnsupportedActionAttribute(EntityUID, String),
+    /// Error when evaluating an action attribute
+    #[error(transparent)]
+    ActionAttrEval(EntityAttrEvaluationError),
+    /// Error thrown when the schema contains the `__expr` escape.
+    /// Support for this escape form has been dropped.
     #[error("uses the `__expr` escape, which is no longer supported")]
     ExprEscapeUsed,
 }

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -1,7 +1,7 @@
 //! This module contains the definition of `ValidatorActionId` and the types it relies on
 
 use cedar_policy_core::{
-    ast::{EntityType, EntityUID, RestrictedExpr},
+    ast::{EntityType, EntityUID, PartialValueSerializedAsExpr},
     transitive_closure::TCNode,
 };
 use serde::Serialize;
@@ -38,7 +38,10 @@ pub struct ValidatorActionId {
     /// The actual attribute value for this action, used to construct an
     /// `Entity` for this action. Could also be used for more precise
     /// typechecking by partial evaluation.
-    pub(crate) attributes: HashMap<SmolStr, RestrictedExpr>,
+    ///
+    /// Attributes are serialized as `RestrictedExpr`s, so that roundtripping
+    /// works seamlessly.
+    pub(crate) attributes: HashMap<SmolStr, PartialValueSerializedAsExpr>,
 }
 
 impl ValidatorActionId {

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1894,6 +1894,7 @@ mod test {
             }}))
             .expect("Expected valid schema"),
             ActionBehavior::PermitAttributes,
+            Extensions::all_available(),
         )
         .expect("Expected valid schema")
     }
@@ -2002,6 +2003,7 @@ mod test {
             }}))
             .expect("Expected valid schema"),
             ActionBehavior::PermitAttributes,
+            Extensions::all_available(),
         )
         .expect("Expected valid schema")
     }
@@ -2125,6 +2127,7 @@ mod test {
             }}))
             .expect("Expected valid schema"),
             ActionBehavior::PermitAttributes,
+            Extensions::all_available(),
         )
         .expect("Expected valid schema");
 
@@ -2166,6 +2169,7 @@ mod test {
             ))
             .expect("Expected valid schema"),
             ActionBehavior::PermitAttributes,
+            Extensions::all_available(),
         )
         .expect("Expected valid schema")
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Option to eagerly evaluate entity attributes and re-use across calls to `is_authorized`.
 - New APIs to `Entities` to make it easy to add a collection of entities to an existing `Entities` structure.
 - Export the `cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind}` and
   `cedar_policy_core::authorizer::AuthorizationError` error types.
@@ -22,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The main validation entry point now checks for warnings previously only
   available through `confusable_string_checker`
 - The `is` operation as described in [RFC 5](https://github.com/cedar-policy/rfcs/blob/main/text/0005-is-operator.md).
+- `Entity::new_no_attrs()` which provides an infallible constructor for `Entity`
+  in the case that there are no attributes. (See changes to `Entity::new()` below.)
 
 ### Changed
 
@@ -48,7 +49,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the behavior of `.isInRange()`.
 - Standardize on duplicates being errors instead of last-write-wins in the
   JSON-based APIs in the `frontend` module.
+- `Entity::new()` now eagerly evaluates entity attributes, leading to
+  performance improvements (particularly when entity data is reused across
+  multiple `is_authorized` calls). As a result, it returns `Result`, because
+  attribute evaluation can fail.
+- `Entities::from_json_*()` also now eagerly evaluates entity attributes, and as
+  a result returns errors when attribute evaluation fails.
+- `Entity::attr()` now returns errors in many fewer cases (because the attribute
+  is stored in already-evaluated form), and its error type has changed.
 - `<EntityId as FromStr>::Error` is now `Infallible` instead of `ParseErrors`.
+- `SchemaError` has a new variant corresponding to errors evaluating action
+  attributes.
 - Improve the `Display` impls for `Policy` and `PolicySet`, and add a `Display`
   impl for `Template`.  The displayed representations now more closely match the
   original input, whether the input was in string or JSON form.


### PR DESCRIPTION
## Description of changes

See [RFC 34](https://github.com/cedar-policy/rfcs/pull/34) for high-level description.

Some internal notes: 
* Core's `Entity`, Validator's `ValidatorNamespaceDef`, and Validator's `ValidatorActionId` were all updated to store attributes as partial value (action attributes, in the validator case); but the existing serialization behavior for these types was preserved -- they still serialize as `RestrictedExpr`.
* RFC 34 changes where a bunch of errors are thrown, which means a bunch of internal APIs throw more or less errors than they used to.  Some error types had variants added or removed, and some (non-public-facing) error types were renamed for clarity.  Some tests have to do more `.unwrap()`, some less.
* We do get to remove not only `Entities::evaluate()` but quite a bit of code that was supporting it.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
