### PR TITLE
Avoid an inconsequential clone in typechecking

### DIFF
--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1300,9 +1300,9 @@ impl<'a> Typechecker<'a> {
                         let type_of_eq = self.type_of_equality(
                             request_env,
                             arg1,
-                            lhs_ty.data().clone(),
+                            lhs_ty.data(),
                             arg2,
-                            rhs_ty.data().clone(),
+                            rhs_ty.data(),
                         );
 
                         if self.mode.is_strict() {
@@ -1529,14 +1529,14 @@ impl<'a> Typechecker<'a> {
         &self,
         request_env: &RequestEnv,
         lhs_expr: &'b Expr,
-        lhs_ty: Option<Type>,
+        lhs_ty: &Option<Type>,
         rhs_expr: &'b Expr,
-        rhs_ty: Option<Type>,
+        rhs_ty: &Option<Type>,
     ) -> Type {
         // If we know the types are disjoint, then we can return give the
         // expression type False. See `are_types_disjoint` definition for
         // explanation of why fewer types are disjoint than may be expected.
-        let disjoint_types = match (&lhs_ty, &rhs_ty) {
+        let disjoint_types = match (lhs_ty, rhs_ty) {
             (Some(lhs_ty), Some(rhs_ty)) => Type::are_types_disjoint(lhs_ty, rhs_ty),
             _ => false,
         };
@@ -1562,6 +1562,7 @@ impl<'a> Typechecker<'a> {
             } else {
                 let left_is_unspecified = Typechecker::is_unspecified_entity(request_env, lhs_expr);
                 let right_is_specified = rhs_ty
+                    .as_ref()
                     .map(|ty| Type::must_be_specified_entity(&ty))
                     .unwrap_or(false);
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1563,7 +1563,7 @@ impl<'a> Typechecker<'a> {
                 let left_is_unspecified = Typechecker::is_unspecified_entity(request_env, lhs_expr);
                 let right_is_specified = rhs_ty
                     .as_ref()
-                    .map(|ty| Type::must_be_specified_entity(&ty))
+                    .map(|ty| Type::must_be_specified_entity(ty))
                     .unwrap_or(false);
 
                 if left_is_unspecified && right_is_specified {

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1563,7 +1563,7 @@ impl<'a> Typechecker<'a> {
                 let left_is_unspecified = Typechecker::is_unspecified_entity(request_env, lhs_expr);
                 let right_is_specified = rhs_ty
                     .as_ref()
-                    .map(|ty| Type::must_be_specified_entity(ty))
+                    .map(Type::must_be_specified_entity)
                     .unwrap_or(false);
 
                 if left_is_unspecified && right_is_specified {


### PR DESCRIPTION
## Description of changes

Doesn't make any real difference, but I noticed a clone that didn't need to be there.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
