### PR TITLE
Improve schema parsing error messages when a cycle exists in the action   hierarchy 

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -64,8 +64,8 @@ pub enum SchemaError {
     #[error("duplicate common type `{0}`")]
     DuplicateCommonType(String),
     /// Cycle in the schema's action hierarchy.
-    #[error("cycle in action hierarchy")]
-    CycleInActionHierarchy,
+    #[error("cycle in action hierarchy containing `{0}`")]
+    CycleInActionHierarchy(EntityUID),
     /// Parse errors occurring while parsing an entity type.
     #[error("parse error in entity type: {}", Self::format_parse_errs(.0))]
     ParseEntityType(ParseErrors),
@@ -110,7 +110,9 @@ impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
             transitive_closure::TcError::MissingTcEdge { .. } => {
                 SchemaError::ActionTransitiveClosure(Box::new(e))
             }
-            transitive_closure::TcError::HasCycle { .. } => SchemaError::CycleInActionHierarchy,
+            transitive_closure::TcError::HasCycle { vertex_with_loop } => {
+                SchemaError::CycleInActionHierarchy(vertex_with_loop)
+            }
         }
     }
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -72,6 +72,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ValidationError::location`. (#405)
 - `ValidationWarningKind` is now `non_exhaustive`, allowing future warnings to
   be added without a breaking change. (#404)
+- Improve schema parsing error messages when a cycle exists in the action
+  hierarchy to includes an action which is part of the cycle (#436, resolving #416).
 
 ### Fixed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1177,8 +1177,8 @@ pub enum SchemaError {
     #[error("duplicate common type `{0}`")]
     DuplicateCommonType(String),
     /// Cycle in the schema's action hierarchy.
-    #[error("cycle in action hierarchy")]
-    CycleInActionHierarchy,
+    #[error("cycle in action hierarchy containing `{0}`")]
+    CycleInActionHierarchy(EntityUid),
     /// Parse errors occurring while parsing an entity type.
     #[error("parse error in entity type: {0}")]
     ParseEntityType(ParseErrors),
@@ -1280,8 +1280,8 @@ impl From<cedar_policy_validator::SchemaError> for SchemaError {
             cedar_policy_validator::SchemaError::DuplicateCommonType(c) => {
                 Self::DuplicateCommonType(c)
             }
-            cedar_policy_validator::SchemaError::CycleInActionHierarchy => {
-                Self::CycleInActionHierarchy
+            cedar_policy_validator::SchemaError::CycleInActionHierarchy(e) => {
+                Self::CycleInActionHierarchy(EntityUid(e))
             }
             cedar_policy_validator::SchemaError::ParseEntityType(e) => Self::ParseEntityType(e),
             cedar_policy_validator::SchemaError::ParseNamespace(e) => Self::ParseNamespace(e),


### PR DESCRIPTION
Improve schema parsing error messages when a cycle exists in the action hierarchy to includes an action which is part of the cycle (fix #416)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
