### PR TITLE
add `RestrictedExpression::new_entity_uid()`

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (#396)
 - `Entity::new_no_attrs()` which provides an infallible constructor for `Entity`
   in the case that there are no attributes. (See changes to `Entity::new()` below.)
+- `RestrictedExpression::new_entity_uid()` (#442, resolving #350)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2960,6 +2960,11 @@ impl RestrictedExpression {
         Self(ast::RestrictedExpr::val(value))
     }
 
+    /// Create an expression representing a literal `EntityUid`.
+    pub fn new_entity_uid(value: EntityUid) -> Self {
+        Self(ast::RestrictedExpr::val(value.0))
+    }
+
     /// Create an expression representing a record.
     ///
     /// Error if any key appears two or more times in `fields`.


### PR DESCRIPTION
## Description of changes

Adds a new constructor to go with the other similar ones

## Issue #, if available

#350

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
