### PR TITLE
fix: DRT CI needs `Context::iter()` to be fully public

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -282,8 +282,6 @@ impl Context {
     /// if the `Context` is purely unknown
     //
     // PANIC SAFETY: This is safe due to the invariant on `self.context`, `self.context` must always be a record
-    #[allow(clippy::panic)]
-    #[cfg(fuzzing)]
     pub fn iter<'s>(&'s self) -> Option<Box<dyn Iterator<Item = (&SmolStr, PartialValue)> + 's>> {
         // PANIC SAFETY invariant on `self.context` ensures that it is a record
         #[allow(clippy::panic)]


### PR DESCRIPTION
## Description of changes

this problem was introduced by #430, I thought it was only needed for fuzzing, but actually it is needed for the CI process for DRT even without `cfg(fuzzing)`



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
