### PR TITLE
Improve error messages for `ToASTError::WrongNode`

### DIFF
--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -21,7 +21,7 @@ use smol_str::SmolStr;
 // still recover other parts
 type Node<N> = ASTNode<Option<N>>;
 
-/// The set of policy statements that forms an authorization policy
+/// The set of policy statements that forms a policy set
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Policies(pub Vec<Node<Policy>>);
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3867,6 +3867,14 @@ mod tests {
                 "expected an entity uid or matching template slot, found literal `1`",
             ),
             (
+                r#"permit(principal is User in User, action, resource);"#,
+                "expected an entity uid or matching template slot, found name `User`",
+            ),
+            (
+                r#"permit(principal, action, resource is File in File);"#,
+                "expected an entity uid or matching template slot, found name `File`",
+            ),
+            (
                 r#"permit(principal is 1, action, resource);"#,
                 "unexpected token `1`",
             ),


### PR DESCRIPTION
## Description of changes

Improve error messages for `ToASTError::WrongNode`, by providing suggestions in some cases, tweaking wording, and showing the actual literal/name that was unexpected.  Adds two new tests and adjust the expectations of others.

## Issue #, if available

Fixes #255.  Doesn't end up providing the error message suggested in #255, but I feel that the resulting error message here is also fine.  (Feel free to disagree and comment, though.)

Also improves some of the messages in #409, but not enough to consider this PR as resolving #409.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
