### PR TITLE
Improve ergonomics somewhat for the `ParseErrors` type

### DIFF
--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -541,6 +541,11 @@ impl ParseErrors {
         ParseErrors(Vec::with_capacity(capacity))
     }
 
+    /// Add an error to the `ParseErrors`
+    pub(super) fn push(&mut self, err: impl Into<ParseError>) {
+        self.0.push(err.into());
+    }
+
     // TODO(spinda): Can we get rid of this?
     /// returns a Vec with stringified versions of the ParserErrors
     pub fn errors_as_strings(&self) -> Vec<String> {
@@ -655,15 +660,9 @@ impl DerefMut for ParseErrors {
     }
 }
 
-impl From<ParseError> for ParseErrors {
-    fn from(err: ParseError) -> Self {
-        vec![err].into()
-    }
-}
-
-impl From<ToCSTError> for ParseErrors {
-    fn from(err: ToCSTError) -> Self {
-        ParseError::from(err).into()
+impl<T: Into<ParseError>> From<T> for ParseErrors {
+    fn from(err: T) -> Self {
+        vec![err.into()].into()
     }
 }
 
@@ -673,9 +672,15 @@ impl From<Vec<ParseError>> for ParseErrors {
     }
 }
 
-impl FromIterator<ParseError> for ParseErrors {
-    fn from_iter<T: IntoIterator<Item = ParseError>>(errs: T) -> Self {
-        ParseErrors(errs.into_iter().collect())
+impl<T: Into<ParseError>> FromIterator<T> for ParseErrors {
+    fn from_iter<I: IntoIterator<Item = T>>(errs: I) -> Self {
+        ParseErrors(errs.into_iter().map(Into::into).collect())
+    }
+}
+
+impl<T: Into<ParseError>> Extend<T> for ParseErrors {
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.0.extend(iter.into_iter().map(Into::into))
     }
 }
 

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -52,12 +52,12 @@ fn parse_collect_errors<'a, P, T>(
 
     let mut errors: err::ParseErrors = errs
         .into_iter()
-        .map(|recovery| err::ToCSTError::from_raw_err_recovery(recovery).into())
+        .map(|recovery| err::ToCSTError::from_raw_err_recovery(recovery))
         .collect();
     let parsed = match result {
         Ok(parsed) => parsed,
         Err(e) => {
-            errors.push(err::ToCSTError::from_raw_parse_err(e).into());
+            errors.push(err::ToCSTError::from_raw_parse_err(e));
             return Err(errors);
         }
     };


### PR DESCRIPTION
## Description of changes

For `.push()`, `.extend()`, and `.collect()`, you no longer need to convert your error to `ParseError` yourself; those methods will take anything that is `Into<ParseError>`.  This saves a surprising amount of space at a surprising number of callsites.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
