### PR TITLE
Add CEDAR_INTEGRATION_TESTS_PATH that overrides CARGO_MANIFEST_DIR

### DIFF
--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -114,14 +114,18 @@ fn constant_true() -> bool {
 ///
 /// # Panics
 ///
-/// Panics if the environment variable `CARGO_MANIFEST_DIR` is not set.
-/// This variable should be set by Cargo at build-time.
+/// Panics if the environment variable `CARGO_MANIFEST_DIR` is not set,
+/// and `CEDAR_INTEGRATION_TESTS_PATH` is not set.
+/// `CARGO_MANIFEST_DIR` should be set by Cargo at build-time, but
+/// `CEDAR_INTEGRATION_TESTS_PATH` overrides `CARGO_MANIFEST_DIR`.
 pub fn resolve_integration_test_path(path: impl AsRef<Path>) -> PathBuf {
     if path.as_ref().is_relative() {
-        let mut full_path = PathBuf::new();
+        if let Ok(integration_tests_env_var) = env::var("CEDAR_INTEGRATION_TESTS_PATH") {
+            return PathBuf::from(integration_tests_env_var);
+        }
         let manifest_dir = env::var("CARGO_MANIFEST_DIR")
             .expect("`CARGO_MANIFEST_DIR` should be set by Cargo at build-time.");
-        full_path.push(manifest_dir.clone());
+        let mut full_path = PathBuf::from(manifest_dir.clone());
         full_path.push("..");
         // We run `cargo test` for cedar-drt. In that case, CARGO_MANIFEST_DIR will be
         // `cedar-spec/cedar-drt` and we want `../cedar/cedar-integration-tests`


### PR DESCRIPTION
## Description of changes
Add CEDAR_INTEGRATION_TESTS_PATH that overrides CARGO_MANIFEST_DIR.

This will allow us to avoid gross code like `manifest_dir.ends_with("cedar-drt")` for the Lean DRT.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
