### PR TITLE
Improve some policy parse errors surrounding template slots

### DIFF
--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -130,7 +130,7 @@ impl FromNormalizedStr for Name {
 // want to generalize later
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct SlotId(ValidSlotId);
+pub struct SlotId(pub(crate) ValidSlotId);
 
 impl SlotId {
     /// Get the slot for `principal`
@@ -171,7 +171,7 @@ impl std::fmt::Display for SlotId {
 
 /// Two possible variants for Slots
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-enum ValidSlotId {
+pub(crate) enum ValidSlotId {
     #[serde(rename = "?principal")]
     Principal,
     #[serde(rename = "?resource")]

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -2710,8 +2710,8 @@ mod test {
         assert_matches!(
             ast,
             Err(FromJsonError::TemplateToPolicy(
-                ast::UnexpectedSlotError::Named(_)
-            ))
+                ast::UnexpectedSlotError::FoundSlot(s)
+            )) => assert_eq!(s, ast::SlotId::principal())
         );
     }
 

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -671,60 +671,227 @@ mod parse_tests {
 
     #[test]
     fn no_slots_in_condition() {
-        let srcs = [
-            r#"
+        /// Assert that at least one of the errors in the `ParseErrors` contains the given text.
+        ///
+        /// `src` is the original policy source, just for better assertion-failure messages
+        fn assert_some_error_contains(errs: &err::ParseErrors, text: &str, src: &str) {
+            assert!(
+                errs.iter().any(|e| e.to_string().contains(text)),
+                "for the following policy:\n{src}\nactual errors were:\n{errs}"
+            );
+        }
+
+        let src = r#"
             permit(principal, action, resource) when {
                 resource == ?resource
             };
-            "#,
-            r#"
+            "#;
+        let slot_in_when_clause_error =
+            "found template slot ?resource in a `when` clause; slots are currently unsupported in `when` clauses";
+        let unexpected_template_error =
+            "expected a static policy, got a template containing the slot ?resource; try removing the template slot(s) from this policy";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+
+        let src = r#"
             permit(principal, action, resource) when {
                 resource == ?principal
             };
-            "#,
-            r#"
+            "#;
+        let slot_in_when_clause_error =
+            "found template slot ?principal in a `when` clause; slots are currently unsupported in `when` clauses";
+        let unexpected_template_error =
+            "expected a static policy, got a template containing the slot ?principal; try removing the template slot(s) from this policy";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+        });
+
+        let src = r#"
             permit(principal, action, resource) when {
                 resource == ?blah
             };
-            "#,
-            r#"
+            "#;
+        // TODO(#451): improve these errors
+        let error = "invalid token";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+
+        let src = r#"
             permit(principal, action, resource) unless {
                 resource == ?resource
             };
-            "#,
-            r#"
+            "#;
+        let slot_in_unless_clause_error =
+            "found template slot ?resource in a `unless` clause; slots are currently unsupported in `unless` clauses";
+        let unexpected_template_error =
+            "expected a static policy, got a template containing the slot ?resource; try removing the template slot(s) from this policy";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+
+        let src = r#"
             permit(principal, action, resource) unless {
                 resource == ?principal
             };
-            "#,
-            r#"
+            "#;
+        let slot_in_unless_clause_error =
+            "found template slot ?principal in a `unless` clause; slots are currently unsupported in `unless` clauses";
+        let unexpected_template_error =
+            "expected a static policy, got a template containing the slot ?principal; try removing the template slot(s) from this policy";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+
+        let src = r#"
             permit(principal, action, resource) unless {
                 resource == ?blah
             };
-            "#,
-            r#"
+            "#;
+        // TODO(#451): improve these errors
+        let error = "invalid token";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, error, src);
+        });
+
+        let src = r#"
             permit(principal, action, resource) unless {
                 resource == ?resource
             } when {
                 resource == ?resource
-            }
-            "#,
-        ];
-
-        for src in srcs {
-            let p = parse_policy(None, src);
-            assert_matches!(p, Err(_));
-            let p = parse_policy_template(None, src);
-            assert_matches!(p, Err(_));
-            let p = parse_policy_to_est_and_ast(None, src);
-            assert_matches!(p, Err(_));
-            let p = parse_policy_template_to_est_and_ast(None, src);
-            assert_matches!(p, Err(_));
-            let p = parse_policyset(src);
-            assert_matches!(p, Err(_));
-            let p = parse_policyset_to_ests_and_pset(src);
-            assert_matches!(p, Err(_));
-        }
+            };
+            "#;
+        let slot_in_when_clause_error =
+            "found template slot ?resource in a `when` clause; slots are currently unsupported in `when` clauses";
+        let slot_in_unless_clause_error =
+            "found template slot ?resource in a `unless` clause; slots are currently unsupported in `unless` clauses";
+        let unexpected_template_error =
+            "expected a static policy, got a template containing the slot ?resource; try removing the template slot(s) from this policy";
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+            assert_some_error_contains(&e, unexpected_template_error, src);
+        });
+        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policyset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
+        assert_matches!(parse_policyset_to_ests_and_pset(src), Err(e) => {
+            assert_some_error_contains(&e, slot_in_when_clause_error, src);
+            assert_some_error_contains(&e, slot_in_unless_clause_error, src);
+        });
     }
 
     #[test]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -86,7 +86,7 @@ pub enum ParseLiteralError {
     ParseLiteral(String),
 }
 
-/// Errors in  the CST -> AST transform, mostly well-formedness issues.
+/// Errors in the CST -> AST transform, mostly well-formedness issues.
 #[derive(Debug, Diagnostic, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ToASTError {
@@ -98,15 +98,23 @@ pub enum ToASTError {
     DuplicatePolicyId(PolicyID),
     /// Returned when a template is encountered but a static policy is expected
     #[error(
-        "expected a static policy, got a template. Try removing the template slots from this policy"
+        "expected a static policy, got a template containing the slot {slot}; try removing the template slot(s) from this policy"
     )]
-    UnexpectedTemplate,
+    UnexpectedTemplate {
+        /// Slot that was found (which is not valid in a static policy)
+        slot: cst::Slot,
+    },
     /// Returned when we attempt to parse a policy with malformed or conflicting annotations
     #[error("this policy uses poorly formed or duplicate annotations")]
     BadAnnotations,
-    /// Returned when a policy contains Template Slots in the condition clause. This is not currently supported.
-    #[error("template slots are currently unsupported in policy condition clauses")]
-    SlotsInConditionClause,
+    /// Returned when a policy contains template slots in a when/unless clause. This is not currently supported. See RFC 3
+    #[error("found template slot {slot} in a `{clausetype}` clause; slots are currently unsupported in `{clausetype}` clauses")]
+    SlotsInConditionClause {
+        /// Slot that was found in a when/unless clause
+        slot: cst::Slot,
+        /// Clause type, e.g. "when" or "unless"
+        clausetype: &'static str,
+    },
     /// Returned when a policy is missing one of the 3 required scope clauses. (`principal`, `action`, and `resource`)
     #[error("this policy is missing the `{0}` variable in the scope")]
     MissingScopeConstraint(Var),


### PR DESCRIPTION
## Description of changes

This required some refactoring in order to report the specific slot (like `?principal`) that was involved in the error.

## Issue #, if available

Fixes #245. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
