### PR TITLE
Fix bug in add_template with existing link of same name.

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -161,7 +161,11 @@ impl PolicySet {
     }
 
     /// Add a template to the policy set.
+    /// If a link with the same name already exists, this will error.
     pub fn add_template(&mut self, t: Template) -> Result<(), PolicySetError> {
+        if self.links.contains_key(t.id()) {
+            return Err(PolicySetError::Occupied);
+        }
         // TODO: Use `try_insert` when stabilized.
         // https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.try_insert
         match self.templates.entry(t.id().clone()) {

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -161,7 +161,7 @@ impl PolicySet {
     }
 
     /// Add a template to the policy set.
-    /// If a link with the same name already exists, this will error.
+    /// If a link or template with the same name already exists, this will error.
     pub fn add_template(&mut self, t: Template) -> Result<(), PolicySetError> {
         if self.links.contains_key(t.id()) {
             return Err(PolicySetError::Occupied);

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2.4.2
 
 ### Changed
-- Fixed bug (#370) related to how the validator handles template-linked policies 
+- Fixed bug (#370) related to how the validator handles template-linked policies
 
 ## 2.4.1
 ### Added
@@ -37,6 +37,7 @@ exist to the `RecordAttrDoesNotExist` error message.
 Now it will not, since we know `{"foo": 5} has bar` is `False`, and the
 validator will return an error for a policy that can never fire.
 - Removed deprecated `__expr` escapes from integration tests.
+- Calling `add_template` with a `PolicyId` that is an existing link will now error.
 
 ## 2.3.3
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3662,6 +3662,36 @@ mod policy_set_tests {
             )))
         );
     }
+
+    #[test]
+    fn pset_add_template_conflict_link() {
+        let template = Template::parse(
+            Some("policy0".into()),
+            "permit(principal == ?principal, action, resource);",
+        )
+        .expect("Template Parse Failure");
+        let mut pset = PolicySet::new();
+        pset.add_template(template).unwrap();
+        let env: HashMap<SlotId, EntityUid> =
+            std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
+        pset.link(
+            PolicyId::from_str("policy0").unwrap(),
+            PolicyId::from_str("policy3").unwrap(),
+            env,
+        )
+        .unwrap();
+        let template = Template::parse(
+            Some("policy3".into()),
+            "permit(principal == ?principal, action, resource);",
+        )
+        .expect("Template Parse Failure");
+
+        assert_matches!(
+            pset.add_template(template),
+            Err(PolicySetError::AlreadyDefined)
+        );
+        //Should not panic
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes
Fix bug in add_template with existing link of same name.

## Issue #, if available
Related to https://github.com/cedar-policy/cedar/issues/455

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
