### PR TITLE
Refactor `TryFrom<cst::*> for est::Expr`

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -28,7 +28,6 @@ use crate::ast;
 use crate::entities::EntityUidJson;
 use crate::parser::cst;
 use crate::parser::err::{ParseError, ParseErrors, ToASTError};
-use crate::parser::ASTNode;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::SmolStr;
@@ -167,10 +166,7 @@ impl TryFrom<cst::Cond> for Clause {
                 });
                 Err(ParseError::ToAST(ToASTError::EmptyClause(ident)).into())
             }
-            Some(ASTNode { node: Some(e), .. }) => e.try_into(),
-            Some(ASTNode { node: None, .. }) => {
-                Err(ParseError::ToAST(ToASTError::MissingNodeData).into())
-            }
+            Some(e) => e.try_into(),
         };
         let expr = match expr {
             Ok(expr) => Some(expr),


### PR DESCRIPTION
These are changes I found useful when adding source location information to `ToASTError`. Refactor the implementation of `TryFrom<cst::*>` to be for `TryFrom<AstNode<Option<cst::*>>>` instead. Source information is stored on the `AstNode` struct, so this makes the location of the current root node available for the error reporting.  It also reduces verbosity around error handling for missing node data in some cases.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
