### PR TITLE
improve `miette` integration for parse errors

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -21,6 +21,7 @@ use super::{
 use crate::entities::JsonSerializationError;
 use crate::parser;
 use crate::parser::err::ParseErrors;
+use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::hash::{Hash, Hasher};
@@ -590,7 +591,7 @@ impl<'a> Hash for RestrictedExprShapeOnly<'a> {
 
 /// Error when constructing a restricted expression from unrestricted
 
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
 pub enum RestrictedExprError {
     /// An expression was expected to be a "restricted" expression, but contained
     /// a feature that is not allowed in restricted expressions. The `feature`

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast::PatternElem;
+use miette::Diagnostic;
 use rustc_lexer::unescape::{unescape_str, EscapeError};
 use smol_str::SmolStr;
 use std::ops::Range;
@@ -66,14 +67,16 @@ pub(crate) fn to_pattern(s: &str) -> Result<Vec<PatternElem>, Vec<UnescapeError>
 }
 
 /// Errors generated when processing escapes
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Diagnostic, Error, PartialEq, Eq)]
 pub struct UnescapeError {
     /// underlying EscapeError
     err: EscapeError,
     /// copy of the input string which had the error
+    #[source_code]
     input: String,
     /// Range of the input string where the error occurred
     /// This range must be within the length of `input`
+    #[label]
     range: Range<usize>,
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Better integration with `miette` for `ParseErrors`. If you have previously
+  been just using the `Display` trait to get the error message from a
+  `ParseErrors`, you may want to consider also examining other data provided by
+  the `miette::Diagnostic` trait, for instance `.help()`.
+  Alternately, you can use `miette` and its `fancy` feature to format the error
+  and all associated information in a pretty human-readable format or as JSON.
+  For more details, see `miette`'s
+  [documentation](https://docs.rs/miette/latest/miette/index.html).
 - Rename `cedar_policy_core::est::EstToAstError` to
   `cedar_policy_core::est::FromJsonError`. (#197)
 - Rename `cedar_policy_core::entities::JsonDeserializationError::ExtensionsError`

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -18,6 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 itertools = "0.10"
+miette = "5.9.0"
 thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true}


### PR DESCRIPTION
## Description of changes

Make better use of the rich `miette` error fields, for our parse errors.

In some cases, moves helpful text out of `Display` and into `.help()`.  Users of `Display` who are unaware of `miette` will see this as a regression, but structured errors are in the end going to be better for everyone.  For more discussion of these tradeoffs, see #326 and #182.

Improves tests in a bunch of cases.

No breaking/functionality change, other than that the text of some error messages has changed.

## Issue #, if available

Partially resolves, but does not fully resolve, #182. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
