### PR TITLE
Further tweak to CST->EST converison

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -166,7 +166,7 @@ impl TryFrom<cst::Cond> for Clause {
                 });
                 Err(ParseError::ToAST(ToASTError::EmptyClause(ident)).into())
             }
-            Some(e) => e.try_into(),
+            Some(ref e) => e.try_into(),
         };
         let expr = match expr {
             Ok(expr) => Some(expr),

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -23,6 +23,8 @@ use std::ops::Range;
 use miette::{Diagnostic, LabeledSpan, Severity, SourceCode};
 use serde::{Deserialize, Serialize};
 
+use super::err::ToASTError;
+
 /// Describes where in policy source code a node in the CST or expression AST
 /// occurs.
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
@@ -291,5 +293,11 @@ impl<N> ASTNode<Option<N>> {
         F: FnOnce(N, SourceInfo) -> Option<R>,
     {
         f(self.node?, self.info)
+    }
+
+    /// Get node data if present, or return an error result for `MissingNodeData`
+    /// if it is `None`.
+    pub fn ok_or_missing(&self) -> Result<&N, ToASTError> {
+        self.node.as_ref().ok_or(ToASTError::MissingNodeData)
     }
 }


### PR DESCRIPTION
## Description of changes

Another change to make adding source information to `ToASTError` nicer. Abstract the pattern `node.node.ok_or(ToASTError::MissingNodeData)` into one utility function so that when the `ToASTError` needs a source source location I only have to add it in place instead of everywhere the pattern appears. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
