### PR TITLE
Improve error on incorrect function/method calls

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1266,8 +1266,8 @@ impl TryFrom<&ASTNode<Option<cst::Member>>> for Expr {
     }
 }
 
-/// Return the single argument in arguments iterator, or return a wrong arity
-/// error if the iterator has 0 more more than 1 element.
+/// Return the single argument in `args` iterator, or return a wrong arity error
+/// if the iterator has 0 elements or more than 1 element.
 pub fn extract_single_argument<T>(
     args: impl ExactSizeIterator<Item = T>,
     fn_name: &'static str,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -44,6 +44,7 @@ use crate::ast::{
     ExprConstructionError, PatternElem, PolicySetError, PrincipalConstraint,
     PrincipalOrResourceConstraint, ResourceConstraint,
 };
+use crate::est::extract_single_argument;
 use itertools::Either;
 use smol_str::SmolStr;
 use std::cmp::Ordering;
@@ -451,32 +452,37 @@ impl ast::Id {
         errs: &mut ParseErrors,
         span: miette::SourceSpan,
     ) -> Option<ast::Expr> {
-        let mut adj_args = args.iter_mut().peekable();
-        match (self.as_ref(), adj_args.next(), adj_args.peek()) {
-            ("contains", Some(a), None) => {
-                // move the value out of the argument, replacing it with a dummy,
-                // after this we can no longer use the original args
-                let arg = mem::replace(a, ast::Expr::val(false));
-                Some(construct_method_contains(e, arg, span))
-            }
-            ("containsAll", Some(a), None) => {
-                let arg = mem::replace(a, ast::Expr::val(false));
-                Some(construct_method_contains_all(e, arg, span))
-            }
-            ("containsAny", Some(a), None) => {
-                let arg = mem::replace(a, ast::Expr::val(false));
-                Some(construct_method_contains_any(e, arg, span))
-            }
-            (name, _, _) => {
-                if EXTENSION_STYLES.methods.contains(&name) {
+        match self.as_ref() {
+            "contains" => extract_single_argument(args.into_iter(), "contains", span)
+                .map(|arg| construct_method_contains(e, arg, span))
+                .map_err(|err| errs.push(err))
+                .ok(),
+            "containsAll" => extract_single_argument(args.into_iter(), "containsAll", span)
+                .map(|arg| construct_method_contains_all(e, arg, span))
+                .map_err(|err| errs.push(err))
+                .ok(),
+            "containsAny" => extract_single_argument(args.into_iter(), "containsAny", span)
+                .map(|arg| construct_method_contains_any(e, arg, span))
+                .map_err(|err| errs.push(err))
+                .ok(),
+            id => {
+                if EXTENSION_STYLES.methods.contains(&id) {
                     args.insert(0, e);
                     // INVARIANT (MethodStyleArgs), we call insert above, so args is non-empty
-                    Some(construct_ext_meth(name.to_string(), args, span))
+                    Some(construct_ext_meth(id.to_string(), args, span))
                 } else {
-                    errs.push(ToASTError::new(
-                        ToASTErrorKind::InvalidMethodName(name.to_string()),
-                        span,
-                    ));
+                    let unqual_name = ast::Name::unqualified_name(self.clone());
+                    if EXTENSION_STYLES.functions.contains(&unqual_name) {
+                        errs.push(ToASTError::new(
+                            ToASTErrorKind::MethodCallOnFunction(unqual_name.id),
+                            span,
+                        ));
+                    } else {
+                        errs.push(ToASTError::new(
+                            ToASTErrorKind::InvalidMethodName(id.to_string()),
+                            span,
+                        ));
+                    }
                     None
                 }
             }
@@ -2008,15 +2014,14 @@ impl ast::Name {
         // error on standard methods
         if self.path.is_empty() {
             let id = self.id.as_ref();
-            match id {
-                "contains" | "containsAll" | "containsAny" => {
-                    errs.push(ToASTError::new(
-                        ToASTErrorKind::FunctionCallOnMethod(self.id),
-                        span,
-                    ));
-                    return None;
-                }
-                _ => {}
+            if EXTENSION_STYLES.methods.contains(id)
+                || matches!(id, "contains" | "containsAll" | "containsAny")
+            {
+                errs.push(ToASTError::new(
+                    ToASTErrorKind::FunctionCallOnMethod(self.id),
+                    span,
+                ));
+                return None;
             }
         }
         if EXTENSION_STYLES.functions.contains(&self) {
@@ -4114,5 +4119,73 @@ mod tests {
                 ));
             }
         );
+    }
+
+    #[test]
+    fn invalid_methods_function_calls() {
+        let invalid_exprs = [
+            (
+                r#"contains([], 1)"#,
+                ExpectedErrorMessage::error_and_help(
+                    "`contains` is a method, not a function",
+                    "use a method-style call: `e.contains(..)`",
+                ),
+            ),
+            (
+                r#"[].contains()"#,
+                ExpectedErrorMessage::error(
+                    "call to `contains` requires exactly 1 argument, but got 0 arguments",
+                ),
+            ),
+            (
+                r#"[].contains(1, 2)"#,
+                ExpectedErrorMessage::error(
+                    "call to `contains` requires exactly 1 argument, but got 2 arguments",
+                ),
+            ),
+            (
+                r#"[].containsAll()"#,
+                ExpectedErrorMessage::error(
+                    "call to `containsAll` requires exactly 1 argument, but got 0 arguments",
+                ),
+            ),
+            (
+                r#"[].containsAll(1, 2)"#,
+                ExpectedErrorMessage::error(
+                    "call to `containsAll` requires exactly 1 argument, but got 2 arguments",
+                ),
+            ),
+            (
+                r#"[].containsAny()"#,
+                ExpectedErrorMessage::error(
+                    "call to `containsAny` requires exactly 1 argument, but got 0 arguments",
+                ),
+            ),
+            (
+                r#"[].containsAny(1, 2)"#,
+                ExpectedErrorMessage::error(
+                    "call to `containsAny` requires exactly 1 argument, but got 2 arguments",
+                ),
+            ),
+            (
+                r#""1.1.1.1".ip()"#,
+                ExpectedErrorMessage::error_and_help(
+                    "`ip` is a function, not a method",
+                    "use a function-style call: `ip(..)`",
+                ),
+            ),
+            (
+                r#"greaterThan(1, 2)"#,
+                ExpectedErrorMessage::error_and_help(
+                    "`greaterThan` is a method, not a function",
+                    "use a method-style call: `e.greaterThan(..)`",
+                ),
+            ),
+        ];
+        for (src, expected) in invalid_exprs {
+            assert_matches!(parse_expr(src), Err(e) => {
+                expect_err(src, &e, &expected);
+            });
+        }
     }
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -362,7 +362,7 @@ pub enum ToASTErrorKind {
     /// Returned when a CST expression is invalid
     #[error("`{0}` is not a valid expression")]
     InvalidExpression(cst::Name),
-    /// Returned when a function or method is called with the wrong arity.
+    /// Returned when a function or method is called with the wrong arity
     #[error("call to `{name}` requires exactly {expected} argument{}, but got {got} argument{}", if .expected == &1 { "" } else { "s" }, if .got == &1 { "" } else { "s" })]
     WrongArity {
         /// Name of the function or method being called

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -261,6 +261,10 @@ pub enum ToASTErrorKind {
     #[error("`{0}` is a method, not a function")]
     #[diagnostic(help("use a method-style call: `e.{0}(..)`"))]
     FunctionCallOnMethod(crate::ast::Id),
+    /// Returned when a policy attempts to call a function in the method style
+    #[error("`{0}` is a function, not a method")]
+    #[diagnostic(help("use a function-style call: `{0}(..)`"))]
+    MethodCallOnFunction(crate::ast::Id),
     /// Returned when the right hand side of a `like` expression is not a constant pattern literal
     #[error("right hand side of a `like` expression must be a pattern literal, but got `{0}`")]
     InvalidPattern(String),
@@ -358,10 +362,10 @@ pub enum ToASTErrorKind {
     /// Returned when a CST expression is invalid
     #[error("`{0}` is not a valid expression")]
     InvalidExpression(cst::Name),
-    /// Returned when a function has wrong arity
+    /// Returned when a function or method is called with the wrong arity.
     #[error("call to `{name}` requires exactly {expected} argument{}, but got {got} argument{}", if .expected == &1 { "" } else { "s" }, if .got == &1 { "" } else { "s" })]
     WrongArity {
-        /// Name of the function being called
+        /// Name of the function or method being called
         name: &'static str,
         /// The expected number of arguments
         expected: usize,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve parser error messages to more reliably notice that a function or
+  method does exists when it is called with an incorrect number of arguments or
+  using the wrong call style.
 - Include source spans on more parser error messages.
 - Better integration with `miette` for `ParseErrors`. If you have previously
   been just using the `Display` trait to get the error message from a


### PR DESCRIPTION
## Description of changes

Improve parser error messages to more reliably notice that a function or method does exists when it is called with an incorrect number of arguments or using the wrong call style.

For example `[].contains(1, 2)` now gives the following error where previously it said ``not a valid method name: `contains` `` (this message was already given in the cst->est conversion, but not cst->ast). 

```
Error:   × failed to parse policy set
  ╰─▶ call to `contains` requires exactly 1 argument, but got 2 arguments
   ╭─[<stdin>:2:1]
 2 │ 
 3 │ [].contains(1,2)
   · ───────────────
 4 │ 
   ╰────
```

This PR includes a similar fix for when an extension function is called as a method or an extension method is called as a function. 


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
