### PR TITLE
add `track_caller` more places, and refactor with `assert_matches`

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -371,6 +371,7 @@ where
     /// Panics if the self value is not `Data`.
     // PANIC SAFETY: This function is intended to panic, and says so in the documentation
     #[allow(clippy::panic)]
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     pub fn expect(self, msg: &str) -> &'a T {
         match self {
             Self::Data(e) => e,

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -3865,14 +3865,11 @@ pub mod test {
         );
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_restricted_expression_error(v: Result<PartialValue>) {
-        match v {
-            Err(e) => assert_matches!(
-                e.error_kind(),
-                EvaluationErrorKind::InvalidRestrictedExpression { .. }
-            ),
-            Ok(v) => panic!("Got wrong response: {v}"),
-        }
+        assert_matches!(v, Err(e) => {
+            assert_matches!(e.error_kind(), EvaluationErrorKind::InvalidRestrictedExpression { .. });
+        });
     }
 
     #[test]

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -301,37 +301,32 @@ mod tests {
     use crate::evaluator::Evaluator;
     use crate::extensions::Extensions;
     use crate::parser::parse_expr;
+    use cool_asserts::assert_matches;
 
     /// Asserts that a `Result` is an `Err::ExtensionErr` with our extension name
-    fn assert_decimal_err<T>(res: evaluator::Result<T>) {
-        match res {
-            Err(e) => match e.error_kind() {
-                evaluator::EvaluationErrorKind::FailedExtensionFunctionApplication {
-                    extension_name,
-                    msg,
-                } => {
-                    println!("{msg}");
-                    assert_eq!(
-                        *extension_name,
-                        Name::parse_unqualified_name("decimal")
-                            .expect("should be a valid identifier")
-                    )
-                }
-                _ => panic!("Expected a decimal ExtensionErr, got {:?}", e),
-            },
-            Ok(_) => panic!("Expected a decimal ExtensionErr, got Ok"),
-        }
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
+    fn assert_decimal_err<T: std::fmt::Debug>(res: evaluator::Result<T>) {
+        assert_matches!(res, Err(e) => {
+            assert_matches!(e.error_kind(), evaluator::EvaluationErrorKind::FailedExtensionFunctionApplication {
+                extension_name,
+                msg,
+            } => {
+                println!("{msg}");
+                assert_eq!(
+                    *extension_name,
+                    Name::parse_unqualified_name("decimal")
+                        .expect("should be a valid identifier")
+                )
+            });
+        });
     }
 
     /// Asserts that a `Result` is a decimal value
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_decimal_valid(res: evaluator::Result<Value>) {
-        match res {
-            Ok(Value::ExtensionValue(ev)) => {
-                assert_eq!(ev.typename(), Decimal::typename())
-            }
-            Ok(v) => panic!("Expected decimal ExtensionValue, got {:?}", v),
-            Err(e) => panic!("Expected Ok, got Err: {:?}", e),
-        }
+        assert_matches!(res, Ok(Value::ExtensionValue(ev)) => {
+            assert_eq!(ev.typename(), Decimal::typename());
+        });
     }
 
     /// this test just ensures that the right functions are marked constructors

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -410,23 +410,17 @@ mod tests {
 
     /// This helper function asserts that a `Result` is actually an
     /// `Err::ExtensionErr` with our extension name
-    fn assert_ipaddr_err<T>(res: evaluator::Result<T>) {
-        match res {
-            Err(e) => match e.error_kind() {
-                evaluator::EvaluationErrorKind::FailedExtensionFunctionApplication {
-                    extension_name,
-                    ..
-                } => {
-                    assert_eq!(
-                        *extension_name,
-                        Name::parse_unqualified_name("ipaddr")
-                            .expect("should be a valid identifier")
-                    )
-                }
-                _ => panic!("Expected an ipaddr ExtensionErr, got {:?}", e),
-            },
-            Ok(_) => panic!("Expected an ipaddr ExtensionErr, got Ok"),
-        }
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
+    fn assert_ipaddr_err<T: std::fmt::Debug>(res: evaluator::Result<T>) {
+        assert_matches!(res, Err(e) => assert_matches!(e.error_kind(),
+            evaluator::EvaluationErrorKind::FailedExtensionFunctionApplication { extension_name, .. } => {
+                assert_eq!(
+                    *extension_name,
+                    Name::parse_unqualified_name("ipaddr")
+                        .expect("should be a valid identifier")
+                );
+            }
+        ));
     }
 
     /// This helper function returns an `Expr` that calls `ip()` with the given single argument

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3571,6 +3571,7 @@ mod tests {
         test_invalid(r"\aaa\u{}", 2);
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn expect_action_error(test: &str, euid_strs: Vec<&str>) {
         let euids = euid_strs
             .iter()

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -1800,6 +1800,7 @@ mod partial_schema {
 
     use crate::{NamespaceDefinition, Validator};
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_validates_with_empty_schema(policy: StaticPolicy) {
         let schema = serde_json::from_str::<NamespaceDefinition>(
             r#"

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -67,10 +67,12 @@ fn namespaced_entity_type_schema() -> SchemaFragment {
     .expect("Expected valid schema")
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_expr_typechecks_namespace_schema(e: Expr, t: Type) {
     assert_typechecks(namespaced_entity_type_schema(), e, t)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_expr_typecheck_fails_namespace_schema(e: Expr, t: Option<Type>, errs: Vec<TypeError>) {
     assert_typecheck_fails(namespaced_entity_type_schema(), e, t, errs)
 }
@@ -470,6 +472,7 @@ fn multiple_namespaces_applies_to() {
 
 // Test cases added for namespace bug found by DRT.
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails_namespace_schema(
     p: StaticPolicy,
     expected_type_errors: Vec<TypeError>,

--- a/cedar-policy-validator/src/typecheck/test_optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test_optional_attributes.rs
@@ -61,10 +61,12 @@ fn schema_with_optionals() -> NamespaceDefinition {
     .expect("Expected valid schema.")
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typechecks_optional_schema(p: StaticPolicy) {
     assert_policy_typechecks(schema_with_optionals(), p);
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails_optional_schema(
     p: StaticPolicy,
     expected_type_errors: Vec<TypeError>,
@@ -312,6 +314,7 @@ fn guarded_has_true_short_circuits() {
     assert_policy_typechecks_optional_schema(policy);
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_name_access_fails(policy: StaticPolicy) {
     let optional_attr: SmolStr = "name".into();
     assert_policy_typecheck_fails_optional_schema(

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -15,6 +15,7 @@ use crate::{AttributeAccess, NamespaceDefinition, TypeError, ValidationMode, Val
 
 use super::test_utils::empty_schema_file;
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_partial_typecheck(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: StaticPolicy,
@@ -30,6 +31,7 @@ pub(crate) fn assert_partial_typecheck(
     assert!(typechecked, "Expected that policy would typecheck.");
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_partial_typecheck_fail(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: StaticPolicy,
@@ -46,10 +48,12 @@ pub(crate) fn assert_partial_typecheck_fail(
     assert!(!typechecked, "Expected that policy would not typecheck.");
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typechecks_empty_schema(policy: StaticPolicy) {
     assert_partial_typecheck(empty_schema_file(), policy)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typecheck_fails_empty_schema(
     policy: StaticPolicy,
     expected_type_errors: Vec<TypeError>,
@@ -483,10 +487,12 @@ fn partial_schema_file() -> NamespaceDefinition {
     .expect("Expected valid schema")
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typechecks_partial_schema(policy: StaticPolicy) {
     assert_partial_typecheck(partial_schema_file(), policy)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typecheck_fails_partial_schema(
     policy: StaticPolicy,
     expected_type_errors: Vec<TypeError>,

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -108,18 +108,22 @@ fn simple_schema_file() -> NamespaceDefinition {
     .expect("Expected valid schema")
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_simple_schema(expr: Expr, expected: Type) {
     assert_typechecks(simple_schema_file(), expr, expected)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typechecks_simple_schema(p: impl Into<Arc<Template>>) {
     assert_policy_typechecks(simple_schema_file(), p)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typechecks_permissive_simple_schema(p: impl Into<Arc<Template>>) {
     assert_policy_typechecks_for_mode(simple_schema_file(), p, ValidationMode::Permissive)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails_simple_schema(
     p: impl Into<Arc<Template>>,
     expected_type_errors: Vec<TypeError>,
@@ -127,6 +131,7 @@ fn assert_policy_typecheck_fails_simple_schema(
     assert_policy_typecheck_fails(simple_schema_file(), p, expected_type_errors)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_permissive_fails_simple_schema(
     p: impl Into<Arc<Template>>,
     expected_type_errors: Vec<TypeError>,

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -22,6 +22,8 @@
 #![allow(clippy::panic)]
 // PANIC SAFETY unit tests
 #![allow(clippy::indexing_slicing)]
+
+use cool_asserts::assert_matches;
 use serde_json::json;
 use std::str::FromStr;
 
@@ -34,6 +36,7 @@ use crate::{
 
 use super::test_utils::with_typechecker_from_schema;
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
     schema: SchemaFragment,
     env: &RequestEnv,
@@ -47,20 +50,13 @@ fn assert_typechecks_strict(
         let answer = typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs);
 
         assert_eq!(errs, vec![], "Expression should not contain any errors.");
-        match answer {
-            crate::typecheck::TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
-                assert!(expr_type.eq_shape(&e_strict), "Transformed expression does not have the expected shape. expected: {:?}, actual: {:?}", e_strict, expr_type)
-            }
-            crate::typecheck::TypecheckAnswer::TypecheckFail { .. } => {
-                panic!("Typechecking should have succeeded for expression {:?}", e)
-            }
-            crate::typecheck::TypecheckAnswer::RecursionLimit => {
-                panic!("Should not have hit recursion liimt for: {:?}", e)
-            }
-        }
+        assert_matches!(answer, crate::typecheck::TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
+            assert!(expr_type.eq_shape(&e_strict), "Transformed expression does not have the expected shape. expected: {:?}, actual: {:?}", e_strict, expr_type)
+        });
     });
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_strict_type_error(
     schema: SchemaFragment,
     env: &RequestEnv,
@@ -79,20 +75,13 @@ fn assert_strict_type_error(
             vec![expected_error]
         );
 
-        match answer {
-            crate::typecheck::TypecheckAnswer::TypecheckFail { expr_recovery_type } => {
-                assert!(expr_recovery_type.eq_shape(&e_strict), "Transformed expression does not have the expected shape. expected: {:?}, actual: {:?}", e_strict, expr_recovery_type)
-            }
-            crate::typecheck::TypecheckAnswer::TypecheckSuccess { .. } => {
-                panic!("Typechecking should have failed for expression {:?}", e)
-            }
-            crate::typecheck::TypecheckAnswer::RecursionLimit => {
-                panic!("Should not have hit recursion limit for {:?}", e)
-            }
-        }
+        assert_matches!(answer, crate::typecheck::TypecheckAnswer::TypecheckFail { expr_recovery_type } => {
+            assert!(expr_recovery_type.eq_shape(&e_strict), "Transformed expression does not have the expected shape. expected: {:?}, actual: {:?}", e_strict, expr_recovery_type)
+        });
     });
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_types_must_match(
     schema: SchemaFragment,
     env: &RequestEnv,

--- a/cedar-policy-validator/src/typecheck/test_type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test_type_annotation.rs
@@ -26,8 +26,8 @@ use std::collections::HashSet;
 
 use cedar_policy_core::ast::{EntityUID, Expr, ExprBuilder};
 
-use crate::{types::Type, SchemaFragment};
 use super::test_utils::{empty_schema_file, with_typechecker_from_schema};
+use crate::{types::Type, SchemaFragment};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_expr_has_annotated_ast(e: &Expr, annotated: &Expr<Option<Type>>) {

--- a/cedar-policy-validator/src/typecheck/test_unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test_unspecified_entity.rs
@@ -63,10 +63,12 @@ fn schema_with_unspecified() -> NamespaceDefinition {
     .expect("Expected valid schema.")
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typechecks(p: StaticPolicy) {
     test_utils::assert_policy_typechecks(schema_with_unspecified(), p);
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails(p: StaticPolicy, expected_type_errors: Vec<TypeError>) {
     test_utils::assert_policy_typecheck_fails(schema_with_unspecified(), p, expected_type_errors);
 }

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -23,6 +23,8 @@
 #![allow(clippy::panic)]
 // PANIC SAFETY unit tests
 #![allow(clippy::indexing_slicing)]
+
+use cool_asserts::assert_matches;
 use std::{collections::HashSet, sync::Arc};
 
 use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprShapeOnly, StaticPolicy, Template};
@@ -33,7 +35,6 @@ use crate::{
     types::{EffectSet, OpenTag, RequestEnv, Type},
     NamespaceDefinition, ValidationMode, ValidatorSchema,
 };
-
 use super::{TypecheckAnswer, Typechecker};
 
 impl TypeError {
@@ -107,6 +108,7 @@ pub(crate) fn with_typechecker_from_schema<F>(
 /// Assert expected == actual by by asserting expected <: actual && actual <: expected.
 /// In the future it might better to only assert actual <: expected to allow
 /// improvement to the typechecker to return more specific types.
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_types_eq(schema: &ValidatorSchema, expected: &Type, actual: &Type) {
     assert!(
             Type::is_subtype(schema, expected, actual, ValidationMode::Permissive),
@@ -120,6 +122,7 @@ pub(crate) fn assert_types_eq(schema: &ValidatorSchema, expected: &Type, actual:
 /// in the expected list of type errors, and that the expected number of
 /// type errors were generated. Equality of types in TypeErrors is
 /// determined in the same way as in `assert_types_eq`.
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_expected_type_errors(expected: &Vec<TypeError>, actual: &HashSet<TypeError>) {
     expected.iter().for_each(|expected| {
             assert!(
@@ -140,6 +143,7 @@ pub(crate) fn assert_expected_type_errors(expected: &Vec<TypeError>, actual: &Ha
     );
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_policy_typechecks(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: impl Into<Arc<Template>>,
@@ -147,6 +151,7 @@ pub(crate) fn assert_policy_typechecks(
     assert_policy_typechecks_for_mode(schema, policy, ValidationMode::Strict)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_policy_typechecks_for_mode(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: impl Into<Arc<Template>>,
@@ -177,6 +182,7 @@ pub(crate) fn assert_policy_typechecks_for_mode(
     });
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_policy_typecheck_fails(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: impl Into<Arc<Template>>,
@@ -190,6 +196,7 @@ pub(crate) fn assert_policy_typecheck_fails(
     )
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_policy_typecheck_fails_for_mode(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     policy: impl Into<Arc<Template>>,
@@ -207,6 +214,7 @@ pub(crate) fn assert_policy_typecheck_fails_for_mode(
 
 /// Assert that expr type checks successfully with a particular type, and
 /// that it does not generate any type errors.
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typechecks(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     expr: Expr,
@@ -215,6 +223,7 @@ pub(crate) fn assert_typechecks(
     assert_typechecks_for_mode(schema, expr, expected, ValidationMode::Strict);
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typechecks_for_mode(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     expr: Expr,
@@ -225,28 +234,11 @@ pub(crate) fn assert_typechecks_for_mode(
         typechecker.mode = mode;
         let mut type_errors = HashSet::new();
         let actual = typechecker.typecheck_expr(&expr, &mut type_errors);
-        assert_types_eq(
-            typechecker.schema,
-            &expected,
-            &match actual {
-                TypecheckAnswer::TypecheckSuccess { expr_type, .. } => expr_type
-                    .into_data()
-                    .expect("Typechecked expression must have type."),
-                TypecheckAnswer::TypecheckFail { .. } => {
-                    panic!(
-                        "Expected that expression would typecheck. Errors: {}",
-                        type_errors
-                            .iter()
-                            .map(|e| format!("{:#?}", e))
-                            .collect::<Vec<_>>()
-                            .join(",")
-                    );
-                }
-                TypecheckAnswer::RecursionLimit => panic!("Should not have hit recursion limit"),
-            },
-        );
-        assert!(
-            type_errors.is_empty(),
+        assert_matches!(actual, TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
+            assert_types_eq(typechecker.schema, &expected, &expr_type.into_data().expect("Typechecked expression must have type"));
+        });
+        assert_eq!(
+            type_errors, HashSet::new(),
             "Did not expect any errors, saw {:#?}.",
             type_errors
         );
@@ -257,6 +249,7 @@ pub(crate) fn assert_typechecks_for_mode(
 /// expressions. Failed type checking will still return a type that is used
 /// to continue typechecking, so the `expected` type must match the returned
 /// type for this to pass.
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typecheck_fails(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     expr: Expr,
@@ -272,6 +265,7 @@ pub(crate) fn assert_typecheck_fails(
     )
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typecheck_fails_for_mode(
     schema: impl TryInto<ValidatorSchema, Error = impl core::fmt::Debug>,
     expr: Expr,
@@ -283,21 +277,16 @@ pub(crate) fn assert_typecheck_fails_for_mode(
         typechecker.mode = mode;
         let mut type_errors = HashSet::new();
         let actual = typechecker.typecheck_expr(&expr, &mut type_errors);
-        let actual_ty = match actual {
-            TypecheckAnswer::TypecheckSuccess { .. } => {
-                panic!("Expected that expression would not typecheck.")
+        assert_matches!(actual, TypecheckAnswer::TypecheckFail { expr_recovery_type } => {
+            match (expected_ty.as_ref(), expr_recovery_type.data()) {
+                (None, None) => (),
+                (Some(expected_ty), Some(actual_ty)) => {
+                    assert_types_eq(typechecker.schema, expected_ty, actual_ty);
+                }
+                _ => panic!("Expected that actual type would be defined iff expected type is defined."),
             }
-            TypecheckAnswer::TypecheckFail { expr_recovery_type } => expr_recovery_type,
-            TypecheckAnswer::RecursionLimit => panic!("Should not have hit recursion limit"),
-        };
-        match (expected_ty.as_ref(), actual_ty.data()) {
-            (None, None) => (),
-            (Some(expected_ty), Some(actual_ty)) => {
-                assert_types_eq(typechecker.schema, expected_ty, actual_ty)
-            }
-            _ => panic!("Expected that actual type would be defined iff expected type is defined."),
-        }
-        assert_expected_type_errors(&expected_type_errors, &type_errors);
+            assert_expected_type_errors(&expected_type_errors, &type_errors);
+        });
     });
 }
 
@@ -310,10 +299,12 @@ pub(crate) fn empty_schema_file() -> NamespaceDefinition {
     NamespaceDefinition::new([], [])
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typechecks_empty_schema(expr: Expr, expected: Type) {
     assert_typechecks(empty_schema_file(), expr, expected)
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typechecks_empty_schema_permissive(expr: Expr, expected: Type) {
     assert_typechecks_for_mode(
         empty_schema_file(),
@@ -323,6 +314,7 @@ pub(crate) fn assert_typechecks_empty_schema_permissive(expr: Expr, expected: Ty
     )
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typecheck_fails_empty_schema(
     expr: Expr,
     expected: Type,
@@ -331,6 +323,7 @@ pub(crate) fn assert_typecheck_fails_empty_schema(
     assert_typecheck_fails(empty_schema_file(), expr, Some(expected), type_errors);
 }
 
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_typecheck_fails_empty_schema_without_type(
     expr: Expr,
     type_errors: Vec<TypeError>,

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -29,13 +29,13 @@ use std::{collections::HashSet, sync::Arc};
 
 use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprShapeOnly, StaticPolicy, Template};
 
+use super::{TypecheckAnswer, Typechecker};
 use crate::{
     schema::ACTION_ENTITY_TYPE,
     type_error::TypeError,
     types::{EffectSet, OpenTag, RequestEnv, Type},
     NamespaceDefinition, ValidationMode, ValidatorSchema,
 };
-use super::{TypecheckAnswer, Typechecker};
 
 impl TypeError {
     /// Testing utility for an unexpected type error when exactly one type was
@@ -238,7 +238,8 @@ pub(crate) fn assert_typechecks_for_mode(
             assert_types_eq(typechecker.schema, &expected, &expr_type.into_data().expect("Typechecked expression must have type"));
         });
         assert_eq!(
-            type_errors, HashSet::new(),
+            type_errors,
+            HashSet::new(),
             "Did not expect any errors, saw {:#?}.",
             type_errors
         );

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1650,10 +1650,10 @@ impl<'a> Effect<'a> {
 #[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod test {
-    use crate::{ActionBehavior, SchemaType, ValidatorNamespaceDef};
     use super::*;
-    use std::collections::HashMap;
+    use crate::{ActionBehavior, SchemaType, ValidatorNamespaceDef};
     use cool_asserts::assert_matches;
+    use std::collections::HashMap;
 
     impl Type {
         pub(crate) fn entity_lub<'a>(es: impl IntoIterator<Item = &'a str>) -> Type {

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1650,11 +1650,10 @@ impl<'a> Effect<'a> {
 #[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use crate::{ActionBehavior, SchemaType, ValidatorNamespaceDef};
-
     use super::*;
+    use std::collections::HashMap;
+    use cool_asserts::assert_matches;
 
     impl Type {
         pub(crate) fn entity_lub<'a>(es: impl IntoIterator<Item = &'a str>) -> Type {
@@ -1693,6 +1692,7 @@ mod test {
         }
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_least_upper_bound(schema: ValidatorSchema, lhs: Type, rhs: Type, lub: Option<Type>) {
         assert_eq!(
             Type::least_upper_bound(&schema, &lhs, &rhs, ValidationMode::Permissive),
@@ -1704,6 +1704,7 @@ mod test {
         );
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_entity_lub(
         schema: ValidatorSchema,
         lhs: Type,
@@ -1712,38 +1713,36 @@ mod test {
         lub_attrs: &[(&str, Type)],
     ) {
         let lub = Type::least_upper_bound(&schema, &lhs, &rhs, ValidationMode::Permissive);
-        match lub {
-            Some(Type::EntityOrRecord(EntityRecordKind::Entity(entity_lub))) => {
-                assert_eq!(
-                    lub_names
+        assert_matches!(lub, Some(Type::EntityOrRecord(EntityRecordKind::Entity(entity_lub))) => {
+            assert_eq!(
+                lub_names
+                    .iter()
+                    .map(|s| s.parse().expect("Expected valid entity type name."))
+                    .collect::<BTreeSet<_>>(),
+                entity_lub.lub_elements,
+                "Incorrect entity types composing LUB."
+            );
+            assert_eq!(
+                Attributes::with_attributes(
+                    lub_attrs
                         .iter()
-                        .map(|s| s.parse().expect("Expected valid entity type name."))
-                        .collect::<BTreeSet<_>>(),
-                    entity_lub.lub_elements,
-                    "Incorrect entity types composing LUB."
-                );
-                assert_eq!(
-                    Attributes::with_attributes(
-                        lub_attrs
-                            .iter()
-                            .map(|(s, t)| (
-                                AsRef::<str>::as_ref(s).into(),
-                                AttributeType::required_attribute(t.clone())
-                            ))
-                            .collect::<BTreeMap<_, _>>()
-                    ),
-                    entity_lub.get_attribute_types(&schema),
-                    "Incorrect computed record type for LUB."
-                );
-            }
-            _ => panic!("Expected entity least upper bound."),
-        }
+                        .map(|(s, t)| (
+                            AsRef::<str>::as_ref(s).into(),
+                            AttributeType::required_attribute(t.clone())
+                        ))
+                        .collect::<BTreeMap<_, _>>()
+                ),
+                entity_lub.get_attribute_types(&schema),
+                "Incorrect computed record type for LUB."
+            );
+        });
     }
 
     fn empty_schema() -> ValidatorSchema {
         ValidatorSchema::empty()
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_least_upper_bound_empty_schema(lhs: Type, rhs: Type, lub: Option<Type>) {
         assert_least_upper_bound(empty_schema(), lhs, rhs, lub);
     }
@@ -2025,10 +2024,12 @@ mod test {
         .expect("Expected valid schema")
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_least_upper_bound_simple_schema(lhs: Type, rhs: Type, lub: Option<Type>) {
         assert_least_upper_bound(simple_schema(), lhs, rhs, lub);
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_entity_lub_attrs_simple_schema(
         lhs: Type,
         rhs: Type,
@@ -2134,10 +2135,12 @@ mod test {
         .expect("Expected valid schema")
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_least_upper_bound_attr_schema(lhs: Type, rhs: Type, lub: Option<Type>) {
         assert_least_upper_bound(attr_schema(), lhs, rhs, lub);
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_entity_lub_attrs_attr_schema(
         lhs: Type,
         rhs: Type,
@@ -2300,6 +2303,7 @@ mod test {
         .expect("Expected valid schema")
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_entity_lub_attrs_rec_schema(
         lhs: Type,
         rhs: Type,
@@ -2333,9 +2337,10 @@ mod test {
         );
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_json_parses_to_schema_type(ty: Type) {
         let json_str = serde_json::value::Value::Object(ty.to_type_json()).to_string();
-        println!("{}", json_str);
+        println!("{json_str}");
         let parsed_schema_type: SchemaType = serde_json::from_str(&json_str)
             .expect("JSON representation should have parsed into a schema type");
         let type_from_schema_type =
@@ -2374,6 +2379,7 @@ mod test {
         ]));
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_displays_as(ty: Type, repr: &str) {
         assert_eq!(
             ty.to_string(),

--- a/cedar-policy/src/frontend/utils.rs
+++ b/cedar-policy/src/frontend/utils.rs
@@ -90,6 +90,7 @@ impl InterfaceResult {
 }
 
 #[cfg(test)]
+#[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_is_failure(result: &InterfaceResult, internal: bool, err: &str) {
     use cool_asserts::assert_matches;
     use itertools::Itertools;

--- a/cedar-policy/src/frontend/validate.rs
+++ b/cedar-policy/src/frontend/validate.rs
@@ -145,8 +145,8 @@ enum ValidateAnswer {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod test {
-    use crate::frontend::utils::assert_is_failure;
     use super::*;
+    use crate::frontend::utils::assert_is_failure;
     use cool_asserts::assert_matches;
     use std::collections::HashMap;
 

--- a/cedar-policy/src/frontend/validate.rs
+++ b/cedar-policy/src/frontend/validate.rs
@@ -146,8 +146,8 @@ enum ValidateAnswer {
 #[cfg(test)]
 mod test {
     use crate::frontend::utils::assert_is_failure;
-
     use super::*;
+    use cool_asserts::assert_matches;
     use std::collections::HashMap;
 
     #[test]
@@ -433,42 +433,24 @@ mod test {
         );
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_validates_without_notes(result: InterfaceResult) {
-        match result {
-            InterfaceResult::Success { result } => {
-                let parsed_result: ValidateAnswer = serde_json::from_str(result.as_str()).unwrap();
-                match parsed_result {
-                    ValidateAnswer::ParseFailed { .. } => {
-                        panic!("expected parse to succeed, but got {parsed_result:?}")
-                    }
-                    ValidateAnswer::Success { notes, .. } => {
-                        assert_eq!(notes.len(), 0, "Unexpected validation notes: {notes:?}");
-                    }
-                }
-            }
-            InterfaceResult::Failure { .. } => {
-                panic!("expected call to succeed but got {:?}", &result)
-            }
-        }
+        assert_matches!(result, InterfaceResult::Success { result } => {
+            let parsed_result: ValidateAnswer = serde_json::from_str(result.as_str()).unwrap();
+            assert_matches!(parsed_result, ValidateAnswer::Success { notes, .. } => {
+                assert_eq!(notes.len(), 0, "Unexpected validation notes: {notes:?}");
+            });
+        });
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_validates_with_notes(result: InterfaceResult, expected_num_notes: usize) {
-        match result {
-            InterfaceResult::Success { result } => {
-                let parsed_result: ValidateAnswer = serde_json::from_str(result.as_str()).unwrap();
-                match parsed_result {
-                    ValidateAnswer::ParseFailed { .. } => {
-                        panic!("expected parse to succeed, but got {parsed_result:?}")
-                    }
-                    ValidateAnswer::Success { notes, .. } => {
-                        assert_eq!(notes.len(), expected_num_notes);
-                    }
-                }
-            }
-            InterfaceResult::Failure { .. } => {
-                panic!("expected call to succeed but got {:?}", &result)
-            }
-        }
+        assert_matches!(result, InterfaceResult::Success { result } => {
+            let parsed_result: ValidateAnswer = serde_json::from_str(result.as_str()).unwrap();
+            assert_matches!(parsed_result, ValidateAnswer::Success { notes, .. } => {
+                assert_eq!(notes.len(), expected_num_notes);
+            });
+        });
     }
 
     #[test]

--- a/cedar-policy/src/prop_test_policy_set.rs
+++ b/cedar-policy/src/prop_test_policy_set.rs
@@ -48,6 +48,7 @@ impl PolicySetModel {
         }
     }
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_name_unique(&self, policy_id: &String) {
         assert!(!self.static_policy_names.iter().any(|p| p == policy_id));
         assert!(!self.link_names.iter().any(|p| p == policy_id));


### PR DESCRIPTION
## Description of changes

I recently learned about `#[track_caller]`, and there are a number of places we can apply it to testing utility functions to hopefully make test failures easier to debug.

While I was in the neighborhood, simplified a number of these testing utilities using `assert_matches!()`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
