### PR TITLE
Improve error message in invalid template slot

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1139,10 +1139,11 @@ fn interpret_primary(
                 }
             }
         }
-        cst::Primary::Slot(node) => match node.ok_or_missing()? {
-            cst::Slot::Principal => Ok(Either::Right(Expr::slot(ast::SlotId::principal()))),
-            cst::Slot::Resource => Ok(Either::Right(Expr::slot(ast::SlotId::resource()))),
-        },
+        cst::Primary::Slot(node) => Ok(Either::Right(Expr::slot(
+            node.ok_or_missing()?
+                .try_into()
+                .map_err(|e| node.to_ast_err(e))?,
+        ))),
         cst::Primary::Expr(e) => Ok(Either::Right(e.try_into()?)),
         cst::Primary::EList(nodes) => nodes
             .into_iter()

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -774,8 +774,10 @@ mod parse_tests {
                 resource == ?blah
             };
             "#;
-        // TODO(#451): improve these errors
-        let error = ExpectedErrorMessage::error("invalid token");
+        let error = ExpectedErrorMessage::error_and_help(
+            "`?blah` is not a valid template slot",
+            "a template slot may only be `?principal` or `?resource`",
+        );
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &error);
         });
@@ -868,8 +870,10 @@ mod parse_tests {
                 resource == ?blah
             };
             "#;
-        // TODO(#451): improve these errors
-        let error = ExpectedErrorMessage::error("invalid token");
+        let error = ExpectedErrorMessage::error_and_help(
+            "`?blah` is not a valid template slot",
+            "a template slot may only be `?principal` or `?resource`",
+        );
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &error);
         });

--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -369,6 +369,8 @@ pub enum Slot {
     Principal,
     /// Slot for Resource Constraints
     Resource,
+    /// Slot other than one of the valid slots
+    Other(SmolStr),
 }
 
 impl Slot {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -383,6 +383,10 @@ pub enum ToASTErrorKind {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidIs(#[from] InvalidIsError),
+    /// Returned when a policy contains a template slot other than `?principal` or `?resource`
+    #[error("`{0}` is not a valid template slot")]
+    #[diagnostic(help("a template slot may only be `?principal` or `?resource`"))]
+    InvalidSlot(SmolStr),
 }
 
 impl ToASTErrorKind {
@@ -568,6 +572,7 @@ lazy_static! {
         ("CONTEXT", "`context`"),
         ("PRINCIPAL_SLOT", "`?principal`"),
         ("RESOURCE_SLOT", "`?resource`"),
+        ("OTHER SLOT", "template slot"),
         ("IDENTIFIER", "identifier"),
         ("NUMBER", "number"),
         ("STRINGLIT", "string literal"),

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -572,7 +572,7 @@ lazy_static! {
         ("CONTEXT", "`context`"),
         ("PRINCIPAL_SLOT", "`?principal`"),
         ("RESOURCE_SLOT", "`?resource`"),
-        ("OTHER SLOT", "template slot"),
+        ("OTHER_SLOT", "template slot"),
         ("IDENTIFIER", "identifier"),
         ("NUMBER", "number"),
         ("STRINGLIT", "string literal"),

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -442,10 +442,11 @@ impl fmt::Display for Str {
 impl std::fmt::Display for Slot {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let src = match self {
-            Slot::Principal => "principal",
-            Slot::Resource => "resource",
+            Slot::Principal => "?principal",
+            Slot::Resource => "?resource",
+            Slot::Other(slot) => slot.as_ref(),
         };
-        write!(f, "?{src}")
+        write!(f, "{src}")
     }
 }
 

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -44,6 +44,7 @@ match {
     // Valid slots, hardcoded for now, may be generalized later
     "?principal" => PRINCIPAL_SLOT,
     "?resource" => RESOURCE_SLOT,
+    r"\?[_a-zA-Z][_a-zA-Z0-9]*" => OTHER_SLOT,
 
     // data input
     r"[_a-zA-Z][_a-zA-Z0-9]*" => IDENTIFIER,
@@ -345,6 +346,8 @@ Slot: Node<Option<cst::Slot>> = {
         => Node::new(Some(cst::Slot::Principal), l, r),
     <l:@L> RESOURCE_SLOT <r:@R>
         => Node::new(Some(cst::Slot::Resource), l, r),
+    <l:@L> <s: OTHER_SLOT> <r:@R>
+        => Node::new(Some(cst::Slot::Other(s.into())), l, r),
 }
 
 // LITERAL   := BOOL | INT | STR

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve parer error message when a policy includes an invalid template slot.
+  The error now identifies that the policy used an invalid slot and suggests using
+  one of the valid slots.
 - Improve parser error messages to more reliably notice that a function or
   method does exists when it is called with an incorrect number of arguments or
   using the wrong call style.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve parer error message when a policy includes an invalid template slot.
+- Improve parser error message when a policy includes an invalid template slot.
   The error now identifies that the policy used an invalid slot and suggests using
   one of the valid slots.
 - Improve parser error messages to more reliably notice that a function or


### PR DESCRIPTION
## Description of changes

The parser previously failed to lex invalid templates slots, so `principal in ?princpl` would fail with `invalid token`. Fix #451. 

The error is now

```
  × failed to parse policy set
  ╰─▶ expected an entity uid or matching template slot, found ?principl instead of ?principal
   ╭─[<stdin>:1:1]
 1 │ permit(principal in ?principl, action, resource);
   ·                     ─────────
   ╰────
```

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
