### PR TITLE
Improve parse errors around invalid `is` expressions

### DIFF
--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -70,7 +70,7 @@ pub struct VariableDef {
     /// not used for anything other than error reporting.
     pub unused_type_name: Option<Node<Name>>,
     /// type of entity using current `var is type` syntax
-    pub entity_type: Option<Node<Name>>,
+    pub entity_type: Option<Node<Add>>,
     /// hierarchy of entity
     pub ineq: Option<(RelOp, Node<Expr>)>,
 }
@@ -197,7 +197,7 @@ pub enum Relation {
         /// element that may be an entity type and `in` an entity
         target: Node<Add>,
         /// entity type to check for
-        entity_type: Node<Name>,
+        entity_type: Node<Add>,
         /// entity that the target may be `in`
         in_entity: Option<Node<Add>>,
     },

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -4279,6 +4279,12 @@ mod tests {
                 ),
             ),
             (
+                r#"permit(principal, action, resource) when { principal is User in User::"alice" in Group::"friends" };"#,
+                ExpectedErrorMessage::error(
+                    "unexpected token `in`"
+                ),
+            ),
+            (
                 r#"permit(principal, action, resource) when { principal is User == User::"alice" in Group::"friends" };"#,
                 ExpectedErrorMessage::error(
                     "unexpected token `==`"

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -4101,28 +4101,30 @@ mod tests {
             ),
             (
                 r#"permit(principal is User == User::"Alice", action, resource);"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessage::error_and_help(
                     "`is` cannot appear in the scope at the same time as `==`",
+                    "try moving `is` into a `when` condition"
                 ),
             ),
             (
                 r#"permit(principal, action, resource is Doc == Doc::"a");"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessage::error_and_help(
                     "`is` cannot appear in the scope at the same time as `==`",
+                    "try moving `is` into a `when` condition"
                 ),
             ),
             (
                 r#"permit(principal is User::"alice", action, resource);"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"alice"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource is File::"f");"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `File::"f"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
@@ -4147,7 +4149,7 @@ mod tests {
                 r#"permit(principal is User::"Alice" in Group::"f", action, resource);"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"Alice"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
@@ -4160,50 +4162,71 @@ mod tests {
                 r#"permit(principal, action, resource is File::"file" in Folder::"folder");"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `File::"file"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal is 1, action, resource);"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `1`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource is 1);"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `1`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action is Action, resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal, action is Action::"a", resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal, action is Action in Action::"A", resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal, action is Action in Action, resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal, action is Action::"a" in Action::"b", resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal, action is Action in ?action, resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal, action is ?action, resource);"#,
-                ExpectedErrorMessage::error("`is` cannot appear in the action scope"),
+                ExpectedErrorMessage::error_and_help(
+                    "`is` cannot appear in the action scope",
+                    "try moving `action is ..` into a `when` condition"
+                ),
             ),
             (
                 r#"permit(principal is User in ?resource, action, resource);"#,
@@ -4217,42 +4240,42 @@ mod tests {
                 r#"permit(principal is ?principal, action, resource);"#,
                 ExpectedErrorMessage::error_and_help(
                     "right hand side of an `is` expression must be an entity type name, but got `?principal`",
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource is ?resource);"#,
                 ExpectedErrorMessage::error_and_help(
                     "right hand side of an `is` expression must be an entity type name, but got `?resource`",
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is 1 };"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `1`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is User::"alice" in Group::"friends" };"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"alice"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is ! User::"alice" in Group::"friends" };"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `!User::"alice"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is User::"alice" + User::"alice" in Group::"friends" };"#,
                 ExpectedErrorMessage::error_and_help(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"alice" + User::"alice"`"#,
-                    "consider using `==` to test for equality"
+                    "try using `==` to test for equality"
                 ),
             ),
             (

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -267,6 +267,10 @@ pub enum ToASTErrorKind {
     /// Returned when the right hand side of a `like` expression is not a constant pattern literal
     #[error("right hand side of a `like` expression must be a pattern literal, but got `{0}`")]
     InvalidPattern(String),
+    /// Returned when the right hand side of a `is` expression is not an entity type name
+    #[error("right hand side of an `is` expression must be an entity type name, but got `{0}`")]
+    #[diagnostic(help("consider using `==` to test for equality"))]
+    IsInvalidName(String),
     /// Returned when an unexpected node is in the policy scope clause
     #[error("expected {expected}, found {got}")]
     WrongNode {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -269,7 +269,7 @@ pub enum ToASTErrorKind {
     InvalidPattern(String),
     /// Returned when the right hand side of a `is` expression is not an entity type name
     #[error("right hand side of an `is` expression must be an entity type name, but got `{0}`")]
-    #[diagnostic(help("consider using `==` to test for equality"))]
+    #[diagnostic(help("try using `==` to test for equality"))]
     IsInvalidName(String),
     /// Returned when an unexpected node is in the policy scope clause
     #[error("expected {expected}, found {got}")]
@@ -477,9 +477,11 @@ impl std::fmt::Display for Ref {
 pub enum InvalidIsError {
     /// The action scope may not contain an `is`
     #[error("`is` cannot appear in the action scope")]
+    #[diagnostic(help("try moving `action is ..` into a `when` condition"))]
     ActionScope,
     /// An `is` cannot appear with this operator in the policy scope
     #[error("`is` cannot appear in the scope at the same time as `{0}`")]
+    #[diagnostic(help("try moving `is` into a `when` condition"))]
     WrongOp(cst::RelOp),
 }
 

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -94,7 +94,7 @@ pub Policy: Node<Option<cst::Policy>> = {
     <l:@L> <err:!> <r:@R> => { errors.push(err); Node::new(None,l,r) },
 }
 
-// VariableDef := Variable [':' Name] [('in' | '==') Expr]
+// VariableDef := Variable [':' Name] ['is' Add] [('in' | '==') Expr]
 VariableDef: Node<Option<cst::VariableDef>> = {
     <l:@L> <variable: AnyIdent> <unused_type_name: (":" <Name>)?> <entity_type: (IS <Add>)?>
         <ineq: (RelOp Expr)?> <r:@R>

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -96,7 +96,7 @@ pub Policy: Node<Option<cst::Policy>> = {
 
 // VariableDef := Variable [':' Name] [('in' | '==') Expr]
 VariableDef: Node<Option<cst::VariableDef>> = {
-    <l:@L> <variable: AnyIdent> <unused_type_name: (":" <Name>)?> <entity_type: (IS <Name>)?>
+    <l:@L> <variable: AnyIdent> <unused_type_name: (":" <Name>)?> <entity_type: (IS <Add>)?>
         <ineq: (RelOp Expr)?> <r:@R>
         => Node::new(Some(cst::VariableDef{ variable,unused_type_name,entity_type,ineq, }),l,r),
 }
@@ -198,7 +198,7 @@ Relation: Node<Option<cst::Relation>> = {
     },
     <l:@L> <t:Add> LIKE <p:Add> <r:@R>
         => Node::new(Some(cst::Relation::Like{target: t, pattern: p}),l,r),
-    <l:@L> <t:Add> IS <n:Name> <e: (IN <Add>)?> <r:@R>
+    <l:@L> <t:Add> IS <n:Add> <e: (IN <Add>)?> <r:@R>
         => Node::new(Some(cst::Relation::IsIn{target: t, entity_type: n, in_entity: e}),l,r),
 }
 // RelOp     := '<' | '<=' | '>=' | '>' | '!=' | '==' | 'in'

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -95,6 +95,9 @@ pub Policy: Node<Option<cst::Policy>> = {
 }
 
 // VariableDef := Variable [':' Name] ['is' Add] [('in' | '==') Expr]
+// The argument to `is`, if present, is parsed as an `Add` rather than a `Name`
+// to enable better error reporting. It is parsed as an `Add` rather than an
+// `Expr` to void ambiguity with a subsequent `in`.
 VariableDef: Node<Option<cst::VariableDef>> = {
     <l:@L> <variable: AnyIdent> <unused_type_name: (":" <Name>)?> <entity_type: (IS <Add>)?>
         <ineq: (RelOp Expr)?> <r:@R>

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -178,7 +178,7 @@ And: Node<Option<cst::And>> = {
     <l:@L> <i:Relation> <e:("&&" <Relation>)*> <r:@R>
         => Node::new(Some(cst::And{initial: i, extended: e}),l,r),
 }
-// Relation := Add {RelOp Add} | Add HAS Add | Add LIKE Add | Add IS Name (IN Add)?
+// Relation := Add {RelOp Add} | Add HAS Add | Add LIKE Add | Add IS Add (IN Add)?
 Relation: Node<Option<cst::Relation>> = {
     <l:@L> <i:Add> <e:(RelOp Add)*> <r:@R>
         => Node::new(Some(cst::Relation::Common{initial: i, extended: e}),l,r),

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improve parse error around invalid `is` expressions.
 - Improve parser error message when a policy includes an invalid template slot.
   The error now identifies that the policy used an invalid slot and suggests using
   one of the valid slots.


### PR DESCRIPTION
## Description of changes

Fix #409 by parsing an `Add` rather than an `Name` in `is` expression. This allows for parsing expression in this position so that `principal is User::"alice"` can parse, allowing for a more useful error in when building the ast. The `Add` production needs to be used instead of `Expr` to avoid ambiguity with the `.. is .. in ..` form.

## Checklist for requesting a review.


The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
