### PR TITLE
[CLI] accept policies in JSON format and/or from stdin in more targets

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Requests are now validated by default if a schema is provided. This can be
   disabled with `--request-validation=false`.
 - The `-s` short form can now be used for `--schema` across all subcommands.
+- The `-p`/`--policies` flag can now be omitted across all subcommands where it
+  is present. If the flag is omitted, policies will be read from `stdin`.
+- `--policy-format` flag to many subcommands, allowing you to pass policies in
+  JSON format. The default remains `human` format.
 
 ### Changed
 

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -103,9 +103,9 @@ pub struct ValidateArgs {
     /// File containing the schema
     #[arg(short, long = "schema", value_name = "FILE")]
     pub schema_file: String,
-    /// File containing the policy set
-    #[arg(short, long = "policies", value_name = "FILE")]
-    pub policies_file: String,
+    /// Policies args (incorporated by reference)
+    #[command(flatten)]
+    pub policies: PoliciesArgs,
     /// Report a validation failure for non-fatal warnings
     #[arg(long)]
     pub deny_warnings: bool,
@@ -118,9 +118,9 @@ pub struct ValidateArgs {
 
 #[derive(Args, Debug)]
 pub struct CheckParseArgs {
-    /// Optional policy file name. If none is provided, read input from stdin.
-    #[arg(short, long = "policies", value_name = "FILE")]
-    pub policies_file: Option<String>,
+    /// Policies args (incorporated by reference)
+    #[command(flatten)]
+    pub policies: PoliciesArgs,
 }
 
 /// This struct contains the arguments that together specify a request.
@@ -265,18 +265,40 @@ impl RequestArgs {
     }
 }
 
+/// This struct contains the arguments that together specify an input policy or policy set.
+#[derive(Args, Debug)]
+pub struct PoliciesArgs {
+    /// File containing the static Cedar policies and/or templates. If not provided, read policies from stdin.
+    #[arg(short, long = "policies", value_name = "FILE")]
+    pub policies_file: Option<String>,
+    /// Format of policies in the `--policies` file
+    #[arg(long = "policy-format", default_value_t, value_enum)]
+    pub policy_format: PolicyFormat,
+}
+
+impl PoliciesArgs {
+    /// Turn this `PoliciesArgs` into the appropriate `PolicySet` object
+    fn get_policy_set(&self) -> Result<PolicySet> {
+        match self.policy_format {
+            PolicyFormat::Human => read_policy_set(self.policies_file.as_ref()),
+            PolicyFormat::Json => read_json_policy(self.policies_file.as_ref()),
+        }
+    }
+}
+
 #[derive(Args, Debug)]
 pub struct AuthorizeArgs {
     /// Request args (incorporated by reference)
     #[command(flatten)]
     pub request: RequestArgs,
-    /// File containing the static Cedar policies and templates to evaluate against
-    #[arg(short, long = "policies", value_name = "FILE")]
-    pub policies_file: String,
+    /// Policies args (incorporated by reference)
+    #[command(flatten)]
+    pub policies: PoliciesArgs,
     /// File containing template linked policies
     #[arg(short = 'k', long = "template-linked", value_name = "FILE")]
     pub template_linked_file: Option<String>,
     /// File containing schema information
+    ///
     /// Used to populate the store with action entities and for schema-based
     /// parsing of entity hierarchy, if present
     #[arg(short, long = "schema", value_name = "FILE")]
@@ -292,11 +314,20 @@ pub struct AuthorizeArgs {
     pub timing: bool,
 }
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
+pub enum PolicyFormat {
+    /// The standard human-readable Cedar policy format, documented at https://docs.cedarpolicy.com/policies/syntax-policy.html
+    #[default]
+    Human,
+    /// Cedar's JSON policy format, documented at https://docs.cedarpolicy.com/policies/json-format.html
+    Json,
+}
+
 #[derive(Args, Debug)]
 pub struct LinkArgs {
-    /// File containing static policies and templates.
-    #[arg(short, long = "policies", value_name = "FILE")]
-    pub policies_file: String,
+    /// Policies args (incorporated by reference)
+    #[command(flatten)]
+    pub policies: PoliciesArgs,
     /// File containing template-linked policies
     #[arg(short = 'k', long = "template-linked", value_name = "FILE")]
     pub template_linked_file: String,
@@ -313,9 +344,9 @@ pub struct LinkArgs {
 
 #[derive(Args, Debug)]
 pub struct FormatArgs {
-    /// Optional policy file name. If none is provided, read input from stdin.
+    /// File containing the static Cedar policies and/or templates. If not provided, read policies from stdin.
     #[arg(short, long = "policies", value_name = "FILE")]
-    pub policy_file: Option<String>,
+    pub policies_file: Option<String>,
 
     /// Custom line width (default: 80).
     #[arg(short, long, value_name = "UINT", default_value_t = 80)]
@@ -423,7 +454,7 @@ impl Termination for CedarExitCode {
 }
 
 pub fn check_parse(args: &CheckParseArgs) -> CedarExitCode {
-    match read_policy_set(args.policies_file.as_ref()) {
+    match args.policies.get_policy_set() {
         Ok(_) => CedarExitCode::Success,
         Err(e) => {
             println!("{e:?}");
@@ -445,7 +476,7 @@ pub fn validate(args: &ValidateArgs) -> CedarExitCode {
         ValidationMode::default()
     };
 
-    let pset = match read_policy_set(Some(&args.policies_file)) {
+    let pset = match args.policies.get_policy_set() {
         Ok(pset) => pset,
         Err(e) => {
             println!("{e:?}");
@@ -551,7 +582,7 @@ pub fn link(args: &LinkArgs) -> CedarExitCode {
 }
 
 fn format_policies_inner(args: &FormatArgs) -> Result<()> {
-    let policies_str = read_from_file_or_stdin(args.policy_file.as_ref(), "policy set")?;
+    let policies_str = read_from_file_or_stdin(args.policies_file.as_ref(), "policy set")?;
     let config = Config {
         line_width: args.line_width,
         indent_width: args.indent_width,
@@ -674,7 +705,7 @@ fn create_slot_env(data: &HashMap<SlotId, String>) -> Result<HashMap<SlotId, Ent
 }
 
 fn link_inner(args: &LinkArgs) -> Result<()> {
-    let mut policies = read_policy_set(Some(&args.policies_file))?;
+    let mut policies = args.policies.get_policy_set()?;
     let slotenv = create_slot_env(&args.arguments.data)?;
     policies.link(
         PolicyId::from_str(&args.template_id)?,
@@ -811,7 +842,7 @@ pub fn authorize(args: &AuthorizeArgs) -> CedarExitCode {
     println!();
     let ans = execute_request(
         &args.request,
-        &args.policies_file,
+        &args.policies,
         args.template_linked_file.as_ref(),
         &args.entities_file,
         args.schema_file.as_ref(),
@@ -910,18 +941,7 @@ fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet> {
     Ok(new_ps)
 }
 
-fn read_policy_and_links(
-    policies_filename: impl AsRef<Path>,
-    links_filename: Option<impl AsRef<Path>>,
-) -> Result<PolicySet> {
-    let mut pset = read_policy_set(Some(policies_filename.as_ref()))?;
-    if let Some(links_filename) = links_filename {
-        add_template_links_to_set(links_filename.as_ref(), &mut pset)?;
-    }
-    Ok(pset)
-}
-
-// Read from a file (when `filename` is a `Some`) or stdin (when `filename` is `None`)
+// Read from a file (when `filename` is a `Some`) or stdin (when `filename` is `None`) to a `String`
 fn read_from_file_or_stdin(filename: Option<impl AsRef<Path>>, context: &str) -> Result<String> {
     let mut src_str = String::new();
     match filename.as_ref() {
@@ -929,11 +949,7 @@ fn read_from_file_or_stdin(filename: Option<impl AsRef<Path>>, context: &str) ->
             src_str = std::fs::read_to_string(path)
                 .into_diagnostic()
                 .wrap_err_with(|| {
-                    format!(
-                        "failed to open {} file {}",
-                        context,
-                        path.as_ref().display()
-                    )
+                    format!("failed to open {context} file {}", path.as_ref().display())
                 })?;
         }
         None => {
@@ -950,6 +966,8 @@ fn read_from_file(filename: impl AsRef<Path>, context: &str) -> Result<String> {
     read_from_file_or_stdin(Some(filename), context)
 }
 
+/// Read a policy set, in Cedar human syntax, from the file given in `filename`,
+/// or from stdin if `filename` is `None`.
 fn read_policy_set(
     filename: Option<impl AsRef<Path> + std::marker::Copy>,
 ) -> miette::Result<PolicySet> {
@@ -967,6 +985,47 @@ fn read_policy_set(
     rename_from_id_annotation(ps)
 }
 
+/// Read a policy, in Cedar JSON (EST) syntax, from the file given in `filename`,
+/// or from stdin if `filename` is `None`.
+fn read_json_policy(
+    filename: Option<impl AsRef<Path> + std::marker::Copy>,
+) -> miette::Result<PolicySet> {
+    let context = "JSON policy";
+    let json = match filename.as_ref() {
+        Some(path) => {
+            let f = OpenOptions::new()
+                .read(true)
+                .open(path)
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!("failed to open {context} file {}", path.as_ref().display())
+                })?;
+            serde_json::from_reader(f)
+                .into_diagnostic()
+                .wrap_err_with(|| {
+                    format!("failed to read {context} file {}", path.as_ref().display())
+                })?
+        }
+        None => serde_json::from_reader(std::io::stdin())
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read {context} from stdin"))?,
+    };
+    let policy = Policy::from_json(None, json)
+        // TODO: for pretty source annotations:
+        /*
+        .map_err(|err| {
+            let name = filename.map_or_else(
+                || "<stdin>".to_owned(),
+                |n| n.as_ref().display().to_string(),
+            );
+            Report::new(err).with_source_code(NamedSource::new(name, source))
+        })
+        */
+        .wrap_err_with(|| format!("failed to parse {context}"))?;
+    PolicySet::from_policies([policy])
+        .wrap_err_with(|| format!("failed to create policy set from {context}"))
+}
+
 fn read_schema_file(filename: impl AsRef<Path> + std::marker::Copy) -> Result<Schema> {
     let schema_src = read_from_file(filename, "schema")?;
     Schema::from_str(&schema_src).wrap_err_with(|| {
@@ -980,14 +1039,19 @@ fn read_schema_file(filename: impl AsRef<Path> + std::marker::Copy) -> Result<Sc
 /// This uses the Cedar API to call the authorization engine.
 fn execute_request(
     request: &RequestArgs,
-    policies_filename: impl AsRef<Path> + std::marker::Copy,
+    policies: &PoliciesArgs,
     links_filename: Option<impl AsRef<Path>>,
     entities_filename: impl AsRef<Path>,
     schema_filename: Option<impl AsRef<Path> + std::marker::Copy>,
     compute_duration: bool,
 ) -> Result<Response, Vec<Report>> {
     let mut errs = vec![];
-    let policies = match read_policy_and_links(policies_filename.as_ref(), links_filename) {
+    let policies = match policies.get_policy_set().and_then(|mut pset| {
+        if let Some(links_filename) = links_filename {
+            add_template_links_to_set(links_filename.as_ref(), &mut pset)?;
+        }
+        Ok(pset)
+    }) {
         Ok(pset) => pset,
         Err(e) => {
             errs.push(e);

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -25,12 +25,15 @@ use cedar_policy::SlotId;
 use cedar_policy_cli::check_parse;
 use cedar_policy_cli::{
     authorize, evaluate, link, validate, Arguments, AuthorizeArgs, CedarExitCode, CheckParseArgs,
-    EvaluateArgs, LinkArgs, RequestArgs, ValidateArgs,
+    EvaluateArgs, LinkArgs, PoliciesArgs, PolicyFormat, RequestArgs, ValidateArgs,
 };
 
 fn run_check_parse_test(policies_file: impl Into<String>, expected_exit_code: CedarExitCode) {
     let cmd = CheckParseArgs {
-        policies_file: Some(policies_file.into()),
+        policies: PoliciesArgs {
+            policies_file: Some(policies_file.into()),
+            policy_format: PolicyFormat::Human,
+        },
     };
     let output = check_parse(&cmd);
     assert_eq!(output, expected_exit_code, "{:#?}", cmd);
@@ -73,7 +76,10 @@ fn run_authorize_test_with_linked_policies(
             request_json_file: None,
             request_validation: true,
         },
-        policies_file: policies_file.into(),
+        policies: PoliciesArgs {
+            policies_file: Some(policies_file.into()),
+            policy_format: PolicyFormat::Human,
+        },
         template_linked_file: links_file.map(|x| x.to_string()),
         schema_file: None,
         entities_file: entities_file.into(),
@@ -93,7 +99,10 @@ fn run_link_test(
     expected: CedarExitCode,
 ) {
     let cmd = LinkArgs {
-        policies_file: policies_file.into(),
+        policies: PoliciesArgs {
+            policies_file: Some(policies_file.into()),
+            policy_format: PolicyFormat::Human,
+        },
         template_linked_file: links_file.into(),
         template_id: template_id.into(),
         new_id: linked_id.into(),
@@ -138,7 +147,10 @@ fn run_authorize_test_context(
             request_json_file: None,
             request_validation: true,
         },
-        policies_file: policies_file.into(),
+        policies: PoliciesArgs {
+            policies_file: Some(policies_file.into()),
+            policy_format: PolicyFormat::Human,
+        },
         template_linked_file: None,
         schema_file: None,
         entities_file: entities_file.into(),
@@ -164,7 +176,10 @@ fn run_authorize_test_json(
             request_json_file: Some(request_json.into()),
             request_validation: true,
         },
-        policies_file: policies_file.into(),
+        policies: PoliciesArgs {
+            policies_file: Some(policies_file.into()),
+            policy_format: PolicyFormat::Human,
+        },
         template_linked_file: None,
         schema_file: None,
         entities_file: entities_file.into(),
@@ -444,7 +459,10 @@ fn test_authorize_samples() {
 fn run_validate_test(policies_file: &str, schema_file: &str, exit_code: CedarExitCode) {
     let cmd = ValidateArgs {
         schema_file: schema_file.into(),
-        policies_file: policies_file.into(),
+        policies: PoliciesArgs {
+            policies_file: Some(policies_file.into()),
+            policy_format: PolicyFormat::Human,
+        },
         deny_warnings: false,
         partial_validate: false,
     };


### PR DESCRIPTION
## Description of changes

Allows the CLI to accept policies in JSON (EST) format, using the flag `--policy-format=json`.  The default remains `--policy-format=human`, so this is a backwards compatible change.

Factors out the code for accepting policy sets, so that all targets (except `format`, which is special because it doesn't use the full parser) accept the same options under the same names and share code for parsing policies.  In particular, all of these targets now allow omitting `-p`/`--policies`, and thus reading policies from stdin.  (Previously this was supported on some targets and not others.)

## Issue #, if available

Related to #461, and probably a building block for #461, but doesn't resolve it.  #461 wants a CLI command for converting policies from human to json and back.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
