### PR TITLE
Cedar language version markers in changelogs

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 3.0.0
 
+Now uses Cedar language version 3.0.0.
+
 ### Added
 
 - `--deny-warnings` option to `validate` command. This option turns non-fatal
@@ -20,9 +22,13 @@
 
 ## 2.4.2
 
+Now uses Cedar language version 2.1.2.
+
 ## 2.4.1
 
 ## 2.4.0
+
+Now uses Cedar language version 2.1.1.
 
 ### Changed
 
@@ -40,6 +46,8 @@
 ## 2.3.1
 
 ## 2.3.0
+
+Now uses Cedar language version 2.1.0.
 
 ## 2.2.0
 
@@ -70,3 +78,5 @@
 ## 2.0.0
 
 Initial release of `cedar-policy-cli`.
+
+Uses Cedar language version 2.0.0.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.0.0] - Coming soon
+Cedar Language Version: 3.0.0
 
 ### Added
 


### PR DESCRIPTION
## Description of changes

This PR is to the 3.0 release branch.

- Add text to the main changelog about the Cedar language version for 3.0.0.  (It's also language version 3, as RFC 20 was a breaking language change.)
- Add text to the CLI changelog indicating the Cedar language version.  CLI users may care about which language version each version of the CLI gives them.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
