### PR TITLE
Partial cherry-pick #496 to `main`

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Now uses Cedar language version 3.0.0.
+
 ### Added
 
 - `--deny-warnings` option to `validate` command. This option turns non-fatal
@@ -24,9 +26,13 @@
 
 ## 2.4.2
 
+Now uses Cedar language version 2.1.2.
+
 ## 2.4.1
 
 ## 2.4.0
+
+Now uses Cedar language version 2.1.1.
 
 ### Changed
 
@@ -44,6 +50,8 @@
 ## 2.3.1
 
 ## 2.3.0
+
+Now uses Cedar language version 2.1.0.
 
 ## 2.2.0
 
@@ -74,3 +82,5 @@
 ## 2.0.0
 
 Initial release of `cedar-policy-cli`.
+
+Uses Cedar language version 2.0.0.


### PR DESCRIPTION
## Description of changes

Adds language version numbers to the CLI changelog per #496. 

Doesn't add the language version marker to the main 3.0.0 changelog, because the `main` branch doesn't currently delineate 3.0.0 changes from other unreleased changes.  (It doesn't have a 3.0.0 section yet.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
