### PR TITLE
cleanup in some tests of errors

### DIFF
--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -382,8 +382,8 @@ mod test_utils {
 mod test {
     use super::*;
     use crate::ast::{test_generators::*, Template};
-    use std::collections::HashSet;
     use cool_asserts::assert_matches;
+    use std::collections::HashSet;
 
     #[test]
     fn test_template_parsing() {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -20,7 +20,6 @@ use std::iter;
 use std::ops::{Deref, DerefMut};
 
 use either::Either;
-use itertools::Itertools;
 use lalrpop_util as lalr;
 use lazy_static::lazy_static;
 use miette::{Diagnostic, LabeledSpan, SourceSpan};
@@ -628,16 +627,6 @@ impl ParseErrors {
     /// returns a Vec with stringified versions of the ParseErrors
     pub fn errors_as_strings(&self) -> Vec<String> {
         self.0.iter().map(ToString::to_string).collect()
-    }
-
-    /// Display the `ParseErrors`, newline-separated, with `help()`s if present
-    pub fn pretty_with_helps(&self) -> String {
-        self.iter()
-            .map(|e| match e.help() {
-                Some(help) => format!("{e}\n  help: {help}"),
-                None => format!("{e}"),
-            })
-            .join("\n")
     }
 }
 

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -67,6 +67,25 @@ impl<'a> ExpectedErrorMessage<'a> {
     }
 }
 
+impl<'a> std::fmt::Display for ExpectedErrorMessage<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.prefix {
+            writeln!(f, "expected error to start with: {}", self.error)?;
+            match self.help.as_deref() {
+                Some(help) => writeln!(f, "expected help to start with: {help}")?,
+                None => writeln!(f, "  with no help message")?,
+            }
+        } else {
+            writeln!(f, "expected error: {}", self.error)?;
+            match self.help.as_deref() {
+                Some(help) => writeln!(f, "expected help: {help}")?,
+                None => writeln!(f, "  with no help message")?,
+            }
+        }
+        Ok(())
+    }
+}
+
 /// Forms in which [`expect_err()`] accepts the original input text.
 /// See notes on [`expect_err()`].
 pub enum OriginalInput<'a> {
@@ -124,12 +143,12 @@ pub fn expect_err<'a>(
                 )
             }
             (None, None) => (),
-            (Some(_), None) => panic!(
-                "for the following input:\n{}\nfound a help message but none was expected",
+            (Some(actual), None) => panic!(
+                "for the following input:\n{}\ndid not expect a help message, but found one: {actual}",
                 src.into()
             ),
-            (None, Some(_)) => panic!(
-                "for the following input:\n{}\ndid not find a help message, but one was expected",
+            (None, Some(expected)) => panic!(
+                "for the following input:\n{}\ndid not find a help message, but expected one: {expected}",
                 src.into()
             ),
         }


### PR DESCRIPTION
## Description of changes

In tests wishing to pretty-print a `ParseErrors`, use `miette::Report` rather than `.pretty_with_helps()`.  In fact, remove `.pretty_with_helps()`, which was introduced in #467 and has not been released yet, so that's not a breaking change.

Other small refactors in places we previously used `.pretty_with_helps()`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
