### PR TITLE
CLI `evaluate` shows source spans on parse errr

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -545,7 +545,7 @@ pub fn evaluate(args: &EvaluateArgs) -> (CedarExitCode, EvalResult) {
         match Expression::from_str(&args.expression).wrap_err("failed to parse the expression") {
             Ok(expr) => expr,
             Err(e) => {
-                println!("{e:?}");
+                println!("{:?}", e.with_source_code(args.expression.clone()));
                 return (CedarExitCode::Failure, EvalResult::Bool(false));
             }
         };


### PR DESCRIPTION
## Description of changes

Small change to get the nicely underlined spans for parse errors on `cedar evaluate`

```console
[jkastner@dev-dsk-jkastner-1a-3309db3b cedar]$ cedar evaluate '1 / 2'
  × failed to parse the expression
  ╰─▶ division is not supported
   ╭────
 1 │ 1 / 2
   · ─────
   ╰────

```

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
