### PR TITLE
rename `ASTNode` to `Node`

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -24,7 +24,7 @@ use crate::entities::{
 use crate::extensions::Extensions;
 use crate::parser::cst::{self, Ident};
 use crate::parser::err::{ParseErrors, ToASTError, ToASTErrorKind};
-use crate::parser::{unescape, ASTNode};
+use crate::parser::{unescape, Node};
 use crate::{ast, FromNormalizedStr};
 use either::Either;
 use itertools::Itertools;
@@ -783,9 +783,9 @@ impl From<ast::SlotId> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Expr>>> for Expr {
+impl TryFrom<&Node<Option<cst::Expr>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(e: &ASTNode<Option<cst::Expr>>) -> Result<Expr, ParseErrors> {
+    fn try_from(e: &Node<Option<cst::Expr>>) -> Result<Expr, ParseErrors> {
         match &*e.ok_or_missing()?.expr {
             cst::ExprData::Or(node) => node.try_into(),
             cst::ExprData::If(if_node, then_node, else_node) => {
@@ -798,9 +798,9 @@ impl TryFrom<&ASTNode<Option<cst::Expr>>> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Or>>> for Expr {
+impl TryFrom<&Node<Option<cst::Or>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(o: &ASTNode<Option<cst::Or>>) -> Result<Expr, ParseErrors> {
+    fn try_from(o: &Node<Option<cst::Or>>) -> Result<Expr, ParseErrors> {
         let o_node = o.ok_or_missing()?;
         let mut expr = (&o_node.initial).try_into()?;
         for node in &o_node.extended {
@@ -811,9 +811,9 @@ impl TryFrom<&ASTNode<Option<cst::Or>>> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::And>>> for Expr {
+impl TryFrom<&Node<Option<cst::And>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(a: &ASTNode<Option<cst::And>>) -> Result<Expr, ParseErrors> {
+    fn try_from(a: &Node<Option<cst::And>>) -> Result<Expr, ParseErrors> {
         let a_node = a.ok_or_missing()?;
         let mut expr = (&a_node.initial).try_into()?;
         for node in &a_node.extended {
@@ -824,9 +824,9 @@ impl TryFrom<&ASTNode<Option<cst::And>>> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Relation>>> for Expr {
+impl TryFrom<&Node<Option<cst::Relation>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(r: &ASTNode<Option<cst::Relation>>) -> Result<Expr, ParseErrors> {
+    fn try_from(r: &Node<Option<cst::Relation>>) -> Result<Expr, ParseErrors> {
         match r.ok_or_missing()? {
             cst::Relation::Common { initial, extended } => {
                 let mut expr = initial.try_into()?;
@@ -903,9 +903,9 @@ impl TryFrom<&ASTNode<Option<cst::Relation>>> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Add>>> for Expr {
+impl TryFrom<&Node<Option<cst::Add>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(a: &ASTNode<Option<cst::Add>>) -> Result<Expr, ParseErrors> {
+    fn try_from(a: &Node<Option<cst::Add>>) -> Result<Expr, ParseErrors> {
         let a_node = a.ok_or_missing()?;
         let mut expr = (&a_node.initial).try_into()?;
         for (op, node) in &a_node.extended {
@@ -984,9 +984,9 @@ fn is_primary_name(primary: &cst::Primary) -> Option<&cst::Name> {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Mult>>> for Expr {
+impl TryFrom<&Node<Option<cst::Mult>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(m: &ASTNode<Option<cst::Mult>>) -> Result<Expr, ParseErrors> {
+    fn try_from(m: &Node<Option<cst::Mult>>) -> Result<Expr, ParseErrors> {
         let m_node = m.ok_or_missing()?;
         let mut expr = (&m_node.initial).try_into()?;
         for (op, node) in &m_node.extended {
@@ -1007,9 +1007,9 @@ impl TryFrom<&ASTNode<Option<cst::Mult>>> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Unary>>> for Expr {
+impl TryFrom<&Node<Option<cst::Unary>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(u: &ASTNode<Option<cst::Unary>>) -> Result<Expr, ParseErrors> {
+    fn try_from(u: &Node<Option<cst::Unary>>) -> Result<Expr, ParseErrors> {
         let u_node = u.ok_or_missing()?;
         let inner = (&u_node.item).try_into()?;
         match u_node.op {
@@ -1077,7 +1077,7 @@ impl TryFrom<&ASTNode<Option<cst::Unary>>> for Expr {
 /// handling, because in that case it is not a valid expression. In all other
 /// cases a `Primary` can be converted into an `Expr`.)
 fn interpret_primary(
-    p: &ASTNode<Option<cst::Primary>>,
+    p: &Node<Option<cst::Primary>>,
 ) -> Result<Either<ast::Name, Expr>, ParseErrors> {
     match p.ok_or_missing()? {
         cst::Primary::Literal(lit) => Ok(Either::Right(lit.try_into()?)),
@@ -1132,7 +1132,7 @@ fn interpret_primary(
                     Err(ToASTError::new(
                         ToASTErrorKind::InvalidExpression(cst::Name {
                             path: path.to_vec(),
-                            name: ASTNode::new(Some(id.clone()), l, r),
+                            name: Node::new(Some(id.clone()), l, r),
                         }),
                         miette::SourceSpan::from(l..r),
                     )
@@ -1175,9 +1175,9 @@ fn interpret_primary(
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Member>>> for Expr {
+impl TryFrom<&Node<Option<cst::Member>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(m: &ASTNode<Option<cst::Member>>) -> Result<Expr, ParseErrors> {
+    fn try_from(m: &Node<Option<cst::Member>>) -> Result<Expr, ParseErrors> {
         let m_node = m.ok_or_missing()?;
         let mut item: Either<ast::Name, Expr> = interpret_primary(&m_node.item)?;
         for access in &m_node.access {
@@ -1292,9 +1292,9 @@ pub fn extract_single_argument<T>(
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Literal>>> for Expr {
+impl TryFrom<&Node<Option<cst::Literal>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(lit: &ASTNode<Option<cst::Literal>>) -> Result<Expr, ParseErrors> {
+    fn try_from(lit: &Node<Option<cst::Literal>>) -> Result<Expr, ParseErrors> {
         match lit.ok_or_missing()? {
             cst::Literal::True => Ok(Expr::lit(CedarValueJson::Bool(true))),
             cst::Literal::False => Ok(Expr::lit(CedarValueJson::Bool(false))),
@@ -1312,9 +1312,9 @@ impl TryFrom<&ASTNode<Option<cst::Literal>>> for Expr {
     }
 }
 
-impl TryFrom<&ASTNode<Option<cst::Name>>> for Expr {
+impl TryFrom<&Node<Option<cst::Name>>> for Expr {
     type Error = ParseErrors;
-    fn try_from(name: &ASTNode<Option<cst::Name>>) -> Result<Expr, ParseErrors> {
+    fn try_from(name: &Node<Option<cst::Name>>) -> Result<Expr, ParseErrors> {
         let name_node = name.ok_or_missing()?;
         let base_name = name_node.name.ok_or_missing()?;
         match (&name_node.path[..], base_name) {
@@ -1333,7 +1333,7 @@ impl TryFrom<&ASTNode<Option<cst::Name>>> for Expr {
                 Err(name
                     .to_ast_err(ToASTErrorKind::InvalidExpression(cst::Name {
                         path: path.to_vec(),
-                        name: ASTNode::new(Some(id.clone()), l, r),
+                        name: Node::new(Some(id.clone()), l, r),
                     }))
                     .into())
             }
@@ -1379,13 +1379,13 @@ mod test {
 
     #[test]
     fn test_invalid_expr_from_cst_name() {
-        let path = vec![ASTNode::new(
+        let path = vec![Node::new(
             Some(cst::Ident::Ident("some_long_str".into())),
             0,
             12,
         )];
-        let name = ASTNode::new(Some(cst::Ident::Else), 13, 16);
-        let cst_name = ASTNode::new(Some(cst::Name { path, name }), 0, 16);
+        let name = Node::new(Some(cst::Ident::Else), 13, 16);
+        let cst_name = Node::new(Some(cst::Name { path, name }), 0, 16);
 
         assert_matches!(Expr::try_from(&cst_name), Err(e) => {
             assert!(e.len() == 1);

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -26,7 +26,7 @@ pub mod err;
 mod fmt;
 /// Metadata wrapper for CST Nodes
 mod node;
-pub use node::ASTNode;
+pub use node::Node;
 /// Step one: Convert text to CST
 pub mod text_to_cst;
 /// Utility functions to unescape string literals

--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-use super::node::ASTNode;
 use smol_str::SmolStr;
+
 // shortcut because we need CST nodes to potentially be empty,
 // for example, if part of it failed the parse, we can
 // still recover other parts
-type Node<N> = ASTNode<Option<N>>;
+type Node<N> = super::node::Node<Option<N>>;
 
 /// The set of policy statements that forms a policy set
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -30,13 +30,13 @@ use crate::ast::{self, InputInteger, PolicyID, RestrictedExprError, Var};
 use crate::parser::unescape::UnescapeError;
 
 use crate::parser::fmt::join_with_conjunction;
-use crate::parser::node::ASTNode;
+use crate::parser::node::Node;
 
 use super::cst;
 
 pub(crate) type RawLocation = usize;
 pub(crate) type RawToken<'a> = lalr::lexer::Token<'a>;
-pub(crate) type RawUserError = ASTNode<String>;
+pub(crate) type RawUserError = Node<String>;
 
 pub(crate) type RawParseError<'a> = lalr::ParseError<RawLocation, RawToken<'a>, RawUserError>;
 pub(crate) type RawErrorRecovery<'a> = lalr::ErrorRecovery<RawLocation, RawToken<'a>, RawUserError>;

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -17,10 +17,10 @@
 use std::fmt::{self, Write};
 
 use super::cst::*;
-use super::node::ASTNode;
+use super::node::Node;
 
 /// Helper struct to handle non-existent nodes
-struct View<'a, T>(&'a ASTNode<Option<T>>);
+struct View<'a, T>(&'a Node<Option<T>>);
 impl<'a, T: fmt::Display> fmt::Display for View<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(n) = &self.0.as_inner() {

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -4,7 +4,7 @@ use lalrpop_util::{ParseError, ErrorRecovery};
 
 use crate::parser::*;
 use crate::parser::err::{RawErrorRecovery, RawUserError};
-use crate::parser::node::ASTNode as Node;
+use crate::parser::node::Node;
 
 grammar<'err>(errors: &'err mut Vec<RawErrorRecovery<'input>>);
 
@@ -362,7 +362,7 @@ Literal: Node<Option<cst::Literal>> = {
     <l:@L> <n:NUMBER> <r:@R> =>? match u64::from_str(n) {
         Ok(n) => Ok(Node::new(Some(cst::Literal::Num(n)),l,r)),
         Err(e) => Err(ParseError::User {
-            error: ASTNode::new(format!("integer parse error: {e}"),l,r),
+            error: Node::new(format!("integer parse error: {e}"),l,r),
         }),
     },
     <l:@L> <s:Str> <r:@R>

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -24,54 +24,54 @@ use super::err::{ToASTError, ToASTErrorKind};
 
 /// Metadata for our syntax trees
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ASTNode<N> {
+pub struct Node<T> {
     /// Main data represented
-    pub node: N,
+    pub node: T,
 
     /// Source location
     pub loc: miette::SourceSpan,
 }
 
-impl<N> ASTNode<N> {
+impl<T> Node<T> {
     /// Create a new Node with the source location [left, right)
-    pub fn new(node: N, left: usize, right: usize) -> Self {
-        ASTNode::with_source_loc(node, left..right)
+    pub fn new(node: T, left: usize, right: usize) -> Self {
+        Node::with_source_loc(node, left..right)
     }
 
     /// Create a new Node with the given source location
-    pub fn with_source_loc(node: N, loc: impl Into<miette::SourceSpan>) -> Self {
-        ASTNode {
+    pub fn with_source_loc(node: T, loc: impl Into<miette::SourceSpan>) -> Self {
+        Node {
             node,
             loc: loc.into(),
         }
     }
 
     /// Transform the inner value while retaining the attached source info.
-    pub fn map<M>(self, f: impl FnOnce(N) -> M) -> ASTNode<M> {
-        ASTNode {
+    pub fn map<R>(self, f: impl FnOnce(T) -> R) -> Node<R> {
+        Node {
             node: f(self.node),
             loc: self.loc,
         }
     }
 
-    /// Converts from `&ASTNode<N>` to `ASTNode<&N>`.
-    pub fn as_ref(&self) -> ASTNode<&N> {
-        ASTNode {
+    /// Converts from `&Node<T>` to `Node<&T>`.
+    pub fn as_ref(&self) -> Node<&T> {
+        Node {
             node: &self.node,
             loc: self.loc,
         }
     }
 
-    /// Converts from `&mut ASTNode<N>` to `ASTNode<&mut N>`.
-    pub fn as_mut(&mut self) -> ASTNode<&mut N> {
-        ASTNode {
+    /// Converts from `&mut Node<T>` to `Node<&mut T>`.
+    pub fn as_mut(&mut self) -> Node<&mut T> {
+        Node {
             node: &mut self.node,
             loc: self.loc,
         }
     }
 
-    /// Consume the `ASTNode`, yielding the node and attached source info.
-    pub fn into_inner(self) -> (N, miette::SourceSpan) {
+    /// Consume the `Node`, yielding the node and attached source info.
+    pub fn into_inner(self) -> (T, miette::SourceSpan) {
         (self.node, self.loc)
     }
 
@@ -81,27 +81,27 @@ impl<N> ASTNode<N> {
     }
 }
 
-impl<N: Clone> ASTNode<&N> {
-    /// Converts a `ASTNode<&N>` to a `ASTNode<N>` by cloning the inner value.
-    pub fn cloned(self) -> ASTNode<N> {
+impl<T: Clone> Node<&T> {
+    /// Converts a `Node<&T>` to a `Node<T>` by cloning the inner value.
+    pub fn cloned(self) -> Node<T> {
         self.map(|value| value.clone())
     }
 }
 
-impl<N: Copy> ASTNode<&N> {
-    /// Converts a `ASTNode<&N>` to a `ASTNode<N>` by copying the inner value.
-    pub fn copied(self) -> ASTNode<N> {
+impl<T: Copy> Node<&T> {
+    /// Converts a `Node<&T>` to a `Node<T>` by copying the inner value.
+    pub fn copied(self) -> Node<T> {
         self.map(|value| *value)
     }
 }
 
-impl<N: Display> Display for ASTNode<N> {
+impl<T: Display> Display for Node<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         Display::fmt(&self.node, f)
     }
 }
 
-impl<N: std::error::Error> std::error::Error for ASTNode<N> {
+impl<T: std::error::Error> std::error::Error for Node<T> {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         self.node.source()
     }
@@ -118,7 +118,7 @@ impl<N: std::error::Error> std::error::Error for ASTNode<N> {
 }
 
 // impl Diagnostic by taking `labels()` from .loc and everything else from .node
-impl<N: Diagnostic> Diagnostic for ASTNode<N> {
+impl<T: Diagnostic> Diagnostic for Node<T> {
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.node.code()
     }
@@ -155,35 +155,35 @@ impl<N: Diagnostic> Diagnostic for ASTNode<N> {
 }
 
 // Ignore the metadata this node contains
-impl<N: PartialEq> PartialEq for ASTNode<N> {
+impl<T: PartialEq> PartialEq for Node<T> {
     /// ignores metadata
     fn eq(&self, other: &Self) -> bool {
         self.node == other.node
     }
 }
-impl<N: Eq> Eq for ASTNode<N> {}
-impl<N: Hash> Hash for ASTNode<N> {
+impl<T: Eq> Eq for Node<T> {}
+impl<T: Hash> Hash for Node<T> {
     /// ignores metadata
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.node.hash(state);
     }
 }
 
-/// Convenience methods on `ASTNode<Option<N>>`
-impl<N> ASTNode<Option<N>> {
+/// Convenience methods on `Node<Option<T>>`
+impl<T> Node<Option<T>> {
     /// Similar to `.as_inner()`, but also gives access to the `SourceSpan`
-    pub fn as_inner_pair(&self) -> (Option<&N>, miette::SourceSpan) {
+    pub fn as_inner_pair(&self) -> (Option<&T>, miette::SourceSpan) {
         (self.node.as_ref(), self.loc)
     }
 
-    /// Get the inner data as `&N`, if it exists
-    pub fn as_inner(&self) -> Option<&N> {
+    /// Get the inner data as `&T`, if it exists
+    pub fn as_inner(&self) -> Option<&T> {
         self.node.as_ref()
     }
 
     /// `None` if the node is empty, otherwise a node without the `Option`
-    pub fn collapse(&self) -> Option<ASTNode<&N>> {
-        self.node.as_ref().map(|node| ASTNode {
+    pub fn collapse(&self) -> Option<Node<&T>> {
+        self.node.as_ref().map(|node| Node {
             node,
             loc: self.loc,
         })
@@ -193,7 +193,7 @@ impl<N> ASTNode<Option<N>> {
     /// if no main data or if `f` returns `None`.
     pub fn apply<F, R>(&self, f: F) -> Option<R>
     where
-        F: FnOnce(&N, miette::SourceSpan) -> Option<R>,
+        F: FnOnce(&T, miette::SourceSpan) -> Option<R>,
     {
         f(self.node.as_ref()?, self.loc)
     }
@@ -202,14 +202,14 @@ impl<N> ASTNode<Option<N>> {
     /// Returns `None` if no main data or if `f` returns `None`.
     pub fn into_apply<F, R>(self, f: F) -> Option<R>
     where
-        F: FnOnce(N, miette::SourceSpan) -> Option<R>,
+        F: FnOnce(T, miette::SourceSpan) -> Option<R>,
     {
         f(self.node?, self.loc)
     }
 
     /// Get node data if present, or return an error result for `MissingNodeData`
     /// if it is `None`.
-    pub fn ok_or_missing(&self) -> Result<&N, ToASTError> {
+    pub fn ok_or_missing(&self) -> Result<&T, ToASTError> {
         self.node
             .as_ref()
             .ok_or_else(|| self.to_ast_err(ToASTErrorKind::MissingNodeData))

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -80,39 +80,37 @@ lazy_static! {
 }
 
 /// Create CST for multiple policies from text
-pub fn parse_policies(
-    text: &str,
-) -> Result<node::ASTNode<Option<cst::Policies>>, err::ParseErrors> {
+pub fn parse_policies(text: &str) -> Result<node::Node<Option<cst::Policies>>, err::ParseErrors> {
     parse_collect_errors(&*POLICIES_PARSER, grammar::PoliciesParser::parse, text)
 }
 
 /// Create CST for one policy statement from text
-pub fn parse_policy(text: &str) -> Result<node::ASTNode<Option<cst::Policy>>, err::ParseErrors> {
+pub fn parse_policy(text: &str) -> Result<node::Node<Option<cst::Policy>>, err::ParseErrors> {
     parse_collect_errors(&*POLICY_PARSER, grammar::PolicyParser::parse, text)
 }
 
 /// Create CST for one Expression from text
-pub fn parse_expr(text: &str) -> Result<node::ASTNode<Option<cst::Expr>>, err::ParseErrors> {
+pub fn parse_expr(text: &str) -> Result<node::Node<Option<cst::Expr>>, err::ParseErrors> {
     parse_collect_errors(&*EXPR_PARSER, grammar::ExprParser::parse, text)
 }
 
 /// Create CST for one Entity Ref (i.e., UID) from text
-pub fn parse_ref(text: &str) -> Result<node::ASTNode<Option<cst::Ref>>, err::ParseErrors> {
+pub fn parse_ref(text: &str) -> Result<node::Node<Option<cst::Ref>>, err::ParseErrors> {
     parse_collect_errors(&*REF_PARSER, grammar::RefParser::parse, text)
 }
 
 /// Create CST for one Primary value from text
-pub fn parse_primary(text: &str) -> Result<node::ASTNode<Option<cst::Primary>>, err::ParseErrors> {
+pub fn parse_primary(text: &str) -> Result<node::Node<Option<cst::Primary>>, err::ParseErrors> {
     parse_collect_errors(&*PRIMARY_PARSER, grammar::PrimaryParser::parse, text)
 }
 
 /// Parse text as a Name, or fail if it does not parse as a Name
-pub fn parse_name(text: &str) -> Result<node::ASTNode<Option<cst::Name>>, err::ParseErrors> {
+pub fn parse_name(text: &str) -> Result<node::Node<Option<cst::Name>>, err::ParseErrors> {
     parse_collect_errors(&*NAME_PARSER, grammar::NameParser::parse, text)
 }
 
 /// Parse text as an identifier, or fail if it does not parse as an identifier
-pub fn parse_ident(text: &str) -> Result<node::ASTNode<Option<cst::Ident>>, err::ParseErrors> {
+pub fn parse_ident(text: &str) -> Result<node::Node<Option<cst::Ident>>, err::ParseErrors> {
     parse_collect_errors(&*IDENT_PARSER, grammar::IdentParser::parse, text)
 }
 

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -16,7 +16,7 @@
 
 use super::utils::*;
 use super::Context;
-use cedar_policy_core::parser::{cst::*, ASTNode};
+use cedar_policy_core::parser::{cst::*, Node};
 use pretty::RcDoc;
 
 use super::token::Comment;
@@ -34,7 +34,7 @@ impl Doc for Ident {
     }
 }
 
-impl Doc for ASTNode<Option<VariableDef>> {
+impl Doc for Node<Option<VariableDef>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let vd = self.as_inner()?;
         let start_comment = get_comment_at_start(self.loc, &mut context.tokens)?;
@@ -102,7 +102,7 @@ impl Doc for ASTNode<Option<VariableDef>> {
     }
 }
 
-impl Doc for ASTNode<Option<Cond>> {
+impl Doc for Node<Option<Cond>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let cond = self.as_inner()?;
         let lb_comment = get_comment_after_end(cond.cond.loc, &mut context.tokens)?;
@@ -164,14 +164,14 @@ impl Doc for ASTNode<Option<Cond>> {
     }
 }
 
-impl Doc for ASTNode<Option<Expr>> {
+impl Doc for Node<Option<Expr>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         match self.as_inner()?.expr.as_ref() {
             ExprData::If(c, t, e) => {
                 fn pp_group<'n>(
                     s: &str,
                     c: Comment,
-                    e: &'n ASTNode<Option<Expr>>,
+                    e: &'n Node<Option<Expr>>,
                     context: &mut Context<'_>,
                 ) -> RcDoc<'n> {
                     add_comment(RcDoc::as_string(s), c, RcDoc::nil()).append(
@@ -197,7 +197,7 @@ impl Doc for ASTNode<Option<Expr>> {
     }
 }
 
-impl Doc for ASTNode<Option<Or>> {
+impl Doc for Node<Option<Or>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
@@ -217,7 +217,7 @@ impl Doc for ASTNode<Option<Or>> {
     }
 }
 
-impl Doc for ASTNode<Option<And>> {
+impl Doc for Node<Option<And>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
@@ -237,7 +237,7 @@ impl Doc for ASTNode<Option<And>> {
     }
 }
 
-impl Doc for ASTNode<Option<Relation>> {
+impl Doc for Node<Option<Relation>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         match e {
@@ -334,7 +334,7 @@ impl Doc for AddOp {
     }
 }
 
-impl Doc for ASTNode<Option<Add>> {
+impl Doc for Node<Option<Add>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
@@ -370,7 +370,7 @@ impl Doc for MultOp {
     }
 }
 
-impl Doc for ASTNode<Option<Mult>> {
+impl Doc for Node<Option<Mult>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
@@ -400,7 +400,7 @@ impl Doc for ASTNode<Option<Mult>> {
     }
 }
 
-impl Doc for ASTNode<Option<Unary>> {
+impl Doc for Node<Option<Unary>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         if let Some(op) = e.op {
@@ -458,7 +458,7 @@ impl Doc for Member {
     }
 }
 
-impl Doc for ASTNode<Option<RecInit>> {
+impl Doc for Node<Option<RecInit>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         let key_doc = e.0.to_doc(context)?;
@@ -476,7 +476,7 @@ impl Doc for ASTNode<Option<RecInit>> {
     }
 }
 
-impl Doc for ASTNode<Option<Name>> {
+impl Doc for Node<Option<Name>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         let path = &e.path;
@@ -511,7 +511,7 @@ impl Doc for ASTNode<Option<Name>> {
     }
 }
 
-impl Doc for ASTNode<Option<Str>> {
+impl Doc for Node<Option<Str>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         Some(add_comment(
@@ -522,7 +522,7 @@ impl Doc for ASTNode<Option<Str>> {
     }
 }
 
-impl Doc for ASTNode<Option<Ref>> {
+impl Doc for Node<Option<Ref>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         match self.as_inner()? {
             Ref::Uid { path, eid } => Some(
@@ -539,7 +539,7 @@ impl Doc for ASTNode<Option<Ref>> {
     }
 }
 
-impl Doc for ASTNode<Option<Literal>> {
+impl Doc for Node<Option<Literal>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         Some(add_comment(
             RcDoc::as_string(self.as_inner()?),
@@ -549,7 +549,7 @@ impl Doc for ASTNode<Option<Literal>> {
     }
 }
 
-impl Doc for ASTNode<Option<Slot>> {
+impl Doc for Node<Option<Slot>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         Some(add_comment(
             RcDoc::as_string(self.as_inner()?),
@@ -559,7 +559,7 @@ impl Doc for ASTNode<Option<Slot>> {
     }
 }
 
-impl Doc for ASTNode<Option<Primary>> {
+impl Doc for Node<Option<Primary>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         match e {
@@ -651,7 +651,7 @@ impl Doc for ASTNode<Option<Primary>> {
     }
 }
 
-impl Doc for ASTNode<Option<MemAccess>> {
+impl Doc for Node<Option<MemAccess>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let e = self.as_inner()?;
         match e {
@@ -720,7 +720,7 @@ impl Doc for ASTNode<Option<MemAccess>> {
     }
 }
 
-impl Doc for ASTNode<Option<Annotation>> {
+impl Doc for Node<Option<Annotation>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let annotation = self.as_inner()?;
         let id_doc = annotation.key.to_doc(context);
@@ -750,7 +750,7 @@ impl Doc for ASTNode<Option<Annotation>> {
     }
 }
 
-impl Doc for ASTNode<Option<Ident>> {
+impl Doc for Node<Option<Ident>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         Some(add_comment(
             self.as_inner()?.to_doc(context)?,
@@ -760,7 +760,7 @@ impl Doc for ASTNode<Option<Ident>> {
     }
 }
 
-impl Doc for ASTNode<Option<Policy>> {
+impl Doc for Node<Option<Policy>> {
     fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
         let policy = self.as_inner()?;
 


### PR DESCRIPTION
## Description of changes

Since these nodes are used primarily in our CST, the name ASTNode is confusing.  While we're at it, I also replaced the type parameter `N` with the more standard `T`.

This type is internal-only, no breaking changes here.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
