### PR TITLE
remove redundant constructor

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1132,7 +1132,7 @@ fn interpret_primary(
                     Err(ToASTError::new(
                         ToASTErrorKind::InvalidExpression(cst::Name {
                             path: path.to_vec(),
-                            name: Node::new(Some(id.clone()), l, r),
+                            name: Node::with_source_loc(Some(id.clone()), l..r),
                         }),
                         miette::SourceSpan::from(l..r),
                     )
@@ -1333,7 +1333,7 @@ impl TryFrom<&Node<Option<cst::Name>>> for Expr {
                 Err(name
                     .to_ast_err(ToASTErrorKind::InvalidExpression(cst::Name {
                         path: path.to_vec(),
-                        name: Node::new(Some(id.clone()), l, r),
+                        name: Node::with_source_loc(Some(id.clone()), l..r),
                     }))
                     .into())
             }
@@ -1379,13 +1379,12 @@ mod test {
 
     #[test]
     fn test_invalid_expr_from_cst_name() {
-        let path = vec![Node::new(
+        let path = vec![Node::with_source_loc(
             Some(cst::Ident::Ident("some_long_str".into())),
-            0,
-            12,
+            0..12,
         )];
-        let name = Node::new(Some(cst::Ident::Else), 13, 16);
-        let cst_name = Node::new(Some(cst::Name { path, name }), 0, 16);
+        let name = Node::with_source_loc(Some(cst::Ident::Else), 13..16);
+        let cst_name = Node::with_source_loc(Some(cst::Name { path, name }), 0..16);
 
         assert_matches!(Expr::try_from(&cst_name), Err(e) => {
             assert!(e.len() == 1);

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -73,12 +73,12 @@ Comma<E>: Vec<E> = {
 
 // Policies := {Policy}
 pub Policies: Node<Option<cst::Policies>> = {
-    <l:@L> <ps:Policy*> <r:@R> => Node::new(Some(cst::Policies(ps)),l,r),
+    <l:@L> <ps:Policy*> <r:@R> => Node::with_source_loc(Some(cst::Policies(ps)),l..r),
 }
 
 // Annotations := {'@' Ident '(' String ')'}
 Annotation: Node<Option<cst::Annotation>> = {
-    <l:@L> "@" <key:AnyIdent> "(" <value:Str> ")" <r:@R> => Node::new(Some(cst::Annotation{key,value}),l,r)
+    <l:@L> "@" <key:AnyIdent> "(" <value:Str> ")" <r:@R> => Node::with_source_loc(Some(cst::Annotation{key,value}),l..r)
 }
 
 // Policy := "label" ('permit' | 'forbid') '(' {VariableDef} ')' {Cond} ;
@@ -90,8 +90,8 @@ pub Policy: Node<Option<cst::Policy>> = {
     <conds:Cond*>
     ";"
     <r:@R>
-    => Node::new(Some(cst::Policy{ annotations,effect,variables,conds }),l,r),
-    <l:@L> <err:!> <r:@R> => { errors.push(err); Node::new(None,l,r) },
+    => Node::with_source_loc(Some(cst::Policy{ annotations,effect,variables,conds }),l..r),
+    <l:@L> <err:!> <r:@R> => { errors.push(err); Node::with_source_loc(None,l..r) },
 }
 
 // VariableDef := Variable [':' Name] ['is' Add] [('in' | '==') Expr]
@@ -101,50 +101,50 @@ pub Policy: Node<Option<cst::Policy>> = {
 VariableDef: Node<Option<cst::VariableDef>> = {
     <l:@L> <variable: AnyIdent> <unused_type_name: (":" <Name>)?> <entity_type: (IS <Add>)?>
         <ineq: (RelOp Expr)?> <r:@R>
-        => Node::new(Some(cst::VariableDef{ variable,unused_type_name,entity_type,ineq, }),l,r),
+        => Node::with_source_loc(Some(cst::VariableDef{ variable,unused_type_name,entity_type,ineq, }),l..r),
 }
 
 // Identifier, but not the special ones
 CommonIdent: Node<Option<cst::Ident>> = {
     <l:@L> PRINCIPAL <r:@R>
-        => Node::new(Some(cst::Ident::Principal),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Principal),l..r),
     <l:@L> ACTION <r:@R>
-        => Node::new(Some(cst::Ident::Action),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Action),l..r),
     <l:@L> RESOURCE <r:@R>
-        => Node::new(Some(cst::Ident::Resource),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Resource),l..r),
     <l:@L> CONTEXT <r:@R>
-        => Node::new(Some(cst::Ident::Context),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Context),l..r),
     <l:@L> PERMIT <r:@R>
-        => Node::new(Some(cst::Ident::Permit),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Permit),l..r),
     <l:@L> FORBID <r:@R>
-        => Node::new(Some(cst::Ident::Forbid),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Forbid),l..r),
     <l:@L> WHEN <r:@R>
-        => Node::new(Some(cst::Ident::When),l,r),
+        => Node::with_source_loc(Some(cst::Ident::When),l..r),
     <l:@L> UNLESS <r:@R>
-        => Node::new(Some(cst::Ident::Unless),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Unless),l..r),
     <l:@L> IN <r:@R>
-        => Node::new(Some(cst::Ident::In),l,r),
+        => Node::with_source_loc(Some(cst::Ident::In),l..r),
     <l:@L> HAS <r:@R>
-        => Node::new(Some(cst::Ident::Has),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Has),l..r),
     <l:@L> LIKE <r:@R>
-        => Node::new(Some(cst::Ident::Like),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Like),l..r),
     <l:@L> IS <r:@R>
-        => Node::new(Some(cst::Ident::Is),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Is),l..r),
     <l:@L> THEN <r:@R>
-        => Node::new(Some(cst::Ident::Then),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Then),l..r),
     <l:@L> ELSE <r:@R>
-        => Node::new(Some(cst::Ident::Else),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Else),l..r),
     <l:@L> <i:IDENTIFIER> <r:@R>
-        => Node::new(Some(cst::Ident::Ident( i.into() )),l,r),
+        => Node::with_source_loc(Some(cst::Ident::Ident( i.into() )),l..r),
 }
 // The special ones, play multiple roles
 SpecialIdent: Node<Option<cst::Ident>> = {
     <l:@L> IF <r:@R>
-        => Node::new(Some(cst::Ident::If),l,r),
+        => Node::with_source_loc(Some(cst::Ident::If),l..r),
     <l:@L> TRUE <r:@R>
-        => Node::new(Some(cst::Ident::True),l,r),
+        => Node::with_source_loc(Some(cst::Ident::True),l..r),
     <l:@L> FALSE <r:@R>
-        => Node::new(Some(cst::Ident::False),l,r),
+        => Node::with_source_loc(Some(cst::Ident::False),l..r),
 }
 #[inline]
 AnyIdent: Node<Option<cst::Ident>> = {
@@ -155,54 +155,54 @@ pub Ident: Node<Option<cst::Ident>> = AnyIdent;
 // Cond := ('when' | 'unless') '{' Expr '}'
 Cond: Node<Option<cst::Cond>> = {
     <l:@L> <i:AnyIdent> "{" <e:Expr> "}" <r:@R>
-        => Node::new(Some(cst::Cond{cond: i, expr: Some(e)}),l,r),
+        => Node::with_source_loc(Some(cst::Cond{cond: i, expr: Some(e)}),l..r),
     // specifically catch the error case for empty-body, so we can report a good
     // error message
     <l:@L> <i:AnyIdent> "{" "}" <r:@R>
-        => Node::new(Some(cst::Cond{cond: i, expr: None}),l,r),
+        => Node::with_source_loc(Some(cst::Cond{cond: i, expr: None}),l..r),
 }
 
 // Expr := Or | 'if' Expr 'then' Expr 'else' Expr
 pub Expr: Node<Option<cst::Expr>> = {
     <l:@L> <o:Or> <r:@R>
-        => Node::new(Some(cst::Expr{ expr: Box::new(cst::ExprData::Or(o)) }),l,r),
+        => Node::with_source_loc(Some(cst::Expr{ expr: Box::new(cst::ExprData::Or(o)) }),l..r),
     <l:@L> IF <i:Expr> THEN <t:Expr> ELSE <e:Expr> <r:@R>
-        => Node::new(Some(cst::Expr{ expr: Box::new(cst::ExprData::If(i,t,e)) }),l,r),
-    <l:@L> <err:!> <r:@R> => { errors.push(err); Node::new(None,l,r) },
+        => Node::with_source_loc(Some(cst::Expr{ expr: Box::new(cst::ExprData::If(i,t,e)) }),l..r),
+    <l:@L> <err:!> <r:@R> => { errors.push(err); Node::with_source_loc(None,l..r) },
 }
 
 // Or := And {'||' And}
 Or: Node<Option<cst::Or>> = {
     <l:@L> <i:And> <e:("||" <And>)*> <r:@R>
-        => Node::new(Some(cst::Or{initial: i, extended: e}),l,r),
+        => Node::with_source_loc(Some(cst::Or{initial: i, extended: e}),l..r),
 }
 // And := Relation {'&&' Relation}
 And: Node<Option<cst::And>> = {
     <l:@L> <i:Relation> <e:("&&" <Relation>)*> <r:@R>
-        => Node::new(Some(cst::And{initial: i, extended: e}),l,r),
+        => Node::with_source_loc(Some(cst::And{initial: i, extended: e}),l..r),
 }
 // Relation := Add {RelOp Add} | Add HAS Add | Add LIKE Add | Add IS Add (IN Add)?
 Relation: Node<Option<cst::Relation>> = {
     <l:@L> <i:Add> <e:(RelOp Add)*> <r:@R>
-        => Node::new(Some(cst::Relation::Common{initial: i, extended: e}),l,r),
+        => Node::with_source_loc(Some(cst::Relation::Common{initial: i, extended: e}),l..r),
     <l:@L> <t:Add> HAS <f:Add> <r:@R>
-        => Node::new(Some(cst::Relation::Has{target: t, field: f}),l,r),
+        => Node::with_source_loc(Some(cst::Relation::Has{target: t, field: f}),l..r),
     <l:@L> <t:Add> HAS IF <r:@R> => {
         // Create an add expression from this identifier
-        let id0 = Node::new(Some(cst::Ident::If),l,r);
-        let id1 = Node::new(Some(cst::Name{path: vec![], name: id0}),l,r);
-        let id2 = Node::new(Some(cst::Primary::Name(id1)),l,r);
-        let id3 = Node::new(Some(cst::Member{ item: id2, access: vec![] }),l,r);
-        let id4 = Node::new(Some(cst::Unary{op: None, item:id3}),l,r);
-        let id5 = Node::new(Some(cst::Mult{initial: id4, extended: vec![]}),l,r);
-        let id6 = Node::new(Some(cst::Add{initial:id5, extended: vec![]}),l,r);
+        let id0 = Node::with_source_loc(Some(cst::Ident::If),l..r);
+        let id1 = Node::with_source_loc(Some(cst::Name{path: vec![], name: id0}),l..r);
+        let id2 = Node::with_source_loc(Some(cst::Primary::Name(id1)),l..r);
+        let id3 = Node::with_source_loc(Some(cst::Member{ item: id2, access: vec![] }),l..r);
+        let id4 = Node::with_source_loc(Some(cst::Unary{op: None, item:id3}),l..r);
+        let id5 = Node::with_source_loc(Some(cst::Mult{initial: id4, extended: vec![]}),l..r);
+        let id6 = Node::with_source_loc(Some(cst::Add{initial:id5, extended: vec![]}),l..r);
 
-        Node::new(Some(cst::Relation::Has{target: t, field: id6}),l,r)
+        Node::with_source_loc(Some(cst::Relation::Has{target: t, field: id6}),l..r)
     },
     <l:@L> <t:Add> LIKE <p:Add> <r:@R>
-        => Node::new(Some(cst::Relation::Like{target: t, pattern: p}),l,r),
+        => Node::with_source_loc(Some(cst::Relation::Like{target: t, pattern: p}),l..r),
     <l:@L> <t:Add> IS <n:Add> <e: (IN <Add>)?> <r:@R>
-        => Node::new(Some(cst::Relation::IsIn{target: t, entity_type: n, in_entity: e}),l,r),
+        => Node::with_source_loc(Some(cst::Relation::IsIn{target: t, entity_type: n, in_entity: e}),l..r),
 }
 // RelOp     := '<' | '<=' | '>=' | '>' | '!=' | '==' | 'in'
 RelOp: cst::RelOp = {
@@ -227,51 +227,51 @@ MultOp: cst::MultOp = {
 // Add := Mult {('+' | '-') Mult}
 Add: Node<Option<cst::Add>> = {
     <l:@L> <i:Mult> <e:(AddOp Mult)*> <r:@R>
-        => Node::new(Some(cst::Add{initial:i, extended: e}),l,r),
+        => Node::with_source_loc(Some(cst::Add{initial:i, extended: e}),l..r),
 }
 // Mult := Unary {('*' | '/' | '%') Unary}
 Mult: Node<Option<cst::Mult>> = {
     <l:@L> <i:Unary>  <e:(MultOp Unary)*> <r:@R>
-        => Node::new(Some(cst::Mult{initial: i, extended: e}),l,r),
+        => Node::with_source_loc(Some(cst::Mult{initial: i, extended: e}),l..r),
 }
 // Unary := ['!' {'!'} | '-' {'-'}] Member
 Unary: Node<Option<cst::Unary>> = {
     <l:@L> <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: None, item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: None, item:m}),l..r),
     <l:@L> "!" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Bang(1)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Bang(1)), item:m}),l..r),
     <l:@L> "!" "!" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Bang(2)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Bang(2)), item:m}),l..r),
     <l:@L> "!" "!" "!" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Bang(3)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Bang(3)), item:m}),l..r),
     <l:@L> "!" "!" "!" "!" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Bang(4)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Bang(4)), item:m}),l..r),
     <l:@L> "!" "!" "!" "!" "!"+ <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::OverBang), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::OverBang), item:m}),l..r),
     <l:@L> "-" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Dash(1)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Dash(1)), item:m}),l..r),
     <l:@L> "-" "-" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Dash(2)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Dash(2)), item:m}),l..r),
     <l:@L> "-" "-" "-" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Dash(3)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Dash(3)), item:m}),l..r),
     <l:@L> "-" "-" "-" "-" <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::Dash(4)), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::Dash(4)), item:m}),l..r),
     <l:@L> "-" "-" "-" "-" "-"+ <m:Member> <r:@R>
-        => Node::new(Some(cst::Unary{op: Some(cst::NegOp::OverDash), item:m}),l,r),
+        => Node::with_source_loc(Some(cst::Unary{op: Some(cst::NegOp::OverDash), item:m}),l..r),
 }
 // Member := Primary { MemAccess }
 Member: Node<Option<cst::Member>> = {
     <l:@L> <p:Primary> <a:MemAccess*> <r:@R>
-        => Node::new(Some(cst::Member{ item: p, access: a }),l,r),
+        => Node::with_source_loc(Some(cst::Member{ item: p, access: a }),l..r),
 }
 // MemAccess := '.' IDENT | '(' [ExprList] ')' | '[' Expr ']'
 MemAccess: Node<Option<cst::MemAccess>> = {
     <l:@L> "." <i:AnyIdent> <r:@R>
-        => Node::new(Some(cst::MemAccess::Field(i)),l,r),
+        => Node::with_source_loc(Some(cst::MemAccess::Field(i)),l..r),
     <l:@L> "(" <es:Comma<Expr>> ")" <r:@R>
-        => Node::new(Some(cst::MemAccess::Call(es)),l,r),
+        => Node::with_source_loc(Some(cst::MemAccess::Call(es)),l..r),
     <l:@L> "[" <e:Expr> "]" <r:@R>
-        => Node::new(Some(cst::MemAccess::Index(e)),l,r),
+        => Node::with_source_loc(Some(cst::MemAccess::Index(e)),l..r),
 }
 // Primary   := LITERAL |
 //              Ref |
@@ -282,19 +282,19 @@ MemAccess: Node<Option<cst::MemAccess>> = {
 //              '{' [MapOrFieldInits] '}'
 pub Primary: Node<Option<cst::Primary>> = {
     <l:@L> <lit:Literal> <r:@R>
-        => Node::new(Some(cst::Primary::Literal(lit)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::Literal(lit)),l..r),
     <l:@L> <refr:Ref> <r:@R>
-        => Node::new(Some(cst::Primary::Ref(refr)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::Ref(refr)),l..r),
     <l:@L> <n:Name> <r:@R>
-        => Node::new(Some(cst::Primary::Name(n)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::Name(n)),l..r),
     <l:@L> <s:Slot> <r:@R>
-        => Node::new(Some(cst::Primary::Slot(s)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::Slot(s)),l..r),
     <l:@L> "(" <e:Expr> ")" <r:@R>
-        => Node::new(Some(cst::Primary::Expr(e)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::Expr(e)),l..r),
     <l:@L> "[" <es:Comma<Expr>> "]" <r:@R>
-        => Node::new(Some(cst::Primary::EList(es)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::EList(es)),l..r),
     <l:@L> "{" <is:Comma<RecInit>> "}" <r:@R>
-        => Node::new(Some(cst::Primary::RInits(is)),l,r),
+        => Node::with_source_loc(Some(cst::Primary::RInits(is)),l..r),
 }
 
 // Name := IDENT {'::' IDENT}
@@ -304,71 +304,71 @@ pub Name: Node<Option<cst::Name>> = NameInline;
 #[inline]
 NameInline: Node<Option<cst::Name>> = {
     <l:@L> <n:CommonIdent> <r:@R>
-        => Node::new(Some(cst::Name{path: vec![], name: n}),l,r),
+        => Node::with_source_loc(Some(cst::Name{path: vec![], name: n}),l..r),
     <l:@L> <p:(<AnyIdent> "::")+> <n:AnyIdent> <r:@R>
-        => Node::new(Some(cst::Name{path: p, name: n}),l,r)
+        => Node::with_source_loc(Some(cst::Name{path: p, name: n}),l..r)
 }
 // Ref := Name '::' (STR | '{' [RefInits] '}')
 pub Ref: Node<Option<cst::Ref>> = {
     <l:@L> <n:NameInline> "::" <s:Str> <r:@R>
-        => Node::new(Some(cst::Ref::Uid{path:n,eid:s}),l,r),
+        => Node::with_source_loc(Some(cst::Ref::Uid{path:n,eid:s}),l..r),
     <l:@L> <n:NameInline> "::" "{" <is:Comma<RefInit>> "}" <r:@R>
-        => Node::new(Some(cst::Ref::Ref{path:n,rinits:is}),l,r),
+        => Node::with_source_loc(Some(cst::Ref::Ref{path:n,rinits:is}),l..r),
 }
 
 // RefInit := IDENT ':' LITERAL
 RefInit: Node<Option<cst::RefInit>> = {
     <l:@L> <i:AnyIdent> ":" <lit:Literal> <r:@R>
-        => Node::new(Some(cst::RefInit(i,lit)),l,r),
+        => Node::with_source_loc(Some(cst::RefInit(i,lit)),l..r),
 }
 // RecInit  := Expr ':' Expr   -or-   IDENT : Expr
 RecInit: Node<Option<cst::RecInit>> = {
     <l:@L> IF ":" <e2:Expr> <r:@R>
         => {
             // Create an expression from this identifier
-            let id0 = Node::new(Some(cst::Ident::If),l,r);
-            let id1 = Node::new(Some(cst::Name{path: vec![], name: id0}),l,r);
-            let id2 = Node::new(Some(cst::Primary::Name(id1)),l,r);
-            let id3 = Node::new(Some(cst::Member{ item: id2, access: vec![] }),l,r);
-            let id4 = Node::new(Some(cst::Unary{op: None, item:id3}),l,r);
-            let id5 = Node::new(Some(cst::Mult{initial: id4, extended: vec![]}),l,r);
-            let id6 = Node::new(Some(cst::Add{initial:id5, extended: vec![]}),l,r);
-            let id7 = Node::new(Some(cst::Relation::Common{initial: id6, extended: vec![]}),l,r);
-            let id8 = Node::new(Some(cst::And{initial: id7, extended: vec![]}),l,r);
-            let id9 = Node::new(Some(cst::Or{initial: id8, extended: vec![]}),l,r);
-            let e1 = Node::new(Some(cst::Expr{ expr: Box::new(cst::ExprData::Or(id9)) }),l,r);
+            let id0 = Node::with_source_loc(Some(cst::Ident::If),l..r);
+            let id1 = Node::with_source_loc(Some(cst::Name{path: vec![], name: id0}),l..r);
+            let id2 = Node::with_source_loc(Some(cst::Primary::Name(id1)),l..r);
+            let id3 = Node::with_source_loc(Some(cst::Member{ item: id2, access: vec![] }),l..r);
+            let id4 = Node::with_source_loc(Some(cst::Unary{op: None, item:id3}),l..r);
+            let id5 = Node::with_source_loc(Some(cst::Mult{initial: id4, extended: vec![]}),l..r);
+            let id6 = Node::with_source_loc(Some(cst::Add{initial:id5, extended: vec![]}),l..r);
+            let id7 = Node::with_source_loc(Some(cst::Relation::Common{initial: id6, extended: vec![]}),l..r);
+            let id8 = Node::with_source_loc(Some(cst::And{initial: id7, extended: vec![]}),l..r);
+            let id9 = Node::with_source_loc(Some(cst::Or{initial: id8, extended: vec![]}),l..r);
+            let e1 = Node::with_source_loc(Some(cst::Expr{ expr: Box::new(cst::ExprData::Or(id9)) }),l..r);
 
-            Node::new(Some(cst::RecInit(e1,e2)),l,r)
+            Node::with_source_loc(Some(cst::RecInit(e1,e2)),l..r)
         },
     <l:@L> <e1:Expr> ":" <e2:Expr> <r:@R>
-        => Node::new(Some(cst::RecInit(e1,e2)),l,r),
+        => Node::with_source_loc(Some(cst::RecInit(e1,e2)),l..r),
 }
 
 Slot: Node<Option<cst::Slot>> = {
     <l:@L> PRINCIPAL_SLOT <r:@R>
-        => Node::new(Some(cst::Slot::Principal), l, r),
+        => Node::with_source_loc(Some(cst::Slot::Principal), l..r),
     <l:@L> RESOURCE_SLOT <r:@R>
-        => Node::new(Some(cst::Slot::Resource), l, r),
+        => Node::with_source_loc(Some(cst::Slot::Resource), l..r),
     <l:@L> <s: OTHER_SLOT> <r:@R>
-        => Node::new(Some(cst::Slot::Other(s.into())), l, r),
+        => Node::with_source_loc(Some(cst::Slot::Other(s.into())), l..r),
 }
 
 // LITERAL   := BOOL | INT | STR
 Literal: Node<Option<cst::Literal>> = {
     <l:@L> TRUE <r:@R>
-        => Node::new(Some(cst::Literal::True),l,r),
+        => Node::with_source_loc(Some(cst::Literal::True),l..r),
     <l:@L> FALSE <r:@R>
-        => Node::new(Some(cst::Literal::False),l,r),
+        => Node::with_source_loc(Some(cst::Literal::False),l..r),
     <l:@L> <n:NUMBER> <r:@R> =>? match u64::from_str(n) {
-        Ok(n) => Ok(Node::new(Some(cst::Literal::Num(n)),l,r)),
+        Ok(n) => Ok(Node::with_source_loc(Some(cst::Literal::Num(n)),l..r)),
         Err(e) => Err(ParseError::User {
-            error: Node::new(format!("integer parse error: {e}"),l,r),
+            error: Node::with_source_loc(format!("integer parse error: {e}"),l..r),
         }),
     },
     <l:@L> <s:Str> <r:@R>
-        => Node::new(Some(cst::Literal::Str(s)),l,r),
+        => Node::with_source_loc(Some(cst::Literal::Str(s)),l..r),
 }
 Str: Node<Option<cst::Str>> = {
     <l:@L> <s:STRINGLIT> <r:@R>
-        => Node::new(Some(cst::Str::String(s[1..(s.len() - 1)].into())),l,r),
+        => Node::with_source_loc(Some(cst::Str::String(s[1..(s.len() - 1)].into())),l..r),
 }

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -33,11 +33,6 @@ pub struct Node<T> {
 }
 
 impl<T> Node<T> {
-    /// Create a new Node with the source location [left, right)
-    pub fn new(node: T, left: usize, right: usize) -> Self {
-        Node::with_source_loc(node, left..right)
-    }
-
     /// Create a new Node with the given source location
     pub fn with_source_loc(node: T, loc: impl Into<miette::SourceSpan>) -> Self {
         Node {


### PR DESCRIPTION
## Description of changes

`Node` had a constructor `new` and a constructor `with_source_loc` which were almost identical.  I consolidated into just `with_source_loc`, which I feel results in better / more readable patterns at callsites.

Not a public type, no breaking changes here.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
