### PR TITLE
remove `Node::as_inner_pair`

### DIFF
--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -166,11 +166,6 @@ impl<T: Hash> Hash for Node<T> {
 
 /// Convenience methods on `Node<Option<T>>`
 impl<T> Node<Option<T>> {
-    /// Similar to `.as_inner()`, but also gives access to the `SourceSpan`
-    pub fn as_inner_pair(&self) -> (Option<&T>, miette::SourceSpan) {
-        (self.node.as_ref(), self.loc)
-    }
-
     /// Get the inner data as `&T`, if it exists
     pub fn as_inner(&self) -> Option<&T> {
         self.node.as_ref()


### PR DESCRIPTION
## Description of changes

Another refactor relating to the internal type `Node`.

I don't think `Node::as_inner_pair()` was helping.  Replaced it with calls to `as_inner()` and accessing `self.loc` directly, which I think is clearer.  (In some places, where there are more than one `SourceSpan`s involved, it makes it super clear which span is being used.)

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
