### PR TITLE
Integrate validation errors with miette

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -505,19 +505,21 @@ pub fn validate(args: &ValidateArgs) -> CedarExitCode {
         CedarExitCode::Success
     };
 
-    let mut errors = result.validation_errors().peekable();
+    let (errors, warnings) = result.into_errors_and_warnings();
+    let mut errors = errors.peekable();
+    let mut warnings = warnings.peekable();
+
     if errors.peek().is_some() {
         println!("Validation Errors:");
         for note in errors {
-            println!("{}", note);
+            println!("{:?}", Report::new(note.into_owned()));
         }
     }
 
-    let mut warnings = result.validation_warnings().peekable();
     if warnings.peek().is_some() {
         println!("Validation Warnings:");
         for note in warnings {
-            println!("{}", note);
+            println!("{:?}", Report::new(note.into_owned()));
         }
     }
 

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -495,35 +495,21 @@ pub fn validate(args: &ValidateArgs) -> CedarExitCode {
     let validator = Validator::new(schema);
     let result = validator.validate(&pset, mode);
 
-    let exit_code = if !result.validation_passed()
+    if !result.validation_passed()
         || (args.deny_warnings && !result.validation_passed_without_warnings())
     {
-        println!("Validation Failed");
+        println!(
+            "{:?}",
+            Report::new(result).wrap_err("policy set validation failed")
+        );
         CedarExitCode::ValidationFailure
     } else {
-        println!("Validation Passed");
+        println!(
+            "{:?}",
+            Report::new(result).wrap_err("policy set validation passed")
+        );
         CedarExitCode::Success
-    };
-
-    let (errors, warnings) = result.into_errors_and_warnings();
-    let mut errors = errors.peekable();
-    let mut warnings = warnings.peekable();
-
-    if errors.peek().is_some() {
-        println!("Validation Errors:");
-        for note in errors {
-            println!("{:?}", Report::new(note.into_owned()));
-        }
     }
-
-    if warnings.peek().is_some() {
-        println!("Validation Warnings:");
-        for note in warnings {
-            println!("{:?}", Report::new(note.into_owned()));
-        }
-    }
-
-    exit_code
 }
 
 pub fn evaluate(args: &EvaluateArgs) -> (CedarExitCode, EvalResult) {

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -58,6 +58,7 @@ impl std::fmt::Display for ValidationWarning<'_> {
 
 #[derive(Debug, Clone, PartialEq, Diagnostic, Error, Eq)]
 #[non_exhaustive]
+#[diagnostic(severity(Warning))]
 pub enum ValidationWarningKind {
     /// A string contains mixed scripts. Different scripts can contain visually similar characters which may be confused for each other.
     #[error("string `\"{0}\"` contains mixed scripts")]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `ValidationResult` returned from `Validator::validate` now has a static
+  lifetime, allowing it to be used in more contexts. The lifetime parameter
+  will be removed in a future major version. 
 - Improve parse error around invalid `is` expressions.
 - Improve parser error message when a policy includes an invalid template slot.
   The error now identifies that the policy used an invalid slot and suggests using

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1022,7 +1022,7 @@ impl Validator {
 
     /// Validate all policies in a policy set, collecting all validation errors
     /// found into the returned `ValidationResult`. Each error is returned together with the
-    /// policy id of the policy where the error was found. If a policy i
+    /// policy id of the policy where the error was found. If a policy id
     /// included in the input policy set does not appear in the output iterator, then
     /// that policy passed the validator. If the function `validation_passed`
     /// returns true, then there were no validation errors found, so all
@@ -1631,8 +1631,8 @@ impl<'a> std::fmt::Display for SourceLocation<'a> {
     }
 }
 
-impl<'a, 'b> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation<'b> {
-    fn from(loc: cedar_policy_validator::SourceLocation<'a>) -> SourceLocation<'b> {
+impl<'a> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation<'static> {
+    fn from(loc: cedar_policy_validator::SourceLocation<'a>) -> SourceLocation<'static> {
         let policy_id: PolicyId = PolicyId(loc.policy_id().clone());
         let source_range = loc.source_span();
         Self {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1519,7 +1519,7 @@ impl<'a> Diagnostic for ValidationResult<'a> {
 /// and provides details specific to that kind of problem. The error also records
 /// where the problem was encountered.
 #[derive(Debug, Error)]
-#[error("validation error on {}: {}", self.location, self.error_kind())]
+#[error("validation error on {location}: {}", self.error_kind())]
 pub struct ValidationError<'a> {
     location: SourceLocation<'static>,
     error_kind: ValidationErrorKind,
@@ -1633,7 +1633,7 @@ impl<'a> std::fmt::Display for SourceLocation<'a> {
 
 impl<'a> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation<'static> {
     fn from(loc: cedar_policy_validator::SourceLocation<'a>) -> SourceLocation<'static> {
-        let policy_id: PolicyId = PolicyId(loc.policy_id().clone());
+        let policy_id = PolicyId(loc.policy_id().clone());
         let source_range = loc.source_span();
         Self {
             policy_id,
@@ -1655,7 +1655,7 @@ pub fn confusable_string_checker<'a>(
 }
 
 #[derive(Debug, Error)]
-#[error("validation warning on {}: {}", .location, .kind)]
+#[error("validation warning on {location}: {kind}")]
 /// Warnings found in Cedar policies
 pub struct ValidationWarning<'a> {
     location: SourceLocation<'static>,


### PR DESCRIPTION
## Description of changes

Validation errors were not being printed using the pretty miette style. This PR makes the whole `ValidationResult` a `Diagnostic` implemented in the same style as a `ParseErrors` and uses this to print the result in the CLI. Source locations still aren't printed because the `Report` struct needs to be given the source code string, but this change allows for print help messages.

Pretty printing the `ValidationResult` with a miette `Report` did not work initially because `Report::new` wants arguments with static lifetimes, but `ValidationResult` is parametrized by a lifetime `'a` inherited from the policy set that was validated. Removing the lifetime on the struct would be an breaking change to the api, so I have worked around the issue by using the lifetime only on a `PhantomData` field in the struct, allowing the lifetime parameter to be set to `'static`. I think this avoids any breaking api changes, but review on that point is welcome.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
