### PR TITLE
Add `help` to some type errors

### DIFF
--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -481,7 +481,8 @@ mod test {
                 TypeError::expected_type(
                     Expr::val(1),
                     Type::primitive_long(),
-                    Type::singleton_boolean(true)
+                    Type::singleton_boolean(true),
+                    None,
                 )
                 .kind
             )]

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -523,10 +523,10 @@ impl Display for AttributeAccess {
     }
 }
 
-// These tests all assume that the typecheck found an error while checking the
+// These tests all assume that the typechecker found an error while checking the
 // outermost `GetAttr` in the expressions. If the attribute didn't exist at all,
-// only the message included in the final error. If it was an optional attribute
-// without a guard, then the help is also printed. See
+// only the primary message would included in the final error. If it was an
+// optional attribute without a guard, then the help message is also printed.
 #[cfg(test)]
 mod test_attr_access {
     use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprBuilder, Var};

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -330,6 +330,8 @@ pub(crate) enum UnexpectedTypeHelp {
     TypeTestNotSupported,
     #[error("Cedar does not support string concatenation")]
     ConcatenationNotSupported,
+    #[error("Cedar does not support computing the union, intersection, or difference of sets")]
+    SetOperationsNotSupported,
 }
 
 /// Structure containing details about an incompatible type error.

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -40,8 +40,10 @@ use crate::{
     extensions::all_available_extension_schemas,
     fuzzy_match::fuzzy_search,
     schema::{is_action_entity_type, ValidatorSchema},
-    types::{AttributeType, Effect, EffectSet, EntityRecordKind, OpenTag, RequestEnv, Type},
-    AttributeAccess, ValidationMode,
+    types::{
+        AttributeType, Effect, EffectSet, EntityRecordKind, OpenTag, Primitive, RequestEnv, Type,
+    },
+    AttributeAccess, UnexpectedTypeHelp, ValidationMode,
 };
 
 use super::type_error::TypeError;
@@ -312,6 +314,7 @@ impl<'a> Typechecker<'a> {
                 expr,
                 Type::primitive_boolean(),
                 &mut type_errors,
+                |_| None,
             );
 
             let is_false = ty.contains_type(&Type::singleton_boolean(false));
@@ -374,6 +377,7 @@ impl<'a> Typechecker<'a> {
                         &condition_expr,
                         Type::primitive_boolean(),
                         &mut type_errors,
+                        |_| None,
                     );
 
                     let is_false = ty.contains_type(&Type::singleton_boolean(false));
@@ -664,6 +668,7 @@ impl<'a> Typechecker<'a> {
                     test_expr,
                     Type::primitive_boolean(),
                     type_errors,
+                    |_| None,
                 );
                 ans_test.then_typecheck(|typ_test, eff_test| {
                     // If the guard has type `true` or `false`, we short circuit,
@@ -759,6 +764,7 @@ impl<'a> Typechecker<'a> {
                     left,
                     Type::primitive_boolean(),
                     type_errors,
+                    |_| None,
                 );
                 ans_left.then_typecheck(|typ_left, eff_left| {
                     match typ_left.data() {
@@ -787,6 +793,7 @@ impl<'a> Typechecker<'a> {
                                 right,
                                 Type::primitive_boolean(),
                                 type_errors,
+                                |_| None,
                             );
                             ans_right.then_typecheck(|typ_right, eff_right| {
                                 match (typ_left.data(), typ_right.data()) {
@@ -855,6 +862,7 @@ impl<'a> Typechecker<'a> {
                     left,
                     Type::primitive_boolean(),
                     type_errors,
+                    |_| None,
                 );
                 ans_left.then_typecheck(|ty_expr_left, eff_left| match ty_expr_left.data() {
                     // Contrary to `&&` where short circuiting did not permit
@@ -876,6 +884,7 @@ impl<'a> Typechecker<'a> {
                             right,
                             Type::primitive_boolean(),
                             type_errors,
+                            |_| None,
                         );
                         ans_right.then_typecheck(|ty_expr_right, eff_right| {
                             match (ty_expr_left.data(), ty_expr_right.data()) {
@@ -960,6 +969,13 @@ impl<'a> Typechecker<'a> {
                     expr,
                     &[Type::any_entity_reference(), Type::any_record()],
                     type_errors,
+                    |actual| match actual {
+                        Type::Set { .. } => Some(UnexpectedTypeHelp::TryUsingContains),
+                        Type::Primitive {
+                            primitive_type: Primitive::String,
+                        } => Some(UnexpectedTypeHelp::TryUsingLike),
+                        _ => None,
+                    },
                 );
 
                 actual.then_typecheck(|typ_expr_actual, _| match typ_expr_actual.data() {
@@ -1033,6 +1049,13 @@ impl<'a> Typechecker<'a> {
                     expr,
                     &[Type::any_entity_reference(), Type::any_record()],
                     type_errors,
+                    |actual| match actual {
+                        Type::Set { .. } => Some(UnexpectedTypeHelp::TryUsingContains),
+                        Type::Primitive {
+                            primitive_type: Primitive::String,
+                        } => Some(UnexpectedTypeHelp::TryUsingLike),
+                        _ => None,
+                    },
                 );
                 actual.then_typecheck(|typ_expr_actual, _| match typ_expr_actual.data() {
                     Some(typ_actual) => {
@@ -1129,6 +1152,14 @@ impl<'a> Typechecker<'a> {
                     expr,
                     Type::primitive_string(),
                     type_errors,
+                    |actual| match actual {
+                        Type::EntityOrRecord(
+                            EntityRecordKind::AnyEntity
+                            | EntityRecordKind::Entity(_)
+                            | EntityRecordKind::ActionEntity { .. },
+                        ) => Some(UnexpectedTypeHelp::TryUsingIs),
+                        _ => None,
+                    },
                 );
                 actual.then_typecheck(|actual_expr_ty, _| {
                     TypecheckAnswer::success(
@@ -1149,6 +1180,7 @@ impl<'a> Typechecker<'a> {
                     expr,
                     Type::any_entity_reference(),
                     type_errors,
+                    |_| Some(UnexpectedTypeHelp::TypeTestNotSupported),
                 )
                 .then_typecheck(|expr_ty, _| {
                     match expr_ty.data() {
@@ -1368,6 +1400,7 @@ impl<'a> Typechecker<'a> {
                     arg1,
                     Type::primitive_long(),
                     type_errors,
+                    |_| None,
                 );
                 ans_arg1.then_typecheck(|expr_ty_arg1, _| {
                     let ans_arg2 = self.expect_type(
@@ -1376,6 +1409,7 @@ impl<'a> Typechecker<'a> {
                         arg2,
                         Type::primitive_long(),
                         type_errors,
+                        |_| None,
                     );
                     ans_arg2.then_typecheck(|expr_ty_arg2, _| {
                         TypecheckAnswer::success(
@@ -1388,12 +1422,22 @@ impl<'a> Typechecker<'a> {
             }
 
             BinaryOp::Add | BinaryOp::Sub => {
+                let help_builder = |actual: &Type| match (op, actual) {
+                    (
+                        BinaryOp::Add,
+                        Type::Primitive {
+                            primitive_type: Primitive::String,
+                        },
+                    ) => Some(UnexpectedTypeHelp::ConcatenationNotSupported),
+                    _ => None,
+                };
                 let ans_arg1 = self.expect_type(
                     request_env,
                     prior_eff,
                     arg1,
                     Type::primitive_long(),
                     type_errors,
+                    help_builder,
                 );
                 ans_arg1.then_typecheck(|expr_ty_arg1, _| {
                     let ans_arg2 = self.expect_type(
@@ -1402,6 +1446,7 @@ impl<'a> Typechecker<'a> {
                         arg2,
                         Type::primitive_long(),
                         type_errors,
+                        help_builder,
                     );
                     ans_arg2.then_typecheck(|expr_ty_arg2, _| {
                         TypecheckAnswer::success(
@@ -1419,74 +1464,117 @@ impl<'a> Typechecker<'a> {
 
             BinaryOp::Contains => {
                 // The first argument must be a set.
-                self.expect_type(request_env, prior_eff, arg1, Type::any_set(), type_errors)
-                    .then_typecheck(|expr_ty_arg1, _| {
-                        // The second argument may be any type. We do not care if the element type cannot be in the set.
-                        self.typecheck(request_env, prior_eff, arg2, type_errors)
-                            .then_typecheck(|expr_ty_arg2, _| {
-                                if self.mode.is_strict() {
-                                    let annotated_expr =
-                                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                            .with_same_source_span(bin_expr)
-                                            .binary_app(
-                                                *op,
-                                                expr_ty_arg1.clone(),
-                                                expr_ty_arg2.clone(),
-                                            );
-                                    self.enforce_strict_equality(
-                                        bin_expr,
-                                        annotated_expr,
-                                        &match expr_ty_arg1.data() {
-                                            Some(Type::Set {
-                                                element_type: Some(ty),
-                                            }) => Some(*ty.clone()),
-                                            _ => None,
-                                        },
-                                        expr_ty_arg2.data(),
-                                        type_errors,
-                                    )
-                                } else {
-                                    TypecheckAnswer::success(
-                                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                            .with_same_source_span(bin_expr)
-                                            .binary_app(*op, expr_ty_arg1, expr_ty_arg2),
-                                    )
-                                }
-                            })
-                    })
+                self.expect_type(
+                    request_env,
+                    prior_eff,
+                    arg1,
+                    Type::any_set(),
+                    type_errors,
+                    |actual| match actual {
+                        Type::EntityOrRecord(
+                            EntityRecordKind::AnyEntity
+                            | EntityRecordKind::Entity(_)
+                            | EntityRecordKind::ActionEntity { .. },
+                        ) => Some(UnexpectedTypeHelp::TryUsingIn),
+                        Type::EntityOrRecord(EntityRecordKind::Record { .. }) => {
+                            Some(UnexpectedTypeHelp::TryUsingHas)
+                        }
+                        Type::Primitive {
+                            primitive_type: Primitive::String,
+                        } => Some(UnexpectedTypeHelp::TryUsingLike),
+                        _ => None,
+                    },
+                )
+                .then_typecheck(|expr_ty_arg1, _| {
+                    // The second argument may be any type. We do not care if the element type cannot be in the set.
+                    self.typecheck(request_env, prior_eff, arg2, type_errors)
+                        .then_typecheck(|expr_ty_arg2, _| {
+                            if self.mode.is_strict() {
+                                let annotated_expr =
+                                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                                        .with_same_source_span(bin_expr)
+                                        .binary_app(
+                                            *op,
+                                            expr_ty_arg1.clone(),
+                                            expr_ty_arg2.clone(),
+                                        );
+                                self.enforce_strict_equality(
+                                    bin_expr,
+                                    annotated_expr,
+                                    &match expr_ty_arg1.data() {
+                                        Some(Type::Set {
+                                            element_type: Some(ty),
+                                        }) => Some(*ty.clone()),
+                                        _ => None,
+                                    },
+                                    expr_ty_arg2.data(),
+                                    type_errors,
+                                )
+                            } else {
+                                TypecheckAnswer::success(
+                                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                                        .with_same_source_span(bin_expr)
+                                        .binary_app(*op, expr_ty_arg1, expr_ty_arg2),
+                                )
+                            }
+                        })
+                })
             }
 
             BinaryOp::ContainsAll | BinaryOp::ContainsAny => {
                 // Both arguments to a `containsAll` or `containsAny` must be sets.
-                self.expect_type(request_env, prior_eff, arg1, Type::any_set(), type_errors)
-                    .then_typecheck(|expr_ty_arg1, _| {
-                        self.expect_type(request_env, prior_eff, arg2, Type::any_set(), type_errors)
-                            .then_typecheck(|expr_ty_arg2, _| {
-                                if self.mode.is_strict() {
-                                    let annotated_expr =
-                                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                            .with_same_source_span(bin_expr)
-                                            .binary_app(
-                                                *op,
-                                                expr_ty_arg1.clone(),
-                                                expr_ty_arg2.clone(),
-                                            );
-                                    self.enforce_strict_equality(
-                                        bin_expr,
-                                        annotated_expr,
-                                        expr_ty_arg1.data(),
-                                        expr_ty_arg2.data(),
-                                        type_errors,
-                                    )
-                                } else {
-                                    TypecheckAnswer::success(
-                                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                                            .with_same_source_span(bin_expr)
-                                            .binary_app(*op, expr_ty_arg1, expr_ty_arg2),
-                                    )
-                                }
-                            })
+                self.expect_type(
+                    request_env,
+                    prior_eff,
+                    arg1,
+                    Type::any_set(),
+                    type_errors,
+                    |actual| match actual {
+                        Type::EntityOrRecord(
+                            EntityRecordKind::AnyEntity
+                            | EntityRecordKind::Entity(_)
+                            | EntityRecordKind::ActionEntity { .. },
+                        ) => Some(UnexpectedTypeHelp::TryUsingIn),
+                        Type::EntityOrRecord(EntityRecordKind::Record { .. }) => {
+                            Some(UnexpectedTypeHelp::TryUsingHas)
+                        }
+                        Type::Primitive {
+                            primitive_type: Primitive::String,
+                        } => Some(UnexpectedTypeHelp::TryUsingLike),
+                        _ => None,
+                    },
+                )
+                .then_typecheck(|expr_ty_arg1, _| {
+                    self.expect_type(
+                        request_env,
+                        prior_eff,
+                        arg2,
+                        Type::any_set(),
+                        type_errors,
+                        |_| Some(UnexpectedTypeHelp::TryUsingSingleContains),
+                    )
+                    .then_typecheck(|expr_ty_arg2, _| {
+                        if self.mode.is_strict() {
+                            let annotated_expr =
+                                ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                                    .with_same_source_span(bin_expr)
+                                    .binary_app(*op, expr_ty_arg1.clone(), expr_ty_arg2.clone());
+                            self.enforce_strict_equality(
+                                bin_expr,
+                                annotated_expr,
+                                expr_ty_arg1.data(),
+                                expr_ty_arg2.data(),
+                                type_errors,
+                            )
+                        } else {
+                            TypecheckAnswer::success(
+                                ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                                    .with_same_source_span(bin_expr)
+                                    .binary_app(*op, expr_ty_arg1, expr_ty_arg2),
+                            )
+                        }
                     })
+                })
             }
         }
     }
@@ -1548,6 +1636,7 @@ impl<'a> Typechecker<'a> {
             arg,
             Type::primitive_long(),
             type_errors,
+            |_| None,
         );
         ans_arg.then_typecheck(|arg_expr_ty, _| {
             TypecheckAnswer::success({
@@ -1636,6 +1725,7 @@ impl<'a> Typechecker<'a> {
             lhs,
             Type::any_entity_reference(),
             type_errors,
+            |_| Some(UnexpectedTypeHelp::TryUsingContains),
         );
         let ty_rhs = self.expect_one_of_types(
             request_env,
@@ -1646,6 +1736,13 @@ impl<'a> Typechecker<'a> {
                 Type::any_entity_reference(),
             ],
             type_errors,
+            |actual| match actual {
+                Type::Set { .. } => Some(UnexpectedTypeHelp::TryUsingContains),
+                Type::Primitive {
+                    primitive_type: Primitive::String,
+                } => Some(UnexpectedTypeHelp::TryUsingLike),
+                _ => None,
+            },
         );
 
         let lhs_typechecked = ty_lhs.typechecked();
@@ -2146,6 +2243,7 @@ impl<'a> Typechecker<'a> {
                     arg,
                     Type::primitive_boolean(),
                     type_errors,
+                    |_| None,
                 );
                 ans_arg.then_typecheck(|typ_expr_arg, _| match typ_expr_arg.data() {
                     Some(typ_arg) => {
@@ -2177,6 +2275,7 @@ impl<'a> Typechecker<'a> {
                     arg,
                     Type::primitive_long(),
                     type_errors,
+                    |_| None,
                 );
                 ans_arg.then_typecheck(|typ_expr_arg, _| {
                     TypecheckAnswer::success(
@@ -2192,14 +2291,18 @@ impl<'a> Typechecker<'a> {
     /// Check that an expression has a type that is a subtype of one of the
     /// given types. If not, generate a type error and return TypecheckFail.
     /// Return the TypecheckSuccess with the type otherwise.
-    fn expect_one_of_types<'b>(
+    fn expect_one_of_types<'b, 'c, F>(
         &self,
         request_env: &RequestEnv,
         prior_eff: &EffectSet<'b>,
         expr: &'b Expr,
         expected: &[Type],
         type_errors: &mut Vec<TypeError>,
-    ) -> TypecheckAnswer<'b> {
+        type_error_help: F,
+    ) -> TypecheckAnswer<'b>
+    where
+        F: FnOnce(&Type) -> Option<UnexpectedTypeHelp>,
+    {
         let actual = self.typecheck(request_env, prior_eff, expr, type_errors);
         actual.then_typecheck(|mut typ_actual, eff_actual| match typ_actual.data() {
             Some(actual_ty) => {
@@ -2223,6 +2326,7 @@ impl<'a> Typechecker<'a> {
                         expr.clone(),
                         expected.to_vec(),
                         actual_ty.clone(),
+                        type_error_help(actual_ty),
                     ));
                     // Some code (e.g., typechecking And) depends on
                     // `expect_type` not returning an expression with a type
@@ -2246,15 +2350,26 @@ impl<'a> Typechecker<'a> {
     /// Check that an expression has a type that is a subtype of a given type.
     /// If not, generate a type error and return None. Otherwise, return the
     /// type.
-    fn expect_type<'b>(
+    fn expect_type<'b, F>(
         &self,
         request_env: &RequestEnv,
         prior_eff: &EffectSet<'b>,
         expr: &'b Expr,
         expected: Type,
         type_errors: &mut Vec<TypeError>,
-    ) -> TypecheckAnswer<'b> {
-        self.expect_one_of_types(request_env, prior_eff, expr, &[expected], type_errors)
+        type_error_help: F,
+    ) -> TypecheckAnswer<'b>
+    where
+        F: FnOnce(&Type) -> Option<UnexpectedTypeHelp>,
+    {
+        self.expect_one_of_types(
+            request_env,
+            prior_eff,
+            expr,
+            &[expected],
+            type_errors,
+            type_error_help,
+        )
     }
 
     /// Return the least upper bound of all types is the `types` vector. If
@@ -2399,7 +2514,14 @@ impl<'a> Typechecker<'a> {
                     }
                 } else {
                     let typechecked_args = zip(args.as_ref(), arg_tys).map(|(arg, ty)| {
-                        self.expect_type(request_env, prior_eff, arg, ty.clone(), type_errors)
+                        self.expect_type(
+                            request_env,
+                            prior_eff,
+                            arg,
+                            ty.clone(),
+                            type_errors,
+                            |_| None,
+                        )
                     });
                     TypecheckAnswer::sequence_all_then_typecheck(
                         typechecked_args,

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -2291,7 +2291,7 @@ impl<'a> Typechecker<'a> {
     /// Check that an expression has a type that is a subtype of one of the
     /// given types. If not, generate a type error and return TypecheckFail.
     /// Return the TypecheckSuccess with the type otherwise.
-    fn expect_one_of_types<'b, 'c, F>(
+    fn expect_one_of_types<'b, F>(
         &self,
         request_env: &RequestEnv,
         prior_eff: &EffectSet<'b>,

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -969,13 +969,7 @@ impl<'a> Typechecker<'a> {
                     expr,
                     &[Type::any_entity_reference(), Type::any_record()],
                     type_errors,
-                    |actual| match actual {
-                        Type::Set { .. } => Some(UnexpectedTypeHelp::TryUsingContains),
-                        Type::Primitive {
-                            primitive_type: Primitive::String,
-                        } => Some(UnexpectedTypeHelp::TryUsingLike),
-                        _ => None,
-                    },
+                    |_| None,
                 );
 
                 actual.then_typecheck(|typ_expr_actual, _| match typ_expr_actual.data() {
@@ -1429,6 +1423,7 @@ impl<'a> Typechecker<'a> {
                             primitive_type: Primitive::String,
                         },
                     ) => Some(UnexpectedTypeHelp::ConcatenationNotSupported),
+                    (_, Type::Set { .. }) => Some(UnexpectedTypeHelp::SetOperationsNotSupported),
                     _ => None,
                 };
                 let ans_arg1 = self.expect_type(

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -27,7 +27,7 @@ use smol_str::SmolStr;
 
 use crate::{
     type_error::TypeError, types::Type, AttributeAccess, AttributesOrContext, EntityType,
-    NamespaceDefinition, SchemaFragment, ValidationMode,
+    NamespaceDefinition, SchemaFragment, UnexpectedTypeHelp, ValidationMode,
 };
 
 use super::test_utils::{
@@ -173,6 +173,7 @@ fn and_typecheck_fails() {
             Expr::val(1),
             Type::primitive_boolean(),
             Type::primitive_long(),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -182,6 +183,7 @@ fn and_typecheck_fails() {
             Expr::val(1),
             Type::primitive_boolean(),
             Type::primitive_long(),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -194,6 +196,7 @@ fn and_typecheck_fails() {
             Expr::val(true),
             Type::primitive_long(),
             Type::singleton_boolean(true),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -206,6 +209,7 @@ fn and_typecheck_fails() {
             Expr::val(true),
             Type::primitive_long(),
             Type::singleton_boolean(true),
+            None,
         )],
     );
 }
@@ -243,6 +247,7 @@ fn or_right_true_fails_left() {
             Expr::val(1),
             Type::primitive_boolean(),
             Type::primitive_long(),
+            None,
         )],
     );
 }
@@ -291,6 +296,7 @@ fn or_typecheck_fails() {
             Expr::val(1),
             Type::primitive_boolean(),
             Type::primitive_long(),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -300,6 +306,7 @@ fn or_typecheck_fails() {
             Expr::val(1),
             Type::primitive_boolean(),
             Type::primitive_long(),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -312,6 +319,7 @@ fn or_typecheck_fails() {
             Expr::val(true),
             Type::primitive_long(),
             Type::singleton_boolean(true),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -324,6 +332,7 @@ fn or_typecheck_fails() {
             Expr::val(true),
             Type::primitive_long(),
             Type::singleton_boolean(true),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -336,6 +345,7 @@ fn or_typecheck_fails() {
             Expr::val(true),
             Type::primitive_long(),
             Type::singleton_boolean(true),
+            None,
         )],
     );
 }
@@ -592,6 +602,7 @@ fn has_typecheck_fails() {
             Expr::val(true),
             vec![Type::any_entity_reference(), Type::any_record()],
             Type::singleton_boolean(true),
+            None,
         )],
     );
 }
@@ -636,6 +647,7 @@ fn record_get_attr_typecheck_fails() {
             Expr::val(2),
             vec![Type::any_entity_reference(), Type::any_record()],
             Type::primitive_long(),
+            None,
         )],
     );
 }
@@ -744,6 +756,7 @@ fn in_typecheck_fails() {
                 Expr::val(0),
                 Type::any_entity_reference(),
                 Type::primitive_long(),
+                Some(UnexpectedTypeHelp::TryUsingContains),
             ),
             TypeError::expected_one_of_types(
                 Expr::val(true),
@@ -752,6 +765,7 @@ fn in_typecheck_fails() {
                     Type::any_entity_reference(),
                 ],
                 Type::singleton_boolean(true),
+                None,
             ),
         ],
     );
@@ -775,6 +789,7 @@ fn contains_typecheck_fails() {
             Expr::val("foo"),
             Type::any_set(),
             Type::primitive_string(),
+            Some(UnexpectedTypeHelp::TryUsingLike),
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -784,6 +799,7 @@ fn contains_typecheck_fails() {
             Expr::val(1),
             Type::any_set(),
             Type::primitive_long(),
+            None,
         )],
     );
     assert_typecheck_fails_empty_schema(
@@ -799,6 +815,7 @@ fn contains_typecheck_fails() {
                 "foo".into(),
                 AttributeType::new(Type::primitive_long(), true),
             )]),
+            Some(UnexpectedTypeHelp::TryUsingHas),
         )],
     );
 }
@@ -846,11 +863,12 @@ fn contains_all_typecheck_fails() {
         Expr::contains_all(Expr::val(1), Expr::val(true)),
         Type::primitive_boolean(),
         vec![
-            TypeError::expected_type(Expr::val(1), Type::any_set(), Type::primitive_long()),
+            TypeError::expected_type(Expr::val(1), Type::any_set(), Type::primitive_long(), None),
             TypeError::expected_type(
                 Expr::val(true),
                 Type::any_set(),
                 Type::singleton_boolean(true),
+                Some(UnexpectedTypeHelp::TryUsingSingleContains),
             ),
         ],
     );
@@ -916,6 +934,7 @@ fn like_typecheck_fails() {
             Expr::val(1),
             Type::primitive_string(),
             Type::primitive_long(),
+            None,
         )],
     );
 }
@@ -938,11 +957,13 @@ fn less_than_typecheck_fails() {
                 Expr::val(true),
                 Type::primitive_long(),
                 Type::singleton_boolean(true),
+                None,
             ),
             TypeError::expected_type(
                 Expr::val(false),
                 Type::primitive_long(),
                 Type::singleton_boolean(false),
+                None,
             ),
         ],
     )
@@ -963,6 +984,7 @@ fn not_typecheck_fails() {
             Expr::val(1),
             Type::primitive_boolean(),
             Type::primitive_long(),
+            None,
         )],
     );
 }
@@ -1021,6 +1043,7 @@ fn if_typecheck_fails() {
                 Expr::val("fail"),
                 Type::primitive_boolean(),
                 Type::primitive_string(),
+                None,
             ),
         ],
     );
@@ -1042,6 +1065,7 @@ fn neg_typecheck_fails() {
             Expr::val("foo"),
             Type::primitive_long(),
             Type::primitive_string(),
+            None,
         )],
     )
 }
@@ -1062,6 +1086,7 @@ fn mul_typecheck_fails() {
             Expr::val("foo"),
             Type::primitive_long(),
             Type::primitive_string(),
+            None,
         )],
     )
 }
@@ -1084,6 +1109,7 @@ fn add_sub_typecheck_fails() {
             Expr::val("foo"),
             Type::primitive_long(),
             Type::primitive_string(),
+            Some(UnexpectedTypeHelp::ConcatenationNotSupported),
         )],
     );
 
@@ -1095,6 +1121,7 @@ fn add_sub_typecheck_fails() {
             Expr::val("bar"),
             Type::primitive_long(),
             Type::primitive_string(),
+            None,
         )],
     );
 }
@@ -1111,6 +1138,7 @@ fn is_typecheck_fails() {
             Expr::val(1),
             Type::any_entity_reference(),
             Type::primitive_long(),
+            Some(UnexpectedTypeHelp::TypeTestNotSupported),
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_extensions.rs
+++ b/cedar-policy-validator/src/typecheck/test_extensions.rs
@@ -49,6 +49,7 @@ fn ip_extension_typecheck_fails() {
             Expr::val(3),
             Type::primitive_string(),
             Type::primitive_long(),
+            None,
         )],
     );
     let expr = Expr::from_str("ip(\"foo\")").expect("parsing should succeed");
@@ -74,6 +75,7 @@ fn ip_extension_typecheck_fails() {
             Expr::val(3),
             Type::extension(ipaddr_name),
             Type::primitive_long(),
+            None,
         )],
     );
 }
@@ -112,6 +114,7 @@ fn decimal_extension_typecheck_fails() {
             Expr::val(3),
             Type::primitive_string(),
             Type::primitive_long(),
+            None,
         )],
     );
     let expr = Expr::from_str("decimal(\"foo\")").expect("parsing should succeed");
@@ -137,6 +140,7 @@ fn decimal_extension_typecheck_fails() {
             Expr::val(3),
             Type::extension(decimal_name),
             Type::primitive_long(),
+            None,
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -139,6 +139,7 @@ fn namespaced_entity_can_type_error() {
             Expr::from_str(r#"N::S::Foo::"alice""#).expect("Expr should parse."),
             Type::primitive_long(),
             Type::named_entity_reference_from_str("N::S::Foo"),
+            None,
         )],
     );
 }
@@ -498,6 +499,7 @@ fn namespaced_entity_is_wrong_type_and() {
             Expr::val(r#"N::S::Foo::"alice""#.parse::<EntityUID>().expect("EUID should parse.")),
             Type::primitive_boolean(),
             Type::named_entity_reference_from_str("N::S::Foo"),
+            None,
         )],
     );
 }
@@ -520,6 +522,7 @@ fn namespaced_entity_is_wrong_type_when() {
             Expr::val(r#"N::S::Foo::"alice""#.parse::<EntityUID>().expect("EUID should parse.")),
             Type::primitive_boolean(),
             Type::named_entity_reference_from_str("N::S::Foo"),
+            None,
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -11,6 +11,7 @@ use cedar_policy_core::{ast::StaticPolicy, parser::parse_policy};
 use crate::typecheck::test_utils::assert_expected_type_errors;
 use crate::typecheck::Typechecker;
 use crate::types::{EntityLUB, Type};
+use crate::UnexpectedTypeHelp;
 use crate::{AttributeAccess, NamespaceDefinition, TypeError, ValidationMode, ValidatorSchema};
 
 use super::test_utils::empty_schema_file;
@@ -362,6 +363,7 @@ mod fails_empty_schema {
                 Expr::val("a"),
                 Type::primitive_long(),
                 Type::primitive_string(),
+                None,
             )],
         );
         assert_typecheck_fails_empty_schema(
@@ -374,6 +376,7 @@ mod fails_empty_schema {
                 Expr::val(1),
                 Type::any_set(),
                 Type::primitive_long(),
+                None,
             )],
         );
         assert_typecheck_fails_empty_schema(
@@ -386,6 +389,7 @@ mod fails_empty_schema {
                 Expr::val(1),
                 Type::any_set(),
                 Type::primitive_long(),
+                Some(UnexpectedTypeHelp::TryUsingSingleContains),
             )],
         );
     }
@@ -402,6 +406,7 @@ mod fails_empty_schema {
                 Expr::from_str("principal.foo + 1").unwrap(),
                 Type::primitive_boolean(),
                 Type::primitive_long(),
+                None,
             )],
         )
     }
@@ -610,6 +615,7 @@ mod fail_partial_schema {
                 Expr::get_attr(Expr::var(Var::Principal), "name".into()),
                 Type::primitive_long(),
                 Type::primitive_string(),
+                None,
             )],
         );
     }

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -780,6 +780,7 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
             Expr::val(true),
             Type::primitive_long(),
             Type::True,
+            None,
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -47,7 +47,10 @@ fn assert_typechecks_strict(
     with_typechecker_from_schema(schema, |mut typechecker| {
         typechecker.mode = ValidationMode::Strict;
         let mut errs = Vec::new();
-        let answer = typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs);
+        let answer =
+            typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs, |_| {
+                None
+            });
 
         assert_eq!(errs, vec![], "Expression should not contain any errors.");
         assert_matches!(answer, crate::typecheck::TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
@@ -68,7 +71,10 @@ fn assert_strict_type_error(
     with_typechecker_from_schema(schema, |mut typechecker| {
         typechecker.mode = ValidationMode::Strict;
         let mut errs = Vec::new();
-        let answer = typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs);
+        let answer =
+            typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs, |_| {
+                None
+            });
 
         assert_eq!(
             errs.into_iter().map(|e| e.kind).collect::<Vec<_>>(),
@@ -157,6 +163,7 @@ fn strict_typecheck_catches_regular_type_error() {
                 &Expr::from_str("1 + false").unwrap(),
                 Type::primitive_long(),
                 &mut errs,
+                |_| None,
             );
 
             assert!(errs.len() == 1);

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -34,15 +34,20 @@ use crate::{
     schema::ACTION_ENTITY_TYPE,
     type_error::TypeError,
     types::{EffectSet, OpenTag, RequestEnv, Type},
-    NamespaceDefinition, ValidationMode, ValidatorSchema,
+    NamespaceDefinition, UnexpectedTypeHelp, ValidationMode, ValidatorSchema,
 };
 
 impl TypeError {
     /// Testing utility for an unexpected type error when exactly one type was
     /// expected.
     #[cfg(test)]
-    pub(crate) fn expected_type(on_expr: Expr, expected: Type, actual: Type) -> Self {
-        TypeError::expected_one_of_types(on_expr, vec![expected], actual)
+    pub(crate) fn expected_type(
+        on_expr: Expr,
+        expected: Type,
+        actual: Type,
+        help: Option<UnexpectedTypeHelp>,
+    ) -> Self {
+        TypeError::expected_one_of_types(on_expr, vec![expected], actual, help)
     }
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Add hints suggesting how to fix some type errors.
 - Improve parse error around invalid `is` expressions.
 - Improve parser error message when a policy includes an invalid template slot.
   The error now identifies that the policy used an invalid slot and suggests using


### PR DESCRIPTION
## Description of changes

Add help messages on to type errors where we can suggest a useful fix. For example, an error from using `in` with a non-entity on the left will suggest using `contains`, `containsAll` or `containsAny` instead.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
