### PR TITLE
Fix TinyTodo build error

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1387,8 +1387,7 @@ impl<'a> ValidationResult<'a> {
     }
 
     /// Get an iterator over the errors found by the validator.
-    pub fn validation_errors<'b>(&self) -> impl Iterator<Item = &ValidationError<'b>>
-    {
+    pub fn validation_errors<'b>(&self) -> impl Iterator<Item = &ValidationError<'b>> {
         self.validation_errors.iter()
     }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1387,12 +1387,13 @@ impl<'a> ValidationResult<'a> {
     }
 
     /// Get an iterator over the errors found by the validator.
-    pub fn validation_errors(&self) -> impl Iterator<Item = &ValidationError<'static>> {
+    pub fn validation_errors<'b>(&self) -> impl Iterator<Item = &ValidationError<'b>>
+    {
         self.validation_errors.iter()
     }
 
     /// Get an iterator over the warnings found by the validator.
-    pub fn validation_warnings(&self) -> impl Iterator<Item = &ValidationWarning<'static>> {
+    pub fn validation_warnings<'b>(&self) -> impl Iterator<Item = &ValidationWarning<'b>> {
         self.validation_warnings.iter()
     }
 
@@ -1632,9 +1633,12 @@ impl<'a> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation<'st
 /// checks are also provided through [`Validator::validate`] which provides more
 /// comprehensive error detection, but this function can be used to check for
 /// confusable strings without defining a schema.
-pub fn confusable_string_checker<'a>(
+pub fn confusable_string_checker<'a, 'b>(
     templates: impl Iterator<Item = &'a Template> + 'a,
-) -> impl Iterator<Item = ValidationWarning<'static>> + 'a {
+) -> impl Iterator<Item = ValidationWarning<'b>> + 'a
+where
+    'b: 'a,
+{
     cedar_policy_validator::confusable_string_checks(templates.map(|t| &t.ast))
         .map(std::convert::Into::into)
 }


### PR DESCRIPTION
PR #512 was not as backwards compatible as I had hoped. A function using a `'static` lifetime parameter caused some other lifetimes parameters to be inferred to be `'static` when the relevant variables did not have a static lifetime. Using a fully generic `'b` lifetime seems to solve this.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT 

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
