### PR TITLE
API for extracting values from template-linked policy

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `AsRef<str>` implementation for `PolicyId`.
+- New API `template_links` for `Policy` to retrieve the linked values for a 
+  template-linked policy. (resolving #489)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2612,6 +2612,22 @@ impl Policy {
         }
     }
 
+    /// Get the values this `Template` is linked to, expressed as a map from `SlotId` to `EntityUid`.
+    /// If this is a static policy, this will return `None`.
+    pub fn template_links(&self) -> Option<HashMap<SlotId, EntityUid>> {
+        if self.is_static() {
+            None
+        } else {
+            let wrapped_vals: HashMap<SlotId, EntityUid> = self
+                .ast
+                .env()
+                .into_iter()
+                .map(|(key, value)| (SlotId(*key), EntityUid(value.clone())))
+                .collect();
+            Some(wrapped_vals)
+        }
+    }
+
     /// Get the `Effect` (`Permit` or `Forbid`) for this instance
     pub fn effect(&self) -> Effect {
         self.ast.effect()

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -495,6 +495,41 @@ mod policy_set_tests {
     use cool_asserts::assert_matches;
 
     #[test]
+    fn template_link_lookup() {
+        let mut pset = PolicySet::new();
+        let p = Policy::parse(Some("p".into()), "permit(principal,action,resource);")
+            .expect("Failed to parse");
+        pset.add(p).expect("Failed to add");
+        let template = Template::parse(
+            Some("t".into()),
+            "permit(principal == ?principal, action, resource);",
+        )
+        .expect("Failed to parse");
+        pset.add_template(template).expect("Add failed");
+
+        let env: HashMap<SlotId, EntityUid> =
+            std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
+        pset.link(
+            PolicyId::from_str("t").unwrap(),
+            PolicyId::from_str("id").unwrap(),
+            env.clone(),
+        )
+        .expect("Failed to link");
+
+        let p0 = pset.policy(&PolicyId::from_str("p").unwrap()).unwrap();
+        let tp = pset.policy(&PolicyId::from_str("id").unwrap()).unwrap();
+
+        let env0 = p0.template_links();
+        assert_eq!(env0, None, "A normal policy should not have template links");
+        let env1 = tp.template_links();
+        assert_eq!(
+            env1,
+            Some(env),
+            "A template-linked policy's links should be stored properly"
+        );
+    }
+
+    #[test]
     fn link_conflicts() {
         let mut pset = PolicySet::new();
         let p1 = Policy::parse(Some("id".into()), "permit(principal,action,resource);")

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -519,7 +519,11 @@ mod policy_set_tests {
         let p0 = pset.policy(&PolicyId::from_str("p").unwrap()).unwrap();
         let tp = pset.policy(&PolicyId::from_str("id").unwrap()).unwrap();
 
-        assert_eq!(p0.template_links(), None, "A normal policy should not have template links");
+        assert_eq!(
+            p0.template_links(),
+            None,
+            "A normal policy should not have template links"
+        );
         assert_eq!(
             tp.template_links(),
             Some(env),

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -519,11 +519,9 @@ mod policy_set_tests {
         let p0 = pset.policy(&PolicyId::from_str("p").unwrap()).unwrap();
         let tp = pset.policy(&PolicyId::from_str("id").unwrap()).unwrap();
 
-        let env0 = p0.template_links();
-        assert_eq!(env0, None, "A normal policy should not have template links");
-        let env1 = tp.template_links();
+        assert_eq!(p0.template_links(), None, "A normal policy should not have template links");
         assert_eq!(
-            env1,
+            tp.template_links(),
             Some(env),
             "A template-linked policy's links should be stored properly"
         );


### PR DESCRIPTION
## Description of changes

Adds `Policy` API `template_links` to return the values linked in to a template-linked policy. Companion to existing API `template_id`.

## Issue #, if available

#489 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
