### PR TITLE
use downstream tinytodo build

### DIFF
--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -111,9 +111,11 @@ jobs:
              printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
              cargo build
              cargo test
-      - name: build tinytodo
+      - name: echo
         working-directory: cedar-examples/tinytodo
         run: echo "'${{ needs.get-branch-name.outputs.branch_name }}'"
+      - name: build tinytodo
+        working-directory: cedar-examples/tinytodo
         run: |
              printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
              cargo build

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -121,7 +121,7 @@ jobs:
 
   build-tiny-todo:
     needs: get-branch-name
-    uses: cedar-policy/cedar-examples/.github/workflows/build_tiny_todo_reusable.yml@${{ needs.get-branch-name.outputs.branch_name }}
+    uses: cedar-policy/cedar-examples/.github/workflows/build_tiny_todo_reusable.yml@main
     with:
       cedar_policy_ref: ${{ github.head_ref }}
 

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -114,12 +114,6 @@ jobs:
       - name: echo
         working-directory: cedar-examples/tinytodo
         run: echo "'${{ needs.get-branch-name.outputs.branch_name }}'"
-      - name: build tinytodo
-        working-directory: cedar-examples/tinytodo
-        run: |
-             printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
-             cargo build
-             cargo test
 
   build-tiny-todo:
     needs: get-branch-name

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -118,3 +118,9 @@ jobs:
              cargo build
              cargo test
 
+  build-tiny-todo:
+    needs: get-branch-name
+    uses: cedar-policy/cedar-examples/.github/workflows/build_tiny_todo_reusable.yml@${{ needs.get-branch-name.outputs.branch_name }}
+    with:
+      cedar_policy_ref: ${{ github.head_ref }}
+

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -113,6 +113,7 @@ jobs:
              cargo test
       - name: build tinytodo
         working-directory: cedar-examples/tinytodo
+        run: echo "'${{ needs.get-branch-name.outputs.branch_name }}'"
         run: |
              printf "\npath = \"../cedar/cedar-policy\"" >> Cargo.toml
              cargo build


### PR DESCRIPTION
## Description of changes
use downstream tinytodo build

## Issue #, if available
https://github.com/cedar-policy/cedar/issues/488

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
