### PR TITLE
refactor to remove possibility of panic in `Context::empty()`

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -193,10 +193,9 @@ impl Context {
     //
     // INVARIANT(ContextRecord): via invariant on `Self::from_pairs`
     pub fn empty() -> Self {
-        // PANIC SAFETY: empty set of keys cannot contain a duplicate key
-        #[allow(clippy::expect_used)]
-        Self::from_pairs([], Extensions::none())
-            .expect("empty set of keys cannot contain a duplicate key")
+        Self {
+            context: PartialValue::Value(Value::empty_record()).into(),
+        }
     }
 
     /// Create a `Context` from a `RestrictedExpr`, which must be a `Record`.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `AsRef<str>` implementation for `PolicyId`.
-- New API `template_links` for `Policy` to retrieve the linked values for a 
+- New API `template_links` for `Policy` to retrieve the linked values for a
   template-linked policy. (resolving #489)
 
 ### Changed
@@ -38,6 +38,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For the `partial-eval` experimental feature: make the return values of
   `RequestBuilder`'s `principal`, `action`, `resource`, `context` and
   `schema` functions `#[must_use]`.
+
+### Fixed
+
+- Possible panic (when stack size limit reached) in `Context::empty()` (#524,
+  fixed by #526)
 
 ## [3.0.0] - 2023-12-15
 Cedar Language Version: 3.0.0


### PR DESCRIPTION
## Description of changes

This refactor avoids a possible panic in `Context::empty()`.  The PANIC SAFETY comment didn't account for the possibility of a `RecursionLimit` error, leading to #524. 

## Issue #, if available

Fixes #524 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
