### PR TITLE
Improve a couple doc strings

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1707,7 +1707,7 @@ impl<'a> Diagnostic for ValidationWarning<'a> {
     }
 }
 
-/// Unique identifier portion of the [`EntityUid`] type.
+/// Identifier portion of the [`EntityUid`] type.
 ///
 /// An `EntityId` can can be constructed using [`EntityId::from_str`] or by
 /// calling `parse()` on a string. This implementation is `Infallible`, so the
@@ -1744,7 +1744,7 @@ impl std::fmt::Display for EntityId {
     }
 }
 
-/// Represents a concatenation of Namespaces and `TypeName`.
+/// Represents an entity type name. Consists of a namespace and the type name.
 ///
 /// An `EntityTypeName` can can be constructed using
 /// [`EntityTypeName::from_str`] or by calling `parse()` on a string. Unlike
@@ -1817,7 +1817,7 @@ impl std::fmt::Display for EntityTypeName {
     }
 }
 
-/// Represents an namespace.
+/// Represents a namespace.
 ///
 /// An `EntityNamespace` can can be constructed using
 /// [`EntityNamespace::from_str`] or by calling `parse()` on a string.
@@ -1847,7 +1847,7 @@ impl std::fmt::Display for EntityNamespace {
     }
 }
 
-/// Unique Id for an entity, such as `User::"alice"`.
+/// Unique id for an entity, such as `User::"alice"`.
 ///
 /// An `EntityUid` contains an [`EntityTypeName`] and [`EntityId`]. It can
 /// be constructed from these components using
@@ -2689,7 +2689,7 @@ impl TemplateResourceConstraint {
     }
 }
 
-/// Unique Ids assigned to policies and templates.
+/// Unique ids assigned to policies and templates.
 ///
 /// A `PolicyId` can can be constructed using [`PolicyId::from_str`] or by
 /// calling `parse()` on a string. This currently always returns `Ok()`.
@@ -3395,14 +3395,14 @@ impl<'a> RequestBuilder<'a> {
     }
 }
 
-/// Represents an authorization request tuple  asking the question, "Can this
-/// principal take this action on this resource in this context?"
-///
 /// An authorization request is a tuple `<P, A, R, C>` where
 /// * P is the principal [`EntityUid`],
 /// * A is the action [`EntityUid`] ,
 /// * R is the resource [`EntityUid`], and
 /// * C is the request [`Context`] record.
+///
+/// It represents an authorization request asking the question, "Can this
+/// principal take this action on this resource in this context?"
 #[repr(transparent)]
 #[derive(Debug, RefCast)]
 pub struct Request(pub(crate) ast::Request);

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1754,8 +1754,9 @@ impl std::fmt::Display for EntityId {
 /// ```
 /// # use cedar_policy::EntityTypeName;
 /// let id : Result<EntityTypeName, _> = "Namespace::Type".parse();
-/// # assert_eq!(id.unwrap().basename(), "Type");
-/// # assert_eq!(id.unwrap().namespace(), "Namespace");
+/// # let id = id.unwrap();
+/// # assert_eq!(id.basename(), "Type");
+/// # assert_eq!(id.namespace(), "Namespace");
 /// ```
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1716,6 +1716,7 @@ impl<'a> Diagnostic for ValidationWarning<'a> {
 /// ```
 /// # use cedar_policy::EntityId;
 /// let id : EntityId = "my-id".parse().unwrap_or_else(|never| match never {});
+/// # assert_eq!(id.as_ref(), "my-id");
 /// ```
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
@@ -1752,7 +1753,9 @@ impl std::fmt::Display for EntityId {
 ///
 /// ```
 /// # use cedar_policy::EntityTypeName;
-/// let id : Result<EntityTypeName, _> = "MyType".parse();
+/// let id : Result<EntityTypeName, _> = "Namespace::Type".parse();
+/// # assert_eq!(id.unwrap().basename(), "Type");
+/// # assert_eq!(id.unwrap().namespace(), "Namespace");
 /// ```
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
@@ -1813,12 +1816,22 @@ impl std::fmt::Display for EntityTypeName {
     }
 }
 
-/// Represents a namespace
+/// Represents an namespace.
+///
+/// An `EntityNamespace` can can be constructed using
+/// [`EntityNamespace::from_str`] or by calling `parse()` on a string.
+/// _This can fail_, so it is important to properly handle an `Err` result.
+///
+/// ```
+/// # use cedar_policy::EntityNamespace;
+/// let id : Result<EntityNamespace, _> = "My::Name::Space".parse();
+/// # assert_eq!(id.unwrap().to_string(), "My::Name::Space".to_string());
+/// ```
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EntityNamespace(ast::Name);
 
-// This FromStr implementation requires the _normalized_ representation of the
-// namespace. See https://github.com/cedar-policy/rfcs/pull/9/.
+/// This FromStr implementation requires the _normalized_ representation of the
+/// namespace. See https://github.com/cedar-policy/rfcs/pull/9/.
 impl FromStr for EntityNamespace {
     type Err = ParseErrors;
 
@@ -2683,6 +2696,7 @@ impl TemplateResourceConstraint {
 /// ```
 /// # use cedar_policy::PolicyId;
 /// let id : PolicyId = "my-id".parse().unwrap();
+/// # assert_eq!(id.as_ref(), "my-id");
 /// ```
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, RefCast)]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1831,7 +1831,7 @@ impl std::fmt::Display for EntityTypeName {
 pub struct EntityNamespace(ast::Name);
 
 /// This FromStr implementation requires the _normalized_ representation of the
-/// namespace. See https://github.com/cedar-policy/rfcs/pull/9/.
+/// namespace. See <https://github.com/cedar-policy/rfcs/pull/9/>.
 impl FromStr for EntityNamespace {
     type Err = ParseErrors;
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3397,7 +3397,7 @@ impl<'a> RequestBuilder<'a> {
 
 /// An authorization request is a tuple `<P, A, R, C>` where
 /// * P is the principal [`EntityUid`],
-/// * A is the action [`EntityUid`] ,
+/// * A is the action [`EntityUid`],
 /// * R is the resource [`EntityUid`], and
 /// * C is the request [`Context`] record.
 ///

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1801,8 +1801,8 @@ impl EntityTypeName {
     }
 }
 
-// This FromStr implementation requires the _normalized_ representation of the
-// type name. See https://github.com/cedar-policy/rfcs/pull/9/.
+/// This `FromStr` implementation requires the _normalized_ representation of the
+/// type name. See <https://github.com/cedar-policy/rfcs/pull/9/>.
 impl FromStr for EntityTypeName {
     type Err = ParseErrors;
 
@@ -1831,7 +1831,7 @@ impl std::fmt::Display for EntityTypeName {
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EntityNamespace(ast::Name);
 
-/// This FromStr implementation requires the _normalized_ representation of the
+/// This `FromStr` implementation requires the _normalized_ representation of the
 /// namespace. See <https://github.com/cedar-policy/rfcs/pull/9/>.
 impl FromStr for EntityNamespace {
     type Err = ParseErrors;


### PR DESCRIPTION
## Description of changes

When reading the docs it's not immediately obvious to me that `PolicyId` (for example) should be constructed using `.parse()` since the `FromStr` impl is buried in a long list of trait implementations. This PR adds top level comments for this and similar structs describing how they can be constructed.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
