### PR TITLE
Re-enable clippy

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -19,7 +19,7 @@ jobs:
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - run: cargo doc --all-features --no-deps
       # Clippy is configured by `.cargo/config.toml` to deny on lints like
-      # `unwrap_used`. The aren't detected by `panic_safety.sh` which only
+      # `unwrap_used`. They aren't detected by `panic_safety.sh` which only
       # looks for comments where we've added an `allow` directive for clippy.
       - run: cargo clippy --all-features
       - run: cargo test --verbose --features "experimental"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,6 +18,10 @@ jobs:
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose --features "experimental"
       - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
       - run: cargo doc --all-features --no-deps
+      # Clippy is configured by `.cargo/config.toml` to deny on lints like
+      # `unwrap_used`. The aren't detected by `panic_safety.sh` which only
+      # looks for comments where we've added an `allow` directive for clippy.
+      - run: cargo clippy --all-features
       - run: cargo test --verbose --features "experimental"
       - run: cargo test --verbose
       - run: cargo test --verbose --no-default-features


### PR DESCRIPTION
## Description of changes

When discussing #498 we forgot that clippy was responsible for denying `unwrap()` expressions. Re-enable clippy in CI so that it will continue to detect these. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
