### PR TITLE
Tweak `build_and_test.yml` for slightly faster build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -10,23 +10,59 @@ jobs:
       matrix:
         toolchain:
           - stable
+
+    # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
+    # doesn't trigger a fresh build.
+    env:
+      RUSTFLAGS:'-D warnings -F unsafe-code'
+
     steps:
       - uses: actions/checkout@v3
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: ./panic_safety.sh
-      - run: cargo fmt --all --check
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --all-features --verbose
       - run: cargo doc --all-features --no-deps
+
+      # All targets are run with the same `RUSTFLAGS
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+      - run: cargo test --verbose -- --ignored
+      - run: cargo bench --no-run --profile=dev
+      - run: cargo test --verbose --no-default-features
+      - run: cargo build --verbose --features "experimental"
+      - run: cargo test --verbose --features "experimental"
+      - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
+
+  # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
+  # don't effect it. As a side effect, this will run in parallel, saving some
+  # time.
+  clippy:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       # Clippy is configured by `.cargo/config.toml` to deny on lints like
       # `unwrap_used`. They aren't detected by `panic_safety.sh` which only
       # looks for comments where we've added an `allow` directive for clippy.
       - run: cargo clippy --all-features
-      - run: cargo test --verbose
-      - run: cargo test --verbose -- --ignored
-      - run: cargo bench --no-run --profile=dev
-      - run: cargo test --verbose --features "experimental"
-      - run: cargo test --verbose --no-default-features
-      - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
+
+  # Run `cargo fmt` independently so that tests are executed even if you forgot
+  # to format before pushing.
+  format:
+    runs-on: ubuntu-latest
+     strategy:
+       matrix:
+         toolchain:
+           - stable
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo fmt --all --check
 
   cargo-deny:
     name: cargo deny

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,18 +15,17 @@ jobs:
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: ./panic_safety.sh
       - run: cargo fmt --all --check
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose --features "experimental"
-      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --verbose
+      - run: RUSTFLAGS="-D warnings -F unsafe-code" cargo build --all-features --verbose
       - run: cargo doc --all-features --no-deps
       # Clippy is configured by `.cargo/config.toml` to deny on lints like
       # `unwrap_used`. They aren't detected by `panic_safety.sh` which only
       # looks for comments where we've added an `allow` directive for clippy.
       - run: cargo clippy --all-features
-      - run: cargo test --verbose --features "experimental"
       - run: cargo test --verbose
-      - run: cargo test --verbose --no-default-features
       - run: cargo test --verbose -- --ignored
-      - run: cargo bench --no-run
+      - run: cargo bench --no-run --profile=dev
+      - run: cargo test --verbose --features "experimental"
+      - run: cargo test --verbose --no-default-features
       - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
 
   cargo-deny:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS:'-D warnings -F unsafe-code'
+      RUSTFLAGS: '-D warnings -F unsafe-code'
 
     steps:
       - uses: actions/checkout@v3
@@ -54,10 +54,10 @@ jobs:
   # to format before pushing.
   format:
     runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         toolchain:
-           - stable
+    strategy:
+      matrix:
+        toolchain:
+          - stable
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Description of changes

* Do the `RUSTFLAGS="-D warnings -F unsafe-code"` build once for `--all-features`. AFAIK there's no reason to do it separately for different feature combinations.
* Reorganize test runs so that all default feature test come before other features, avoiding partial rebuilds.
* Do `cargo bench --no-run` with `--profile=dev` to avoid rebuilding the library in release profile. We just care that the bench code compiles.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
- [ ] 
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
