### PR TITLE
Fix for #285

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -166,9 +166,7 @@ impl Entities {
             // `Schema`
             let checker = EntitySchemaConformanceChecker::new(schema, extensions);
             for entity in entity_map.values() {
-                let uid = entity.uid();
-                let etype = uid.entity_type();
-                if !etype.is_action() {
+                if !entity.uid().entity_type().is_action() {
                     checker.validate_entity(entity)?;
                 }
             }
@@ -186,13 +184,11 @@ impl Entities {
         // conformance with the schema and add action entities to the store.
         // This is fine to do after TC because the action hierarchy in the
         // schema already satisfies TC, and action and non-action entities
-        // will never be in the same hierarchy.
+        // can never be in the same hierarchy when using schema-based parsing.
         if let Some(schema) = schema {
             let checker = EntitySchemaConformanceChecker::new(schema, extensions);
             for entity in entity_map.values() {
-                let uid = entity.uid();
-                let etype = uid.entity_type();
-                if etype.is_action() {
+                if entity.uid().entity_type().is_action() {
                     checker.validate_entity(entity)?;
                 }
             }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Action entities in the store will pass schema-based validation without requiring
+  the transitive closure to be pre-computed. (#581, resolving #285)
+
 ## [3.0.1] - 2023-12-21
 Cedar Language Version: 3.0.0
 


### PR DESCRIPTION
## Description of changes

Reordered schema-based parsing code so that action entities are check _after_ TC computation instead of before. See code comments for why (I think) this is ok.

## Issue #, if available

#285 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
