### PR TITLE
Added `PolicyId::new()`

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2691,17 +2691,24 @@ impl TemplateResourceConstraint {
 
 /// Unique ids assigned to policies and templates.
 ///
-/// A `PolicyId` can can be constructed using [`PolicyId::from_str`] or by
+/// A [`PolicyId`] can can be constructed using [`PolicyId::from_str`] or by
 /// calling `parse()` on a string. This currently always returns `Ok()`.
 ///
 /// ```
 /// # use cedar_policy::PolicyId;
-/// let id : PolicyId = "my-id".parse().unwrap();
+/// let id = PolicyId::new("my-id");
 /// # assert_eq!(id.as_ref(), "my-id");
 /// ```
 #[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, RefCast)]
 pub struct PolicyId(ast::PolicyID);
+
+impl PolicyId {
+    /// Construct a [`PolicyId`] from a source string
+    pub fn new(id: impl AsRef<str>) -> Self {
+        Self(ast::PolicyID::from_string(id.as_ref()))
+    }
+}
 
 impl FromStr for PolicyId {
     type Err = ParseErrors;


### PR DESCRIPTION
## Description of changes
Adds `PolicyId::new()`, a total function for constructing policy ids.
I will file a separate PR that moves the `FromStr` implementation to use `Infallible`, but that's a breaking change so wanted it separable.
## Issue #, if available
551
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).


I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
