### PR TITLE
Moved (PolicyId as FromStr)::Err to `Infallible`

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -696,12 +696,12 @@ fn link_inner(args: &LinkArgs) -> Result<()> {
     let mut policies = args.policies.get_policy_set()?;
     let slotenv = create_slot_env(&args.arguments.data)?;
     policies.link(
-        PolicyId::from_str(&args.template_id)?,
-        PolicyId::from_str(&args.new_id)?,
+        PolicyId::new(&args.template_id),
+        PolicyId::new(&args.new_id),
         slotenv,
     )?;
     let linked = policies
-        .policy(&PolicyId::from_str(&args.new_id)?)
+        .policy(&PolicyId::new(&args.new_id))
         .ok_or_else(|| miette!("Failed to add template-linked policy"))?;
     println!("Template Linked Policy Added: {linked}");
     let linked = TemplateLinked {
@@ -775,8 +775,8 @@ fn add_template_links_to_set(path: impl AsRef<Path>, policy_set: &mut PolicySet)
     for template_linked in load_liked_file(path)? {
         let slot_env = create_slot_env(&template_linked.args)?;
         policy_set.link(
-            PolicyId::from_str(&template_linked.template_id)?,
-            PolicyId::from_str(&template_linked.link_id)?,
+            PolicyId::new(&template_linked.template_id),
+            PolicyId::new(&template_linked.link_id),
             slot_env,
         )?;
     }
@@ -911,7 +911,7 @@ fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet> {
         Some(anno) => anno.parse().map(|a| t.new_id(a)),
     });
     for t in t_iter {
-        let template = t.wrap_err("failed to parse policy id annotation")?;
+        let template = t.unwrap_or_else(|never| match never {});
         new_ps
             .add_template(template)
             .wrap_err("failed to add template to policy set")?;
@@ -921,7 +921,7 @@ fn rename_from_id_annotation(ps: PolicySet) -> Result<PolicySet> {
         Some(anno) => anno.parse().map(|a| p.new_id(a)),
     });
     for p in p_iter {
-        let policy = p.wrap_err("failed to parse policy id annotation")?;
+        let policy = p.unwrap_or_else(|never| match never {});
         new_ps
             .add(policy)
             .wrap_err("failed to add template to policy set")?;

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Moved `(PolicyId as FromStr)::Err` to `Infallible` (#588 resolving #551)
 - Add hints suggesting how to fix some type errors. (#513)
 - The `ValidationResult` returned from `Validator::validate` now has a static
   lifetime, allowing it to be used in more contexts. The lifetime parameter

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2692,8 +2692,9 @@ impl TemplateResourceConstraint {
 /// Unique ids assigned to policies and templates.
 ///
 /// A [`PolicyId`] can can be constructed using [`PolicyId::from_str`] or by
-/// calling `parse()` on a string. This currently always returns `Ok()`.
-///
+/// calling `parse()` on a string.
+/// This implementation is [`Infallible`], so the parsed [`EntityId`] can be extracted safely.
+/// Examples:
 /// ```
 /// # use cedar_policy::PolicyId;
 /// let id = PolicyId::new("my-id");

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2697,6 +2697,7 @@ impl TemplateResourceConstraint {
 /// ```
 /// # use cedar_policy::PolicyId;
 /// let id = PolicyId::new("my-id");
+/// let id : PolicyId = "my-id".parse().unwrap_or_else(|never| match never {});
 /// # assert_eq!(id.as_ref(), "my-id");
 /// ```
 #[repr(transparent)]
@@ -2711,7 +2712,7 @@ impl PolicyId {
 }
 
 impl FromStr for PolicyId {
-    type Err = ParseErrors;
+    type Err = Infallible;
 
     /// Create a `PolicyId` from a string. Currently always returns `Ok()`.
     fn from_str(id: &str) -> Result<Self, Self::Err> {

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -24,8 +24,8 @@ use crate::api::EntityTypeName;
 use crate::api::PartialResponse;
 use crate::PolicyId;
 use crate::{
-    Authorizer, Context, Decision, Entities, EntityUid, ParseErrors, Policy, PolicySet, Request,
-    Response, Schema, SlotId, Template,
+    Authorizer, Context, Decision, Entities, EntityUid, Policy, PolicySet, Request, Response,
+    Schema, SlotId, Template,
 };
 use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 use itertools::Itertools;
@@ -496,11 +496,7 @@ fn parse_instantiations(
     let template_id = PolicyId::from_str(instantiation.template_id.as_str());
     let instance_id = PolicyId::from_str(instantiation.result_policy_id.as_str());
     match (template_id, instance_id) {
-        (Ok(_), Err(e)) | (Err(e), Ok(_)) => Err(e.errors_as_strings()),
-        (Err(mut e1), Err(mut e2)) => {
-            e1.0.append(&mut e2.0);
-            Err(ParseErrors(e1.0).errors_as_strings())
-        }
+        (Err(never), _) | (_, Err(never)) => match never {},
         (Ok(template_id), Ok(instance_id)) => {
             let mut vals = HashMap::new();
             for i in instantiation.instantiations.0 {


### PR DESCRIPTION
## Description of changes
Moves the `FromStr` impl for `PolicyId` to be `Infallible`, since it never returns an Error.
## Issue #, if available
551
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
