### PR TITLE
Update integration tests to store id of erroring policies

### DIFF
--- a/cedar-integration-tests/corpus_tests/001da0d96e1d1296182b6818ba28cf8603a22ae3.json
+++ b/cedar-integration-tests/corpus_tests/001da0d96e1d1296182b6818ba28cf8603a22ae3.json
@@ -24,7 +24,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -70,7 +70,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -116,7 +116,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -139,7 +139,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -162,7 +162,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -185,7 +185,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/005b19a44b16074bb1322d9d25512abfe121daff.json
+++ b/cedar-integration-tests/corpus_tests/005b19a44b16074bb1322d9d25512abfe121daff.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/01a2a267879d14f88be8deb00f1ad2c8bc504daf.json
+++ b/cedar-integration-tests/corpus_tests/01a2a267879d14f88be8deb00f1ad2c8bc504daf.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/021d24aa9ce1072ccc65dddfcd8b1a7e375787a6.json
+++ b/cedar-integration-tests/corpus_tests/021d24aa9ce1072ccc65dddfcd8b1a7e375787a6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0241a89fbf150dd7b0577a17c0e4ab3d89e59b34.json
+++ b/cedar-integration-tests/corpus_tests/0241a89fbf150dd7b0577a17c0e4ab3d89e59b34.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/027083f3b76fbddceb11ebd87326cc2d9bc5a6aa.json
+++ b/cedar-integration-tests/corpus_tests/027083f3b76fbddceb11ebd87326cc2d9bc5a6aa.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/02a49223197987f55c4eb3a434db07b1d23a377a.json
+++ b/cedar-integration-tests/corpus_tests/02a49223197987f55c4eb3a434db07b1d23a377a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `l::l::A::r`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/02ffc16957f384b0168838937ca001e56f6b2eb6.json
+++ b/cedar-integration-tests/corpus_tests/02ffc16957f384b0168838937ca001e56f6b2eb6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/030831a33c04c85f8cf1efe16875826a19fc5cc5.json
+++ b/cedar-integration-tests/corpus_tests/030831a33c04c85f8cf1efe16875826a19fc5cc5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/03628ca780763f86b2c24cfdbd7a98bc0df23e2d.json
+++ b/cedar-integration-tests/corpus_tests/03628ca780763f86b2c24cfdbd7a98bc0df23e2d.json
@@ -60,7 +60,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/03bd38f3357bc4079ecf1dc9fff65f6c695727fd.json
+++ b/cedar-integration-tests/corpus_tests/03bd38f3357bc4079ecf1dc9fff65f6c695727fd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/046c5a37b575d3dbabeaae9997b2f94c42061491.json
+++ b/cedar-integration-tests/corpus_tests/046c5a37b575d3dbabeaae9997b2f94c42061491.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::D::Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/04ab8774dce503da2421cd6d038f69c5601734bc.json
+++ b/cedar-integration-tests/corpus_tests/04ab8774dce503da2421cd6d038f69c5601734bc.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/05ced0c2a3b26e996cd9857050b5cb568f3c55a4.json
+++ b/cedar-integration-tests/corpus_tests/05ced0c2a3b26e996cd9857050b5cb568f3c55a4.json
@@ -60,7 +60,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0642ad216c4c962428c4e1f6f94a1db8247af415.json
+++ b/cedar-integration-tests/corpus_tests/0642ad216c4c962428c4e1f6f94a1db8247af415.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/06d021d379ba0cc92ffbb243a9024b20a9dac326.json
+++ b/cedar-integration-tests/corpus_tests/06d021d379ba0cc92ffbb243a9024b20a9dac326.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/06e93ed14b5d21cc49f2e9e5ec072467bb247284.json
+++ b/cedar-integration-tests/corpus_tests/06e93ed14b5d21cc49f2e9e5ec072467bb247284.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/07c8a8cfabada6bb90447010829e8e73fc84580d.json
+++ b/cedar-integration-tests/corpus_tests/07c8a8cfabada6bb90447010829e8e73fc84580d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0821f9d8ec765af8242685b3dce67d7b4f358ec2.json
+++ b/cedar-integration-tests/corpus_tests/0821f9d8ec765af8242685b3dce67d7b4f358ec2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0838cceb544b3bfcb7069ef1840a5147c926c4d6.json
+++ b/cedar-integration-tests/corpus_tests/0838cceb544b3bfcb7069ef1840a5147c926c4d6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/08500c1c65e96341b3eef33c68658af8078fd824.json
+++ b/cedar-integration-tests/corpus_tests/08500c1c65e96341b3eef33c68658af8078fd824.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhh`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/08b97eac230b3d3f0877670ac672eaeff6b040b0.json
+++ b/cedar-integration-tests/corpus_tests/08b97eac230b3d3f0877670ac672eaeff6b040b0.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -100,7 +100,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -121,7 +121,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -142,7 +142,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -163,7 +163,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/098ba12b4f5c65c43dd6f6ec2ba0e59642149b25.json
+++ b/cedar-integration-tests/corpus_tests/098ba12b4f5c65c43dd6f6ec2ba0e59642149b25.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0ad7f53251425c9d8f3f0bcb9ececdfbe65fbaac.json
+++ b/cedar-integration-tests/corpus_tests/0ad7f53251425c9d8f3f0bcb9ececdfbe65fbaac.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0c0777cdd6151d7e1f444ff3ac045d45e99de86f.json
+++ b/cedar-integration-tests/corpus_tests/0c0777cdd6151d7e1f444ff3ac045d45e99de86f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0c367b79cc920e0feaf83ea234081b5ed3e76fa5.json
+++ b/cedar-integration-tests/corpus_tests/0c367b79cc920e0feaf83ea234081b5ed3e76fa5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0c504a6e9b059221d5f7cadc7c33b075f40fa27c.json
+++ b/cedar-integration-tests/corpus_tests/0c504a6e9b059221d5f7cadc7c33b075f40fa27c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/0ef8dad0b5a647ae0a7c1dd48d2bfb403009d4eb.json
+++ b/cedar-integration-tests/corpus_tests/0ef8dad0b5a647ae0a7c1dd48d2bfb403009d4eb.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0f662f9123a3f835c7dc1004515f79b1609d2e58.json
+++ b/cedar-integration-tests/corpus_tests/0f662f9123a3f835c7dc1004515f79b1609d2e58.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0f6bd61ae5a54f7abc1890148c6f5b9c389afef8.json
+++ b/cedar-integration-tests/corpus_tests/0f6bd61ae5a54f7abc1890148c6f5b9c389afef8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0f77f6c224018df9fc00f3068dc4a4cb198b78e1.json
+++ b/cedar-integration-tests/corpus_tests/0f77f6c224018df9fc00f3068dc4a4cb198b78e1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/0ff6d747c763a5a1c6266cb4a4e7ae80cc8d6234.json
+++ b/cedar-integration-tests/corpus_tests/0ff6d747c763a5a1c6266cb4a4e7ae80cc8d6234.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/106c7942e09695b70e209e67e8df5655de990003.json
+++ b/cedar-integration-tests/corpus_tests/106c7942e09695b70e209e67e8df5655de990003.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/107926a401aafb1e4f5723ba817fd79792b4541b.json
+++ b/cedar-integration-tests/corpus_tests/107926a401aafb1e4f5723ba817fd79792b4541b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/10aea06c714dbebcb199fd92684892b0df616040.json
+++ b/cedar-integration-tests/corpus_tests/10aea06c714dbebcb199fd92684892b0df616040.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/10fcd998b35b276ab130e82d0b618ed9ee17c343.json
+++ b/cedar-integration-tests/corpus_tests/10fcd998b35b276ab130e82d0b618ed9ee17c343.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/1122b4b025e0ef19724f6d8589d0786227300bb0.json
+++ b/cedar-integration-tests/corpus_tests/1122b4b025e0ef19724f6d8589d0786227300bb0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/11e63c6e406ca8e5bd9d4957af1c32cb531a23e6.json
+++ b/cedar-integration-tests/corpus_tests/11e63c6e406ca8e5bd9d4957af1c32cb531a23e6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/13080c2b5bf30ca368724495c797a520d073aa45.json
+++ b/cedar-integration-tests/corpus_tests/13080c2b5bf30ca368724495c797a520d073aa45.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/138f76b366b2306738303807e1936a89f7f2762b.json
+++ b/cedar-integration-tests/corpus_tests/138f76b366b2306738303807e1936a89f7f2762b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1394e48d6330fa784673907ee1460d41a4e2659b.json
+++ b/cedar-integration-tests/corpus_tests/1394e48d6330fa784673907ee1460d41a4e2659b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A97w::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/13c95d614c44c554c6f335fd59c6e95cbd0ad9cc.json
+++ b/cedar-integration-tests/corpus_tests/13c95d614c44c554c6f335fd59c6e95cbd0ad9cc.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/14b98c1a51be833bbaf6cb341851e2ff30a8223b.json
+++ b/cedar-integration-tests/corpus_tests/14b98c1a51be833bbaf6cb341851e2ff30a8223b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/14baa465818b2da2f72d88d491dbbb20d0fe58bb.json
+++ b/cedar-integration-tests/corpus_tests/14baa465818b2da2f72d88d491dbbb20d0fe58bb.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/14c24424e78073eb033bd799898f71cd5d022b0d.json
+++ b/cedar-integration-tests/corpus_tests/14c24424e78073eb033bd799898f71cd5d022b0d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/14e83b8120617ff2c6781d31c8c787af29d10bd7.json
+++ b/cedar-integration-tests/corpus_tests/14e83b8120617ff2c6781d31c8c787af29d10bd7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `y`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/15343f50af0a75480ffdaceaf71b379e1d66df18.json
+++ b/cedar-integration-tests/corpus_tests/15343f50af0a75480ffdaceaf71b379e1d66df18.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/15563f0ff844401488c49316ba8cb82f870c3caa.json
+++ b/cedar-integration-tests/corpus_tests/15563f0ff844401488c49316ba8cb82f870c3caa.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1571103f55b41633bd2465963f25a783b98d46ac.json
+++ b/cedar-integration-tests/corpus_tests/1571103f55b41633bd2465963f25a783b98d46ac.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16124eb0d0d15e8d7322eaaa3eff361b4dbe506a.json
+++ b/cedar-integration-tests/corpus_tests/16124eb0d0d15e8d7322eaaa3eff361b4dbe506a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/163083371b5763682e22beff81ec7dc11208e336.json
+++ b/cedar-integration-tests/corpus_tests/163083371b5763682e22beff81ec7dc11208e336.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16837047727ca7d0c2d7ce7be3a30d78e25c1313.json
+++ b/cedar-integration-tests/corpus_tests/16837047727ca7d0c2d7ce7be3a30d78e25c1313.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16c049e91f396ebf938fb47fd7f0432b4db1e2b0.json
+++ b/cedar-integration-tests/corpus_tests/16c049e91f396ebf938fb47fd7f0432b4db1e2b0.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/16c992ac81a16c5bba204e9ba8e7b5b4f15f3c49.json
+++ b/cedar-integration-tests/corpus_tests/16c992ac81a16c5bba204e9ba8e7b5b4f15f3c49.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/170466057a2b0d393044c1cb000aea4a624cb320.json
+++ b/cedar-integration-tests/corpus_tests/170466057a2b0d393044c1cb000aea4a624cb320.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1744b70eb7f065316e50f3a750afbbf6e9c242ee.json
+++ b/cedar-integration-tests/corpus_tests/1744b70eb7f065316e50f3a750afbbf6e9c242ee.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/17668072f20aabadd9a184797bf67efb9c07ad98.json
+++ b/cedar-integration-tests/corpus_tests/17668072f20aabadd9a184797bf67efb9c07ad98.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/177a22b9e2eae9a5db91db8c064db7dbc4976235.json
+++ b/cedar-integration-tests/corpus_tests/177a22b9e2eae9a5db91db8c064db7dbc4976235.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/19fbe4b90f1e0114f2201dbe7bbf8e943cf7bd00.json
+++ b/cedar-integration-tests/corpus_tests/19fbe4b90f1e0114f2201dbe7bbf8e943cf7bd00.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1b03f18a65dafe6bc111ad12c0de50aa56bf5179.json
+++ b/cedar-integration-tests/corpus_tests/1b03f18a65dafe6bc111ad12c0de50aa56bf5179.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c2c15353c3261b6f53162583408aebbf8d259e8.json
+++ b/cedar-integration-tests/corpus_tests/1c2c15353c3261b6f53162583408aebbf8d259e8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c473ec0a248a595b1dde9b9a357404233b05583.json
+++ b/cedar-integration-tests/corpus_tests/1c473ec0a248a595b1dde9b9a357404233b05583.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A000::r::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c56d0ecf8bcdccadcf11f9c01742360b1f5cbfd.json
+++ b/cedar-integration-tests/corpus_tests/1c56d0ecf8bcdccadcf11f9c01742360b1f5cbfd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1c9e4a8ba9c69657e4f1a7ea2f7e52f4aa11cbde.json
+++ b/cedar-integration-tests/corpus_tests/1c9e4a8ba9c69657e4f1a7ea2f7e52f4aa11cbde.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1dbfb0d25adfd0ba48b9759273247ce82f8da3e5.json
+++ b/cedar-integration-tests/corpus_tests/1dbfb0d25adfd0ba48b9759273247ce82f8da3e5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1dc0dbcb9b9121975d3398e1e6a2893b6361cbea.json
+++ b/cedar-integration-tests/corpus_tests/1dc0dbcb9b9121975d3398e1e6a2893b6361cbea.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1e92f99bd2bca10ab16f9f78768fdd849c1f930a.json
+++ b/cedar-integration-tests/corpus_tests/1e92f99bd2bca10ab16f9f78768fdd849c1f930a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1eac86e06597f6e0416b884fc15a81bffa608603.json
+++ b/cedar-integration-tests/corpus_tests/1eac86e06597f6e0416b884fc15a81bffa608603.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1f2be35f573d7d1955f3a95af4f940cc6f4fe290.json
+++ b/cedar-integration-tests/corpus_tests/1f2be35f573d7d1955f3a95af4f940cc6f4fe290.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `n::g::F::r::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1f4f3648c4747c20ca5a99a1859e68a8feac3c1a.json
+++ b/cedar-integration-tests/corpus_tests/1f4f3648c4747c20ca5a99a1859e68a8feac3c1a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1fda47630d60a4aa8f8e54b61d736d8952c4a7f9.json
+++ b/cedar-integration-tests/corpus_tests/1fda47630d60a4aa8f8e54b61d736d8952c4a7f9.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `ZJJJ`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/1ffe07c987be353018d565e8e6efd95c7c100ef5.json
+++ b/cedar-integration-tests/corpus_tests/1ffe07c987be353018d565e8e6efd95c7c100ef5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/211dc14823e42409dac2149cd417c42a96ad49e1.json
+++ b/cedar-integration-tests/corpus_tests/211dc14823e42409dac2149cd417c42a96ad49e1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/21258d5fc152aec138c91355f29f55459971ad7a.json
+++ b/cedar-integration-tests/corpus_tests/21258d5fc152aec138c91355f29f55459971ad7a.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/228801b00e79ed2e44f08cc699ca7e766266fbf5.json
+++ b/cedar-integration-tests/corpus_tests/228801b00e79ed2e44f08cc699ca7e766266fbf5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/22b12bec5e1fe2fbc923f91bf85875f7f8a4ddc4.json
+++ b/cedar-integration-tests/corpus_tests/22b12bec5e1fe2fbc923f91bf85875f7f8a4ddc4.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/250bea468a24ef02741251907f89fe5165b1b7b5.json
+++ b/cedar-integration-tests/corpus_tests/250bea468a24ef02741251907f89fe5165b1b7b5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/26b830fd9423f8de3ddc676eaea3bc442a68fe12.json
+++ b/cedar-integration-tests/corpus_tests/26b830fd9423f8de3ddc676eaea3bc442a68fe12.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/272ae71ac571077560328329952bd2cc5744eafe.json
+++ b/cedar-integration-tests/corpus_tests/272ae71ac571077560328329952bd2cc5744eafe.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/2730bb0abe3e54013677dcccf7b04f96fb0be285.json
+++ b/cedar-integration-tests/corpus_tests/2730bb0abe3e54013677dcccf7b04f96fb0be285.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/274f63c71d3849f3100d4100b20c3da8832edc98.json
+++ b/cedar-integration-tests/corpus_tests/274f63c71d3849f3100d4100b20c3da8832edc98.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/28f2a33ec169a9d5d4f08602156ca79bcb9ae755.json
+++ b/cedar-integration-tests/corpus_tests/28f2a33ec169a9d5d4f08602156ca79bcb9ae755.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/294094e7c55158d15d4b8ad3a2900b44cacdd859.json
+++ b/cedar-integration-tests/corpus_tests/294094e7c55158d15d4b8ad3a2900b44cacdd859.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/298423e730f2241a57e0c47d2966eedc87ad734c.json
+++ b/cedar-integration-tests/corpus_tests/298423e730f2241a57e0c47d2966eedc87ad734c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/29a58ad3bd458097fd0a19b29f16e2435339f87f.json
+++ b/cedar-integration-tests/corpus_tests/29a58ad3bd458097fd0a19b29f16e2435339f87f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/29eaecbeb520e625e4fb499d4020a6c66db79d3d.json
+++ b/cedar-integration-tests/corpus_tests/29eaecbeb520e625e4fb499d4020a6c66db79d3d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/2adbc697e6a4307319167e11381a5264e8da8746.json
+++ b/cedar-integration-tests/corpus_tests/2adbc697e6a4307319167e11381a5264e8da8746.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/2b1fc2caecbcaf4c09a99ef3a2cc3f156112e495.json
+++ b/cedar-integration-tests/corpus_tests/2b1fc2caecbcaf4c09a99ef3a2cc3f156112e495.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/2d6dc2f9cc6324fe07bec72a98ac623cbdecfa12.json
+++ b/cedar-integration-tests/corpus_tests/2d6dc2f9cc6324fe07bec72a98ac623cbdecfa12.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/314551a580d1c09170f5fbfbdfa1339d757e36e7.json
+++ b/cedar-integration-tests/corpus_tests/314551a580d1c09170f5fbfbdfa1339d757e36e7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/315dfa7040e05eacefa4c9ad4ed26555beb7433e.json
+++ b/cedar-integration-tests/corpus_tests/315dfa7040e05eacefa4c9ad4ed26555beb7433e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3221dffdd3a1ea802e024b5dff4991ac868a2602.json
+++ b/cedar-integration-tests/corpus_tests/3221dffdd3a1ea802e024b5dff4991ac868a2602.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3277f98cc8cef0c9e1dff218f5a7ab0fdb3ba0f0.json
+++ b/cedar-integration-tests/corpus_tests/3277f98cc8cef0c9e1dff218f5a7ab0fdb3ba0f0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/328b75efdada2eb6574fb25c99286236d7da72f1.json
+++ b/cedar-integration-tests/corpus_tests/328b75efdada2eb6574fb25c99286236d7da72f1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/33089fa566a0c0200b65f768e03955cc56073945.json
+++ b/cedar-integration-tests/corpus_tests/33089fa566a0c0200b65f768e03955cc56073945.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/33c9613909304c44134d611ad69d72b474ee46e3.json
+++ b/cedar-integration-tests/corpus_tests/33c9613909304c44134d611ad69d72b474ee46e3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/33cc1dba8276b82395d85d8bff2da91103f9f272.json
+++ b/cedar-integration-tests/corpus_tests/33cc1dba8276b82395d85d8bff2da91103f9f272.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/33fd42aeebe4235b607ec620224210d394e169b6.json
+++ b/cedar-integration-tests/corpus_tests/33fd42aeebe4235b607ec620224210d394e169b6.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3499f81f5953dccba2a97c7f97f4c5fc46be27ca.json
+++ b/cedar-integration-tests/corpus_tests/3499f81f5953dccba2a97c7f97f4c5fc46be27ca.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/351318d1185cadb972352f0fd6df3a6801b6df44.json
+++ b/cedar-integration-tests/corpus_tests/351318d1185cadb972352f0fd6df3a6801b6df44.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `lbwwwQw00000000`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/352f61b4d81394cf50e3228ce1bce32da88862f5.json
+++ b/cedar-integration-tests/corpus_tests/352f61b4d81394cf50e3228ce1bce32da88862f5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3610428c0e69a6c0d117385bb428d90b87727d08.json
+++ b/cedar-integration-tests/corpus_tests/3610428c0e69a6c0d117385bb428d90b87727d08.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/36d2e49e789a6339ee9470e61ff03a3fd374b3a9.json
+++ b/cedar-integration-tests/corpus_tests/36d2e49e789a6339ee9470e61ff03a3fd374b3a9.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3741301f229f701463ccb88679111a6ee8ec5f3c.json
+++ b/cedar-integration-tests/corpus_tests/3741301f229f701463ccb88679111a6ee8ec5f3c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `FwGwwwGw`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3789f3fb4358bddc1dac1aa750ce1a17e8fed5ed.json
+++ b/cedar-integration-tests/corpus_tests/3789f3fb4358bddc1dac1aa750ce1a17e8fed5ed.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/37a4a36a832a2c109875c4482a1c757c07e7689a.json
+++ b/cedar-integration-tests/corpus_tests/37a4a36a832a2c109875c4482a1c757c07e7689a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/38d1fcf284cdf4f1c53cb41c358b757918075cc0.json
+++ b/cedar-integration-tests/corpus_tests/38d1fcf284cdf4f1c53cb41c358b757918075cc0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 0"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/39310c282d59af031138d9d5c4a34fb72ee09942.json
+++ b/cedar-integration-tests/corpus_tests/39310c282d59af031138d9d5c4a34fb72ee09942.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3b5b1e469ee9944b3481a2a17500eff50f90fa8f.json
+++ b/cedar-integration-tests/corpus_tests/3b5b1e469ee9944b3481a2a17500eff50f90fa8f.json
@@ -79,7 +79,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -100,7 +100,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -121,7 +121,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -142,7 +142,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -163,7 +163,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3b5c2e23156d25cb6edb89b64ac639cce1d65bb3.json
+++ b/cedar-integration-tests/corpus_tests/3b5c2e23156d25cb6edb89b64ac639cce1d65bb3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3bb34a1db124f10d7f5cc0a12156f7d4de1545ab.json
+++ b/cedar-integration-tests/corpus_tests/3bb34a1db124f10d7f5cc0a12156f7d4de1545ab.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3c41a82958bcbdb29cbf5f6484151423d17f73d8.json
+++ b/cedar-integration-tests/corpus_tests/3c41a82958bcbdb29cbf5f6484151423d17f73d8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3c4c1d09710a15a2e915c4be60ec4c9755322cf1.json
+++ b/cedar-integration-tests/corpus_tests/3c4c1d09710a15a2e915c4be60ec4c9755322cf1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3d7cf966b39a2e156d00c3d1bf96af90c89c0ee8.json
+++ b/cedar-integration-tests/corpus_tests/3d7cf966b39a2e156d00c3d1bf96af90c89c0ee8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3e086215db8ab6f898e05b2d9d42da7a189d69ea.json
+++ b/cedar-integration-tests/corpus_tests/3e086215db8ab6f898e05b2d9d42da7a189d69ea.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3e4d7a1c10e8f73b07964cc389aeac2a26364f36.json
+++ b/cedar-integration-tests/corpus_tests/3e4d7a1c10e8f73b07964cc389aeac2a26364f36.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3e9e94546d3cebfdefdb52c437e3a7b91a38fcca.json
+++ b/cedar-integration-tests/corpus_tests/3e9e94546d3cebfdefdb52c437e3a7b91a38fcca.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/3f7b0ffba42bc51579c020cef13dd8e226b1838c.json
+++ b/cedar-integration-tests/corpus_tests/3f7b0ffba42bc51579c020cef13dd8e226b1838c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/409414c9f886f7fc05131ff28e7e2e1fe5dc98f8.json
+++ b/cedar-integration-tests/corpus_tests/409414c9f886f7fc05131ff28e7e2e1fe5dc98f8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/41720d33fd4859c3997248e38c3c2b706cfd290d.json
+++ b/cedar-integration-tests/corpus_tests/41720d33fd4859c3997248e38c3c2b706cfd290d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/423fe689c6591ef101c51473492bd596e3d5ffce.json
+++ b/cedar-integration-tests/corpus_tests/423fe689c6591ef101c51473492bd596e3d5ffce.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/443a284848778e4b40c74fb093209b78e9eade2a.json
+++ b/cedar-integration-tests/corpus_tests/443a284848778e4b40c74fb093209b78e9eade2a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/446b4abb9c1958bbf5ba0f8f19564ab82ab9cbed.json
+++ b/cedar-integration-tests/corpus_tests/446b4abb9c1958bbf5ba0f8f19564ab82ab9cbed.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/458d087908efdf7dbdc6f52607eba655bf5fddb2.json
+++ b/cedar-integration-tests/corpus_tests/458d087908efdf7dbdc6f52607eba655bf5fddb2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/464729a46d258bcaaf394e5c69445e2c3eb2cfd7.json
+++ b/cedar-integration-tests/corpus_tests/464729a46d258bcaaf394e5c69445e2c3eb2cfd7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/46ccfc10ef864cc7f8c6e7d67036c8c1781844ad.json
+++ b/cedar-integration-tests/corpus_tests/46ccfc10ef864cc7f8c6e7d67036c8c1781844ad.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/46f466ac9e298b4a1a776d92ab79d7cb0d2a8f7c.json
+++ b/cedar-integration-tests/corpus_tests/46f466ac9e298b4a1a776d92ab79d7cb0d2a8f7c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/47735d3eab0f3053c4da1e7a75abb6d7c72281d6.json
+++ b/cedar-integration-tests/corpus_tests/47735d3eab0f3053c4da1e7a75abb6d7c72281d6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4960126cc1c3cb0023a576d6f726f19f667b4144.json
+++ b/cedar-integration-tests/corpus_tests/4960126cc1c3cb0023a576d6f726f19f667b4144.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4968fad648bcffd3a08423cb89c1886b668ed9ed.json
+++ b/cedar-integration-tests/corpus_tests/4968fad648bcffd3a08423cb89c1886b668ed9ed.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/49769b289305dae08c5fd44c2e8f9806b012993b.json
+++ b/cedar-integration-tests/corpus_tests/49769b289305dae08c5fd44c2e8f9806b012993b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/49aeadff64691c2fabe84335637947046a07af31.json
+++ b/cedar-integration-tests/corpus_tests/49aeadff64691c2fabe84335637947046a07af31.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Bsmm`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/49f2b384a40672e51691593bab92fcb170160508.json
+++ b/cedar-integration-tests/corpus_tests/49f2b384a40672e51691593bab92fcb170160508.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::A::v::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4bf1f9af8f34ec7092c461766c881f600ffb4f71.json
+++ b/cedar-integration-tests/corpus_tests/4bf1f9af8f34ec7092c461766c881f600ffb4f71.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `sqp1R111o1`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4c6237f576091e1bee1fe087fe515a0f9299cea6.json
+++ b/cedar-integration-tests/corpus_tests/4c6237f576091e1bee1fe087fe515a0f9299cea6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4d87471123d5d2fcc845ad62f0a378747d1a8a3b.json
+++ b/cedar-integration-tests/corpus_tests/4d87471123d5d2fcc845ad62f0a378747d1a8a3b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -100,7 +100,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -121,7 +121,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -142,7 +142,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -163,7 +163,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4d95dd953c772afec1afee2f596e2cbd1418eb14.json
+++ b/cedar-integration-tests/corpus_tests/4d95dd953c772afec1afee2f596e2cbd1418eb14.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4de777c4c35da461f76ed7df317c337149dce7cf.json
+++ b/cedar-integration-tests/corpus_tests/4de777c4c35da461f76ed7df317c337149dce7cf.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4ec8aedf11f25810b9188269b87398c065e56bc4.json
+++ b/cedar-integration-tests/corpus_tests/4ec8aedf11f25810b9188269b87398c065e56bc4.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/4f7c9ab77e4079e780601dea7a76263027b5ab69.json
+++ b/cedar-integration-tests/corpus_tests/4f7c9ab77e4079e780601dea7a76263027b5ab69.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Kfhhhhhh`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/510c1809882aa069966e45653f72eaa2ead38322.json
+++ b/cedar-integration-tests/corpus_tests/510c1809882aa069966e45653f72eaa2ead38322.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/51ce1fc223eb6743cb0d58410c4ccf00063b83ca.json
+++ b/cedar-integration-tests/corpus_tests/51ce1fc223eb6743cb0d58410c4ccf00063b83ca.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/525e966b4ded22f5b2de78026a3ffab45249c626.json
+++ b/cedar-integration-tests/corpus_tests/525e966b4ded22f5b2de78026a3ffab45249c626.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/53e72c4fde0d52b6941af1e722e15e03c51d13a2.json
+++ b/cedar-integration-tests/corpus_tests/53e72c4fde0d52b6941af1e722e15e03c51d13a2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/54dc49893ab1147dc7febeda5d35646d75f9279a.json
+++ b/cedar-integration-tests/corpus_tests/54dc49893ab1147dc7febeda5d35646d75f9279a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/55bf306cab4c32bfcccb9fe72bb92e6e637dba01.json
+++ b/cedar-integration-tests/corpus_tests/55bf306cab4c32bfcccb9fe72bb92e6e637dba01.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/55d14b8867ce5ed85dd8f30e97a54cd834e77627.json
+++ b/cedar-integration-tests/corpus_tests/55d14b8867ce5ed85dd8f30e97a54cd834e77627.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/55dec050f175508c8f798ba60af64e2b1e4242f8.json
+++ b/cedar-integration-tests/corpus_tests/55dec050f175508c8f798ba60af64e2b1e4242f8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/56446144b3a9f536491ff2bf056a614ae755fa00.json
+++ b/cedar-integration-tests/corpus_tests/56446144b3a9f536491ff2bf056a614ae755fa00.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/564c7b55a6b59d2d4cdffbc67edae64efe5ac1f7.json
+++ b/cedar-integration-tests/corpus_tests/564c7b55a6b59d2d4cdffbc67edae64efe5ac1f7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/56aaf321d34a8330373a5a4c21c140bd6e330cd2.json
+++ b/cedar-integration-tests/corpus_tests/56aaf321d34a8330373a5a4c21c140bd6e330cd2.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/56d4d9311bcdf16e69d505374f59e457440a8aa2.json
+++ b/cedar-integration-tests/corpus_tests/56d4d9311bcdf16e69d505374f59e457440a8aa2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: entity `A0000::\"\"` does not exist"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/575d96f86187dc6fb7ca8b3896f225b66318b7c7.json
+++ b/cedar-integration-tests/corpus_tests/575d96f86187dc6fb7ca8b3896f225b66318b7c7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/57b7cfe0e1f8f9067164d7fb9f13e8b5da276ba5.json
+++ b/cedar-integration-tests/corpus_tests/57b7cfe0e1f8f9067164d7fb9f13e8b5da276ba5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function isMulticast: expected 1, got 0"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/585652a4c05f9b6d0b92999377d7a635f409b73a.json
+++ b/cedar-integration-tests/corpus_tests/585652a4c05f9b6d0b92999377d7a635f409b73a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5957f6406f64415729cbdfb64df1aed9e55091aa.json
+++ b/cedar-integration-tests/corpus_tests/5957f6406f64415729cbdfb64df1aed9e55091aa.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5a2dc81292f0d8dbcf7f8150459c4d62dd9a7841.json
+++ b/cedar-integration-tests/corpus_tests/5a2dc81292f0d8dbcf7f8150459c4d62dd9a7841.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `q::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5b40ceb430b87a6433ab7e2ea69ee5b51243d21f.json
+++ b/cedar-integration-tests/corpus_tests/5b40ceb430b87a6433ab7e2ea69ee5b51243d21f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5b426cc601268dd506e394ef2ab467a302267409.json
+++ b/cedar-integration-tests/corpus_tests/5b426cc601268dd506e394ef2ab467a302267409.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5b53a9d55eee49d43010321b95a98f3f9a30e2db.json
+++ b/cedar-integration-tests/corpus_tests/5b53a9d55eee49d43010321b95a98f3f9a30e2db.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5c2e65275c8bebc22d36a958acbb1651fa208b11.json
+++ b/cedar-integration-tests/corpus_tests/5c2e65275c8bebc22d36a958acbb1651fa208b11.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5ca000e7f1540ba4c90f6a110288612212e12707.json
+++ b/cedar-integration-tests/corpus_tests/5ca000e7f1540ba4c90f6a110288612212e12707.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5d14d9f3cd916cbfb24b2847d264e5d26ea36026.json
+++ b/cedar-integration-tests/corpus_tests/5d14d9f3cd916cbfb24b2847d264e5d26ea36026.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5e75403e4dd3959be0326292d1070386da5a1e37.json
+++ b/cedar-integration-tests/corpus_tests/5e75403e4dd3959be0326292d1070386da5a1e37.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `lessThan`: expected 2, got 3"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5f6f43e48c3d29e6d4a95ada9734f3086e67fe80.json
+++ b/cedar-integration-tests/corpus_tests/5f6f43e48c3d29e6d4a95ada9734f3086e67fe80.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/5f8c11c34b2bf708ee41de0b188ec771a8605a46.json
+++ b/cedar-integration-tests/corpus_tests/5f8c11c34b2bf708ee41de0b188ec771a8605a46.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::A`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/604a41216284beed5afa69f4b724c92d17b36812.json
+++ b/cedar-integration-tests/corpus_tests/604a41216284beed5afa69f4b724c92d17b36812.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/60651d7140cea972984d740f037e2ff585b033f7.json
+++ b/cedar-integration-tests/corpus_tests/60651d7140cea972984d740f037e2ff585b033f7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/62216c7d61a110e80e1bae89f57424161302dd67.json
+++ b/cedar-integration-tests/corpus_tests/62216c7d61a110e80e1bae89f57424161302dd67.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/624156ac4fff56421b32744f2ac8b14b89cf642b.json
+++ b/cedar-integration-tests/corpus_tests/624156ac4fff56421b32744f2ac8b14b89cf642b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/64b6091559a40a09a53f633f18677ce292b71fcc.json
+++ b/cedar-integration-tests/corpus_tests/64b6091559a40a09a53f633f18677ce292b71fcc.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/65a41a239147613edda56c85a5fe6c8f6cfb2aa1.json
+++ b/cedar-integration-tests/corpus_tests/65a41a239147613edda56c85a5fe6c8f6cfb2aa1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/65c5f63b53b6783dbf4d4bb4e97b8a95b4c2b7ac.json
+++ b/cedar-integration-tests/corpus_tests/65c5f63b53b6783dbf4d4bb4e97b8a95b4c2b7ac.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Ruwa1u`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/65d7ad80c51c5bfa56e22a5c11073a26fa23143d.json
+++ b/cedar-integration-tests/corpus_tests/65d7ad80c51c5bfa56e22a5c11073a26fa23143d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/66a64b3581d4f1bb3143a0cc6ebf6919af364cd2.json
+++ b/cedar-integration-tests/corpus_tests/66a64b3581d4f1bb3143a0cc6ebf6919af364cd2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Dosnm00000000`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/676f9f38dc6c2d2e17c7b8055a0f46d9f05bab57.json
+++ b/cedar-integration-tests/corpus_tests/676f9f38dc6c2d2e17c7b8055a0f46d9f05bab57.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/68318f2eefc7de93d2490f6452c804087a99b619.json
+++ b/cedar-integration-tests/corpus_tests/68318f2eefc7de93d2490f6452c804087a99b619.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/691e9453786f2fc93c9edcf3df9e10a9e63370b2.json
+++ b/cedar-integration-tests/corpus_tests/691e9453786f2fc93c9edcf3df9e10a9e63370b2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6921d9a2ecdfcfee6cce4ff1f90ee25865ba761a.json
+++ b/cedar-integration-tests/corpus_tests/6921d9a2ecdfcfee6cce4ff1f90ee25865ba761a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/69d41647b14ed47571fe950f2fbda31127455843.json
+++ b/cedar-integration-tests/corpus_tests/69d41647b14ed47571fe950f2fbda31127455843.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6a7418396e090ede0881c9cd4144898403c3ebbc.json
+++ b/cedar-integration-tests/corpus_tests/6a7418396e090ede0881c9cd4144898403c3ebbc.json
@@ -24,7 +24,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -70,7 +70,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -116,7 +116,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -139,7 +139,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -162,7 +162,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -185,7 +185,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6a80d8de7f543465fbf4d89e1e2b6f6ae0616e82.json
+++ b/cedar-integration-tests/corpus_tests/6a80d8de7f543465fbf4d89e1e2b6f6ae0616e82.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/6b4e82a987352dc8dcce60ddabe05da8409325bf.json
+++ b/cedar-integration-tests/corpus_tests/6b4e82a987352dc8dcce60ddabe05da8409325bf.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6b787ff93eaf47694db647e9981122e6f71896cb.json
+++ b/cedar-integration-tests/corpus_tests/6b787ff93eaf47694db647e9981122e6f71896cb.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6bd85935b72b96cef2480563a8b387fbe994645c.json
+++ b/cedar-integration-tests/corpus_tests/6bd85935b72b96cef2480563a8b387fbe994645c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6c66c9279f1c5e69a767457ec2006f22e3966fe2.json
+++ b/cedar-integration-tests/corpus_tests/6c66c9279f1c5e69a767457ec2006f22e3966fe2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6cfc2e19564dc9b5d218fb1b7c5387cf4ff164bd.json
+++ b/cedar-integration-tests/corpus_tests/6cfc2e19564dc9b5d218fb1b7c5387cf4ff164bd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6e57104bd2645f6d8da6fb3b46cac26ec681221a.json
+++ b/cedar-integration-tests/corpus_tests/6e57104bd2645f6d8da6fb3b46cac26ec681221a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6f39fc31e46817318751745ca182faa912a002f0.json
+++ b/cedar-integration-tests/corpus_tests/6f39fc31e46817318751745ca182faa912a002f0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/6fa62d99a95be2f5acd33b1d6072299cfab24505.json
+++ b/cedar-integration-tests/corpus_tests/6fa62d99a95be2f5acd33b1d6072299cfab24505.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r::W::r::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/6fd8189e2fe88662dc06a04df0676824c692e94a.json
+++ b/cedar-integration-tests/corpus_tests/6fd8189e2fe88662dc06a04df0676824c692e94a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `jj`"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7284584f3d64e4a462729a2952f283b5a6bfe3ea.json
+++ b/cedar-integration-tests/corpus_tests/7284584f3d64e4a462729a2952f283b5a6bfe3ea.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7355653a76b963d961091dc312be4d67c4e3b070.json
+++ b/cedar-integration-tests/corpus_tests/7355653a76b963d961091dc312be4d67c4e3b070.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/73f09692588e0571b635451fc1b3763246eec60f.json
+++ b/cedar-integration-tests/corpus_tests/73f09692588e0571b635451fc1b3763246eec60f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/74cb1c7bc7c5cd009274db3878641b5f68615989.json
+++ b/cedar-integration-tests/corpus_tests/74cb1c7bc7c5cd009274db3878641b5f68615989.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/74fc6528dec498d8409c8a72a7f24be4f27e1888.json
+++ b/cedar-integration-tests/corpus_tests/74fc6528dec498d8409c8a72a7f24be4f27e1888.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/74fe417ab7d038ce58b8dc106bab99fa76eadd17.json
+++ b/cedar-integration-tests/corpus_tests/74fe417ab7d038ce58b8dc106bab99fa76eadd17.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/755f2966b4141044d5f3a1b1737132c905d07ac4.json
+++ b/cedar-integration-tests/corpus_tests/755f2966b4141044d5f3a1b1737132c905d07ac4.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/75f7bec7370822f1887e7ccadf05ffd1e24921f3.json
+++ b/cedar-integration-tests/corpus_tests/75f7bec7370822f1887e7ccadf05ffd1e24921f3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7600b8d3728a0b54b7d8ad5e18adecfe9f71c3f8.json
+++ b/cedar-integration-tests/corpus_tests/7600b8d3728a0b54b7d8ad5e18adecfe9f71c3f8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/764a4880f4e99a191e53a03ef16da22fb02bc397.json
+++ b/cedar-integration-tests/corpus_tests/764a4880f4e99a191e53a03ef16da22fb02bc397.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7876eafee5c27b4be49c894923a72008dd32edc5.json
+++ b/cedar-integration-tests/corpus_tests/7876eafee5c27b4be49c894923a72008dd32edc5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/78e6dc287b333b74145e3812acca38315b888cd5.json
+++ b/cedar-integration-tests/corpus_tests/78e6dc287b333b74145e3812acca38315b888cd5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/79e20304effab67d62ee64404284039250203aa5.json
+++ b/cedar-integration-tests/corpus_tests/79e20304effab67d62ee64404284039250203aa5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `m::r::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7a089572bbbeebd8f64e2e8ae9773b02eff6c7a1.json
+++ b/cedar-integration-tests/corpus_tests/7a089572bbbeebd8f64e2e8ae9773b02eff6c7a1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7af6dce0ed8937af4f3341e8d78ebb9de967563b.json
+++ b/cedar-integration-tests/corpus_tests/7af6dce0ed8937af4f3341e8d78ebb9de967563b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b01b2db594cc56ad84353cc76e1fdad524005db.json
+++ b/cedar-integration-tests/corpus_tests/7b01b2db594cc56ad84353cc76e1fdad524005db.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b316784cf9e60631768b35cb7a7e15ba6d01c05.json
+++ b/cedar-integration-tests/corpus_tests/7b316784cf9e60631768b35cb7a7e15ba6d01c05.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: integer overflow while attempting to multiply `-1537158028109086738` by `60138`"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b8a0adcf9a94ba713b2b01a3e63f16cdc5a6463.json
+++ b/cedar-integration-tests/corpus_tests/7b8a0adcf9a94ba713b2b01a3e63f16cdc5a6463.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7b9bcbbc7a191f346a4b355e999c0e7af112f464.json
+++ b/cedar-integration-tests/corpus_tests/7b9bcbbc7a191f346a4b355e999c0e7af112f464.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7bddb2c6c02a5973392e44c285dda262d41e93ae.json
+++ b/cedar-integration-tests/corpus_tests/7bddb2c6c02a5973392e44c285dda262d41e93ae.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7c2a4e29605b66e49b6344c8cfe34084f2c0c5bc.json
+++ b/cedar-integration-tests/corpus_tests/7c2a4e29605b66e49b6344c8cfe34084f2c0c5bc.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7c86e43a5b649553003524a121d788581e8b519b.json
+++ b/cedar-integration-tests/corpus_tests/7c86e43a5b649553003524a121d788581e8b519b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7c9d4dea53dc2243566328f40cb2bd97ffbbdff8.json
+++ b/cedar-integration-tests/corpus_tests/7c9d4dea53dc2243566328f40cb2bd97ffbbdff8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7ca848ce836993ff836dd884591a6ae2ea97250e.json
+++ b/cedar-integration-tests/corpus_tests/7ca848ce836993ff836dd884591a6ae2ea97250e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: function does not exist: r::A::r"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7d62dbe121e6b9f46e46c164b14c997bde13304b.json
+++ b/cedar-integration-tests/corpus_tests/7d62dbe121e6b9f46e46c164b14c997bde13304b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7e545a5af2c43e384fee0bb2520166cc2a89f0b7.json
+++ b/cedar-integration-tests/corpus_tests/7e545a5af2c43e384fee0bb2520166cc2a89f0b7.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7e650f77996e5262f09093185cb7a9ff74935036.json
+++ b/cedar-integration-tests/corpus_tests/7e650f77996e5262f09093185cb7a9ff74935036.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7ea9e66f0f9e3cd6d923fadea94a4d79f28bc13b.json
+++ b/cedar-integration-tests/corpus_tests/7ea9e66f0f9e3cd6d923fadea94a4d79f28bc13b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7ecad9939f8607228e8fa6d489f56e0f21e7e647.json
+++ b/cedar-integration-tests/corpus_tests/7ecad9939f8607228e8fa6d489f56e0f21e7e647.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7f6f7bc48b745460951322d29033e15a37d81517.json
+++ b/cedar-integration-tests/corpus_tests/7f6f7bc48b745460951322d29033e15a37d81517.json
@@ -24,7 +24,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -70,7 +70,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -116,7 +116,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -139,7 +139,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -162,7 +162,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -185,7 +185,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/7f763280b38e3ae0b4ae15829f53fcd5b8937b62.json
+++ b/cedar-integration-tests/corpus_tests/7f763280b38e3ae0b4ae15829f53fcd5b8937b62.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/812182cd4ad1e94be57a6309c88dd2d69d5fffaf.json
+++ b/cedar-integration-tests/corpus_tests/812182cd4ad1e94be57a6309c88dd2d69d5fffaf.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/82e0009729d4fe23f1ca9992ea9311b61228b36a.json
+++ b/cedar-integration-tests/corpus_tests/82e0009729d4fe23f1ca9992ea9311b61228b36a.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/83296094a7d88d71a4a7b7cbe8d92117cb97f6c0.json
+++ b/cedar-integration-tests/corpus_tests/83296094a7d88d71a4a7b7cbe8d92117cb97f6c0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/834280c350074a677889fb77ec7849eb89d4d304.json
+++ b/cedar-integration-tests/corpus_tests/834280c350074a677889fb77ec7849eb89d4d304.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8422992aa599755d03ee771d9916fe0aa5bcd2ba.json
+++ b/cedar-integration-tests/corpus_tests/8422992aa599755d03ee771d9916fe0aa5bcd2ba.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8499dc3608bd9a3b4dcb97a74e219d48b1de6f5e.json
+++ b/cedar-integration-tests/corpus_tests/8499dc3608bd9a3b4dcb97a74e219d48b1de6f5e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/84f41f5ea0f77e2b817e38052fd58b2593c09f9f.json
+++ b/cedar-integration-tests/corpus_tests/84f41f5ea0f77e2b817e38052fd58b2593c09f9f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/850d5550a7987fccee6e5d66cbafdb33a167ae18.json
+++ b/cedar-integration-tests/corpus_tests/850d5550a7987fccee6e5d66cbafdb33a167ae18.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/870c25a990be727397d9239cd5a34f904c341e77.json
+++ b/cedar-integration-tests/corpus_tests/870c25a990be727397d9239cd5a34f904c341e77.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/88854732ff8c1610ddd340cf53aeeae79e33d222.json
+++ b/cedar-integration-tests/corpus_tests/88854732ff8c1610ddd340cf53aeeae79e33d222.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/88ae543a35ed13de3dc6e368575b1873114207bb.json
+++ b/cedar-integration-tests/corpus_tests/88ae543a35ed13de3dc6e368575b1873114207bb.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/88dfaaec78187b7e68e9ddd7ba4772e5786c89bd.json
+++ b/cedar-integration-tests/corpus_tests/88dfaaec78187b7e68e9ddd7ba4772e5786c89bd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8a03928d0b2ed43f8d66f0732e23554803e3c570.json
+++ b/cedar-integration-tests/corpus_tests/8a03928d0b2ed43f8d66f0732e23554803e3c570.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8a4206baab5492fa446b2a91fc661c08b66f7470.json
+++ b/cedar-integration-tests/corpus_tests/8a4206baab5492fa446b2a91fc661c08b66f7470.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8ae9da22bf3e14fc5beacba0ca1d505943eb5282.json
+++ b/cedar-integration-tests/corpus_tests/8ae9da22bf3e14fc5beacba0ca1d505943eb5282.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8b215be721bd036c5218e7540fc43a8b339e1254.json
+++ b/cedar-integration-tests/corpus_tests/8b215be721bd036c5218e7540fc43a8b339e1254.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8b6ca5e1fd6e3a0e977cddc8421b6566261e8147.json
+++ b/cedar-integration-tests/corpus_tests/8b6ca5e1fd6e3a0e977cddc8421b6566261e8147.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `nww_ww00000::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8c36035fd556368746cadc0f161f7b650cca9cd6.json
+++ b/cedar-integration-tests/corpus_tests/8c36035fd556368746cadc0f161f7b650cca9cd6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8d633bca2c9c6d3ba3b0094c47a6e64372d84f59.json
+++ b/cedar-integration-tests/corpus_tests/8d633bca2c9c6d3ba3b0094c47a6e64372d84f59.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8dbbe63b2dfe8b0977f20105145fe5112b23aebf.json
+++ b/cedar-integration-tests/corpus_tests/8dbbe63b2dfe8b0977f20105145fe5112b23aebf.json
@@ -79,7 +79,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -100,7 +100,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -121,7 +121,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -142,7 +142,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -163,7 +163,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8dcfa6e09d836dedaeb71e79585d2bf8e3ef8bcc.json
+++ b/cedar-integration-tests/corpus_tests/8dcfa6e09d836dedaeb71e79585d2bf8e3ef8bcc.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8f4a8dd71968997861794d08fc5a32d135f848ee.json
+++ b/cedar-integration-tests/corpus_tests/8f4a8dd71968997861794d08fc5a32d135f848ee.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/8fb94680726921adf01d87fcef5aedc39e1ce6b1.json
+++ b/cedar-integration-tests/corpus_tests/8fb94680726921adf01d87fcef5aedc39e1ce6b1.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9121208cfdb1a32bc3faea9856ccdee0de923e7f.json
+++ b/cedar-integration-tests/corpus_tests/9121208cfdb1a32bc3faea9856ccdee0de923e7f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/91ecacebaa77afde6e1994e0cbd9ad9e8972dd8a.json
+++ b/cedar-integration-tests/corpus_tests/91ecacebaa77afde6e1994e0cbd9ad9e8972dd8a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/920c746e731c3ace559a77d13f72dd3215c2611e.json
+++ b/cedar-integration-tests/corpus_tests/920c746e731c3ace559a77d13f72dd3215c2611e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9250519ce2283cfeec18cbbd341db4bd9fc56423.json
+++ b/cedar-integration-tests/corpus_tests/9250519ce2283cfeec18cbbd341db4bd9fc56423.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/942be69eda5e79fd772b447f062a7d9d543097c3.json
+++ b/cedar-integration-tests/corpus_tests/942be69eda5e79fd772b447f062a7d9d543097c3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/94c0be79f2fdbf7665d653e48e8c770bed3d74df.json
+++ b/cedar-integration-tests/corpus_tests/94c0be79f2fdbf7665d653e48e8c770bed3d74df.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/94d1ab0699264fbb5eafc162905fb5200072fe87.json
+++ b/cedar-integration-tests/corpus_tests/94d1ab0699264fbb5eafc162905fb5200072fe87.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `Ahhmm`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/960d3e9de3aa8f15b17f855ffd831ac8c1b9632f.json
+++ b/cedar-integration-tests/corpus_tests/960d3e9de3aa8f15b17f855ffd831ac8c1b9632f.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/961eec7160aaf77e2c58eb965a43edf371548d71.json
+++ b/cedar-integration-tests/corpus_tests/961eec7160aaf77e2c58eb965a43edf371548d71.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/968e29828c432b49c8f1e6e96292f4aa1d28964d.json
+++ b/cedar-integration-tests/corpus_tests/968e29828c432b49c8f1e6e96292f4aa1d28964d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9693f3116d0a2863b0014b2760b84ae20555f640.json
+++ b/cedar-integration-tests/corpus_tests/9693f3116d0a2863b0014b2760b84ae20555f640.json
@@ -24,7 +24,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -70,7 +70,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -116,7 +116,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -139,7 +139,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -162,7 +162,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -185,7 +185,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/972f4782b62c480d9b818d7641eeaa41c81ef5a6.json
+++ b/cedar-integration-tests/corpus_tests/972f4782b62c480d9b818d7641eeaa41c81ef5a6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/9749df77416bd7412963a4f13fe64a9f282adc77.json
+++ b/cedar-integration-tests/corpus_tests/9749df77416bd7412963a4f13fe64a9f282adc77.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/97e5ea8110fd942a8aff42be1e4b8d1f7ad9e98b.json
+++ b/cedar-integration-tests/corpus_tests/97e5ea8110fd942a8aff42be1e4b8d1f7ad9e98b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/97ecdb5a989451af145fda48ed60b28661bf1130.json
+++ b/cedar-integration-tests/corpus_tests/97ecdb5a989451af145fda48ed60b28661bf1130.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/99a86fcf921d0ab33f03b7f1e0f2d5c383cde36c.json
+++ b/cedar-integration-tests/corpus_tests/99a86fcf921d0ab33f03b7f1e0f2d5c383cde36c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/99d7bbfdb6e920b94e2f5940ae498c088336d67f.json
+++ b/cedar-integration-tests/corpus_tests/99d7bbfdb6e920b94e2f5940ae498c088336d67f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/9ae2a4802b9d0889173964d21b2a63126f31d94f.json
+++ b/cedar-integration-tests/corpus_tests/9ae2a4802b9d0889173964d21b2a63126f31d94f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9b55589e73bf3330a31b529138b4a61a0a5918e0.json
+++ b/cedar-integration-tests/corpus_tests/9b55589e73bf3330a31b529138b4a61a0a5918e0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9cad48f121661b1f12380de738bb9e52d98c5f6a.json
+++ b/cedar-integration-tests/corpus_tests/9cad48f121661b1f12380de738bb9e52d98c5f6a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9cbfe496d6bf481368f0dc5de0a9992f17276db2.json
+++ b/cedar-integration-tests/corpus_tests/9cbfe496d6bf481368f0dc5de0a9992f17276db2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d0a212b70378bf1433d4b49c52df64c1398b8cd.json
+++ b/cedar-integration-tests/corpus_tests/9d0a212b70378bf1433d4b49c52df64c1398b8cd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d1dac4b5e28cc86db794732f1a2db6be9e18a0e.json
+++ b/cedar-integration-tests/corpus_tests/9d1dac4b5e28cc86db794732f1a2db6be9e18a0e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d4ca98f581b4ef94b815572be787be546d99ce9.json
+++ b/cedar-integration-tests/corpus_tests/9d4ca98f581b4ef94b815572be787be546d99ce9.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d708a846df604daa636403c267203ff2284d091.json
+++ b/cedar-integration-tests/corpus_tests/9d708a846df604daa636403c267203ff2284d091.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9d9c579f9c3a81af0f81f4fc66fa8164ff39a0b6.json
+++ b/cedar-integration-tests/corpus_tests/9d9c579f9c3a81af0f81f4fc66fa8164ff39a0b6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9deac7d6cae0d5e05635469c985c01f9a22e0d1b.json
+++ b/cedar-integration-tests/corpus_tests/9deac7d6cae0d5e05635469c985c01f9a22e0d1b.json
@@ -24,7 +24,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -70,7 +70,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -116,7 +116,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -139,7 +139,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -162,7 +162,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     },
     {
@@ -185,7 +185,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: record does not have the attribute `f`"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9dfb0e9489663d11ba0b18dc6c295586054d890f.json
+++ b/cedar-integration-tests/corpus_tests/9dfb0e9489663d11ba0b18dc6c295586054d890f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9e383d82ba301840ca5735f1cd71479507f1be99.json
+++ b/cedar-integration-tests/corpus_tests/9e383d82ba301840ca5735f1cd71479507f1be99.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9e78370f0df2823e97e385eba2a8ae7106f923dd.json
+++ b/cedar-integration-tests/corpus_tests/9e78370f0df2823e97e385eba2a8ae7106f923dd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9e9dffc95a866861e43df9e9012d6be10996ed36.json
+++ b/cedar-integration-tests/corpus_tests/9e9dffc95a866861e43df9e9012d6be10996ed36.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9f1c21662ae11397c3676997c668326235093b42.json
+++ b/cedar-integration-tests/corpus_tests/9f1c21662ae11397c3676997c668326235093b42.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9f4d739955479dd973a11169342840d58c77101f.json
+++ b/cedar-integration-tests/corpus_tests/9f4d739955479dd973a11169342840d58c77101f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/9fdb5ebfe43720d72298b5a5bc00dba586d0f996.json
+++ b/cedar-integration-tests/corpus_tests/9fdb5ebfe43720d72298b5a5bc00dba586d0f996.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a3635f0fed60bfe960a1a01dd3bacb35531e2dbe.json
+++ b/cedar-integration-tests/corpus_tests/a3635f0fed60bfe960a1a01dd3bacb35531e2dbe.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a54f9c6bdd7a65aad28eea03eaef38ef77f3914f.json
+++ b/cedar-integration-tests/corpus_tests/a54f9c6bdd7a65aad28eea03eaef38ef77f3914f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a6a34b4a0bae150ab6a591014b93cee198e4fd9e.json
+++ b/cedar-integration-tests/corpus_tests/a6a34b4a0bae150ab6a591014b93cee198e4fd9e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a77b6b9fe492bdd0c3e41e011921a5960d92bd06.json
+++ b/cedar-integration-tests/corpus_tests/a77b6b9fe492bdd0c3e41e011921a5960d92bd06.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a7848e613881d5c8ef76a9b4d2daaf5391f604ca.json
+++ b/cedar-integration-tests/corpus_tests/a7848e613881d5c8ef76a9b4d2daaf5391f604ca.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a815ab0a661a3ff66ab845596fdeefcaaa2232fc.json
+++ b/cedar-integration-tests/corpus_tests/a815ab0a661a3ff66ab845596fdeefcaaa2232fc.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a8b757dff29c824709e5fcd3aeacdf2aa8cfebae.json
+++ b/cedar-integration-tests/corpus_tests/a8b757dff29c824709e5fcd3aeacdf2aa8cfebae.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a8c129e6673079a29c3d31194c0a5fa5f35b811f.json
+++ b/cedar-integration-tests/corpus_tests/a8c129e6673079a29c3d31194c0a5fa5f35b811f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a90bb06aa3fe36f3f82b8ab373d3a9eeba170538.json
+++ b/cedar-integration-tests/corpus_tests/a90bb06aa3fe36f3f82b8ab373d3a9eeba170538.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/a96f74e880792fd63ae1068f22554fd8d3dce2e4.json
+++ b/cedar-integration-tests/corpus_tests/a96f74e880792fd63ae1068f22554fd8d3dce2e4.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ab2df42a94c24da0082192add3e33cc4f77e4cb2.json
+++ b/cedar-integration-tests/corpus_tests/ab2df42a94c24da0082192add3e33cc4f77e4cb2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/acb3ed70ecdb5f18671b256d118caacb1cf1244c.json
+++ b/cedar-integration-tests/corpus_tests/acb3ed70ecdb5f18671b256d118caacb1cf1244c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ad3fbf26c2855d5aaf75f48b29b649bd05692a10.json
+++ b/cedar-integration-tests/corpus_tests/ad3fbf26c2855d5aaf75f48b29b649bd05692a10.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ad60db88a7f37324e6c885200699a54b47768294.json
+++ b/cedar-integration-tests/corpus_tests/ad60db88a7f37324e6c885200699a54b47768294.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ae2c67d1713bca35a2ef40518399e6d3af5f342b.json
+++ b/cedar-integration-tests/corpus_tests/ae2c67d1713bca35a2ef40518399e6d3af5f342b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/aef35a4c59c7b94df6c961749a09f12d8a58a352.json
+++ b/cedar-integration-tests/corpus_tests/aef35a4c59c7b94df6c961749a09f12d8a58a352.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b060c814a9da144f7c44fecc61aa19c899e14908.json
+++ b/cedar-integration-tests/corpus_tests/b060c814a9da144f7c44fecc61aa19c899e14908.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b09c050c89c695099088ec2c50e89094ecf2683e.json
+++ b/cedar-integration-tests/corpus_tests/b09c050c89c695099088ec2c50e89094ecf2683e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `g::r::A::Q::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b1cdf5f8969de06b11f9fe69168f746032eca879.json
+++ b/cedar-integration-tests/corpus_tests/b1cdf5f8969de06b11f9fe69168f746032eca879.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b22b165e1e51019db4f32dc3960a3856509e6b10.json
+++ b/cedar-integration-tests/corpus_tests/b22b165e1e51019db4f32dc3960a3856509e6b10.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b24ab34a4e77453be45d5743cce301254b9d4f70.json
+++ b/cedar-integration-tests/corpus_tests/b24ab34a4e77453be45d5743cce301254b9d4f70.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b26b72b174aded01b6b866bbeb34751b7297733b.json
+++ b/cedar-integration-tests/corpus_tests/b26b72b174aded01b6b866bbeb34751b7297733b.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b537e1d0a5408c81734469f4629f830e78ddef79.json
+++ b/cedar-integration-tests/corpus_tests/b537e1d0a5408c81734469f4629f830e78ddef79.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/b5675f1d0fce1b205972bc991638b47f459c86e8.json
+++ b/cedar-integration-tests/corpus_tests/b5675f1d0fce1b205972bc991638b47f459c86e8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b5cd7ecd8056ac97a3c1081cdbe2bcbc48832bce.json
+++ b/cedar-integration-tests/corpus_tests/b5cd7ecd8056ac97a3c1081cdbe2bcbc48832bce.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b616f53e96b13c4e1daf4dbb82a0b65061c9ac99.json
+++ b/cedar-integration-tests/corpus_tests/b616f53e96b13c4e1daf4dbb82a0b65061c9ac99.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b7c122bef1ed48427641aa2ba120554dedf15bba.json
+++ b/cedar-integration-tests/corpus_tests/b7c122bef1ed48427641aa2ba120554dedf15bba.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 4"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b9ba0cd046f46175d9c494da778329fb92e1b1c8.json
+++ b/cedar-integration-tests/corpus_tests/b9ba0cd046f46175d9c494da778329fb92e1b1c8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/b9c8d6feca161c723f28929d6cbb30479f6924ae.json
+++ b/cedar-integration-tests/corpus_tests/b9c8d6feca161c723f28929d6cbb30479f6924ae.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ba4d87ce7c6c3bca381073a32ddf47de29f6c23a.json
+++ b/cedar-integration-tests/corpus_tests/ba4d87ce7c6c3bca381073a32ddf47de29f6c23a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ba6b355a1bf226a09064499762b03cea811236f5.json
+++ b/cedar-integration-tests/corpus_tests/ba6b355a1bf226a09064499762b03cea811236f5.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/bab94d26d2fcf63c2c0bf4c0b1d783f53ea4e52f.json
+++ b/cedar-integration-tests/corpus_tests/bab94d26d2fcf63c2c0bf4c0b1d783f53ea4e52f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/babfcc8b3847d347f710f4a46ae1ac192986c981.json
+++ b/cedar-integration-tests/corpus_tests/babfcc8b3847d347f710f4a46ae1ac192986c981.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bad207c3066f1ffbd151959fd7bdf29c07b02298.json
+++ b/cedar-integration-tests/corpus_tests/bad207c3066f1ffbd151959fd7bdf29c07b02298.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/baf85e0c1b79dbcd88df62d430e23b2ecbc41685.json
+++ b/cedar-integration-tests/corpus_tests/baf85e0c1b79dbcd88df62d430e23b2ecbc41685.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bb18e52bb813c138683e38f2e1ebc7dfd3131ad7.json
+++ b/cedar-integration-tests/corpus_tests/bb18e52bb813c138683e38f2e1ebc7dfd3131ad7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bb3ef5fe04a8594071227b50ba4e4f1c67070ca3.json
+++ b/cedar-integration-tests/corpus_tests/bb3ef5fe04a8594071227b50ba4e4f1c67070ca3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bba8300156d7b101f3fabdb9a5b66650eef37d04.json
+++ b/cedar-integration-tests/corpus_tests/bba8300156d7b101f3fabdb9a5b66650eef37d04.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/bbbba300ccd3f8a8ce43172dbb79394076c4ccde.json
+++ b/cedar-integration-tests/corpus_tests/bbbba300ccd3f8a8ce43172dbb79394076c4ccde.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bbc1b27f8b8e179db4fc826a1ac81a70c7f0f014.json
+++ b/cedar-integration-tests/corpus_tests/bbc1b27f8b8e179db4fc826a1ac81a70c7f0f014.json
@@ -60,7 +60,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bc0fd67ace59edf84c2d95fce4f8836571d6ac18.json
+++ b/cedar-integration-tests/corpus_tests/bc0fd67ace59edf84c2d95fce4f8836571d6ac18.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bc1eb67eb0bd87437d450690c1cb44032123b3dd.json
+++ b/cedar-integration-tests/corpus_tests/bc1eb67eb0bd87437d450690c1cb44032123b3dd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bc9ab20725b791a5660f678694db33cb4a1ccefe.json
+++ b/cedar-integration-tests/corpus_tests/bc9ab20725b791a5660f678694db33cb4a1ccefe.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd1752d749a28ba01382db7bb02a0a972d2c401a.json
+++ b/cedar-integration-tests/corpus_tests/bd1752d749a28ba01382db7bb02a0a972d2c401a.json
@@ -60,7 +60,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd18bd41ab202db204cea1f32221d6eaf35d8cd9.json
+++ b/cedar-integration-tests/corpus_tests/bd18bd41ab202db204cea1f32221d6eaf35d8cd9.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd4d0d3bd104ad2aa88641b7b6704cc14de00fa2.json
+++ b/cedar-integration-tests/corpus_tests/bd4d0d3bd104ad2aa88641b7b6704cc14de00fa2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd52aeabb79ad9249ef0960923b730c571327ffe.json
+++ b/cedar-integration-tests/corpus_tests/bd52aeabb79ad9249ef0960923b730c571327ffe.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/bd6dde94fdc76cf2ba5c1ac07e02a291730daf56.json
+++ b/cedar-integration-tests/corpus_tests/bd6dde94fdc76cf2ba5c1ac07e02a291730daf56.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/be3efdc8162eb23ea015be57b9d18094521b1551.json
+++ b/cedar-integration-tests/corpus_tests/be3efdc8162eb23ea015be57b9d18094521b1551.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/be4eb076d2594dfc30f6c2b6abba097fbc9ddbff.json
+++ b/cedar-integration-tests/corpus_tests/be4eb076d2594dfc30f6c2b6abba097fbc9ddbff.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c17e0eacd91a90aef1f5a41cd0c44cb32814bd4c.json
+++ b/cedar-integration-tests/corpus_tests/c17e0eacd91a90aef1f5a41cd0c44cb32814bd4c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c1884023c6fee7b6a8d8b93dd10119065e46edfd.json
+++ b/cedar-integration-tests/corpus_tests/c1884023c6fee7b6a8d8b93dd10119065e46edfd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c1c19d5d03c6d67f35702459eaf182a1b36471ad.json
+++ b/cedar-integration-tests/corpus_tests/c1c19d5d03c6d67f35702459eaf182a1b36471ad.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `O`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c46bb5bece5ee9a65e9cf7f2095446fc2b37677e.json
+++ b/cedar-integration-tests/corpus_tests/c46bb5bece5ee9a65e9cf7f2095446fc2b37677e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c48188b8ac4d4f2191db06c508ee38bd1eda54a3.json
+++ b/cedar-integration-tests/corpus_tests/c48188b8ac4d4f2191db06c508ee38bd1eda54a3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c4e59c0c01de0263f75cfe881d291c300e921716.json
+++ b/cedar-integration-tests/corpus_tests/c4e59c0c01de0263f75cfe881d291c300e921716.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c589f1386d9a37a56828e2f7adcde859ff2e7573.json
+++ b/cedar-integration-tests/corpus_tests/c589f1386d9a37a56828e2f7adcde859ff2e7573.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c58bd14e00106a71304c6235f5086baf3967b3c0.json
+++ b/cedar-integration-tests/corpus_tests/c58bd14e00106a71304c6235f5086baf3967b3c0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c58f2dcfcaf1078ac26d626b32fe4e55d108a62a.json
+++ b/cedar-integration-tests/corpus_tests/c58f2dcfcaf1078ac26d626b32fe4e55d108a62a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c5aac7e6da4d23ff344137eebfa4ca251676b6cd.json
+++ b/cedar-integration-tests/corpus_tests/c5aac7e6da4d23ff344137eebfa4ca251676b6cd.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c5dea430902a547482bc3ff849be108adf4ab799.json
+++ b/cedar-integration-tests/corpus_tests/c5dea430902a547482bc3ff849be108adf4ab799.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/c61ef4bc690f842dab4e57f05e83ba0331adc190.json
+++ b/cedar-integration-tests/corpus_tests/c61ef4bc690f842dab4e57f05e83ba0331adc190.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ca2a5665590dadaa410ae37be42cf8c38ebf5228.json
+++ b/cedar-integration-tests/corpus_tests/ca2a5665590dadaa410ae37be42cf8c38ebf5228.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ca4a7fbd3617faa7e877b6038d722296a4b9d27d.json
+++ b/cedar-integration-tests/corpus_tests/ca4a7fbd3617faa7e877b6038d722296a4b9d27d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ca6a97aeccaccf888e717ebcac44c4ee680705b1.json
+++ b/cedar-integration-tests/corpus_tests/ca6a97aeccaccf888e717ebcac44c4ee680705b1.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/ca6bf4ceb4c21f136ef5564dc649eaabe796d2af.json
+++ b/cedar-integration-tests/corpus_tests/ca6bf4ceb4c21f136ef5564dc649eaabe796d2af.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cb4b59edfc9f9d6201f583176e0a6cf4445aafe4.json
+++ b/cedar-integration-tests/corpus_tests/cb4b59edfc9f9d6201f583176e0a6cf4445aafe4.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cb91f70a3b580008e79ad7d2f79c554604d4bf4f.json
+++ b/cedar-integration-tests/corpus_tests/cb91f70a3b580008e79ad7d2f79c554604d4bf4f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cc28740c4d1065a1f7db2d69103dea6bd50cbb4e.json
+++ b/cedar-integration-tests/corpus_tests/cc28740c4d1065a1f7db2d69103dea6bd50cbb4e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cd24b45d64e569bf8a44d0cb26cadd19d02bb896.json
+++ b/cedar-integration-tests/corpus_tests/cd24b45d64e569bf8a44d0cb26cadd19d02bb896.json
@@ -24,7 +24,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -47,7 +47,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -70,7 +70,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -93,7 +93,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -116,7 +116,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -139,7 +139,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -162,7 +162,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     },
     {
@@ -185,7 +185,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: `a::\"\"` does not have the attribute `A`"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cd68929ac20c52e6a5b9f212a83241ae6638e5ae.json
+++ b/cedar-integration-tests/corpus_tests/cd68929ac20c52e6a5b9f212a83241ae6638e5ae.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ce29db8c629bdec52719f2c8d30dd323fbb2ba2e.json
+++ b/cedar-integration-tests/corpus_tests/ce29db8c629bdec52719f2c8d30dd323fbb2ba2e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ce937b05f78203ed138b10bafa0bcaecb8240e5c.json
+++ b/cedar-integration-tests/corpus_tests/ce937b05f78203ed138b10bafa0bcaecb8240e5c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ceb5a1ff1b0982afc158333c77c32248f432b958.json
+++ b/cedar-integration-tests/corpus_tests/ceb5a1ff1b0982afc158333c77c32248f432b958.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/cefaca00ac959a2b9fc2f68db187e24290d6fa39.json
+++ b/cedar-integration-tests/corpus_tests/cefaca00ac959a2b9fc2f68db187e24290d6fa39.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cf8e0b821a33183bb1b27c5204c767cf73046ff2.json
+++ b/cedar-integration-tests/corpus_tests/cf8e0b821a33183bb1b27c5204c767cf73046ff2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/cfdc0aa13f242dd5caecf75aed878d8bdf5015c0.json
+++ b/cedar-integration-tests/corpus_tests/cfdc0aa13f242dd5caecf75aed878d8bdf5015c0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d09c3c69af274d51d9b2e1b8cca81aa059307a68.json
+++ b/cedar-integration-tests/corpus_tests/d09c3c69af274d51d9b2e1b8cca81aa059307a68.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -100,7 +100,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -121,7 +121,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -142,7 +142,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -163,7 +163,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d1c32f30179c22ca32ee6b9a78b6467c4609e103.json
+++ b/cedar-integration-tests/corpus_tests/d1c32f30179c22ca32ee6b9a78b6467c4609e103.json
@@ -60,7 +60,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -81,7 +81,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d2d070eea367ec82a3ccfbba21a7585c51cb63a3.json
+++ b/cedar-integration-tests/corpus_tests/d2d070eea367ec82a3ccfbba21a7585c51cb63a3.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d2fa250e2aba06b4c57ebe4937327d3ef25aa6be.json
+++ b/cedar-integration-tests/corpus_tests/d2fa250e2aba06b4c57ebe4937327d3ef25aa6be.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d37938f9d55ff46236ddb3f7481644229ea84619.json
+++ b/cedar-integration-tests/corpus_tests/d37938f9d55ff46236ddb3f7481644229ea84619.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/d3d751f8974775fad771c94efabf90348ff5c0c8.json
+++ b/cedar-integration-tests/corpus_tests/d3d751f8974775fad771c94efabf90348ff5c0c8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [record, (entity of type `any_entity_type`)], got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d4d0e75ce2a11931b27717f0628d176ba24ccb4f.json
+++ b/cedar-integration-tests/corpus_tests/d4d0e75ce2a11931b27717f0628d176ba24ccb4f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d66406ba3a77c11c5dd3fe24989da26551820f92.json
+++ b/cedar-integration-tests/corpus_tests/d66406ba3a77c11c5dd3fe24989da26551820f92.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d726a4220e6c8f359b14a71ad4dde4392685f4fe.json
+++ b/cedar-integration-tests/corpus_tests/d726a4220e6c8f359b14a71ad4dde4392685f4fe.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/d7f8fbf3df419726990afb22a94eff94e1aad654.json
+++ b/cedar-integration-tests/corpus_tests/d7f8fbf3df419726990afb22a94eff94e1aad654.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d805f68cb4896eb79d0581c2d210692d1f2a3b2a.json
+++ b/cedar-integration-tests/corpus_tests/d805f68cb4896eb79d0581c2d210692d1f2a3b2a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A3::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d874dce35c50c45ac609f378a680b7b8caaeba71.json
+++ b/cedar-integration-tests/corpus_tests/d874dce35c50c45ac609f378a680b7b8caaeba71.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/d8d09ed3ce3ca1bbb7581ba1f5035cff45ea969d.json
+++ b/cedar-integration-tests/corpus_tests/d8d09ed3ce3ca1bbb7581ba1f5035cff45ea969d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/da188d700d07ee66e9aed294ec88e256f96a0099.json
+++ b/cedar-integration-tests/corpus_tests/da188d700d07ee66e9aed294ec88e256f96a0099.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/dc10006036dd185ebf256e9ff21f88aa2bc720bd.json
+++ b/cedar-integration-tests/corpus_tests/dc10006036dd185ebf256e9ff21f88aa2bc720bd.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ddcacf2669cc2037f337afa4ba73f1e07b4a9450.json
+++ b/cedar-integration-tests/corpus_tests/ddcacf2669cc2037f337afa4ba73f1e07b4a9450.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/de6f90ef4c5f6bf96e92b97b4a919db6d534490e.json
+++ b/cedar-integration-tests/corpus_tests/de6f90ef4c5f6bf96e92b97b4a919db6d534490e.json
@@ -19,7 +19,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -40,7 +40,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -82,7 +82,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -103,7 +103,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -124,7 +124,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -145,7 +145,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -166,7 +166,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/defd5589c286ff2dda5865ae0a230c9ef13d90ab.json
+++ b/cedar-integration-tests/corpus_tests/defd5589c286ff2dda5865ae0a230c9ef13d90ab.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `C22::C233::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/df2ea141f627d2600b135b349b67b8865a9510be.json
+++ b/cedar-integration-tests/corpus_tests/df2ea141f627d2600b135b349b67b8865a9510be.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/df717142035535be823880e938720aaf57529996.json
+++ b/cedar-integration-tests/corpus_tests/df717142035535be823880e938720aaf57529996.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e02e2ae73a80519758593d2206484b8292d2c004.json
+++ b/cedar-integration-tests/corpus_tests/e02e2ae73a80519758593d2206484b8292d2c004.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e0f6913f9fa8b06d1b2a1b8b6c02087585d7f986.json
+++ b/cedar-integration-tests/corpus_tests/e0f6913f9fa8b06d1b2a1b8b6c02087585d7f986.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e1c6e1fbb078a7b301b99741c2c13e7648f0ba5a.json
+++ b/cedar-integration-tests/corpus_tests/e1c6e1fbb078a7b301b99741c2c13e7648f0ba5a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e265048e41123c7389400efd99019d7a42fb70cb.json
+++ b/cedar-integration-tests/corpus_tests/e265048e41123c7389400efd99019d7a42fb70cb.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e2c3298a9025cabbcf814803d3a81cf93ced082e.json
+++ b/cedar-integration-tests/corpus_tests/e2c3298a9025cabbcf814803d3a81cf93ced082e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e30bdae252646a9315f7fc3c5014eb07821d7094.json
+++ b/cedar-integration-tests/corpus_tests/e30bdae252646a9315f7fc3c5014eb07821d7094.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e3b78e66463b8a1a89f57b5c2600623f923d00cf.json
+++ b/cedar-integration-tests/corpus_tests/e3b78e66463b8a1a89f57b5c2600623f923d00cf.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e3f5ca95a7fabe1adf9e44fdd782d45071ca5b89.json
+++ b/cedar-integration-tests/corpus_tests/e3f5ca95a7fabe1adf9e44fdd782d45071ca5b89.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e5e6199a3ae1e1ac97512ce3fa10eec795b71302.json
+++ b/cedar-integration-tests/corpus_tests/e5e6199a3ae1e1ac97512ce3fa10eec795b71302.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `W::v::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e707a4f91770c47e0c8a8ba6b52a37a816a5c93d.json
+++ b/cedar-integration-tests/corpus_tests/e707a4f91770c47e0c8a8ba6b52a37a816a5c93d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e724a7ae0f37a356481bfd94170d5e699c0c4315.json
+++ b/cedar-integration-tests/corpus_tests/e724a7ae0f37a356481bfd94170d5e699c0c4315.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got (entity of type `A000::a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e7458302450d25b602e878ab27e3e460a03ce21d.json
+++ b/cedar-integration-tests/corpus_tests/e7458302450d25b602e878ab27e3e460a03ce21d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `A`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e8740bccf611aacef35d92682b472b951ccdb86e.json
+++ b/cedar-integration-tests/corpus_tests/e8740bccf611aacef35d92682b472b951ccdb86e.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/e9b0ec04f07c26ecbbc07d77b61ab84f61e73b74.json
+++ b/cedar-integration-tests/corpus_tests/e9b0ec04f07c26ecbbc07d77b61ab84f61e73b74.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/e9bf9a0ffb7521be078ea0d9800c27c8aaf39ee7.json
+++ b/cedar-integration-tests/corpus_tests/e9bf9a0ffb7521be078ea0d9800c27c8aaf39ee7.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/ea1deadd3d188a9751dfddb6bb567d6e190152e6.json
+++ b/cedar-integration-tests/corpus_tests/ea1deadd3d188a9751dfddb6bb567d6e190152e6.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ea3b3bb7b61997bc73aa38c5229b58386ddc2606.json
+++ b/cedar-integration-tests/corpus_tests/ea3b3bb7b61997bc73aa38c5229b58386ddc2606.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ea67eaf13be16e92be8c2465e7fd55899e0abf80.json
+++ b/cedar-integration-tests/corpus_tests/ea67eaf13be16e92be8c2465e7fd55899e0abf80.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/eabb42b2e81c0bad00a33668a407915bf8a3b0d8.json
+++ b/cedar-integration-tests/corpus_tests/eabb42b2e81c0bad00a33668a407915bf8a3b0d8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/eae3e1fd9f742fe24356b3508199c42e6aa33f09.json
+++ b/cedar-integration-tests/corpus_tests/eae3e1fd9f742fe24356b3508199c42e6aa33f09.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/eb94687cfe8e7a96150ffd9eb9601dc1eda7c66e.json
+++ b/cedar-integration-tests/corpus_tests/eb94687cfe8e7a96150ffd9eb9601dc1eda7c66e.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {

--- a/cedar-integration-tests/corpus_tests/ec161281562607a66b1f81afd1749c629f8b481a.json
+++ b/cedar-integration-tests/corpus_tests/ec161281562607a66b1f81afd1749c629f8b481a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ec9dd30e89a3764e03ddea1cdd980fbfcfc7b2b2.json
+++ b/cedar-integration-tests/corpus_tests/ec9dd30e89a3764e03ddea1cdd980fbfcfc7b2b2.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ed1329e9a9e4ae97dda03d5e6f8dbcc1cd4262f9.json
+++ b/cedar-integration-tests/corpus_tests/ed1329e9a9e4ae97dda03d5e6f8dbcc1cd4262f9.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ed50cb715d57475bc9dacda0ba0dd77c589832e8.json
+++ b/cedar-integration-tests/corpus_tests/ed50cb715d57475bc9dacda0ba0dd77c589832e8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected decimal, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ee0e4d2430b6cdb096fbd181a965b7946bf45eea.json
+++ b/cedar-integration-tests/corpus_tests/ee0e4d2430b6cdb096fbd181a965b7946bf45eea.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ee1fa449052339701d1c55068e63f92c7db896b8.json
+++ b/cedar-integration-tests/corpus_tests/ee1fa449052339701d1c55068e63f92c7db896b8.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ee4b7cbdbb7fcfed6d5e64fdb6e9745a6e70302e.json
+++ b/cedar-integration-tests/corpus_tests/ee4b7cbdbb7fcfed6d5e64fdb6e9745a6e70302e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ef55486f77e837ca67f88749434504a48760bbee.json
+++ b/cedar-integration-tests/corpus_tests/ef55486f77e837ca67f88749434504a48760bbee.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/eff2557e80c650481f9850bc32dbd8a483ef8077.json
+++ b/cedar-integration-tests/corpus_tests/eff2557e80c650481f9850bc32dbd8a483ef8077.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: wrong number of arguments provided to extension function `isInRange`: expected 2, got 3"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f02c1a74821e12d19cc295e9839d01b459d8054e.json
+++ b/cedar-integration-tests/corpus_tests/f02c1a74821e12d19cc295e9839d01b459d8054e.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -102,7 +102,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -123,7 +123,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -144,7 +144,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     },
     {
@@ -165,7 +165,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got record"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f1218de44cefa25cec4475be3b7b4e3a8226fb37.json
+++ b/cedar-integration-tests/corpus_tests/f1218de44cefa25cec4475be3b7b4e3a8226fb37.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `x`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f21be42147b2c967fb72a5a20c0775c178a5abbe.json
+++ b/cedar-integration-tests/corpus_tests/f21be42147b2c967fb72a5a20c0775c178a5abbe.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got set"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f2e255f39e2eef37a9a9255922f0efaa477fd456.json
+++ b/cedar-integration-tests/corpus_tests/f2e255f39e2eef37a9a9255922f0efaa477fd456.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f49bf87abd8fad00a3d20364ecb4da7b19ceb31b.json
+++ b/cedar-integration-tests/corpus_tests/f49bf87abd8fad00a3d20364ecb4da7b19ceb31b.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f5f7588b66978d1dd2254338fbb68ed6ee64a2f0.json
+++ b/cedar-integration-tests/corpus_tests/f5f7588b66978d1dd2254338fbb68ed6ee64a2f0.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f707e8530a96bd2a58b8de7b480670ffdbd34902.json
+++ b/cedar-integration-tests/corpus_tests/f707e8530a96bd2a58b8de7b480670ffdbd34902.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected long, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f7a661059947830ab159b0ed8f0093f339a49d7d.json
+++ b/cedar-integration-tests/corpus_tests/f7a661059947830ab159b0ed8f0093f339a49d7d.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected one of [set, (entity of type `any_entity_type`)], got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f7ce74c11891a7f12cb5572bb109bd86118a25fa.json
+++ b/cedar-integration-tests/corpus_tests/f7ce74c11891a7f12cb5572bb109bd86118a25fa.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f8006bb12f37cc2836361c259c0eec34c848dd2c.json
+++ b/cedar-integration-tests/corpus_tests/f8006bb12f37cc2836361c259c0eec34c848dd2c.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f8a2d5d79f2b1f3dc2eacb01d5716b50e3fed11a.json
+++ b/cedar-integration-tests/corpus_tests/f8a2d5d79f2b1f3dc2eacb01d5716b50e3fed11a.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected ipaddr, got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f9038335a4482bba1a886183685e4de56fd62a10.json
+++ b/cedar-integration-tests/corpus_tests/f9038335a4482bba1a886183685e4de56fd62a10.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected (entity of type `any_entity_type`), got long"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f93f63d216acc608101bc400cb436f26296bf478.json
+++ b/cedar-integration-tests/corpus_tests/f93f63d216acc608101bc400cb436f26296bf478.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `G666666`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f9c354e3ba7eb40a2a786e83eba1831d1c00a8ce.json
+++ b/cedar-integration-tests/corpus_tests/f9c354e3ba7eb40a2a786e83eba1831d1c00a8ce.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/f9e02a91691711a8be7fb43dc371d5a1d58aca0f.json
+++ b/cedar-integration-tests/corpus_tests/f9e02a91691711a8be7fb43dc371d5a1d58aca0f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/faa2a6fa10c7e7030f995f2bc077e6ccecbeee4f.json
+++ b/cedar-integration-tests/corpus_tests/faa2a6fa10c7e7030f995f2bc077e6ccecbeee4f.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got string"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fae02fa9de9b4bdbb061e07c183ff5bab73d20cf.json
+++ b/cedar-integration-tests/corpus_tests/fae02fa9de9b4bdbb061e07c183ff5bab73d20cf.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fbb67cf9a24d6f669bc498ce002672d38048b513.json
+++ b/cedar-integration-tests/corpus_tests/fbb67cf9a24d6f669bc498ce002672d38048b513.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `OJJJ`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fc68e0680604a1abef56806cd2b3d0867a3a2e12.json
+++ b/cedar-integration-tests/corpus_tests/fc68e0680604a1abef56806cd2b3d0867a3a2e12.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `r`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fd4855a6b7c2e0189ede9509e242a8463c29e380.json
+++ b/cedar-integration-tests/corpus_tests/fd4855a6b7c2e0189ede9509e242a8463c29e380.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected set, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fd6c0162c36cf2a9f7b0f1f63cba50e26b7c7473.json
+++ b/cedar-integration-tests/corpus_tests/fd6c0162c36cf2a9f7b0f1f63cba50e26b7c7473.json
@@ -41,7 +41,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -62,7 +62,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -83,7 +83,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -104,7 +104,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -125,7 +125,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -146,7 +146,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     },
     {
@@ -167,7 +167,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `Action`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/fdbc43fb8590b30134d3051354baca39abcc4846.json
+++ b/cedar-integration-tests/corpus_tests/fdbc43fb8590b30134d3051354baca39abcc4846.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected bool, got (entity of type `a`)"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/corpus_tests/ff2bb115942c7257de5f24a3985fa4f2fdd49108.json
+++ b/cedar-integration-tests/corpus_tests/ff2bb115942c7257de5f24a3985fa4f2fdd49108.json
@@ -22,7 +22,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -43,7 +43,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -64,7 +64,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -106,7 +106,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -127,7 +127,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -148,7 +148,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     },
     {
@@ -169,7 +169,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: type error: expected string, got bool"
+        "policy0"
       ]
     }
   ]

--- a/cedar-integration-tests/tests/multi/5.json
+++ b/cedar-integration-tests/tests/multi/5.json
@@ -45,8 +45,8 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "while evaluating policy `policy0`: cannot access attribute `department` of unspecified entity",
-        "while evaluating policy `policy2`: cannot access attribute `jobLevel` of unspecified entity"
+        "policy0",
+        "policy2"
       ]
     },
     {
@@ -90,7 +90,7 @@
         "policy1"
       ],
       "errors": [
-        "while evaluating policy `policy2`: cannot access attribute `jobLevel` of unspecified entity"
+        "policy2"
       ]
     },
     {

--- a/cedar-policy-cli/tests/integration_tests/main.rs
+++ b/cedar-policy-cli/tests/integration_tests/main.rs
@@ -28,63 +28,13 @@ mod example_use_cases_doc;
 mod ip;
 mod multi;
 
+use cedar_policy::integration_testing::JsonTest;
 use cedar_policy::Decision;
 use cedar_policy::EntityUid;
 use cedar_policy::PolicySet;
-use serde::Deserialize;
 use std::env;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-
-/// JSON representation of our integration test file format
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct JsonTest {
-    /// Filename of the policies to use (in pure Cedar syntax)
-    policies: String,
-    /// Filename of a JSON file representing the entity hierarchy
-    entities: String,
-    /// Filename of a JSON file containing the schema.
-    schema: String,
-    /// Whether the given policies are expected to pass the validator with this
-    /// schema, or not
-    should_validate: bool,
-    /// Queries to perform on that data, along with their expected results
-    queries: Vec<JsonRequest>,
-}
-
-/// JSON representation of a single request, along with its expected result,
-/// in our integration test file format
-#[derive(Deserialize)]
-#[serde(deny_unknown_fields)]
-struct JsonRequest {
-    /// Description for the request
-    desc: String,
-    /// Principal for the request
-    #[serde(default)]
-    principal: Option<serde_json::Value>,
-    /// Action for the request
-    #[serde(default)]
-    action: Option<serde_json::Value>,
-    /// Resource for the request
-    #[serde(default)]
-    resource: Option<serde_json::Value>,
-    /// Context for the request
-    context: serde_json::Value,
-    /// Whether to enable request validation for this request
-    #[serde(default = "constant_true")]
-    enable_request_validation: bool,
-    /// Expected decision for the request
-    decision: Decision,
-    /// Expected "reasons" for the request
-    reasons: Vec<String>,
-    /// Expected error/warning messages for the request
-    errors: Vec<String>,
-}
-
-fn constant_true() -> bool {
-    true
-}
 
 fn value_to_euid_string(v: serde_json::Value) -> Result<String, impl miette::Diagnostic> {
     EntityUid::from_json(v).map(|euid| euid.to_string())
@@ -129,7 +79,7 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
     let entity_file = resolve_integration_test_path(&test.entities);
     let schema_file = resolve_integration_test_path(&test.schema);
 
-    for json_request in test.queries.into_iter() {
+    for json_request in test.requests.into_iter() {
         let policies_text = std::fs::read_to_string(policy_file.clone())
             .unwrap_or_else(|e| panic!("error loading policy file {}: {e}", &test.policies));
         let policies_res = PolicySet::from_str(&policies_text);
@@ -182,15 +132,15 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
         let mut entity_args = Vec::new();
         if let Some(s) = json_request.principal {
             entity_args.push("--principal".to_string());
-            entity_args.push(value_to_euid_string(s).unwrap());
+            entity_args.push(value_to_euid_string(s.into()).unwrap());
         }
         if let Some(s) = json_request.resource {
             entity_args.push("--resource".to_string());
-            entity_args.push(value_to_euid_string(s).unwrap());
+            entity_args.push(value_to_euid_string(s.into()).unwrap());
         }
         if let Some(s) = json_request.action {
             entity_args.push("--action".to_string());
-            entity_args.push(value_to_euid_string(s).unwrap());
+            entity_args.push(value_to_euid_string(s.into()).unwrap());
         }
         if !json_request.enable_request_validation {
             entity_args.push("--request-validation=false".to_string());
@@ -220,9 +170,9 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
         let output = String::from_utf8(authorize_cmd.get_output().stdout.clone())
             .expect("output should be valid UTF-8");
 
-        for error in &json_request.errors {
+        for error in json_request.errors {
             assert!(
-                output.contains(error),
+                output.contains(&error.to_string()),
                 "test {} failed for request \"{}\": output does not contain expected error {error:?}.\noutput was: {output}\nstderr was: {}",
                 jsonfile.display(),
                 &json_request.desc,
@@ -230,7 +180,7 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
             );
         }
 
-        if json_request.reasons.is_empty() {
+        if json_request.reason.is_empty() {
             assert!(
                 output.contains("no policies applied to this request"),
                 "test {} failed for request \"{}\": output does not contain the string \"no policies applied to this request\", as expected.\noutput was: {output}\nstderr was: {}",
@@ -240,9 +190,9 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
             );
         } else {
             assert!(output.contains("this decision was due to the following policies"));
-            for reason in &json_request.reasons {
+            for reason in &json_request.reason {
                 assert!(
-                    output.contains(&reason.escape_debug().to_string()),
+                    output.contains(&reason.to_string()),
                     "test {} failed for request \"{}\": output does not contain the reason string {reason:?}.\noutput was: {output}\nstderr was: {}",
                     jsonfile.display(),
                     &json_request.desc,

--- a/cedar-policy-cli/tests/integration_tests/main.rs
+++ b/cedar-policy-cli/tests/integration_tests/main.rs
@@ -137,9 +137,8 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
         // check that the expected decision is "Deny" and that the parse error is
         // of the expected type (NotAFunction).
         if let Err(parse_errs) = policies_res {
-            // We may see a `NotAFunction` parse error for auto-generated policies:
-            // See the comment in the `ExtensionFunctionApp` case of the `Display`
-            // implementation for `Expr` in ast/exprs.rs.
+            // We may see a `NotAFunction` parse error for programmatically generated
+            // policies, which are not guaranteed to be parsable
             assert_eq!(
                 json_request.decision,
                 Decision::Deny,

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -662,7 +662,7 @@ impl StaticPolicy {
     }
 
     /// Clone this policy with a new `Id`.
-    pub fn new_id(&mut self, id: PolicyID) -> Self {
+    pub fn new_id(&self, id: PolicyID) -> Self {
         StaticPolicy(self.0.new_id(id))
     }
 

--- a/cedar-policy-core/src/authorizer/err.rs
+++ b/cedar-policy-core/src/authorizer/err.rs
@@ -32,3 +32,12 @@ pub enum AuthorizationError {
         error: EvaluationError,
     },
 }
+
+impl AuthorizationError {
+    /// Get the id of the erroring policy
+    pub fn id(&self) -> &PolicyID {
+        match self {
+            Self::PolicyEvaluationError { id, error: _ } => id,
+        }
+    }
+}

--- a/cedar-policy-core/src/authorizer/err.rs
+++ b/cedar-policy-core/src/authorizer/err.rs
@@ -32,12 +32,3 @@ pub enum AuthorizationError {
         error: EvaluationError,
     },
 }
-
-impl AuthorizationError {
-    /// Get the id of the erroring policy
-    pub fn id(&self) -> &PolicyID {
-        match self {
-            Self::PolicyEvaluationError { id, error: _ } => id,
-        }
-    }
-}

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   template-linked policy. (#515, resolving #489)
 - Added `EntityId::new()` constructor (#583, resolving #553)
 - New feature for cedar-policy and cedar-policy core to allow targeting wasm
+- `AuthorizationError::id()` to get the id of the policy associated with an
+  authorization error. (#589)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -906,8 +906,10 @@ impl Diagnostics {
     }
 
     /// Get the `PolicyId`s of the policies where an error occurred during authorization.
-    pub fn error_ids(&self) -> impl Iterator<Item = &PolicyId> {
-        self.errors.iter().map(|e| PolicyId::ref_cast(e.id()))
+    pub fn error_policy_ids(&self) -> impl Iterator<Item = &PolicyId> {
+        self.errors.iter().map(|e| match e {
+            AuthorizationError::PolicyEvaluationError { id, error: _ } => PolicyId::ref_cast(id),
+        })
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -904,6 +904,11 @@ impl Diagnostics {
     pub fn errors(&self) -> impl Iterator<Item = &AuthorizationError> + '_ {
         self.errors.iter()
     }
+
+    /// Get the `PolicyId`s of the policies where an error occurred during authorization.
+    pub fn error_ids(&self) -> impl Iterator<Item = &PolicyId> {
+        self.errors.iter().map(|e| PolicyId::ref_cast(e.id()))
+    }
 }
 
 impl Response {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -27,7 +27,6 @@ use cedar_policy_core::ast::{
     ContextCreationError, ExprConstructionError, Integer, RestrictedExprParseError,
 }; // `ContextCreationError` is unsuitable for `pub use` because it contains internal types like `RestrictedExpr`
 use cedar_policy_core::authorizer;
-pub use cedar_policy_core::authorizer::AuthorizationError;
 use cedar_policy_core::entities::{
     self, ContextJsonDeserializationError, ContextSchema, Dereference, JsonDeserializationError,
     JsonDeserializationErrorContext,
@@ -735,6 +734,40 @@ impl Authorizer {
     }
 }
 
+/// Errors that can occur during authorization
+#[derive(Debug, Diagnostic, PartialEq, Eq, Error, Clone)]
+pub enum AuthorizationError {
+    /// An error occurred when evaluating a policy.
+    #[error("while evaluating policy `{id}`: {error}")]
+    PolicyEvaluationError {
+        /// Id of the policy with an error
+        id: ast::PolicyID,
+        /// Underlying evaluation error
+        #[diagnostic(transparent)]
+        error: EvaluationError,
+    },
+}
+
+impl AuthorizationError {
+    /// Get the id of the erroring policy
+    pub fn id(&self) -> &PolicyId {
+        match self {
+            Self::PolicyEvaluationError { id, error: _ } => PolicyId::ref_cast(id),
+        }
+    }
+}
+
+#[doc(hidden)]
+impl From<authorizer::AuthorizationError> for AuthorizationError {
+    fn from(value: authorizer::AuthorizationError) -> Self {
+        match value {
+            authorizer::AuthorizationError::PolicyEvaluationError { id, error } => {
+                Self::PolicyEvaluationError { id, error }
+            }
+        }
+    }
+}
+
 /// Authorization response returned from the `Authorizer`
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Response {
@@ -780,7 +813,7 @@ impl From<authorizer::Diagnostics> for Diagnostics {
     fn from(diagnostics: authorizer::Diagnostics) -> Self {
         Self {
             reason: diagnostics.reason.into_iter().map(PolicyId).collect(),
-            errors: diagnostics.errors,
+            errors: diagnostics.errors.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -903,13 +936,6 @@ impl Diagnostics {
     /// ```
     pub fn errors(&self) -> impl Iterator<Item = &AuthorizationError> + '_ {
         self.errors.iter()
-    }
-
-    /// Get the `PolicyId`s of the policies where an error occurred during authorization.
-    pub fn error_policy_ids(&self) -> impl Iterator<Item = &PolicyId> {
-        self.errors.iter().map(|e| match e {
-            AuthorizationError::PolicyEvaluationError { id, error: _ } => PolicyId::ref_cast(id),
-        })
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -741,6 +741,7 @@ pub enum AuthorizationError {
     #[error("while evaluating policy `{id}`: {error}")]
     PolicyEvaluationError {
         /// Id of the policy with an error
+        #[doc(hidden)]
         id: ast::PolicyID,
         /// Underlying evaluation error
         #[diagnostic(transparent)]

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -37,7 +37,7 @@ use crate::{
     Policy, PolicyId, PolicySet, Request, Schema, ValidationMode, Validator,
 };
 use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashSet,
     env,
@@ -46,7 +46,7 @@ use std::{
 };
 
 /// JSON representation of our integration test file format
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonTest {
     /// Filename of the policies to use (in pure Cedar syntax)
@@ -66,7 +66,7 @@ pub struct JsonTest {
 
 /// JSON representation of a single request, along with its expected result,
 /// in our integration test file format
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct JsonRequest {
     /// Description for the request
@@ -375,7 +375,8 @@ pub fn perform_integration_test_from_json_custom(
                 &json_request.desc
             );
             // check errors
-            let errors: HashSet<PolicyId> = response.diagnostics().error_ids().cloned().collect();
+            let errors: HashSet<PolicyId> =
+                response.diagnostics().error_policy_ids().cloned().collect();
             assert_eq!(
                 errors,
                 json_request.errors.into_iter().collect(),

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -33,8 +33,8 @@
 #![allow(clippy::expect_used)]
 
 use crate::{
-    frontend::is_authorized::InterfaceResponse, Authorizer, Context, Decision, Entities, EntityUid,
-    Policy, PolicyId, PolicySet, Request, Schema, ValidationMode, Validator,
+    frontend::is_authorized::InterfaceResponse, AuthorizationError, Authorizer, Context, Decision,
+    Entities, EntityUid, Policy, PolicyId, PolicySet, Request, Schema, ValidationMode, Validator,
 };
 use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 use serde::{Deserialize, Serialize};
@@ -376,8 +376,12 @@ pub fn perform_integration_test_from_json_custom(
                 &json_request.desc
             );
             // check errors
-            let errors: HashSet<PolicyId> =
-                response.diagnostics().error_policy_ids().cloned().collect();
+            let errors: HashSet<PolicyId> = response
+                .diagnostics()
+                .errors()
+                .map(AuthorizationError::id)
+                .cloned()
+                .collect();
             assert_eq!(
                 errors,
                 json_request.errors.into_iter().collect(),

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -39,6 +39,7 @@ use crate::{
 use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 use serde::Deserialize;
 use std::{
+    collections::HashSet,
     env,
     path::{Path, PathBuf},
     str::FromStr,
@@ -49,18 +50,18 @@ use std::{
 #[serde(deny_unknown_fields)]
 pub struct JsonTest {
     /// Filename of the policies to use (in pure Cedar syntax)
-    policies: String,
+    pub policies: String,
     /// Filename of a JSON file representing the entity hierarchy
-    entities: String,
+    pub entities: String,
     /// Filename of a JSON file containing the schema.
-    schema: String,
+    pub schema: String,
     /// Whether the given policies are expected to pass the validator with this
     /// schema, or not
-    should_validate: bool,
+    pub should_validate: bool,
     /// Requests to perform on that data, along with their expected results
     /// Alias for backwards compatibility
     #[serde(alias = "queries")]
-    requests: Vec<JsonRequest>,
+    pub requests: Vec<JsonRequest>,
 }
 
 /// JSON representation of a single request, along with its expected result,
@@ -69,40 +70,40 @@ pub struct JsonTest {
 #[serde(deny_unknown_fields)]
 pub struct JsonRequest {
     /// Description for the request
-    desc: String,
+    pub desc: String,
     /// Principal for the request, in either explicit or implicit `__entity` form
     ///
     /// Examples:
     /// * `{ "__entity": { "type": "User", "id": "123abc" } }`
     /// * `{ "type": "User", "id": "123abc" }`
     #[serde(default)]
-    principal: Option<JsonValueWithNoDuplicateKeys>,
+    pub principal: Option<JsonValueWithNoDuplicateKeys>,
     /// Action for the request, in either explicit or implicit `__entity` form
     ///
     /// Examples:
     /// * `{ "__entity": { "type": "Action", "id": "view" } }`
     /// * `{ "type": "Action", "id": "view" }`
     #[serde(default)]
-    action: Option<JsonValueWithNoDuplicateKeys>,
+    pub action: Option<JsonValueWithNoDuplicateKeys>,
     /// Resource for the request, in either explicit or implicit `__entity` form
     ///
     /// Examples:
     /// * `{ "__entity": { "type": "User", "id": "123abc" } }`
     /// * `{ "type": "User", "id": "123abc" }`
     #[serde(default)]
-    resource: Option<JsonValueWithNoDuplicateKeys>,
+    pub resource: Option<JsonValueWithNoDuplicateKeys>,
     /// Context for the request. This should be a JSON object, not any other kind
     /// of JSON value
-    context: JsonValueWithNoDuplicateKeys,
+    pub context: JsonValueWithNoDuplicateKeys,
     /// Whether to enable request validation for this request
     #[serde(default = "constant_true")]
-    enable_request_validation: bool,
+    pub enable_request_validation: bool,
     /// Expected decision for the request
-    decision: Decision,
-    /// Expected "reasons" for the request
-    reasons: Vec<String>,
-    /// Expected error/warning messages for the request
-    errors: Vec<String>,
+    pub decision: Decision,
+    /// Expected policies that led to the decision
+    pub reasons: Vec<PolicyId>,
+    /// Expected policies that resulted in errors
+    pub errors: Vec<PolicyId>,
 }
 
 fn constant_true() -> bool {
@@ -213,9 +214,8 @@ pub fn perform_integration_test_from_json_custom(
     // of the expected type.
     let policies_res = PolicySet::from_str(&policies_text);
     if let Err(parse_errs) = policies_res {
-        // We may see a `NotAFunction` parse error for auto-generated policies:
-        // See the comment in the `ExtensionFunctionApp` case of the `Display`
-        // implementation for `Expr` in ast/exprs.rs.
+        // We may see a `NotAFunction` parse error for programmatically generated
+        // policies, which are not guaranteed to be parsable
         for json_request in test.requests {
             assert_eq!(
                 json_request.decision,
@@ -334,41 +334,56 @@ pub fn perform_integration_test_from_json_custom(
                 jsonfile.display()
             )
         });
-        let response = if let Some(custom_impl) = custom_impl_opt {
-            custom_impl.is_authorized(&request.0, &policies.ast, &entities.0)
-        } else {
-            Authorizer::new()
-                .is_authorized(&request, &policies, &entities)
-                .into()
-        };
 
-        let expected_errors = if custom_impl_opt.is_some() {
-            // errors may not exactly match when using a custom implementation, so ignore
-            response
-                .diagnostics()
-                .errors()
-                .map(std::string::ToString::to_string)
-                .collect()
+        if let Some(custom_impl) = custom_impl_opt {
+            let response = custom_impl.is_authorized(&request.0, &policies.ast, &entities.0);
+            // check decision
+            assert_eq!(
+                response.decision(),
+                json_request.decision,
+                "test {} failed for request \"{}\": unexpected decision",
+                jsonfile.display(),
+                &json_request.desc
+            );
+            // check reasons
+            let reasons: HashSet<PolicyId> = response.diagnostics().reason().cloned().collect();
+            assert_eq!(
+                reasons,
+                json_request.reasons.into_iter().collect(),
+                "test {} failed for request \"{}\": unexpected reasons",
+                jsonfile.display(),
+                &json_request.desc
+            );
+            // ignore errors (#586)
         } else {
-            json_request.errors.into_iter().collect()
+            let response = Authorizer::new().is_authorized(&request, &policies, &entities);
+            // check decision
+            assert_eq!(
+                response.decision(),
+                json_request.decision,
+                "test {} failed for request \"{}\": unexpected decision",
+                jsonfile.display(),
+                &json_request.desc
+            );
+            // check reasons
+            let reasons: HashSet<PolicyId> = response.diagnostics().reason().cloned().collect();
+            assert_eq!(
+                reasons,
+                json_request.reasons.into_iter().collect(),
+                "test {} failed for request \"{}\": unexpected reasons",
+                jsonfile.display(),
+                &json_request.desc
+            );
+            // check errors
+            let errors: HashSet<PolicyId> = response.diagnostics().error_ids().cloned().collect();
+            assert_eq!(
+                errors,
+                json_request.errors.into_iter().collect(),
+                "test {} failed for request \"{}\": unexpected errors",
+                jsonfile.display(),
+                &json_request.desc
+            );
         };
-        let expected_response = InterfaceResponse::new(
-            json_request.decision,
-            json_request
-                .reasons
-                .into_iter()
-                .map(|s| PolicyId::from_str(&s).unwrap())
-                .collect(),
-            expected_errors,
-        );
-
-        assert_eq!(
-            response,
-            expected_response,
-            "test {} failed for request \"{}\"",
-            jsonfile.display(),
-            &json_request.desc
-        );
 
         // test that EST roundtrip works for this policy set
         // we can't test that the roundtrip produces the same policies exactly

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -101,7 +101,8 @@ pub struct JsonRequest {
     /// Expected decision for the request
     pub decision: Decision,
     /// Expected policies that led to the decision
-    pub reasons: Vec<PolicyId>,
+    #[serde(alias = "reasons")]
+    pub reason: Vec<PolicyId>,
     /// Expected policies that resulted in errors
     pub errors: Vec<PolicyId>,
 }
@@ -349,7 +350,7 @@ pub fn perform_integration_test_from_json_custom(
             let reasons: HashSet<PolicyId> = response.diagnostics().reason().cloned().collect();
             assert_eq!(
                 reasons,
-                json_request.reasons.into_iter().collect(),
+                json_request.reason.into_iter().collect(),
                 "test {} failed for request \"{}\": unexpected reasons",
                 jsonfile.display(),
                 &json_request.desc
@@ -369,7 +370,7 @@ pub fn perform_integration_test_from_json_custom(
             let reasons: HashSet<PolicyId> = response.diagnostics().reason().cloned().collect();
             assert_eq!(
                 reasons,
-                json_request.reasons.into_iter().collect(),
+                json_request.reason.into_iter().collect(),
                 "test {} failed for request \"{}\": unexpected reasons",
                 jsonfile.display(),
                 &json_request.desc


### PR DESCRIPTION
## Description of changes

This PR updates the “errors” field of the integration tests to store only the id of erroring policies. This will prevent us from having to change the corpus tests whenever an error message changes (which is so far the only reason we’ve had to update the tests), and going forward (#586) will allow for easier comparison with other implementations of Cedar that may produce different messages, but should agree on which policies error.

Specifically, this PR:
* Adds `id` method for `AuthorizationError` (requires a minor version bump)
* Updates integration test format
    * Exposes `JsonTest` and `JsonRequest` fields for reuse in `cedar-spec` and `cedar-policy-cli`
    * Changes errors field to list policy ids rather than error messages
    * Updates corpus tests to match new test format. You can skip this part of the diff.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] equires updates, and I have made / will make these updates myself.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
