### PR TITLE
Fix bug where a single namespace on a var was ignored

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -52,6 +52,8 @@ method checks the request against the schema provided and the
 
 - Action entities in the store will pass schema-based validation without requiring
   the transitive closure to be pre-computed. (#581, resolving #285)
+- Variables qualified by a namespace with a single element are correctly
+  rejected. E.g., `foo::principal` is an error and is not parsed as `principal`.
 
 ## [3.0.1] - 2023-12-21
 Cedar Language Version: 3.0.0


### PR DESCRIPTION
A variable like `foo::principal` was parsed as `principal` due to a comparison `path.len() > 1` where it should have been `path.len() > 0`.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
