### PR TITLE
Fix `is` when type name is also a var name

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -912,10 +912,7 @@ impl ExprOrSpecial<'_> {
                 errs.push(self.to_ast_err(ToASTErrorKind::IsInvalidName(lit.to_string())));
                 None
             }
-            Self::Var { var, .. } => {
-                errs.push(self.to_ast_err(ToASTErrorKind::IsInvalidName(var.to_string())));
-                None
-            }
+            Self::Var { var, .. } => Some(ast::Name::unqualified_name(var.into())),
             Self::Name { name, .. } => Some(name),
             Self::Expr { ref expr, .. } => {
                 errs.push(self.to_ast_err(ToASTErrorKind::IsInvalidName(expr.to_string())));
@@ -4108,6 +4105,48 @@ mod tests {
                     Expr::val(2),
                 ),
             ),
+            (
+                r#"principal::"alice" is principal"#,
+                Expr::is_entity_type(
+                    Expr::val(r#"principal::"alice""#.parse::<EntityUID>().unwrap()),
+                    "principal".parse().unwrap(),
+                ),
+            ),
+            (
+                r#"foo::principal::"alice" is foo::principal"#,
+                Expr::is_entity_type(
+                    Expr::val(r#"foo::principal::"alice""#.parse::<EntityUID>().unwrap()),
+                    "foo::principal".parse().unwrap(),
+                ),
+            ),
+            (
+                r#"principal::foo::"alice" is principal::foo"#,
+                Expr::is_entity_type(
+                    Expr::val(r#"principal::foo::"alice""#.parse::<EntityUID>().unwrap()),
+                    "principal::foo".parse().unwrap(),
+                ),
+            ),
+            (
+                r#"resource::"thing" is resource"#,
+                Expr::is_entity_type(
+                    Expr::val(r#"resource::"thing""#.parse::<EntityUID>().unwrap()),
+                    "resource".parse().unwrap(),
+                ),
+            ),
+            (
+                r#"action::"do" is action"#,
+                Expr::is_entity_type(
+                    Expr::val(r#"action::"do""#.parse::<EntityUID>().unwrap()),
+                    "action".parse().unwrap(),
+                ),
+            ),
+            (
+                r#"context::"stuff" is context"#,
+                Expr::is_entity_type(
+                    Expr::val(r#"context::"stuff""#.parse::<EntityUID>().unwrap()),
+                    "context".parse().unwrap(),
+                ),
+            ),
         ] {
             let e = parse_expr(es).unwrap();
             assert!(
@@ -4129,6 +4168,12 @@ mod tests {
                 ResourceConstraint::any(),
             ),
             (
+                r#"permit(principal is principal, action, resource);"#,
+                PrincipalConstraint::is_entity_type("principal".parse().unwrap()),
+                ActionConstraint::any(),
+                ResourceConstraint::any(),
+            ),
+            (
                 r#"permit(principal is A::User, action, resource);"#,
                 PrincipalConstraint::is_entity_type("A::User".parse().unwrap()),
                 ActionConstraint::any(),
@@ -4138,6 +4183,15 @@ mod tests {
                 r#"permit(principal is User in Group::"thing", action, resource);"#,
                 PrincipalConstraint::is_entity_type_in(
                     "User".parse().unwrap(),
+                    r#"Group::"thing""#.parse().unwrap(),
+                ),
+                ActionConstraint::any(),
+                ResourceConstraint::any(),
+            ),
+            (
+                r#"permit(principal is principal in Group::"thing", action, resource);"#,
+                PrincipalConstraint::is_entity_type_in(
+                    "principal".parse().unwrap(),
                     r#"Group::"thing""#.parse().unwrap(),
                 ),
                 ActionConstraint::any(),

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -54,6 +54,9 @@ method checks the request against the schema provided and the
   the transitive closure to be pre-computed. (#581, resolving #285)
 - Variables qualified by a namespace with a single element are correctly
   rejected. E.g., `foo::principal` is an error and is not parsed as `principal`.
+- The entity type tested for by an `is` expression may be an identifier shared
+  with a builtin variable. E.g., `... is principal` and `... is action` are now
+  accepted by the Cedar parser. (#558)
 
 ## [3.0.1] - 2023-12-21
 Cedar Language Version: 3.0.0


### PR DESCRIPTION
## Description of changes

Fixes a bug in parsing `is` expression where `... is principal` was a parse error even though `principal` is a valid entity type. 

## Issue #, if available

Fix #558

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT 

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
