### PR TITLE
Fix var with keywords in namespace

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2124,12 +2124,13 @@ impl Node<Option<cst::Name>> {
         // signaled when the `Node` without data was created
         let name = self.as_inner()?;
 
-        let path: Vec<_> = name
-            .path
-            .iter()
-            .filter_map(|i| i.to_valid_ident(errs))
-            .collect();
-        if path.len() > 0 {
+        for id in &name.path {
+            // We don't need the actual indent, but we want to report an error
+            // if they're invalid.
+            id.to_valid_ident(errs);
+        }
+
+        if !name.path.is_empty() {
             errs.push(self.to_ast_err(ToASTErrorKind::InvalidPath));
             return None;
         }
@@ -4729,5 +4730,24 @@ mod tests {
         expect_arbitrary_var("foo");
         expect_arbitrary_var("foo::bar");
         expect_arbitrary_var("foo::bar::baz");
+    }
+
+    #[test]
+    fn reserved_ident_var() {
+        #[track_caller]
+        fn expect_reserved_ident(name: &str, reserved: &str) {
+            assert_matches!(parse_expr(name), Err(e) => {
+                expect_err(name, &e, &ExpectedErrorMessage::error(
+                    &format!("this identifier is reserved and cannot be used: `{reserved}`"),
+                ));
+            })
+        }
+        expect_reserved_ident("if::principal", "if");
+        expect_reserved_ident("then::action", "then");
+        expect_reserved_ident("else::resource", "else");
+        expect_reserved_ident("true::context", "true");
+        expect_reserved_ident("false::bar::principal", "false");
+        expect_reserved_ident("foo::in::principal", "in");
+        expect_reserved_ident("foo::is::bar::principal", "is");
     }
 }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2125,7 +2125,7 @@ impl Node<Option<cst::Name>> {
         let name = self.as_inner()?;
 
         for id in &name.path {
-            // We don't need the actual indent, but we want to report an error
+            // We don't need the actual ident, but we want to report an error
             // if they're invalid.
             id.to_valid_ident(errs);
         }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -55,7 +55,7 @@ method checks the request against the schema provided and the
 - Variables qualified by a namespace with a single element are correctly
   rejected. E.g., `foo::principal` is an error and is not parsed as
   `principal`. Variables qualified by a namespace of any size comprised entirely
-  of Cedar keywords are now rejected. E.g., `if::then::else::principal` is an error.
+  of Cedar keywords are correctly rejected. E.g., `if::then::else::principal` is an error.
   (#594 and #596)
 
 ## [3.0.1] - 2023-12-21

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -53,7 +53,10 @@ method checks the request against the schema provided and the
 - Action entities in the store will pass schema-based validation without requiring
   the transitive closure to be pre-computed. (#581, resolving #285)
 - Variables qualified by a namespace with a single element are correctly
-  rejected. E.g., `foo::principal` is an error and is not parsed as `principal`.
+  rejected. E.g., `foo::principal` is an error and is not parsed as
+  `principal`. Variables qualified by a namespace of any size comprised entirely
+  of Cedar keywords are now rejected. E.g., `if::then::else::principal` is an error.
+  (#594 and #596)
 
 ## [3.0.1] - 2023-12-21
 Cedar Language Version: 3.0.0


### PR DESCRIPTION
## Description of changes

Follow on to #594. The parser also accepted variables like `if::then::else::true::false::principal` as long as all namespace identifiers were Cedar keywords and the last identifier was a valid variable. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
