### PR TITLE
Fixes an issue where certain cedar policies couldn't be converted to JSON

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1052,6 +1052,7 @@ impl TryFrom<&Node<Option<cst::Unary>>> for Expr {
                             .map(|y| y == InputInteger::MAX as u64)
                             .unwrap_or(false)) =>
                     {
+                        num_dashes -= 1;
                         Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(InputInteger::MIN)))
                     }
                     _ => (&u_node.item).try_into()?,
@@ -1074,15 +1075,11 @@ impl TryFrom<&Node<Option<cst::Unary>>> for Expr {
                         // not safe to collapse `--` to nothing
                         Ok(Expr::neg(Expr::neg(inner)))
                     }
-                    n => {
-                        if n % 2 == 0 {
-                            // safe to collapse to `--` but not to nothing
-                            Ok(Expr::neg(Expr::neg(inner)))
-                        } else {
-                            // safe to collapse to -
-                            Ok(Expr::neg(inner))
-                        }
-                    }
+                    3 => Ok(Expr::neg(Expr::neg(Expr::neg(inner)))),
+                    4 => Ok(Expr::neg(Expr::neg(Expr::neg(Expr::neg(inner))))),
+                    _ => Err(u
+                        .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Neg))
+                        .into()),
                 }
             }
             Some(cst::NegOp::OverBang) => Err(u

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1022,17 +1022,12 @@ impl TryFrom<&Node<Option<cst::Unary>>> for Expr {
                     3 => Ok(Expr::not(Expr::not(Expr::not(inner)))),
                     4 => Ok(Expr::not(Expr::not(Expr::not(Expr::not(inner))))),
                     _ => Err(u
-                        .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Neg))
+                        .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Not))
                         .into()),
                 }
             }
             Some(cst::NegOp::Dash(0)) => Ok((&u_node.item).try_into()?),
             Some(cst::NegOp::Dash(mut num_dashes)) => {
-                //
-                // && (x
-                //     .checked_sub(1)
-                //     .map(|y| y == InputInteger::MAX as u64)
-                //     .unwrap_or(false)) =>
                 let inner = match &u_node.item.to_lit() {
                     Some(cst::Literal::Num(num))
                         if num

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1574,11 +1574,11 @@ enum AstAccessor {
 }
 
 impl Node<Option<cst::Member>> {
-    // Try to convert `cst::Member` into a `cst::Literal`, i.e.
-    // match `Member(Primary(Literal(_), []))`.
-    // It does not match the `Expr` arm of `Primary`, which means expressions
-    // like `(1)` are not considered as literals on the CST level.
-    fn to_lit(&self) -> Option<&cst::Literal> {
+    /// Try to convert `cst::Member` into a `cst::Literal`, i.e.
+    /// match `Member(Primary(Literal(_), []))`.
+    /// It does not match the `Expr` arm of `Primary`, which means expressions
+    /// like `(1)` are not considered as literals on the CST level.
+    pub fn to_lit(&self) -> Option<&cst::Literal> {
         let m = self.as_ref().node.as_ref()?;
         if !m.access.is_empty() {
             return None;

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -60,6 +60,7 @@ method checks the request against the schema provided and the
 - The entity type tested for by an `is` expression may be an identifier shared
   with a builtin variable. E.g., `... is principal` and `... is action` are now
   accepted by the Cedar parser. (#558)
+- Policies containing the literal `i64::MIN` can now be properly converted to JSON ESTs (#601, resolving #596)
 
 ## [3.0.1] - 2023-12-21
 Cedar Language Version: 3.0.0

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3924,3 +3924,91 @@ mod partial_eval_test {
         assert_eq!(a.residuals(), &p);
     }
 }
+
+#[cfg(test)]
+// PANIC SAFETY: unit tests
+#[allow(clippy::unwrap_used)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_all_ints() {
+        test_single_int(0);
+        test_single_int(i64::MAX);
+        test_single_int(i64::MIN);
+    }
+
+    fn test_single_int(x: i64) {
+        for i in 0..4 {
+            test_single_int_with_dashes(x, i);
+        }
+    }
+
+    fn test_single_int_with_dashes(x: i64, dashes: usize) {
+        let dashes = vec!['-'; dashes].into_iter().collect::<String>();
+        let src = format!(r#"permit(principal, action, resource) when {{ {dashes}{x} }};"#);
+        let p: Policy = src.parse().unwrap();
+        let json = p.to_json().unwrap();
+        let round_trip = Policy::from_json(None, json).unwrap();
+        let pretty_print = format!("{round_trip}");
+        assert!(pretty_print.contains(&x.to_string()));
+    }
+
+    // Serializing a valid 64-bit int that can't be represented in double precision float
+    #[test]
+    fn json_bignum_1() {
+        let src = r#"
+        permit(
+            principal,
+            action == Action::"action",
+            resource
+          ) when {
+            -9223372036854775808
+          };"#;
+        let p: Policy = src.parse().unwrap();
+        p.to_json().unwrap();
+    }
+
+    #[test]
+    fn json_bignum_1a() {
+        let src = r#"
+        permit(principal, action, resource) when { 
+            (true && (-90071992547409921)) && principal
+        };"#;
+        let p: Policy = src.parse().unwrap();
+        let v = p.to_json().unwrap();
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.contains("90071992547409921"));
+    }
+
+    // Deserializing a valid 64-bit int that can't be represented in double precision float
+    #[test]
+    fn json_bignum_2() {
+        let src = r#"{"effect":"permit","principal":{"op":"All"},"action":{"op":"All"},"resource":{"op":"All"},"conditions":[{"kind":"when","body":{"==":{"left":{".":{"left":{"Var":"principal"},"attr":"x"}},"right":{"Value":90071992547409921}}}}]}"#;
+        let v: serde_json::Value = serde_json::from_str(src).unwrap();
+        let p = Policy::from_json(None, v).unwrap();
+        let pretty = format!("{p}");
+        // Ensure the number didn't get rounded
+        assert!(pretty.contains("90071992547409921"));
+    }
+
+    // Deserializing a valid 64-bit int that can't be represented in double precision float
+    #[test]
+    fn json_bignum_2a() {
+        let src = r#"{"effect":"permit","principal":{"op":"All"},"action":{"op":"All"},"resource":{"op":"All"},"conditions":[{"kind":"when","body":{"==":{"left":{".":{"left":{"Var":"principal"},"attr":"x"}},"right":{"Value":-9223372036854775808}}}}]}"#;
+        let v: serde_json::Value = serde_json::from_str(src).unwrap();
+        let p = Policy::from_json(None, v).unwrap();
+        let pretty = format!("{p}");
+        // Ensure the number didn't get rounded
+        assert!(pretty.contains("-9223372036854775808"));
+    }
+
+    // Deserializing a number that doesn't fit in 64 bit integer
+    // This _should_ fail, as there's no way to do this w/out loss of precision
+    #[test]
+    fn json_bignum_3() {
+        let src = r#"{"effect":"permit","principal":{"op":"All"},"action":{"op":"All"},"resource":{"op":"All"},"conditions":[{"kind":"when","body":{"==":{"left":{".":{"left":{"Var":"principal"},"attr":"x"}},"right":{"Value":9223372036854775808}}}}]}"#;
+        let v: serde_json::Value = serde_json::from_str(src).unwrap();
+        assert!(Policy::from_json(None, v).is_err());
+    }
+}

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3936,6 +3936,8 @@ mod test {
         test_single_int(0);
         test_single_int(i64::MAX);
         test_single_int(i64::MIN);
+        test_single_int(7);
+        test_single_int(-7);
     }
 
     fn test_single_int(x: i64) {
@@ -3944,14 +3946,21 @@ mod test {
         }
     }
 
-    fn test_single_int_with_dashes(x: i64, dashes: usize) {
-        let dashes = vec!['-'; dashes].into_iter().collect::<String>();
+    fn test_single_int_with_dashes(x: i64, num_dashes: usize) {
+        let dashes = vec!['-'; num_dashes].into_iter().collect::<String>();
         let src = format!(r#"permit(principal, action, resource) when {{ {dashes}{x} }};"#);
         let p: Policy = src.parse().unwrap();
         let json = p.to_json().unwrap();
         let round_trip = Policy::from_json(None, json).unwrap();
         let pretty_print = format!("{round_trip}");
         assert!(pretty_print.contains(&x.to_string()));
+        if x != 0 {
+            let expected_dashes = if x < 0 { num_dashes + 1 } else { num_dashes };
+            assert_eq!(
+                pretty_print.chars().filter(|c| *c == '-').count(),
+                expected_dashes
+            );
+        }
     }
 
     // Serializing a valid 64-bit int that can't be represented in double precision float


### PR DESCRIPTION
## Description of changes
Previously, the Cedar EST code would fail to generate an EST for any policy containing the constant `-9223372036854775808` (`i64::MIN`). This happened because it was turned into the CST representing the unary op `-` applied to the constant `9223372036854775808`, which outside the range of `i64`. This adds a tiny pass to ensure that unary op is constant folded.
## Issue #, if available
#596 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
