### PR TITLE
increase validator precision for some `Unspecified` cases

### DIFF
--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -2030,6 +2030,16 @@ impl<'a> Typechecker<'a> {
                     }
                 }
             }
+            (Some(EntityType::Specified(_)), None) => {
+                // One or more of the elements on the right is not an entity
+                // literal. The `in` is still valid, so typechecking succeeds
+                // with type Boolean.
+                TypecheckAnswer::success(
+                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                        .with_same_source_loc(in_expr)
+                        .is_in(lhs_expr, rhs_expr),
+                )
+            }
             (Some(EntityType::Unspecified), Some(rhs)) => {
                 // It's perfectly valid for `principal` or `resource` to be `EntityType::Unspecified`
                 if rhs
@@ -2073,16 +2083,6 @@ impl<'a> Typechecker<'a> {
                             .is_in(lhs_expr, rhs_expr),
                     )
                 }
-            }
-            (Some(EntityType::Specified(_)), None) => {
-                // One or more of the elements on the right is not an entity
-                // literal. The `in` is still valid, so typechecking succeeds
-                // with type Boolean.
-                TypecheckAnswer::success(
-                    ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                        .with_same_source_loc(in_expr)
-                        .is_in(lhs_expr, rhs_expr),
-                )
             }
         }
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -47,8 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `schema` functions `#[must_use]`. (#502)
 - For the `partial-eval` experimental feature: make `RequestBuilder::schema`
 return a `RequestBuilder<&Schema>` so the `RequestBuilder<&Schema>::build`
-method checks the request against the schema provided and the 
+method checks the request against the schema provided and the
 `RequestBuilder<UnsetSchema>::build` method becomes infallible. (#559)
+- Increase validator precision in some edge cases involving `Unspecified` (#603)
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

Increases validator precision (typing `False` instead of `Bool`) in some edge cases involving `Unspecified`.  Also, change from `TypecheckFail` to `TypecheckSuccess` in one of these edge cases in particular.

This is a backwards-incompatible change unless/until `ImpossiblePolicy` is moved from an error to a warning.  We should probably not merge this until we've decided whether that will happen.

The change in this PR is (choose one, and delete the other options):

Breaking, unless we wait to merge this until `ImpossiblePolicy` is moved from an error to a warning, in which case non-breaking.  I also only observed the impact of this change in `Permissive` validation mode, which is an experimental feature in 3.x.  I'm not sure (not qualified to determine) whether this change has any impact in `Strict` validation mode, ie, on the stable 3.x validator.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I'm not sure whether this behavior matches the Lean validator, which doesn't yet fully match the Rust validator anyway.  I believe that neither before nor after this PR will the behavior exactly match the Dafny validator, but I propose that this is the correct/ideal behavior, which we want Dafny to match?  (That's a point for discussion below)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
