### PR TITLE
docs: enable crate experimental feature and rust doc_cfg feature while building docs for docs.rs

### DIFF
--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -21,7 +21,7 @@ itertools = "0.12"
 miette = "5.9.0"
 thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
-dhat = { version = "0.3.2", optional = true}
+dhat = { version = "0.3.2", optional = true }
 serde_with = "3.3.0"
 
 # wasm dependencies
@@ -64,7 +64,9 @@ crate_type = ["rlib", "cdylib"]
 # https://github.com/rust-lang/cargo/issues/2911#issuecomment-1483256987 for
 # more information. That issue also tracks a real solution to the problem that
 # could replace this hack.
-cedar-policy = { path = ".", default-features = false, features = ["integration_testing"] }
+cedar-policy = { path = ".", default-features = false, features = [
+    "integration_testing",
+] }
 cool_asserts = "2.0"
 criterion = "0.5"
 globset = "0.4"
@@ -74,3 +76,7 @@ proptest = "1.0.0"
 [[bench]]
 name = "cedar_benchmarks"
 harness = false
+
+[package.metadata.docs.rs]
+features = ["experimental"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/cedar-policy/experimental_warning.md
+++ b/cedar-policy/experimental_warning.md
@@ -1,0 +1,3 @@
+<div class="warning">
+This feature is experimental. For more information see <a href="https://github.com/cedar-policy/rfcs/blob/main/README.md#experimental-features">https://github.com/cedar-policy/rfcs/blob/main/README.md#experimental-features</a>
+</div>

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -245,6 +245,7 @@ impl Entities {
     /// Transform the store into a partial store, where
     /// attempting to dereference a non-existent `EntityUID` results in
     /// a residual instead of an error.
+    #[doc = include_str!("../experimental_warning.md")]
     #[must_use]
     #[cfg(feature = "partial-eval")]
     pub fn partial(self) -> Self {
@@ -717,6 +718,7 @@ impl Authorizer {
     /// The Authorizer will attempt to make as much progress as possible in the presence of unknowns.
     /// If the Authorizer can reach a response, it will return that response.
     /// Otherwise, it will return a list of residual policies that still need to be evaluated.
+    #[doc = include_str!("../experimental_warning.md")]
     #[cfg(feature = "partial-eval")]
     pub fn is_authorized_partial(
         &self,
@@ -735,6 +737,7 @@ impl Authorizer {
 
     /// Evaluate an authorization request and respond with results that always includes
     /// residuals even if the [`Authorizer`] already reached a decision.
+    #[doc = include_str!("../experimental_warning.md")]
     #[cfg(feature = "partial-eval")]
     pub fn evaluate_policies_partial(
         &self,
@@ -807,6 +810,7 @@ pub struct Response {
 
 /// Authorization response returned from `is_authorized_partial`.
 /// It can either be a full concrete response, or a residual response.
+#[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PartialResponse {
@@ -817,6 +821,7 @@ pub enum PartialResponse {
 }
 
 /// A residual response obtained from `is_authorized_partial`.
+#[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ResidualResponse {
@@ -827,6 +832,7 @@ pub struct ResidualResponse {
 }
 
 /// A policy evaluation response obtained from `evaluate_policies_partial`.
+#[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct EvaluationResponse {
@@ -1104,10 +1110,12 @@ pub enum ValidationMode {
     /// have a restricted form which is amenable for analysis.
     #[default]
     Strict,
-    #[cfg(feature = "permissive-validate")]
     /// Validate that policies do not contain any type errors.
+    #[doc = include_str!("../experimental_warning.md")]
+    #[cfg(feature = "permissive-validate")]
     Permissive,
     /// Validate using a partial schema. Policies may contain type errors.
+    #[doc = include_str!("../experimental_warning.md")]
     #[cfg(feature = "partial-validate")]
     Partial,
 }
@@ -2428,6 +2436,7 @@ impl PolicySet {
     }
 
     /// Get all the unknown entities from the policy set
+    #[doc = include_str!("../experimental_warning.md")]
     #[cfg(feature = "partial-eval")]
     pub fn unknown_entities(&self) -> HashSet<EntityUid> {
         let mut entity_uids = HashSet::new();
@@ -3401,6 +3410,7 @@ impl FromStr for RestrictedExpression {
 ///
 /// The default for principal, action, resource, and context fields is Unknown
 /// for partial evaluation.
+#[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 #[derive(Debug)]
 pub struct RequestBuilder<S> {
@@ -3413,6 +3423,7 @@ pub struct RequestBuilder<S> {
 }
 
 /// A marker type that indicates [`Schema`] is not set for a request
+#[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 #[derive(Debug)]
 pub struct UnsetSchema;
@@ -3565,6 +3576,7 @@ pub struct Request(pub(crate) ast::Request);
 
 impl Request {
     /// Create a [`RequestBuilder`]
+    #[doc = include_str!("../experimental_warning.md")]
     #[cfg(feature = "partial-eval")]
     pub fn builder() -> RequestBuilder<UnsetSchema> {
         RequestBuilder::default()

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -99,6 +99,7 @@ fn is_authorized_partial(call: AuthorizationCall) -> PartialAuthorizationAnswer 
 /// the `RecvdSlice`, you can either pass a `Map<String, String>` where the values are all single policies,
 /// or a single String which is a concatenation of multiple policies. If you choose the latter,
 /// policy id's will be auto-generated for you in the format `policyX` where X is a Natural Number (zero or a positive int)
+#[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 pub fn json_is_authorized_partial(input: &str) -> InterfaceResult {
     serde_json::from_str::<AuthorizationCall>(input).map_or_else(
@@ -199,6 +200,7 @@ impl InterfaceDiagnostics {
 }
 
 /// Integration version of a `PartialResponse` that uses `InterfaceDiagnistics` for simpler (de)serialization
+#[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct InterfaceResidualResponse {

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -34,9 +34,22 @@
     clippy::doc_markdown
 )]
 #![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
+// enable doc_auto_cfg feature is docs rs cfg is set and present
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Rust public API
 mod api;
+
+// import feature gated enum and struct so top level module show cfg attr.
+#[cfg(feature = "partial-eval")]
+pub use api::PartialResponse;
+#[cfg(feature = "partial-eval")]
+pub use api::RequestBuilder;
+#[cfg(feature = "partial-eval")]
+pub use api::ResidualResponse;
+#[cfg(feature = "partial-eval")]
+pub use api::UnsetSchema;
+
 pub use api::*;
 
 /// Frontend utilities, see comments in the module itself


### PR DESCRIPTION
## Description of changes
Enable ~~all features~~ experimental features,  [doc_auto_cfg](https://doc.rust-lang.org/rustdoc/unstable-features.html#doc_auto_cfg-automatically-generate-doccfg) and [doc_cfg](https://doc.rust-lang.org/rustdoc/unstable-features.html#doccfg-recording-what-platforms-or-features-are-required-for-code-to-be-present) using docs.rs [metadata](https://docs.rs/about/metadata)

New documentation can be viewed locally by running command
`cargo rustdoc -p cedar-policy --features experimental  --open -- --cfg docsrs`

## Issue #, if available
Closes #607

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
