### PR TITLE
increase validator precision in an edge case

### DIFF
--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -482,14 +482,18 @@ impl Type {
     }
 
     /// Return true if we know that any value in this type must be a specified
-    /// entity. An unspecified entity has type `AnyEntity`, so `AnyEntity` might
-    /// not be specified. Other entity types must be specified.
+    /// entity.
     pub(crate) fn must_be_specified_entity(ty: &Type) -> bool {
         matches!(
             ty,
+            // An unspecified entity has type `AnyEntity`, so `AnyEntity` might
+            // not be specified. Other entity types must be specified.
             Type::EntityOrRecord(
                 EntityRecordKind::Entity(_) | EntityRecordKind::ActionEntity { .. }
             )
+            // It is vacuously true that any value in the type `Never` is a
+            // specified entity.
+            | Type::Never
         )
     }
 


### PR DESCRIPTION
## Description of changes

This PR is an alternate way to address the problem in #603.  Instead of changing `type_of_var_in_entity_literals()` and `type_of_entity_literal_in_entity_literals()`, we merely change the definition of `Type::must_be_specified_entity()`, which will cause cases of `X in []` to be short-circuited out ([here](https://github.com/cedar-policy/cedar/blob/2c456758391cfff0eb23d79d4c9d446ce09fd035/cedar-policy-validator/src/typecheck.rs#L1763)) and never reach those functions in the first place.  This causes `X in []` to be typed `False` for all X, including unspecified X.  This matches the behavior of the Dafny as far as I understand it.

The edge case where this changes validator behavior is only possible when `[]` is a valid expression, which is only true under Permissive validation, which is only an experimental feature in Cedar 3.x, so this is not considered a breaking change from semver perspective, and could be released in a patch or minor of Cedar 3.x.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
