### PR TITLE
reorder some changelog entries, and light editing

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -9,14 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `PolicyId::new()` added to `PolicyId` (#587, resolving #551)
-- `AsRef<str>` implementation for `PolicyId`. (#504, resolving #503)
-- New API `template_links` for `Policy` to retrieve the linked values for a
-  template-linked policy. (#515, resolving #489)
-- Added `EntityId::new()` constructor (#583, resolving #553)
-- New feature for cedar-policy and cedar-policy core to allow targeting wasm
+- `PolicyId::new()` (#587, resolving #551)
+- `EntityId::new()` (#583, resolving #553)
+- `AsRef<str>` implementation for `PolicyId` (#504, resolving #503)
+- `Policy::template_links()` to retrieve the linked values for a
+  template-linked policy (#515, resolving #489)
 - `AuthorizationError::id()` to get the id of the policy associated with an
-  authorization error. (#589)
+  authorization error (#589)
+- `wasm` Cargo feature for targeting Wasm
+- For the `partial-eval` experimental feature: added
+`Authorizer::evaluate_policies_partial()` (#474)
 
 ### Changed
 
@@ -28,29 +30,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and all associated information in a pretty human-readable format or as JSON.
   For more details, see `miette`'s
   [documentation](https://docs.rs/miette/latest/miette/index.html). (#477)
-- Moved `(PolicyId as FromStr)::Err` to `Infallible` (#588, resolving #551)
+- Moved `<PolicyId as FromStr>::Err` to `Infallible` (#588, resolving #551)
 - Add hints suggesting how to fix some type errors. (#513)
 - The `ValidationResult` returned from `Validator::validate` now has a static
   lifetime, allowing it to be used in more contexts. The lifetime parameter
   will be removed in a future major version. (#512)
 - Improve parse error around invalid `is` expressions. (#491, resolving #409)
-- Improve parser error message when a policy includes an invalid template slot.
+- Improve parse error message when a policy includes an invalid template slot.
   The error now identifies that the policy used an invalid slot and suggests using
   one of the valid slots. (#487, resolving #451)
-- Improve parser error messages to more reliably notice that a function or
-  method does exists when it is called with an incorrect number of arguments or
+- Improve parse error messages to more reliably notice that a function or
+  method does exist when it is called with an incorrect number of arguments or
   using the wrong call style. (#482)
-- Include source spans on more parser error messages. (#471, resolving #465)
+- Include source spans on more parse error messages. (#471, resolving #465)
 - Include source spans on more evaluation error messages. (#582)
 - For the `partial-eval` experimental feature: make the return values of
   `RequestBuilder`'s `principal`, `action`, `resource`, `context` and
   `schema` functions `#[must_use]`. (#502)
 - For the `partial-eval` experimental feature: make `RequestBuilder::schema`
 return a `RequestBuilder<&Schema>` so the `RequestBuilder<&Schema>::build`
-method checks the request against the schema provided and the 
+method checks the request against the schema provided and the
 `RequestBuilder<UnsetSchema>::build` method becomes infallible. (#559)
-- For the `partial-eval` experimental feature: added 
-`Authorizer::evaluate_policies_partial` (#474)
 
 ### Fixed
 
@@ -79,58 +79,50 @@ Cedar Language Version: 3.0.0
 
 ### Added
 
+- The `is` operation as described in
+  [RFC 5](https://github.com/cedar-policy/rfcs/blob/main/text/0005-is-operator.md).
+  (#396)
 - Marked the `Template::from_json` and `Template::to_json` apis as public (#458)
 - New APIs to `Entities` to make it easy to add a collection of entities to an
   existing `Entities` structure. (#276)
+- `PolicySet::remove_static`, `PolicySet::remove_template` and
+  `PolicySet::unlink` to remove policies from the policy set. (#337, resolving #328)
+- `PolicySet::get_linked_policies` to get the policies linked to a `Template`. (#337)
 - Export the `cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind}` and
   `cedar_policy_core::authorizer::AuthorizationError` error types. (#260, #271)
 - `ParseError::primary_source_span` to get the primary source span locating an
   error. (#324)
-- Experimental API `PolicySet::unknown_entities` to collect unknown entity UIDs
-  from a `PartialResponse`. (#353, resolving #321)
-- `PolicySet::remove_static`, `PolicySet::remove_template` and
-  `PolicySet::unlink` to remove policies from the policy set. (#337, resolving #328)
-- `PolicySet::get_linked_policies` to get the policies linked to a `Template`. (#337)
 - `ValidationResult::validation_warnings` to access non-fatal warnings returned
   by the validator and `ValidationResult::validation_passed_without_warnings`.
   The main validation entry point now checks for warnings previously only
   available through `confusable_string_checker`. (#404)
-- The `is` operation as described in
-  [RFC 5](https://github.com/cedar-policy/rfcs/blob/main/text/0005-is-operator.md).
-  (#396)
 - `Entity::new_no_attrs()` which provides an infallible constructor for `Entity`
   in the case that there are no attributes. (See changes to `Entity::new()`
   below.) (#430)
 - `RestrictedExpression::new_entity_uid()` (#442, resolving #350)
+- Experimental API `PolicySet::unknown_entities` to collect unknown entity UIDs
+  from a `PartialResponse`. (#353, resolving #321)
 
 ### Changed
 
-- Rename `cedar_policy_core::est::EstToAstError` to
-  `cedar_policy_core::est::FromJsonError`. (#197)
-- Rename `cedar_policy_core::entities::JsonDeserializationError::ExtensionsError`
-  to `cedar_policy_core::entities::JsonDeserializationError::ExtensionFunctionLookup`.
-  (#360)
-- Rename variants in `SchemaError`. (#231)
-- `SchemaError` has a new variant corresponding to errors evaluating action
-  attributes. (#430)
-- `Diagnostics::errors()` now returns an iterator over `AuthorizationError`s.
-  (#260)
-- `Response::new()` now expects a `Vec<AuthorizationError>` as its third
-  argument. (#260)
 - Implement [RFC 19](https://github.com/cedar-policy/rfcs/blob/main/text/0019-stricter-validation.md),
   making validation slightly more strict, but more explainable. (#282)
 - Implement [RFC 20](https://github.com/cedar-policy/rfcs/blob/main/text/0020-unique-record-keys.md),
   disallowing duplicate keys in record values (including record literals in
   policies, request `context`, and records in entity attributes). (#375)
+- `Request::new()` now takes an optional schema argument, and validates the request
+  against that schema. To signal validation errors, it now returns a `Result`.
+  (#393, resolving #191)
 - `Entities::from_*()` methods now automatically add action entities present in
   the `schema` to the constructed `Entities`, if a `schema` is provided. (#360)
 - `Entities::from_*()` methods now validate the entities against the `schema`,
   if a `schema` is provided. (#360)
 - `Entities::from_entities()` and `Entities::add_entities()` now take an
   optional schema argument. (#360)
-- `Request::new()` now takes an optional schema argument, and validates the request
-  against that schema. To signal validation errors, it now returns a `Result`.
-  (#393, resolving #191)
+- `Diagnostics::errors()` now returns an iterator over `AuthorizationError`s.
+  (#260)
+- `Response::new()` now expects a `Vec<AuthorizationError>` as its third
+  argument. (#260)
 - Change the semantics of equality for IP ranges. For example,
   `ip("192.168.0.1/24") == ip("192.168.0.3/24")` was previously `true` and is now
   `false`. The behavior of equality on single IP addresses is unchanged, and so is
@@ -148,6 +140,17 @@ Cedar Language Version: 3.0.0
   is stored in already-evaluated form), and its error type has changed. (#430)
 - `Context::from_*()` methods also now eagerly evaluate the `Context`, and as
   a result return errors when evaluation fails. (#430)
+- Rename `cedar_policy_core::est::EstToAstError` to
+  `cedar_policy_core::est::FromJsonError`. (#197)
+- Rename `cedar_policy_core::entities::JsonDeserializationError::ExtensionsError`
+  to `cedar_policy_core::entities::JsonDeserializationError::ExtensionFunctionLookup`.
+  (#360)
+- Rename variants in `SchemaError`. (#231)
+- `SchemaError` has a new variant corresponding to errors evaluating action
+  attributes. (#430)
+- Improve schema parsing error messages when a cycle exists in the action
+  hierarchy to includes an action which is part of the cycle (#436, resolving
+  #416).
 - `<EntityId as FromStr>::Error` is now `Infallible` instead of `ParseErrors`.
   (#372)
 - Improve the `Display` impls for `Policy` and `PolicySet`, and add a `Display`
@@ -159,9 +162,6 @@ Cedar Language Version: 3.0.0
   `ValidationError::location`. (#405)
 - `ValidationWarningKind` is now `non_exhaustive`, allowing future warnings to
   be added without a breaking change. (#404)
-- Improve schema parsing error messages when a cycle exists in the action
-  hierarchy to includes an action which is part of the cycle (#436, resolving
-  #416).
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

- Reorder changelog entries in Unreleased and in 3.0.0 to (roughly) put the most important changes on top, and changes to experimental features on bottom
- Light editing of some changelog entries


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
