### PR TITLE
move decimal regex behind lazy_static

### DIFF
--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -53,6 +53,11 @@ mod names {
     }
 }
 
+// Global regex, initialized at first use
+lazy_static::lazy_static! {
+    static ref DECIMAL_REGEX : Regex = Regex::new(r"^(-?\d+)\.(\d+)$").unwrap();
+}
+
 /// Help message to display when a String was provided where a decimal value was expected.
 /// This error is likely due to confusion between "1.23" and decimal("1.23").
 const ADVICE_MSG: &str = "maybe you forgot to apply the `decimal` constructor?";
@@ -104,15 +109,14 @@ impl Decimal {
         // check that the string matches the regex
         // PANIC SAFETY: This regex does parse
         #[allow(clippy::unwrap_used)]
-        let re = Regex::new(r"^(-?\d+)\.(\d+)$").unwrap();
-        if !re.is_match(str.as_ref()) {
+        if !DECIMAL_REGEX.is_match(str.as_ref()) {
             return Err(Error::FailedParse(str.as_ref().to_owned()));
         }
 
         // pull out the components before and after the decimal point
         // (the check above should ensure that .captures() and .get() succeed,
         // but we include proper error handling for posterity)
-        let caps = re
+        let caps = DECIMAL_REGEX
             .captures(str.as_ref())
             .ok_or_else(|| Error::FailedParse(str.as_ref().to_owned()))?;
         let l = caps

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -16,8 +16,6 @@
 
 //! This module contains the Cedar 'decimal' extension.
 
-use regex::Regex;
-
 use crate::ast::{
     CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, ExtensionValue,
     ExtensionValueWithArgs, Literal, Name, Type, Value, ValueKind,
@@ -39,10 +37,12 @@ struct Decimal {
     value: i64,
 }
 
-// PANIC SAFETY All `Name`s in here are valid `Name`s
-#[allow(clippy::expect_used)]
-mod names {
+// PANIC SAFETY The `Name`s and `Regex` here are valid
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod constants {
     use super::{Name, EXTENSION_NAME};
+    use regex::Regex;
+
     // PANIC SAFETY all of the names here are valid names
     lazy_static::lazy_static! {
         pub static ref DECIMAL_FROM_STR_NAME : Name = Name::parse_unqualified_name(EXTENSION_NAME).expect("should be a valid identifier");
@@ -51,11 +51,12 @@ mod names {
         pub static ref GREATER_THAN : Name = Name::parse_unqualified_name("greaterThan").expect("should be a valid identifier");
         pub static ref GREATER_THAN_OR_EQUAL : Name = Name::parse_unqualified_name("greaterThanOrEqual").expect("should be a valid identifier");
     }
-}
 
-// Global regex, initialized at first use
-lazy_static::lazy_static! {
-    static ref DECIMAL_REGEX : Regex = Regex::new(r"^(-?\d+)\.(\d+)$").unwrap();
+    // Global regex, initialized at first use
+    // PANIC SAFETY This is a valid `Regex`
+    lazy_static::lazy_static! {
+        pub static ref DECIMAL_REGEX : Regex = Regex::new(r"^(-?\d+)\.(\d+)$").unwrap();
+    }
 }
 
 /// Help message to display when a String was provided where a decimal value was expected.
@@ -94,7 +95,7 @@ fn checked_mul_pow(x: i64, y: u32) -> Result<i64, Error> {
 impl Decimal {
     /// The Cedar typename of decimal values
     fn typename() -> Name {
-        names::DECIMAL_FROM_STR_NAME.clone()
+        constants::DECIMAL_FROM_STR_NAME.clone()
     }
 
     /// Convert a string into a `Decimal` value.
@@ -107,16 +108,14 @@ impl Decimal {
     /// `d * 10 ^ NUM_DIGITS`; this function will error on overflow.
     fn from_str(str: impl AsRef<str>) -> Result<Self, Error> {
         // check that the string matches the regex
-        // PANIC SAFETY: This regex does parse
-        #[allow(clippy::unwrap_used)]
-        if !DECIMAL_REGEX.is_match(str.as_ref()) {
+        if !constants::DECIMAL_REGEX.is_match(str.as_ref()) {
             return Err(Error::FailedParse(str.as_ref().to_owned()));
         }
 
         // pull out the components before and after the decimal point
         // (the check above should ensure that .captures() and .get() succeed,
         // but we include proper error handling for posterity)
-        let caps = DECIMAL_REGEX
+        let caps = constants::DECIMAL_REGEX
             .captures(str.as_ref())
             .ok_or_else(|| Error::FailedParse(str.as_ref().to_owned()))?;
         let l = caps
@@ -172,7 +171,7 @@ const EXTENSION_NAME: &str = "decimal";
 
 fn extension_err(msg: impl Into<String>) -> evaluator::EvaluationError {
     evaluator::EvaluationError::failed_extension_function_application(
-        names::DECIMAL_FROM_STR_NAME.clone(),
+        constants::DECIMAL_FROM_STR_NAME.clone(),
         msg.into(),
         None, // source loc will be added by the evaluator
     )
@@ -183,7 +182,7 @@ fn extension_err(msg: impl Into<String>) -> evaluator::EvaluationError {
 fn decimal_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
     let decimal = Decimal::from_str(str.as_str()).map_err(|e| extension_err(e.to_string()))?;
-    let function_name = names::DECIMAL_FROM_STR_NAME.clone();
+    let function_name = constants::DECIMAL_FROM_STR_NAME.clone();
     let arg_source_loc = arg.source_loc().cloned();
     let e = ExtensionValueWithArgs::new(Arc::new(decimal), function_name, vec![arg.into()]);
     Ok(Value {
@@ -262,38 +261,38 @@ pub fn extension() -> Extension {
         name: Decimal::typename(),
     };
     Extension::new(
-        names::DECIMAL_FROM_STR_NAME.clone(),
+        constants::DECIMAL_FROM_STR_NAME.clone(),
         vec![
             ExtensionFunction::unary(
-                names::DECIMAL_FROM_STR_NAME.clone(),
+                constants::DECIMAL_FROM_STR_NAME.clone(),
                 CallStyle::FunctionStyle,
                 Box::new(decimal_from_str),
                 decimal_type.clone(),
                 Some(SchemaType::String),
             ),
             ExtensionFunction::binary(
-                names::LESS_THAN.clone(),
+                constants::LESS_THAN.clone(),
                 CallStyle::MethodStyle,
                 Box::new(decimal_lt),
                 SchemaType::Bool,
                 (Some(decimal_type.clone()), Some(decimal_type.clone())),
             ),
             ExtensionFunction::binary(
-                names::LESS_THAN_OR_EQUAL.clone(),
+                constants::LESS_THAN_OR_EQUAL.clone(),
                 CallStyle::MethodStyle,
                 Box::new(decimal_le),
                 SchemaType::Bool,
                 (Some(decimal_type.clone()), Some(decimal_type.clone())),
             ),
             ExtensionFunction::binary(
-                names::GREATER_THAN.clone(),
+                constants::GREATER_THAN.clone(),
                 CallStyle::MethodStyle,
                 Box::new(decimal_gt),
                 SchemaType::Bool,
                 (Some(decimal_type.clone()), Some(decimal_type.clone())),
             ),
             ExtensionFunction::binary(
-                names::GREATER_THAN_OR_EQUAL.clone(),
+                constants::GREATER_THAN_OR_EQUAL.clone(),
                 CallStyle::MethodStyle,
                 Box::new(decimal_ge),
                 SchemaType::Bool,


### PR DESCRIPTION
## Description of changes

Resolves #527. While doing some light benchmarking, I observed that authorization was unexpectedly slow for policies containing `decimal(...)`. @cdisselkoen kindly pointed me to this issue, and suggested switching to `lazy_static`.

With this small change, the set of policies I was testing (auto-generated, with >10 uses of `decimal(..)`) went from a median authorization time of 18044μs to 179μs (100x improvement!)

## Issue #, if available

#527 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
