### PR TITLE
Core Entity `.uid()` returns a ref

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -291,8 +291,8 @@ impl Entity {
     }
 
     /// Get the UID of this entity
-    pub fn uid(&self) -> EntityUID {
-        self.uid.clone()
+    pub fn uid(&self) -> &EntityUID {
+        &self.uid
     }
 
     /// Get the value for the given attribute, or `None` if not present
@@ -374,7 +374,7 @@ impl StaticallyTyped for Entity {
 
 impl TCNode<EntityUID> for Entity {
     fn get_key(&self) -> EntityUID {
-        self.uid()
+        self.uid().clone()
     }
 
     fn add_edge_to(&mut self, k: EntityUID) {

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -127,8 +127,10 @@ impl Entities {
             if let Some(checker) = checker.as_ref() {
                 checker.validate_entity(&entity)?;
             }
-            match self.entities.entry(entity.uid()) {
-                hash_map::Entry::Occupied(_) => return Err(EntitiesError::Duplicate(entity.uid())),
+            match self.entities.entry(entity.uid().clone()) {
+                hash_map::Entry::Occupied(_) => {
+                    return Err(EntitiesError::Duplicate(entity.uid().clone()))
+                }
                 hash_map::Entry::Vacant(vacant_entry) => {
                     vacant_entry.insert(entity);
                 }
@@ -198,7 +200,7 @@ impl Entities {
                 schema
                     .action_entities()
                     .into_iter()
-                    .map(|e| (e.uid(), Arc::unwrap_or_clone(e))),
+                    .map(|e| (e.uid().clone(), Arc::unwrap_or_clone(e))),
             );
         }
         Ok(Self {
@@ -310,8 +312,8 @@ impl Entities {
 fn create_entity_map(es: impl Iterator<Item = Entity>) -> Result<HashMap<EntityUID, Entity>> {
     let mut map = HashMap::new();
     for e in es {
-        match map.entry(e.uid()) {
-            hash_map::Entry::Occupied(_) => return Err(EntitiesError::Duplicate(e.uid())),
+        match map.entry(e.uid().clone()) {
+            hash_map::Entry::Occupied(_) => return Err(EntitiesError::Duplicate(e.uid().clone())),
             hash_map::Entry::Vacant(v) => {
                 v.insert(e);
             }
@@ -2564,7 +2566,7 @@ mod schema_based_parsing_tests {
             Dereference::Data(e) => e,
             _ => panic!("expected entity to exist and be concrete"),
         };
-        assert_eq!(parsed_entity.uid(), expected_uid);
+        assert_eq!(parsed_entity.uid(), &expected_uid);
     }
 
     /// Test that involves an action also declared in the schema, but an attribute has a different value (of the same type)

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1015,15 +1015,15 @@ pub mod test {
         let grandparent = Entity::with_uid(EntityUID::with_eid("grandparent"));
         let mut sibling = Entity::with_uid(EntityUID::with_eid("sibling"));
         let unrelated = Entity::with_uid(EntityUID::with_eid("unrelated"));
-        child.add_ancestor(parent.uid());
-        sibling.add_ancestor(parent.uid());
-        parent.add_ancestor(grandparent.uid());
+        child.add_ancestor(parent.uid().clone());
+        sibling.add_ancestor(parent.uid().clone());
+        parent.add_ancestor(grandparent.uid().clone());
         let mut child_diff_type = Entity::with_uid(
             EntityUID::with_eid_and_type("other_type", "other_child")
                 .expect("should be a valid identifier"),
         );
-        child_diff_type.add_ancestor(parent.uid());
-        child_diff_type.add_ancestor(grandparent.uid());
+        child_diff_type.add_ancestor(parent.uid().clone());
+        child_diff_type.add_ancestor(grandparent.uid().clone());
         Entities::from_entities(
             vec![
                 entity_no_attrs_no_parents,
@@ -3561,7 +3561,7 @@ pub mod test {
         //Alice has parent "Friends" but we don't add "Friends" to the slice
         let mut alice = Entity::with_uid(EntityUID::with_eid("Alice"));
         let parent = Entity::with_uid(EntityUID::with_eid("Friends"));
-        alice.add_ancestor(parent.uid());
+        alice.add_ancestor(parent.uid().clone());
         let entities = Entities::from_entities(
             vec![alice],
             None::<&NoEntitiesSchema>,

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -201,7 +201,11 @@ mod tests {
         let mut b = Entity::with_uid(EntityUID::with_eid("B"));
         b.add_ancestor(EntityUID::with_eid("C"));
         let c = Entity::with_uid(EntityUID::with_eid("C"));
-        let mut entities = HashMap::from([(a.uid(), a), (b.uid(), b), (c.uid(), c)]);
+        let mut entities = HashMap::from([
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+        ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
@@ -229,7 +233,11 @@ mod tests {
         let mut b = Entity::with_uid(EntityUID::with_eid("B"));
         b.add_ancestor(EntityUID::with_eid("C"));
         let c = Entity::with_uid(EntityUID::with_eid("C"));
-        let mut entities = HashMap::from([(c.uid(), c), (b.uid(), b), (a.uid(), a)]);
+        let mut entities = HashMap::from([
+            (c.uid().clone(), c),
+            (b.uid().clone(), b),
+            (a.uid().clone(), a),
+        ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
@@ -261,11 +269,11 @@ mod tests {
         d.add_ancestor(EntityUID::with_eid("E"));
         let e = Entity::with_uid(EntityUID::with_eid("E"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -304,11 +312,11 @@ mod tests {
         ham.add_ancestor(EntityUID::with_eid("eggs"));
         let eggs = Entity::with_uid(EntityUID::with_eid("eggs"));
         let mut entities = HashMap::from([
-            (ham.uid(), ham),
-            (bar.uid(), bar),
-            (foo.uid(), foo),
-            (eggs.uid(), eggs),
-            (baz.uid(), baz),
+            (ham.uid().clone(), ham),
+            (bar.uid().clone(), bar),
+            (foo.uid().clone(), foo),
+            (eggs.uid().clone(), eggs),
+            (baz.uid().clone(), baz),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -348,11 +356,11 @@ mod tests {
         d.add_ancestor(EntityUID::with_eid("E"));
         let e = Entity::with_uid(EntityUID::with_eid("E"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -400,14 +408,14 @@ mod tests {
         g.add_ancestor(EntityUID::with_eid("E"));
         let h = Entity::with_uid(EntityUID::with_eid("H"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
-            (f.uid(), f),
-            (g.uid(), g),
-            (h.uid(), h),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
+            (f.uid().clone(), f),
+            (g.uid().clone(), g),
+            (h.uid().clone(), h),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -462,12 +470,12 @@ mod tests {
         let e = Entity::with_uid(EntityUID::with_eid("E"));
         let f = Entity::with_uid(EntityUID::with_eid("F"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
-            (f.uid(), f),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
+            (f.uid().clone(), f),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -512,14 +520,14 @@ mod tests {
         let g = Entity::with_uid(EntityUID::with_eid("G"));
         let h = Entity::with_uid(EntityUID::with_eid("H"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
-            (f.uid(), f),
-            (g.uid(), g),
-            (h.uid(), h),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
+            (f.uid().clone(), f),
+            (g.uid().clone(), g),
+            (h.uid().clone(), h),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -561,7 +569,7 @@ mod tests {
         a.add_ancestor(EntityUID::with_eid("B"));
         let mut b = Entity::with_uid(EntityUID::with_eid("B"));
         b.add_ancestor(EntityUID::with_eid("B"));
-        let mut entities = HashMap::from([(a.uid(), a), (b.uid(), b)]);
+        let mut entities = HashMap::from([(a.uid().clone(), a), (b.uid().clone(), b)]);
         // computing TC should succeed without panicking, infinitely recursing, etc
         assert!(compute_tc_internal(&mut entities).is_ok());
         // fails cycle check
@@ -607,7 +615,7 @@ mod tests {
         let mut c = Entity::with_uid(EntityUID::with_eid("C"));
         c.add_ancestor(EntityUID::with_eid("A"));
         let d = Entity::with_uid(EntityUID::with_eid("D"));
-        let mut entities = HashMap::from([(a.uid(), a), (b.uid(), b), (c.uid(), c), (d.uid(), d)]);
+        let mut entities = HashMap::from([(a.uid().clone(), a), (b.uid().clone(), b), (c.uid().clone(), c), (d.uid().clone(), d)]);
         // computing TC should succeed without panicking, infinitely recursing, etc
         assert!(compute_tc_internal(&mut entities).is_ok());
         // fails cycle check
@@ -671,14 +679,14 @@ mod tests {
         let mut h = Entity::with_uid(EntityUID::with_eid("H"));
         h.add_ancestor(EntityUID::with_eid("D"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
-            (f.uid(), f),
-            (g.uid(), g),
-            (h.uid(), h),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
+            (f.uid().clone(), f),
+            (g.uid().clone(), g),
+            (h.uid().clone(), h),
         ]);
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
@@ -729,12 +737,12 @@ mod tests {
         let mut f = Entity::with_uid(EntityUID::with_eid("F"));
         f.add_ancestor(EntityUID::with_eid("E"));
         let mut entities = HashMap::from([
-            (a.uid(), a),
-            (b.uid(), b),
-            (c.uid(), c),
-            (d.uid(), d),
-            (e.uid(), e),
-            (f.uid(), f),
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+            (e.uid().clone(), e),
+            (f.uid().clone(), f),
         ]);
         // fails TC enforcement
         assert!(enforce_tc(&entities).is_err());

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -615,7 +615,12 @@ mod tests {
         let mut c = Entity::with_uid(EntityUID::with_eid("C"));
         c.add_ancestor(EntityUID::with_eid("A"));
         let d = Entity::with_uid(EntityUID::with_eid("D"));
-        let mut entities = HashMap::from([(a.uid().clone(), a), (b.uid().clone(), b), (c.uid().clone(), c), (d.uid().clone(), d)]);
+        let mut entities = HashMap::from([
+            (a.uid().clone(), a),
+            (b.uid().clone(), b),
+            (c.uid().clone(), c),
+            (d.uid().clone(), d),
+        ]);
         // computing TC should succeed without panicking, infinitely recursing, etc
         assert!(compute_tc_internal(&mut entities).is_ok());
         // fails cycle check

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -25,7 +25,7 @@ impl<'a> CoreSchema<'a> {
         Self {
             actions: schema
                 .action_entities_iter()
-                .map(|e| (e.uid(), Arc::new(e)))
+                .map(|e| (e.uid().clone(), Arc::new(e)))
                 .collect(),
             schema,
         }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1879,7 +1879,7 @@ mod test {
         let schema: ValidatorSchema = schema_fragment.try_into().expect("Schema should construct");
         let view_photo = schema
             .action_entities_iter()
-            .find(|e| e.uid() == r#"ExampleCo::Personnel::Action::"viewPhoto""#.parse().unwrap())
+            .find(|e| e.uid() == &r#"ExampleCo::Personnel::Action::"viewPhoto""#.parse().unwrap())
             .unwrap();
         let ancestors = view_photo.ancestors().collect::<Vec<_>>();
         let read = ancestors[0];
@@ -1939,7 +1939,7 @@ mod test {
         let schema: ValidatorSchema = schema_fragment.try_into().unwrap();
         let view_photo = schema
             .action_entities_iter()
-            .find(|e| e.uid() == r#"ExampleCo::Personnel::Action::"viewPhoto""#.parse().unwrap())
+            .find(|e| e.uid() == &r#"ExampleCo::Personnel::Action::"viewPhoto""#.parse().unwrap())
             .unwrap();
         let ancestors = view_photo.ancestors().collect::<Vec<_>>();
         let read = ancestors[0];

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -178,7 +178,7 @@ impl Entity {
     /// ```
     pub fn uid(&self) -> EntityUid {
         // INVARIANT: By invariant on self and `EntityUid`: Our Uid can't be unspecified
-        EntityUid(self.0.uid())
+        EntityUid(self.0.uid().clone())
     }
 
     /// Get the value for the given attribute, or `None` if not present.
@@ -4115,7 +4115,7 @@ mod test {
     #[test]
     fn json_bignum_1a() {
         let src = r#"
-        permit(principal, action, resource) when { 
+        permit(principal, action, resource) when {
             (true && (-90071992547409921)) && principal
         };"#;
         let p: Policy = src.parse().unwrap();


### PR DESCRIPTION
## Description of changes

Refactors Core's `Entity::uid()` method to return `&EntityUID` and not `EntityUID`, which is the more natural / idiomatic pattern.  This allows us to avoid cloning the UID for callers that really only needed `&EntityUID`.  Conversely, callers that actually needed owned `EntityUID` now have to call `.clone()` themselves.

Non-breaking because this is a Core API.  This PR does not make the corresponding change to the public API.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
