### PR TITLE
Allow annotation keys to be Cedar reserved words

### DIFF
--- a/cedar-policy-core/src/ast.rs
+++ b/cedar-policy-core/src/ast.rs
@@ -22,6 +22,8 @@ mod entity;
 pub use entity::*;
 mod extension;
 pub use extension::*;
+mod id;
+pub use id::*;
 mod integer;
 pub use integer::{InputInteger, Integer};
 mod literal;

--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -195,6 +195,8 @@ impl<'a> arbitrary::Arbitrary<'a> for AnyId {
     }
 }
 
+// PANIC SAFETY: unit-test code
+#[allow(clippy::panic)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -180,7 +180,10 @@ impl<'a> arbitrary::Arbitrary<'a> for AnyId {
                 .collect::<Result<Vec<&char>, _>>()?,
         );
         let s: String = cs.into_iter().collect();
-        crate::parser::parse_ident(&s).unwrap_or_else(|e| panic!("all strings constructed this way should be valid AnyIds, but this one is not: {s:?}\nerror: {e}"));
+        debug_assert!(
+            crate::parser::parse_ident(&s).is_ok(),
+            "all strings constructed this way should be valid AnyIds, but this one is not: {s:?}"
+        );
         Ok(Self::new_unchecked(s))
     }
 

--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -1,0 +1,212 @@
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+
+use crate::{parser::err::ParseErrors, FromNormalizedStr};
+
+/// Identifiers. Anything in `Id` should be a valid identifier, this means it
+/// does not contain, for instance, spaces or characters like '+'; and also is
+/// not one of the Cedar reserved identifiers (at time of writing,
+/// `true | false | if | then | else | in | is | like | has`).
+//
+// For now, internally, `Id`s are just owned `SmolString`s.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+pub struct Id(SmolStr);
+
+impl Id {
+    /// Create a new `Id` from a `String`, where it is the caller's
+    /// responsibility to ensure that the string is indeed a valid identifier.
+    ///
+    /// When possible, callers should not use this, and instead use `s.parse()`,
+    /// which checks that `s` is a valid identifier, and returns a parse error
+    /// if not.
+    ///
+    /// This method was created for the `From<cst::Ident> for Id` impl to use.
+    /// Since `parser::parse_ident()` implicitly uses that `From` impl itself,
+    /// if we tried to make that `From` impl go through `.parse()` like everyone
+    /// else, we'd get infinite recursion.  And, we assert that `cst::Ident` is
+    /// always already checked to contain a valid identifier, otherwise it would
+    /// never have been created.
+    pub(crate) fn new_unchecked(s: impl Into<SmolStr>) -> Id {
+        Id(s.into())
+    }
+
+    /// Get the underlying string
+    pub fn into_smolstr(self) -> SmolStr {
+        self.0
+    }
+}
+
+impl AsRef<str> for Id {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for Id {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+// allow `.parse()` on a string to make an `Id`
+impl std::str::FromStr for Id {
+    type Err = ParseErrors;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_ident(s)
+    }
+}
+
+impl FromNormalizedStr for Id {
+    fn describe_self() -> &'static str {
+        "Id"
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Id {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // identifier syntax:
+        // IDENT     := ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']* - RESERVED
+        // BOOL      := 'true' | 'false'
+        // RESERVED  := BOOL | 'if' | 'then' | 'else' | 'in' | 'is' | 'like' | 'has'
+
+        let construct_list = |s: &str| s.chars().collect::<Vec<char>>();
+        let list_concat = |s1: &[char], s2: &[char]| [s1, s2].concat();
+        // the set of the first character of an identifier
+        let head_letters = construct_list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
+        // the set of the remaining characters of an identifier
+        let tail_letters = list_concat(&construct_list("0123456789"), &head_letters);
+        // identifier character count minus 1
+        let remaining_length = u.int_in_range(0..=16)?;
+        let mut cs = vec![*u.choose(&head_letters)?];
+        cs.extend(
+            (0..remaining_length)
+                .map(|_| u.choose(&tail_letters))
+                .collect::<Result<Vec<&char>, _>>()?,
+        );
+        let mut s: String = cs.into_iter().collect();
+        // Should the parsing fails, the string should be reserved word.
+        // Append a `_` to create a valid Id.
+        if crate::parser::parse_ident(&s).is_err() {
+            s.push('_');
+        }
+        Ok(Self::new_unchecked(s))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            // for arbitrary length
+            <usize as arbitrary::Arbitrary>::size_hint(depth),
+            // for arbitrary choices
+            // we use the size hint of a vector of `u8` to get an underestimate of bytes required by the sequence of choices.
+            <Vec<u8> as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
+/// Like `Id`, except this specifically _can_ contain Cedar reserved identifiers.
+/// (It still can't contain, for instance, spaces or characters like '+'.)
+//
+// For now, internally, `AnyId`s are just owned `SmolString`s.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+pub struct AnyId(SmolStr);
+
+impl AnyId {
+    /// Create a new `AnyId` from a `String`, where it is the caller's
+    /// responsibility to ensure that the string is indeed a valid `AnyId`.
+    ///
+    /// When possible, callers should not use this, and instead use `s.parse()`,
+    /// which checks that `s` is a valid `AnyId`, and returns a parse error
+    /// if not.
+    ///
+    /// This method was created for the `From<cst::Ident> for AnyId` impl to use.
+    /// See notes on `Id::new_unchecked()`.
+    pub(crate) fn new_unchecked(s: impl Into<SmolStr>) -> AnyId {
+        AnyId(s.into())
+    }
+
+    /// Get the underlying string
+    pub fn into_smolstr(self) -> SmolStr {
+        self.0
+    }
+}
+
+impl AsRef<str> for AnyId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for AnyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+// allow `.parse()` on a string to make an `AnyId`
+impl std::str::FromStr for AnyId {
+    type Err = ParseErrors;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_anyid(s)
+    }
+}
+
+impl FromNormalizedStr for AnyId {
+    fn describe_self() -> &'static str {
+        "AnyId"
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for AnyId {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // AnyId syntax:
+        // ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']*
+
+        let construct_list = |s: &str| s.chars().collect::<Vec<char>>();
+        let list_concat = |s1: &[char], s2: &[char]| [s1, s2].concat();
+        // the set of the first character of an AnyId
+        let head_letters = construct_list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
+        // the set of the remaining characters of an AnyId
+        let tail_letters = list_concat(&construct_list("0123456789"), &head_letters);
+        // identifier character count minus 1
+        let remaining_length = u.int_in_range(0..=16)?;
+        let mut cs = vec![*u.choose(&head_letters)?];
+        cs.extend(
+            (0..remaining_length)
+                .map(|_| u.choose(&tail_letters))
+                .collect::<Result<Vec<&char>, _>>()?,
+        );
+        let s: String = cs.into_iter().collect();
+        crate::parser::parse_ident(&s).unwrap_or_else(|e| panic!("all strings constructed this way should be valid AnyIds, but this one is not: {s:?}\nerror: {e}"));
+        Ok(Self::new_unchecked(s))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            // for arbitrary length
+            <usize as arbitrary::Arbitrary>::size_hint(depth),
+            // for arbitrary choices
+            // we use the size hint of a vector of `u8` to get an underestimate of bytes required by the sequence of choices.
+            <Vec<u8> as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn normalized_id() {
+        Id::from_normalized_str("foo").expect("should be OK");
+        Id::from_normalized_str("foo::bar").expect_err("shouldn't be OK");
+        Id::from_normalized_str(r#"foo::"bar""#).expect_err("shouldn't be OK");
+        Id::from_normalized_str(" foo").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo ").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo\n").expect_err("shouldn't be OK");
+        Id::from_normalized_str("foo//comment").expect_err("shouldn't be OK");
+    }
+}

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-use std::sync::Arc;
-
+use super::id::Id;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use smol_str::SmolStr;
+use std::sync::Arc;
 
 use crate::parser::err::ParseErrors;
 use crate::FromNormalizedStr;
@@ -197,123 +196,10 @@ mod vars_test {
     }
 }
 
-/// Identifiers. Anything in `Id` should be a valid identifier, this means it
-/// does not contain, for instance, spaces or characters like '+'; and also is
-/// not one of the Cedar reserved identifiers (at time of writing,
-/// `true | false | if | then | else | in | is | like | has`).
-//
-// For now, internally, `Id`s are just owned `SmolString`s.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub struct Id(SmolStr);
-
-impl Id {
-    /// Create a new `Id` from a `String`, where it is the caller's
-    /// responsibility to ensure that the string is indeed a valid identifier.
-    ///
-    /// When possible, callers should not use this, and instead use `s.parse()`,
-    /// which checks that `s` is a valid identifier, and returns a parse error
-    /// if not.
-    ///
-    /// This method was created for the `From<cst::Ident> for Id` impl to use.
-    /// Since `parser::parse_ident()` implicitly uses that `From` impl itself,
-    /// if we tried to make that `From` impl go through `.parse()` like everyone
-    /// else, we'd get infinite recursion.  And, we assert that `cst::Ident` is
-    /// always already checked to contain a valid identifier, otherwise it would
-    /// never have been created.
-    pub(crate) fn new_unchecked(s: impl Into<SmolStr>) -> Id {
-        Id(s.into())
-    }
-
-    /// Get the underlying string
-    pub fn into_smolstr(self) -> SmolStr {
-        self.0
-    }
-}
-
-impl AsRef<str> for Id {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for Id {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
-    }
-}
-
-// allow `.parse()` on a string to make an `Id`
-impl std::str::FromStr for Id {
-    type Err = ParseErrors;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        crate::parser::parse_ident(s)
-    }
-}
-
-impl FromNormalizedStr for Id {
-    fn describe_self() -> &'static str {
-        "Id"
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for Id {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // identifier syntax:
-        // IDENT     := ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']* - RESERVED
-        // BOOL      := 'true' | 'false'
-        // RESERVED  := BOOL | 'if' | 'then' | 'else' | 'in' | 'is' | 'like' | 'has'
-
-        let construct_list = |s: &str| s.chars().collect::<Vec<char>>();
-        let list_concat = |s1: &[char], s2: &[char]| [s1, s2].concat();
-        // the set of the first character of an identifier
-        let head_letters = construct_list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
-        // the set of the remaining characters of an identifier
-        let tail_letters = list_concat(&construct_list("0123456789"), &head_letters);
-        // identifier character count minus 1
-        let remaining_length = u.int_in_range(0..=16)?;
-        let mut cs = vec![*u.choose(&head_letters)?];
-        cs.extend(
-            (0..remaining_length)
-                .map(|_| u.choose(&tail_letters))
-                .collect::<Result<Vec<&char>, _>>()?,
-        );
-        let mut s: String = cs.into_iter().collect();
-        // Should the parsing fails, the string should be reserved word.
-        // Append a `_` to create a valid Id.
-        if crate::parser::parse_ident(&s).is_err() {
-            s.push('_');
-        }
-        Ok(Self::new_unchecked(s))
-    }
-
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        arbitrary::size_hint::and_all(&[
-            // for arbitrary length
-            <usize as arbitrary::Arbitrary>::size_hint(depth),
-            // for arbitrary choices
-            // we use the size hint of a vector of `u8` to get an underestimate of bytes required by the sequence of choices.
-            <Vec<u8> as arbitrary::Arbitrary>::size_hint(depth),
-        ])
-    }
-}
-
 #[cfg(test)]
 mod test {
 
     use super::*;
-
-    #[test]
-    fn normalized_id() {
-        Id::from_normalized_str("foo").expect("should be OK");
-        Id::from_normalized_str("foo::bar").expect_err("shouldn't be OK");
-        Id::from_normalized_str(r#"foo::"bar""#).expect_err("shouldn't be OK");
-        Id::from_normalized_str(" foo").expect_err("shouldn't be OK");
-        Id::from_normalized_str("foo ").expect_err("shouldn't be OK");
-        Id::from_normalized_str("foo\n").expect_err("shouldn't be OK");
-        Id::from_normalized_str("foo//comment").expect_err("shouldn't be OK");
-    }
 
     #[test]
     fn normalized_name() {

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -197,8 +197,10 @@ mod vars_test {
     }
 }
 
-/// Identifiers. Anything in `Id` should be a valid identifier (and not contain,
-/// for instance, spaces or characters like '+').
+/// Identifiers. Anything in `Id` should be a valid identifier, this means it
+/// does not contain, for instance, spaces or characters like '+'; and also is
+/// not one of the Cedar reserved identifiers (at time of writing,
+/// `true | false | if | then | else | in | is | like | has`).
 //
 // For now, internally, `Id`s are just owned `SmolString`s.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
@@ -223,7 +225,7 @@ impl Id {
     }
 
     /// Get the underlying string
-    pub fn to_smolstr(self) -> SmolStr {
+    pub fn into_smolstr(self) -> SmolStr {
         self.0
     }
 }
@@ -261,7 +263,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Id {
         // identifier syntax:
         // IDENT     := ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']* - RESERVED
         // BOOL      := 'true' | 'false'
-        // RESERVED  := BOOL | 'if' | 'then' | 'else' | 'in' | 'like' | 'has'
+        // RESERVED  := BOOL | 'if' | 'then' | 'else' | 'in' | 'is' | 'like' | 'has'
 
         let construct_list = |s: &str| s.chars().collect::<Vec<char>>();
         let list_concat = |s1: &[char], s2: &[char]| [s1, s2].concat();

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-use crate::ast::*;
+use crate::parser::err::ParseErrors;
+use crate::{ast::*, FromNormalizedStr};
 use itertools::Itertools;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
@@ -63,7 +64,7 @@ impl Template {
     /// Construct a `Template` from its components
     pub fn new(
         id: PolicyID,
-        annotations: BTreeMap<Id, SmolStr>,
+        annotations: BTreeMap<AnyId, SmolStr>,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
@@ -123,12 +124,12 @@ impl Template {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &Id) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
         self.body.annotation(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&Id, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
         self.body.annotations()
     }
 
@@ -366,12 +367,12 @@ impl Policy {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &Id) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
         self.template.annotation(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&Id, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
         self.template.annotations()
     }
 
@@ -672,12 +673,12 @@ impl StaticPolicy {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &Id) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
         self.0.annotation(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&Id, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
         self.0.annotations()
     }
 
@@ -734,10 +735,10 @@ impl StaticPolicy {
         self.0.condition()
     }
 
-    /// Construct a `Policy` from its components
+    /// Construct a `StaticPolicy` from its components
     pub fn new(
         id: PolicyID,
-        annotations: BTreeMap<Id, SmolStr>,
+        annotations: BTreeMap<AnyId, SmolStr>,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
@@ -789,16 +790,106 @@ impl From<StaticPolicy> for Arc<Template> {
     }
 }
 
-/// Policy datatype.
-///
-/// This will also represent the serialized form of policies on disk
-/// and on the network.
+/// Like `Id`, except this specifically _can_ contain Cedar reserved identifiers.
+/// (It still can't contain, for instance, spaces or characters like '+'.)
+//
+// For now, internally, `AnyId`s are just owned `SmolString`s.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+pub struct AnyId(SmolStr);
+
+impl AnyId {
+    /// Create a new `AnyId` from a `String`, where it is the caller's
+    /// responsibility to ensure that the string is indeed a valid `AnyId`.
+    ///
+    /// When possible, callers should not use this, and instead use `s.parse()`,
+    /// which checks that `s` is a valid `AnyId`, and returns a parse error
+    /// if not.
+    ///
+    /// This method was created for the `From<cst::Ident> for AnyId` impl to use.
+    /// See notes on `Id::new_unchecked()`.
+    pub(crate) fn new_unchecked(s: impl Into<SmolStr>) -> AnyId {
+        AnyId(s.into())
+    }
+
+    /// Get the underlying string
+    pub fn into_smolstr(self) -> SmolStr {
+        self.0
+    }
+}
+
+impl AsRef<str> for AnyId {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for AnyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.0)
+    }
+}
+
+// allow `.parse()` on a string to make an `AnyId`
+impl std::str::FromStr for AnyId {
+    type Err = ParseErrors;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_anyid(s)
+    }
+}
+
+impl FromNormalizedStr for AnyId {
+    fn describe_self() -> &'static str {
+        "AnyId"
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for AnyId {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        // AnyId syntax:
+        // ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']*
+
+        let construct_list = |s: &str| s.chars().collect::<Vec<char>>();
+        let list_concat = |s1: &[char], s2: &[char]| [s1, s2].concat();
+        // the set of the first character of an AnyId
+        let head_letters = construct_list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
+        // the set of the remaining characters of an AnyId
+        let tail_letters = list_concat(&construct_list("0123456789"), &head_letters);
+        // identifier character count minus 1
+        let remaining_length = u.int_in_range(0..=16)?;
+        let mut cs = vec![*u.choose(&head_letters)?];
+        cs.extend(
+            (0..remaining_length)
+                .map(|_| u.choose(&tail_letters))
+                .collect::<Result<Vec<&char>, _>>()?,
+        );
+        let s: String = cs.into_iter().collect();
+        crate::parser::parse_ident(&s).unwrap_or_else(|e| panic!("all strings constructed this way should be valid AnyIds, but this one is not: {s:?}\nerror: {e}"));
+        Ok(Self::new_unchecked(s))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            // for arbitrary length
+            <usize as arbitrary::Arbitrary>::size_hint(depth),
+            // for arbitrary choices
+            // we use the size hint of a vector of `u8` to get an underestimate of bytes required by the sequence of choices.
+            <Vec<u8> as arbitrary::Arbitrary>::size_hint(depth),
+        ])
+    }
+}
+
+/// Policy datatype. This is used for both templates (in which case it contains
+/// slots) and static policies (in which case it contains zero slots).
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
 pub struct TemplateBody {
     /// ID of this policy
     id: PolicyID,
-    /// Annotations available for external applications, as key-value store
-    annotations: BTreeMap<Id, SmolStr>,
+    /// Annotations available for external applications, as key-value store.
+    /// Note that the keys are `AnyId`, so Cedar reserved words like `if` and `has`
+    /// are explicitly allowed as annotations.
+    annotations: BTreeMap<AnyId, SmolStr>,
     /// `Effect` of this policy
     effect: Effect,
     /// Head constraint for principal. This will be a boolean-valued expression:
@@ -839,12 +930,12 @@ impl TemplateBody {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &Id) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
         self.annotations.get(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&Id, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
         self.annotations.iter()
     }
 
@@ -913,7 +1004,7 @@ impl TemplateBody {
     /// Construct a `Policy` from its components
     pub fn new(
         id: PolicyID,
-        annotations: BTreeMap<Id, SmolStr>,
+        annotations: BTreeMap<AnyId, SmolStr>,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-use crate::parser::err::ParseErrors;
-use crate::{ast::*, FromNormalizedStr};
+use crate::ast::*;
 use itertools::Itertools;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
@@ -787,96 +786,6 @@ impl From<StaticPolicy> for Arc<Template> {
     fn from(p: StaticPolicy) -> Self {
         let (t, _) = Template::link_static_policy(p);
         t
-    }
-}
-
-/// Like `Id`, except this specifically _can_ contain Cedar reserved identifiers.
-/// (It still can't contain, for instance, spaces or characters like '+'.)
-//
-// For now, internally, `AnyId`s are just owned `SmolString`s.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
-pub struct AnyId(SmolStr);
-
-impl AnyId {
-    /// Create a new `AnyId` from a `String`, where it is the caller's
-    /// responsibility to ensure that the string is indeed a valid `AnyId`.
-    ///
-    /// When possible, callers should not use this, and instead use `s.parse()`,
-    /// which checks that `s` is a valid `AnyId`, and returns a parse error
-    /// if not.
-    ///
-    /// This method was created for the `From<cst::Ident> for AnyId` impl to use.
-    /// See notes on `Id::new_unchecked()`.
-    pub(crate) fn new_unchecked(s: impl Into<SmolStr>) -> AnyId {
-        AnyId(s.into())
-    }
-
-    /// Get the underlying string
-    pub fn into_smolstr(self) -> SmolStr {
-        self.0
-    }
-}
-
-impl AsRef<str> for AnyId {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl std::fmt::Display for AnyId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.0)
-    }
-}
-
-// allow `.parse()` on a string to make an `AnyId`
-impl std::str::FromStr for AnyId {
-    type Err = ParseErrors;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        crate::parser::parse_anyid(s)
-    }
-}
-
-impl FromNormalizedStr for AnyId {
-    fn describe_self() -> &'static str {
-        "AnyId"
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for AnyId {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        // AnyId syntax:
-        // ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']*
-
-        let construct_list = |s: &str| s.chars().collect::<Vec<char>>();
-        let list_concat = |s1: &[char], s2: &[char]| [s1, s2].concat();
-        // the set of the first character of an AnyId
-        let head_letters = construct_list("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_");
-        // the set of the remaining characters of an AnyId
-        let tail_letters = list_concat(&construct_list("0123456789"), &head_letters);
-        // identifier character count minus 1
-        let remaining_length = u.int_in_range(0..=16)?;
-        let mut cs = vec![*u.choose(&head_letters)?];
-        cs.extend(
-            (0..remaining_length)
-                .map(|_| u.choose(&tail_letters))
-                .collect::<Result<Vec<&char>, _>>()?,
-        );
-        let s: String = cs.into_iter().collect();
-        crate::parser::parse_ident(&s).unwrap_or_else(|e| panic!("all strings constructed this way should be valid AnyIds, but this one is not: {s:?}\nerror: {e}"));
-        Ok(Self::new_unchecked(s))
-    }
-
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        arbitrary::size_hint::and_all(&[
-            // for arbitrary length
-            <usize as arbitrary::Arbitrary>::size_hint(depth),
-            // for arbitrary choices
-            // we use the size hint of a vector of `u8` to get an underestimate of bytes required by the sequence of choices.
-            <Vec<u8> as arbitrary::Arbitrary>::size_hint(depth),
-        ])
     }
 }
 
@@ -1748,7 +1657,7 @@ mod test {
 
     use super::{test_generators::*, *};
     use crate::{
-        ast::{entity, name, EntityUID},
+        ast::{entity, id, name, EntityUID},
         parser::{
             err::{ParseError, ParseErrors, ToASTError, ToASTErrorKind},
             parse_policy, Loc,
@@ -2039,7 +1948,7 @@ mod test {
     #[test]
     fn test_iter_once() {
         let id = EntityUID::from_components(
-            name::Name::unqualified_name(name::Id::new_unchecked("s")),
+            name::Name::unqualified_name(id::Id::new_unchecked("s")),
             entity::Eid::new("eid"),
         );
         let mut i = EntityIterator::One(&id);
@@ -2050,11 +1959,11 @@ mod test {
     #[test]
     fn test_iter_mult() {
         let id1 = EntityUID::from_components(
-            name::Name::unqualified_name(name::Id::new_unchecked("s")),
+            name::Name::unqualified_name(id::Id::new_unchecked("s")),
             entity::Eid::new("eid1"),
         );
         let id2 = EntityUID::from_components(
-            name::Name::unqualified_name(name::Id::new_unchecked("s")),
+            name::Name::unqualified_name(id::Id::new_unchecked("s")),
             entity::Eid::new("eid2"),
         );
         let v = vec![&id1, &id2];

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -404,7 +404,7 @@ impl Eq for ValueKind {}
 // The implementation of `PartialEq` for `Value` ignores the `Loc` of the values.
 impl PartialEq for Value {
     fn eq(&self, other: &Value) -> bool {
-        &self.value == &other.value
+        self.value == other.value
     }
 }
 

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -148,7 +148,7 @@ impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
         if etype.is_action() {
             let schema_action = self
                 .schema
-                .action(&uid)
+                .action(uid)
                 .ok_or(EntitySchemaConformanceError::UndeclaredAction { uid: uid.clone() })?;
             // check that the action exactly matches the schema's definition
             if !entity.deep_eq(&schema_action) {

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -347,6 +347,23 @@ pub(crate) fn parse_ident(id: &str) -> Result<ast::Id, err::ParseErrors> {
     }
 }
 
+/// parse an `AnyId`
+///
+/// Private to this crate. Users outside Core should use `AnyId`'s `FromStr` impl
+/// or its constructors
+pub(crate) fn parse_anyid(id: &str) -> Result<ast::AnyId, err::ParseErrors> {
+    let mut errs = err::ParseErrors::new();
+    let cst = text_to_cst::parse_ident(id)?;
+    let Some(ast) = cst.to_any_ident(&mut errs) else {
+        return Err(errs);
+    };
+    if errs.is_empty() {
+        Ok(ast)
+    } else {
+        Err(errs)
+    }
+}
+
 /// Utilities used in tests in this file
 #[cfg(test)]
 mod test_utils {

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -400,11 +400,11 @@ impl Node<Option<cst::Ident>> {
         }
     }
 
-    /// Convert `cst::Ident` to `ast::Id`. This method does not fail for
-    /// reserved identifiers.
+    /// Convert [`cst::Ident`] to [`ast::AnyId`]. This method does not fail for
+    /// reserved identifiers; see notes on [`ast::AnyId`].
     /// (It does fail for invalid identifiers, but there are no invalid
     /// identifiers at the time of this writing; see notes on
-    /// `cst::Ident::Invalid`)
+    /// [`cst::Ident::Invalid`])
     pub fn to_any_ident(&self, errs: &mut ParseErrors) -> Option<ast::AnyId> {
         // if `self` doesn't have data, nothing we can do here, just propagate
         // the `None`; we don't need to signal an error, because one was already

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   For more details, see `miette`'s
   [documentation](https://docs.rs/miette/latest/miette/index.html). (#477)
 - Moved `<PolicyId as FromStr>::Err` to `Infallible` (#588, resolving #551)
+- Cedar reserved words like `if`, `has`, and `true` are now allowed as policy
+  annotation keys. (#634, resolving #623)
 - Add hints suggesting how to fix some type errors. (#513)
 - The `ValidationResult` returned from `Validator::validate` now has a static
   lifetime, allowing it to be used in more contexts. The lifetime parameter


### PR DESCRIPTION
## Description of changes

Allows annotation keys to be Cedar reserved words.  Tests that this works both for human-format and JSON-format (EST) policies.  Fixes #623.

## Issue #, if available

#623 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

(is that right?)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
