### PR TITLE
Updates for cedar-spec#219

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ I confirm that this PR (choose one, and delete the other options):
 
 I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
 
-- [ ] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.
+- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
 - [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
 - [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
 - [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -20,11 +20,10 @@ use serde::{Deserialize, Serialize};
 
 /// Represent an element in a pattern literal (the RHS of the like operation)
 #[derive(Deserialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
-// We need special serialization implementation for CedarDRT because Rust's
-// unicode escape sequences (e.g., `\u{1234}`) can appear in serialized strings
-// and it's difficult to parse them into Dafny characters.
-// Instead we serialize the unicode values of Rust characters and leverage
-// Dafny's type conversion to retrieve the characters.
+// We need special serialization for patterns because Rust's unicode escape
+// sequences (e.g., `\u{1234}`) can appear in serialized strings and it's difficult
+// to parse these into characters in the formal model. Instead we serialize the
+// unicode values of Rust characters.
 #[cfg_attr(not(feature = "arbitrary"), derive(Serialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
@@ -42,13 +41,13 @@ impl Serialize for PatternElem {
     {
         // Helper enum for serialization
         #[derive(Debug, Serialize)]
-        enum PatternElemForDafny {
+        enum PatternElemU32 {
             Char(u32),
             Wildcard,
         }
         match self {
-            Self::Char(c) => PatternElemForDafny::Char(*c as u32).serialize(serializer),
-            Self::Wildcard => PatternElemForDafny::Wildcard.serialize(serializer),
+            Self::Char(c) => PatternElemU32::Char(*c as u32).serialize(serializer),
+            Self::Wildcard => PatternElemU32::Wildcard.serialize(serializer),
         }
     }
 }

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -91,7 +91,7 @@ impl Authorizer {
 
     /// Returns an authorization response for `q` with respect to the given `Slice`.
     ///
-    /// The language spec and Dafny model give a precise definition of how this is
+    /// The language spec and formal model give a precise definition of how this is
     /// computed.
     pub fn is_authorized(&self, q: Request, pset: &PolicySet, entities: &Entities) -> Response {
         match self.is_authorized_core(q, pset, entities) {
@@ -157,7 +157,7 @@ impl Authorizer {
     /// Returns an authorization response for `q` with respect to the given `Slice`.
     /// Partial Evaluation of is_authorized
     ///
-    /// The language spec and Dafny model give a precise definition of how this is
+    /// The language spec and formal model give a precise definition of how this is
     /// computed.
     pub fn is_authorized_core(
         &self,

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -49,7 +49,7 @@ pub use namespace_def::ValidatorNamespaceDef;
 #[cfg(test)]
 pub(crate) use namespace_def::ACTION_ENTITY_TYPE;
 
-// We do not have a dafny model for action attributes, so we disable them by defualt.
+// We do not have a formal model for action attributes, so we disable them by default.
 #[derive(Eq, PartialEq, Copy, Clone, Default)]
 pub enum ActionBehavior {
     /// Action entities cannot have attributes. Attempting to declare attributes

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -660,7 +660,7 @@ impl Authorizer {
     /// Returns an authorization response for `r` with respect to the given
     /// `PolicySet` and `Entities`.
     ///
-    /// The language spec and Dafny model give a precise definition of how this
+    /// The language spec and formal model give a precise definition of how this
     /// is computed.
     /// ```
     /// # use cedar_policy::{Authorizer,Context,Decision,Entities,EntityId,EntityTypeName, EntityUid, Request,PolicySet};


### PR DESCRIPTION
## Description of changes

Updates comments to use "formal model" in places where we previously used "Dafny model". [cedar-spec#219](https://github.com/cedar-policy/cedar-spec/pull/219) deprecates the Dafny model in favor of a model in Lean.

I'm not sure if the alternate serialization used in `cedar-policy-core/src/ast/pattern.rs` is still needed now that we've switched Lean, but what we have now works so I'm hesitant to change it.

There is one other place we refer to "Dafny" in the code -- I've made an issue (#638) to follow up on that later.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar Dafny model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
