### PR TITLE
better errors for bad annotations

### DIFF
--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -117,16 +117,20 @@ fn run_link_test(
 #[allow(clippy::expect_used)]
 // PANIC SAFETY: this is all test code
 #[allow(clippy::unwrap_used)]
+#[track_caller]
 fn run_format_test(policies_file: &str) {
+    let original = std::fs::read_to_string(policies_file).unwrap();
     let format_cmd = assert_cmd::Command::cargo_bin("cedar")
         .expect("bin exists")
         .arg("format")
         .arg("-p")
         .arg(policies_file)
         .assert();
+    let formatted =
+        std::str::from_utf8(&format_cmd.get_output().stdout).expect("output should be decodable");
     assert_eq!(
-        std::str::from_utf8(&format_cmd.get_output().stdout).expect("output should be decodable"),
-        std::fs::read_to_string(policies_file).unwrap()
+        original, formatted,
+        "\noriginal:\n{original}\n\nformatted:\n{formatted}",
     );
 }
 

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -975,6 +975,11 @@ impl Annotations {
     pub fn iter(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.0.iter()
     }
+
+    /// Consume this `Annotations`, iterating over all the annotations
+    pub fn into_iter(self) -> impl Iterator<Item = (AnyId, Annotation)> {
+        self.0.into_iter()
+    }
 }
 
 impl Default for Annotations {

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast::*;
+use crate::parser::Loc;
 use itertools::Itertools;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
@@ -63,7 +64,7 @@ impl Template {
     /// Construct a `Template` from its components
     pub fn new(
         id: PolicyID,
-        annotations: BTreeMap<AnyId, SmolStr>,
+        annotations: Annotations,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
@@ -123,12 +124,12 @@ impl Template {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&Annotation> {
         self.body.annotation(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.body.annotations()
     }
 
@@ -340,7 +341,7 @@ impl Policy {
     pub fn from_when_clause(effect: Effect, when: Expr, id: PolicyID) -> Self {
         let t = Template::new(
             id,
-            BTreeMap::new(),
+            Annotations::new(),
             effect,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -366,12 +367,12 @@ impl Policy {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&Annotation> {
         self.template.annotation(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.template.annotations()
     }
 
@@ -672,12 +673,12 @@ impl StaticPolicy {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&Annotation> {
         self.0.annotation(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.0.annotations()
     }
 
@@ -737,7 +738,7 @@ impl StaticPolicy {
     /// Construct a `StaticPolicy` from its components
     pub fn new(
         id: PolicyID,
-        annotations: BTreeMap<AnyId, SmolStr>,
+        annotations: Annotations,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
@@ -798,7 +799,7 @@ pub struct TemplateBody {
     /// Annotations available for external applications, as key-value store.
     /// Note that the keys are `AnyId`, so Cedar reserved words like `if` and `has`
     /// are explicitly allowed as annotations.
-    annotations: BTreeMap<AnyId, SmolStr>,
+    annotations: Annotations,
     /// `Effect` of this policy
     effect: Effect,
     /// Head constraint for principal. This will be a boolean-valued expression:
@@ -839,12 +840,12 @@ impl TemplateBody {
     }
 
     /// Get data from an annotation.
-    pub fn annotation(&self, key: &AnyId) -> Option<&SmolStr> {
+    pub fn annotation(&self, key: &AnyId) -> Option<&Annotation> {
         self.annotations.get(key)
     }
 
     /// Get all annotation data.
-    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &SmolStr)> {
+    pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.annotations.iter()
     }
 
@@ -913,7 +914,7 @@ impl TemplateBody {
     /// Construct a `Policy` from its components
     pub fn new(
         id: PolicyID,
-        annotations: BTreeMap<AnyId, SmolStr>,
+        annotations: Annotations,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
@@ -940,8 +941,8 @@ impl From<StaticPolicy> for TemplateBody {
 
 impl std::fmt::Display for TemplateBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (k, v) in &self.annotations {
-            writeln!(f, "@{}(\"{}\")", k, v.escape_debug())?
+        for (k, v) in self.annotations.iter() {
+            writeln!(f, "@{}(\"{}\")", k, v.val.escape_debug())?
         }
         write!(
             f,
@@ -952,6 +953,61 @@ impl std::fmt::Display for TemplateBody {
             self.resource_constraint(),
             self.non_head_constraints()
         )
+    }
+}
+
+/// Struct which holds the annotations for a policy
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct Annotations(BTreeMap<AnyId, Annotation>);
+
+impl Annotations {
+    /// Create a new empty `Annotations` (with no annotations)
+    pub fn new() -> Self {
+        Self(BTreeMap::new())
+    }
+
+    /// Get an annotation by key
+    pub fn get(&self, key: &AnyId) -> Option<&Annotation> {
+        self.0.get(key)
+    }
+
+    /// Iterate over all annotations
+    pub fn iter(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
+        self.0.iter()
+    }
+}
+
+impl Default for Annotations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FromIterator<(AnyId, Annotation)> for Annotations {
+    fn from_iter<T: IntoIterator<Item = (AnyId, Annotation)>>(iter: T) -> Self {
+        Self(BTreeMap::from_iter(iter))
+    }
+}
+
+impl From<BTreeMap<AnyId, Annotation>> for Annotations {
+    fn from(value: BTreeMap<AnyId, Annotation>) -> Self {
+        Self(value)
+    }
+}
+
+/// Struct which holds the value of a particular annotation
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+pub struct Annotation {
+    /// Annotation value
+    pub val: SmolStr,
+    /// Source location. Note this is the location of _the entire key-value
+    /// pair_ for the annotation, not just `val` above
+    pub loc: Option<Loc>,
+}
+
+impl AsRef<str> for Annotation {
+    fn as_ref(&self) -> &str {
+        &self.val
     }
 }
 
@@ -1476,8 +1532,8 @@ impl ActionConstraint {
 
 impl std::fmt::Display for StaticPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (k, v) in &self.0.annotations {
-            writeln!(f, "@{}(\"{}\")", k, v.escape_debug())?
+        for (k, v) in self.0.annotations.iter() {
+            writeln!(f, "@{}(\"{}\")", k, v.val.escape_debug())?
         }
         write!(
             f,
@@ -1622,7 +1678,7 @@ pub mod test_generators {
                 for resource in all_resource_constraints() {
                     let permit = Template::new(
                         permit.clone(),
-                        BTreeMap::new(),
+                        Annotations::new(),
                         Effect::Permit,
                         principal.clone(),
                         action.clone(),
@@ -1631,7 +1687,7 @@ pub mod test_generators {
                     );
                     let forbid = Template::new(
                         forbid.clone(),
-                        BTreeMap::new(),
+                        Annotations::new(),
                         Effect::Forbid,
                         principal.clone(),
                         action.clone(),
@@ -1705,7 +1761,7 @@ mod test {
             let a = template.action_constraint().clone();
             let r = template.resource_constraint().clone();
             let nhc = template.non_head_constraints().clone();
-            let t2 = Template::new(id, BTreeMap::new(), effect, p, a, r, nhc);
+            let t2 = Template::new(id, Annotations::new(), effect, p, a, r, nhc);
             assert_eq!(template, t2);
         }
     }
@@ -1740,7 +1796,7 @@ mod test {
         let iid = PolicyID::from_string("iid");
         let t = Arc::new(Template::new(
             tid,
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::Any,
@@ -1770,7 +1826,7 @@ mod test {
         let iid = PolicyID::from_string("iid");
         let t = Arc::new(Template::new(
             tid,
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::Any,
@@ -1810,7 +1866,7 @@ mod test {
         let iid = PolicyID::from_string("linked");
         let t = Arc::new(Template::new(
             tid,
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_in_slot(),
             ActionConstraint::any(),

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -499,14 +499,14 @@ impl std::fmt::Display for PolicySet {
 #[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod test {
-    use std::collections::{BTreeMap, HashMap};
-
+    use super::*;
     use crate::{
-        ast::{ActionConstraint, Effect, Expr, PrincipalConstraint, ResourceConstraint},
+        ast::{
+            ActionConstraint, Annotations, Effect, Expr, PrincipalConstraint, ResourceConstraint,
+        },
         parser,
     };
-
-    use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn link_conflicts() {
@@ -682,7 +682,7 @@ mod test {
         let lid = PolicyID::from_string("link");
         let t = Template::new(
             tid.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -710,7 +710,7 @@ mod test {
         let lid = PolicyID::from_string("link");
         let t = Template::new(
             tid.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::any(),
@@ -745,7 +745,7 @@ mod test {
         let id = PolicyID::from_string("id");
         let p = StaticPolicy::new(
             id.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -773,7 +773,7 @@ mod test {
         let link_id = PolicyID::from_string("link");
         let t = Template::new(
             template_id.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::any(),
@@ -807,7 +807,7 @@ mod test {
         let tid1 = PolicyID::from_string("template");
         let policy1 = StaticPolicy::new(
             id1.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -817,7 +817,7 @@ mod test {
         .expect("Policy Creation Failed");
         let template1 = Template::new(
             tid1.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -836,7 +836,7 @@ mod test {
         let id2 = PolicyID::from_string("id2");
         let policy2 = StaticPolicy::new(
             id2.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq(EntityUID::with_eid("jane")),
             ActionConstraint::any(),
@@ -850,7 +850,7 @@ mod test {
         let tid2 = PolicyID::from_string("template2");
         let template2 = Template::new(
             tid2.clone(),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::any(),

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -431,10 +431,8 @@ impl std::fmt::Debug for Authorizer {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod test {
-    use std::collections::BTreeMap;
-
     use super::*;
-    use crate::ast::RequestSchemaAllPass;
+    use crate::ast::{Annotations, RequestSchemaAllPass};
     use crate::parser;
 
     /// Sanity unit test case for is_authorized.
@@ -517,7 +515,7 @@ mod test {
         let pid = PolicyID::from_string(id);
         StaticPolicy::new(
             pid,
-            BTreeMap::new(),
+            Annotations::new(),
             e,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -531,7 +529,7 @@ mod test {
         let pid = PolicyID::from_string(id);
         StaticPolicy::new(
             pid,
-            BTreeMap::new(),
+            Annotations::new(),
             effect,
             PrincipalConstraint::any(),
             ActionConstraint::any(),

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -143,7 +143,7 @@ impl TryFrom<cst::Policy> for Policy {
                             errs.push(
                                 ToASTError::new(
                                     ToASTErrorKind::DuplicateAnnotation(oentry.key().clone()),
-                                    v.loc.expect(".to_kv_pair() always populates Loc"),
+                                    node.loc,
                                 )
                                 .into(),
                             );

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -364,9 +364,9 @@ pub(crate) fn parse_anyid(id: &str) -> Result<ast::AnyId, err::ParseErrors> {
     }
 }
 
-/// Utilities used in tests in this file
+/// Utilities used in tests in this file (and maybe other files in this crate)
 #[cfg(test)]
-mod test_utils {
+pub(crate) mod test_utils {
     use super::err::ParseErrors;
     use crate::test_utils::*;
 
@@ -388,6 +388,28 @@ mod test_utils {
             "for the following input:\n{src}\nexpected some error to match the following:\n{msg}\nbut actual errors were:\n{:?}", // the Debug representation of `miette::Report` is the pretty one, for some reason
             miette::Report::new(errs.clone()),
         );
+    }
+
+    /// Expect that the given `ParseErrors` contains exactly one error, and that it matches the given `ExpectedErrorMessage`.
+    ///
+    /// `src` is the original input text, just for better assertion-failure messages
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
+    pub fn expect_exactly_one_error(src: &str, errs: &ParseErrors, msg: &ExpectedErrorMessage<'_>) {
+        match errs.len() {
+            0 => panic!("for the following input:\n{src}\nexpected an error, but the `ParseErrors` was empty"),
+            1 => {
+                let err = errs.iter().next().expect("already checked that len was 1");
+                assert!(
+                    msg.matches(err),
+                    "for the following input:\n{src}\nexpected the error to match the following:\n{msg}\nbut actual error was:\n{:?}", // the Debug representation of `miette::Report` is the pretty one, for some reason
+                    miette::Report::new(err.clone()),
+                )
+            }
+            n => panic!(
+                "for the following input:\n{src}\nexpected only one error, but got {n}. Expected to match the following:\n{msg}\nbut actual errors were:\n{:?}", // the Debug representation of `miette::Report` is the pretty one, for some reason
+                miette::Report::new(errs.clone()),
+            )
+        }
     }
 }
 
@@ -663,6 +685,7 @@ mod parse_tests {
     use super::*;
     use crate::test_utils::*;
     use cool_asserts::assert_matches;
+    use miette::Diagnostic;
 
     #[test]
     fn parse_exists() {
@@ -983,8 +1006,53 @@ mod parse_tests {
         // duplicate key
         let src = r#"permit(principal, action, resource) when { context.foo == { "spam": -341, foo: 2, "🦀": true, foo: "baz" } };"#;
         assert_matches!(parse_policy(None, src), Err(e) => {
-            assert_eq!(e.len(), 1);
-            expect_some_error_matches(src, &e, &ExpectedErrorMessage::error("duplicate key `foo` in record literal"));
+            expect_exactly_one_error(src, &e, &ExpectedErrorMessage::error("duplicate key `foo` in record literal"));
         });
+    }
+
+    #[test]
+    fn annotation_errors() {
+        let src = r#"
+            @foo("1")
+            @foo("2")
+            permit(principal, action, resource);
+        "#;
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            expect_exactly_one_error(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
+            let expected_span = 35..44;
+            assert_eq!(&src[expected_span.clone()], r#"@foo("2")"#);
+            itertools::assert_equal(e.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+        });
+
+        let src = r#"
+            @foo("1")
+            @foo("1")
+            permit(principal, action, resource);
+        "#;
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            expect_exactly_one_error(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
+            let expected_span = 35..44;
+            assert_eq!(&src[expected_span.clone()], r#"@foo("1")"#);
+            itertools::assert_equal(e.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+        });
+
+        let src = r#"
+            @foo("1")
+            @bar("yellow")
+            @foo("abc")
+            @hello("goodbye")
+            @bar("123")
+            @foo("def")
+            permit(principal, action, resource);
+        "#;
+        assert_matches!(parse_policy(None, src), Err(e) => {
+            assert_eq!(e.len(), 3); // two errors for @foo and one for @bar
+            expect_some_error_matches(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
+            expect_some_error_matches(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @bar"));
+            for ((err, expected_span), expected_snippet) in e.iter().zip([62..73, 116..127, 140..151]).zip([r#"@foo("abc")"#, r#"@bar("123")"#, r#"@foo("def")"#]) {
+                assert_eq!(&src[expected_span.clone()], expected_snippet);
+                itertools::assert_equal(err.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+            }
+        })
     }
 }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -241,7 +241,7 @@ impl Node<Option<cst::Policy>> {
                             failure = true;
                             errs.push(ToASTError::new(
                                 ToASTErrorKind::DuplicateAnnotation(oentry.key().clone()),
-                                v.loc.expect(".to_kv_pair() always populates Loc"),
+                                node.loc.clone(),
                             ));
                         }
                         Entry::Vacant(ventry) => {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -164,9 +164,9 @@ pub enum ToASTErrorKind {
         /// Slot that was found (which is not valid in a static policy)
         slot: cst::Slot,
     },
-    /// Returned when we attempt to parse a policy with malformed or conflicting annotations
-    #[error("this policy uses poorly formed or duplicate annotations")]
-    BadAnnotations,
+    /// Returned when we attempt to parse a policy or template with duplicate or conflicting annotations
+    #[error("duplicate annotation: @{0}")]
+    DuplicateAnnotation(ast::AnyId),
     /// Returned when a policy contains template slots in a when/unless clause. This is not currently supported. See RFC 3
     #[error("found template slot {slot} in a `{clausetype}` clause")]
     #[diagnostic(help("slots are currently unsupported in `{clausetype}` clauses"))]

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -53,8 +53,11 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
     for (f_p, p) in formatted_policies.into_iter().zip(policies.into_iter()) {
         let (f_anno, anno) = (
             f_p.annotations()
-                .collect::<std::collections::HashMap<_, _>>(),
-            p.annotations().collect::<std::collections::HashMap<_, _>>(),
+                .map(|(k, v)| (k, &v.val))
+                .collect::<std::collections::BTreeMap<_, _>>(),
+            p.annotations()
+                .map(|(k, v)| (k, &v.val))
+                .collect::<std::collections::BTreeMap<_, _>>(),
         );
         if !(f_anno == anno
             && f_p.effect() == p.effect()
@@ -66,9 +69,7 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
                 .eq_shape(p.non_head_constraints()))
         {
             return Err(miette!(
-                "policies differ:\nformatted: {}\ninput: {}",
-                f_p,
-                p
+                "policies differ in meaning or annotations:\noriginal: {p}\nformatted: {f_p}"
             ));
         }
     }

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -417,10 +417,13 @@ impl Validator {
 #[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod test {
-    use std::collections::{BTreeMap, HashMap, HashSet};
+    use std::collections::{HashMap, HashSet};
 
     use cedar_policy_core::{
-        ast::{Effect, Eid, EntityUID, Expr, PolicyID, PrincipalConstraint, ResourceConstraint},
+        ast::{
+            Annotations, Effect, Eid, EntityUID, Expr, PolicyID, PrincipalConstraint,
+            ResourceConstraint,
+        },
         parser::{parse_policy, parse_policy_template},
     };
 
@@ -437,7 +440,7 @@ mod test {
     fn validate_entity_type_empty_schema() -> Result<()> {
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -565,7 +568,7 @@ mod test {
         let singleton_schema = schema_file.try_into().unwrap();
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -600,7 +603,7 @@ mod test {
         let singleton_schema = schema_file.try_into().unwrap();
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(
                 EntityUID::with_eid_and_type("bar_type", "bar_name")
@@ -640,7 +643,7 @@ mod test {
             .expect("should be a valid identifier");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
@@ -688,7 +691,7 @@ mod test {
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
@@ -815,7 +818,7 @@ mod test {
             .expect("Should be a valid identifier");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
@@ -864,7 +867,7 @@ mod test {
             .expect("Expected entity parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
@@ -896,7 +899,7 @@ mod test {
             .expect("Expected entity parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
@@ -932,7 +935,7 @@ mod test {
         let entity_type: Name = "NS::Foo".parse().expect("Expected entity type parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(EntityUID::from_components(entity_type, Eid::new("bar"))),
             ActionConstraint::any(),
@@ -962,7 +965,7 @@ mod test {
         let entity_type: Name = "Bogus::Foo".parse().expect("Expected entity type parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(EntityUID::from_components(entity_type, Eid::new("bar"))),
             ActionConstraint::any(),
@@ -1152,7 +1155,7 @@ mod test {
 
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(principal),
             ActionConstraint::is_eq(action),
@@ -1252,7 +1255,7 @@ mod test {
         let (principal, action, resource, schema) = schema_with_single_principal_action_resource();
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(principal),
             ActionConstraint::is_eq(action),
@@ -1590,7 +1593,7 @@ mod test {
 
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_in([action_grandparent_euid]),
@@ -1621,7 +1624,7 @@ mod test {
         // resource == Unspecified::"foo"
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -1639,7 +1642,7 @@ mod test {
         // principal in Unspecified::"foo"
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_in(EntityUID::unspecified_from_eid(Eid::new("foo"))),
             ActionConstraint::any(),
@@ -1664,7 +1667,7 @@ mod test {
         // resource == Unspecified::"foo"
         let policy = Template::new(
             PolicyID::from_string("policy0"),
-            BTreeMap::new(),
+            Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2351,15 +2351,19 @@ impl PolicySet {
         self.ast
             .get(&id.0)?
             .annotation(&key.as_ref().parse().ok()?)
-            .map(smol_str::SmolStr::as_str)
+            .map(AsRef::as_ref)
     }
 
     /// Extract annotation data from a `Template` by its `PolicyId` and annotation key.
+    //
+    // TODO: unfortunate that this method returns `Option<String>` and the corresponding method
+    // for policies (`.annotation()`) above returns `Option<&str>`, but this can't be changed
+    // without a semver break
     pub fn template_annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<String> {
         self.ast
             .get_template(&id.0)?
             .annotation(&key.as_ref().parse().ok()?)
-            .map(smol_str::SmolStr::to_string)
+            .map(|annot| annot.val.to_string())
     }
 
     /// Returns true iff the `PolicySet` is empty
@@ -2579,14 +2583,14 @@ impl Template {
     pub fn annotation(&self, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .annotation(&key.as_ref().parse().ok()?)
-            .map(smol_str::SmolStr::as_str)
+            .map(AsRef::as_ref)
     }
 
     /// Iterate through annotation data of this `Template` as key-value pairs
     pub fn annotations(&self) -> impl Iterator<Item = (&str, &str)> {
         self.ast
             .annotations()
-            .map(|(k, v)| (k.as_ref(), v.as_str()))
+            .map(|(k, v)| (k.as_ref(), v.as_ref()))
     }
 
     /// Iterate over the open slots in this `Template`
@@ -2924,14 +2928,14 @@ impl Policy {
     pub fn annotation(&self, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .annotation(&key.as_ref().parse().ok()?)
-            .map(smol_str::SmolStr::as_str)
+            .map(AsRef::as_ref)
     }
 
     /// Iterate through annotation data of this template-linked or static policy
     pub fn annotations(&self) -> impl Iterator<Item = (&str, &str)> {
         self.ast
             .annotations()
-            .map(|(k, v)| (k.as_ref(), v.as_str()))
+            .map(|(k, v)| (k.as_ref(), v.as_ref()))
     }
 
     /// Get the `PolicyId` for this template-linked or static policy


### PR DESCRIPTION
## Description of changes

Overhauls the `BadAnnotations` error which previously had a less-than-helpful error message and no associated data.  Adds more specific error messages, avoids adding redundant errors in some cases, and adds more specific source locations than "the entire policy".  Comes with tests for both CST->AST and CST->EST.

Nonbreaking because the changes are to error messages and the `ToASTError` type which is not re-exported in `cedar-policy`.  (And the policy AST.)

## Issue #, if available

Fixes #535

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
