### PR TITLE
better error message for incorrect variable in policy scope

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -4766,7 +4766,7 @@ mod tests {
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
                 "expected a variable that is valid in the policy scope; found: `foo`",
-                "must be one of `principal`, `action`, or `resource`"
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
             ));
             expect_source_snippet(p_src, &e, "foo");
         });
@@ -4798,7 +4798,7 @@ mod tests {
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
                 "expected a variable that is valid in the policy scope; found: `if`",
-                "must be one of `principal`, `action`, or `resource`"
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
             ));
             expect_source_snippet(p_src, &e, "if");
         });
@@ -4807,7 +4807,7 @@ mod tests {
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
                 "expected a variable that is valid in the policy scope; found: `like`",
-                "must be one of `principal`, `action`, or `resource`"
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
             ));
             expect_source_snippet(p_src, &e, "like");
         });

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -4768,21 +4768,31 @@ mod tests {
                 "expected a variable that is valid in the policy scope; found: `foo`",
                 "must be one of `principal`, `action`, or `resource`"
             ));
+            expect_source_snippet(p_src, &e, "foo");
         });
         let p_src = "permit(foo::principal, action, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error(
                 "unexpected token `::`",
             ));
+            expect_source_snippet(p_src, &e, "::");
         });
         let p_src = "permit(resource, action, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("the variable `resource` is invalid in this policy scope clause, the variable `principal` is expected"));
+            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+                "found the variable `resource` where the variable `principal` must be used",
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
+            ));
+            expect_source_snippet(p_src, &e, "resource");
         });
 
         let p_src = "permit(principal, principal, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("the variable `principal` is invalid in this policy scope clause, the variable `action` is expected"));
+            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+                "found the variable `principal` where the variable `action` must be used",
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
+            ));
+            expect_source_snippet(p_src, &e, "principal");
         });
         let p_src = "permit(principal, if, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
@@ -4790,6 +4800,7 @@ mod tests {
                 "expected a variable that is valid in the policy scope; found: `if`",
                 "must be one of `principal`, `action`, or `resource`"
             ));
+            expect_source_snippet(p_src, &e, "if");
         });
 
         let p_src = "permit(principal, action, like);";
@@ -4798,14 +4809,23 @@ mod tests {
                 "expected a variable that is valid in the policy scope; found: `like`",
                 "must be one of `principal`, `action`, or `resource`"
             ));
+            expect_source_snippet(p_src, &e, "like");
         });
         let p_src = "permit(principal, action, principal);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("the variable `principal` is invalid in this policy scope clause, the variable `resource` is expected"));
+            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+                "found the variable `principal` where the variable `resource` must be used",
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
+            ));
+            expect_source_snippet(p_src, &e, "principal");
         });
         let p_src = "permit(principal, action, action);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("the variable `action` is invalid in this policy scope clause, the variable `resource` is expected"));
+            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+                "found the variable `action` where the variable `resource` must be used",
+                "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
+            ));
+            expect_source_snippet(p_src, &e, "action");
         });
     }
 

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -203,7 +203,9 @@ pub enum ToASTErrorKind {
     InvalidCondition(cst::Ident),
     /// Returned when a policy uses a variable in the scope beyond `principal`, `action`, or `resource`
     #[error("expected a variable that is valid in the policy scope; found: `{0}`")]
-    #[diagnostic(help("must be one of `principal`, `action`, or `resource`"))]
+    #[diagnostic(help(
+        "policy scopes must contain a `principal`, `action`, and `resource` element in that order"
+    ))]
     InvalidScopeConstraintVariable(cst::Ident),
     /// Returned when a policy contains an invalid method name
     #[error("not a valid method name: `{0}`")]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -208,8 +208,10 @@ pub enum ToASTErrorKind {
     /// Returned when a policy contains an invalid method name
     #[error("not a valid method name: `{0}`")]
     InvalidMethodName(String),
-    /// Returned when a policy scope clause contains the wrong variable. (`principal` must be in the first clause, etc...)
-    #[error("the variable `{got}` is invalid in this policy scope clause, the variable `{expected}` is expected")]
+    /// Returned when a policy scope clause contains the wrong variable.
+    /// (`principal` must be in the first clause, etc...)
+    #[error("found the variable `{got}` where the variable `{expected}` must be used")]
+    #[diagnostic(help("policy scopes must contain a `principal`, `action`, and `resource` element in that order"))]
     IncorrectVariable {
         /// The variable that is expected in this clause
         expected: Var,

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -211,7 +211,9 @@ pub enum ToASTErrorKind {
     /// Returned when a policy scope clause contains the wrong variable.
     /// (`principal` must be in the first clause, etc...)
     #[error("found the variable `{got}` where the variable `{expected}` must be used")]
-    #[diagnostic(help("policy scopes must contain a `principal`, `action`, and `resource` element in that order"))]
+    #[diagnostic(help(
+        "policy scopes must contain a `principal`, `action`, and `resource` element in that order"
+    ))]
     IncorrectVariable {
         /// The variable that is expected in this clause
         expected: Var,

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -167,3 +167,35 @@ pub fn expect_err<'a>(
         );
     }
 }
+
+/// Expect that the given `err` has a (single) source location, where the
+/// contents of that source location are `snippet`.
+///
+/// `src` is the original input text, used both for assertion-failure messages
+/// but also as the source we assume the error's source location indexes into.
+#[track_caller]
+pub fn expect_source_snippet(
+    src: impl AsRef<str>,
+    err: &impl miette::Diagnostic,
+    snippet: impl AsRef<str>,
+) {
+    use itertools::Itertools;
+    let src = src.as_ref();
+    let snippet = snippet.as_ref();
+    let labels = err.labels().unwrap_or_else(|| panic!(
+        "for the following input:\n{src}\ndid not find a source location, but expected one"
+    ));
+    let label = labels.exactly_one().unwrap_or_else(|labels| panic!(
+        "for the following input:\n{src}\nexpected exactly one source location, but found {}",
+        labels.count(),
+    ));
+    let actual_snippet = {
+        let span = label.inner().clone();
+        &src[span.offset() .. span.offset() + span.len()]
+    };
+    assert_eq!(
+        actual_snippet,
+        snippet,
+        "for the following input:\n{src}\nexpected source snippet to be:\n  {snippet}\nbut it was:\n  {actual_snippet}\n",
+    );
+}

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -182,16 +182,18 @@ pub fn expect_source_snippet(
     use itertools::Itertools;
     let src = src.as_ref();
     let snippet = snippet.as_ref();
-    let labels = err.labels().unwrap_or_else(|| panic!(
-        "for the following input:\n{src}\ndid not find a source location, but expected one"
-    ));
-    let label = labels.exactly_one().unwrap_or_else(|labels| panic!(
-        "for the following input:\n{src}\nexpected exactly one source location, but found {}",
-        labels.count(),
-    ));
+    let labels = err.labels().unwrap_or_else(|| {
+        panic!("for the following input:\n{src}\ndid not find a source location, but expected one")
+    });
+    let label = labels.exactly_one().unwrap_or_else(|labels| {
+        panic!(
+            "for the following input:\n{src}\nexpected exactly one source location, but found {}",
+            labels.count(),
+        )
+    });
     let actual_snippet = {
         let span = label.inner().clone();
-        &src[span.offset() .. span.offset() + span.len()]
+        &src[span.offset()..span.offset() + span.len()]
     };
     assert_eq!(
         actual_snippet,


### PR DESCRIPTION
## Description of changes

Better error message in cases where `principal`, `action`, or `resource` are used multiple times or in the wrong order in the policy scope.

## Issue #, if available

Fixes #562

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
