### PR TITLE
better error message for single =

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -468,7 +468,7 @@ pub fn validate(args: &ValidateArgs) -> CedarExitCode {
     let mode = if args.partial_validate {
         #[cfg(not(feature = "partial-validate"))]
         {
-            println!("Error: arguments include the experimental option `--partial-validate`, but this executable was not built with `partial-validate` experimental feature enabled");
+            eprintln!("Error: arguments include the experimental option `--partial-validate`, but this executable was not built with `partial-validate` experimental feature enabled");
             return CedarExitCode::Failure;
         }
         #[cfg(feature = "partial-validate")]

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -864,7 +864,11 @@ impl TryFrom<&Node<Option<cst::Relation>>> for Expr {
                             expr = Expr::greatereq(expr, rhs);
                         }
                         cst::RelOp::InvalidSingleEq => {
-                            return Err(ToASTError::new(ToASTErrorKind::InvalidSingleEq, r.loc.clone()).into());
+                            return Err(ToASTError::new(
+                                ToASTErrorKind::InvalidSingleEq,
+                                r.loc.clone(),
+                            )
+                            .into());
                         }
                     }
                 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -863,6 +863,9 @@ impl TryFrom<&Node<Option<cst::Relation>>> for Expr {
                         cst::RelOp::GreaterEq => {
                             expr = Expr::greatereq(expr, rhs);
                         }
+                        cst::RelOp::InvalidSingleEq => {
+                            return Err(ToASTError::new(ToASTErrorKind::InvalidSingleEq, r.loc.clone()).into());
+                        }
                     }
                 }
                 Ok(expr)

--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -220,6 +220,10 @@ pub enum RelOp {
     Eq,
     /// in
     In,
+    /// =
+    ///
+    /// This is always invalid, but included so we can give a nice error suggesting '==' instead
+    InvalidSingleEq,
 }
 
 /// Allowed Ops for Add

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -584,6 +584,10 @@ impl Node<Option<cst::VariableDef>> {
                     entity_type.to_expr_or_special(errs)?.into_name(errs)?,
                     eref,
                 )),
+                (cst::RelOp::InvalidSingleEq, _) => {
+                    errs.push(self.to_ast_err(ToASTErrorKind::InvalidSingleEq));
+                    None
+                }
                 (op, _) => {
                     errs.push(self.to_ast_err(ToASTErrorKind::InvalidConstraintOperator(*op)));
                     None
@@ -649,6 +653,10 @@ impl Node<Option<cst::VariableDef>> {
                 }
                 (cst::RelOp::Eq, OneOrMultipleRefs::Multiple(_)) => {
                     errs.push(rel_expr.to_ast_err(ToASTErrorKind::InvalidScopeEqualityRHS));
+                    None
+                }
+                (cst::RelOp::InvalidSingleEq, _) => {
+                    errs.push(self.to_ast_err(ToASTErrorKind::InvalidSingleEq));
                     None
                 }
                 (op, _) => {
@@ -1266,10 +1274,10 @@ impl Node<Option<cst::Relation>> {
                     // error reported and result filtered out
                     (_, None, 1) => None,
                     (f, None, 0) => f,
-                    (Some(f), Some((op, s)), _) => f.into_expr(errs).map(|e| ExprOrSpecial::Expr {
-                        expr: construct_expr_rel(e, *op, s, self.loc.clone()),
+                    (Some(f), Some((op, s)), _) => f.into_expr(errs).map(|e| Some(ExprOrSpecial::Expr {
+                        expr: construct_expr_rel(e, *op, s, self.loc.clone(), errs)?,
                         loc: self.loc.clone(),
-                    }),
+                    }))?,
                     _ => None,
                 }
             }
@@ -1309,7 +1317,7 @@ impl Node<Option<cst::Relation>> {
                     Some(in_entity) => {
                         in_entity
                             .to_expr(errs)
-                            .map(|in_entity| ExprOrSpecial::Expr {
+                            .map(|in_entity| Some(ExprOrSpecial::Expr {
                                 expr: construct_expr_and(
                                     construct_expr_is(t.clone(), n, self.loc.clone()),
                                     construct_expr_rel(
@@ -1317,12 +1325,13 @@ impl Node<Option<cst::Relation>> {
                                         cst::RelOp::In,
                                         in_entity,
                                         self.loc.clone(),
-                                    ),
+                                        errs,
+                                    )?,
                                     std::iter::empty(),
                                     &self.loc,
                                 ),
                                 loc: self.loc.clone(),
-                            })
+                            }))?
                     }
                     None => Some(ExprOrSpecial::Expr {
                         expr: construct_expr_is(t, n, self.loc.clone()),
@@ -2411,16 +2420,20 @@ fn construct_expr_and(
             .and(a, n)
     })
 }
-fn construct_expr_rel(f: ast::Expr, rel: cst::RelOp, s: ast::Expr, loc: Loc) -> ast::Expr {
-    let builder = ast::ExprBuilder::new().with_source_loc(loc);
+fn construct_expr_rel(f: ast::Expr, rel: cst::RelOp, s: ast::Expr, loc: Loc, errs: &mut ParseErrors) -> Option<ast::Expr> {
+    let builder = ast::ExprBuilder::new().with_source_loc(loc.clone());
     match rel {
-        cst::RelOp::Less => builder.less(f, s),
-        cst::RelOp::LessEq => builder.lesseq(f, s),
-        cst::RelOp::GreaterEq => builder.greatereq(f, s),
-        cst::RelOp::Greater => builder.greater(f, s),
-        cst::RelOp::NotEq => builder.noteq(f, s),
-        cst::RelOp::Eq => builder.is_eq(f, s),
-        cst::RelOp::In => builder.is_in(f, s),
+        cst::RelOp::Less => Some(builder.less(f, s)),
+        cst::RelOp::LessEq => Some(builder.lesseq(f, s)),
+        cst::RelOp::GreaterEq => Some(builder.greatereq(f, s)),
+        cst::RelOp::Greater => Some(builder.greater(f, s)),
+        cst::RelOp::NotEq => Some(builder.noteq(f, s)),
+        cst::RelOp::Eq => Some(builder.is_eq(f, s)),
+        cst::RelOp::In => Some(builder.is_in(f, s)),
+        cst::RelOp::InvalidSingleEq => {
+            errs.push(ToASTError::new(ToASTErrorKind::InvalidSingleEq, loc));
+            None
+        }
     }
 }
 /// used for a chain of addition and/or subtraction

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1274,10 +1274,12 @@ impl Node<Option<cst::Relation>> {
                     // error reported and result filtered out
                     (_, None, 1) => None,
                     (f, None, 0) => f,
-                    (Some(f), Some((op, s)), _) => f.into_expr(errs).map(|e| Some(ExprOrSpecial::Expr {
-                        expr: construct_expr_rel(e, *op, s, self.loc.clone(), errs)?,
-                        loc: self.loc.clone(),
-                    }))?,
+                    (Some(f), Some((op, s)), _) => f.into_expr(errs).map(|e| {
+                        Some(ExprOrSpecial::Expr {
+                            expr: construct_expr_rel(e, *op, s, self.loc.clone(), errs)?,
+                            loc: self.loc.clone(),
+                        })
+                    })?,
                     _ => None,
                 }
             }
@@ -1314,25 +1316,23 @@ impl Node<Option<cst::Relation>> {
                 entity_type.to_expr_or_special(errs)?.into_name(errs),
             ) {
                 (Some(t), Some(n)) => match in_entity {
-                    Some(in_entity) => {
-                        in_entity
-                            .to_expr(errs)
-                            .map(|in_entity| Some(ExprOrSpecial::Expr {
-                                expr: construct_expr_and(
-                                    construct_expr_is(t.clone(), n, self.loc.clone()),
-                                    construct_expr_rel(
-                                        t,
-                                        cst::RelOp::In,
-                                        in_entity,
-                                        self.loc.clone(),
-                                        errs,
-                                    )?,
-                                    std::iter::empty(),
-                                    &self.loc,
-                                ),
-                                loc: self.loc.clone(),
-                            }))?
-                    }
+                    Some(in_entity) => in_entity.to_expr(errs).map(|in_entity| {
+                        Some(ExprOrSpecial::Expr {
+                            expr: construct_expr_and(
+                                construct_expr_is(t.clone(), n, self.loc.clone()),
+                                construct_expr_rel(
+                                    t,
+                                    cst::RelOp::In,
+                                    in_entity,
+                                    self.loc.clone(),
+                                    errs,
+                                )?,
+                                std::iter::empty(),
+                                &self.loc,
+                            ),
+                            loc: self.loc.clone(),
+                        })
+                    })?,
                     None => Some(ExprOrSpecial::Expr {
                         expr: construct_expr_is(t, n, self.loc.clone()),
                         loc: self.loc.clone(),
@@ -2420,7 +2420,13 @@ fn construct_expr_and(
             .and(a, n)
     })
 }
-fn construct_expr_rel(f: ast::Expr, rel: cst::RelOp, s: ast::Expr, loc: Loc, errs: &mut ParseErrors) -> Option<ast::Expr> {
+fn construct_expr_rel(
+    f: ast::Expr,
+    rel: cst::RelOp,
+    s: ast::Expr,
+    loc: Loc,
+    errs: &mut ParseErrors,
+) -> Option<ast::Expr> {
     let builder = ast::ExprBuilder::new().with_source_loc(loc.clone());
     match rel {
         cst::RelOp::Less => Some(builder.less(f, s)),
@@ -4828,21 +4834,28 @@ mod tests {
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
                 "not a valid policy scope constraint: >",
-                "policy scope constraints must either `==`, `in`, `is`, or `_ is _ in _`"
+                "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
             ));
         });
         let p_src = r#"permit(principal, action != Action::"view", resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
                 "not a valid policy scope constraint: !=",
-                "policy scope constraints must either `==`, `in`, `is`, or `_ is _ in _`"
+                "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
             ));
         });
         let p_src = r#"permit(principal, action, resource <= Folder::"things");"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
                 "not a valid policy scope constraint: <=",
-                "policy scope constraints must either `==`, `in`, `is`, or `_ is _ in _`"
+                "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
+            ));
+        });
+        let p_src = r#"permit(principal = User::"alice", action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+                "'=' is not a valid operator in Cedar",
+                "try using '==' instead",
             ));
         });
     }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -193,6 +193,11 @@ pub enum ToASTErrorKind {
     /// See [`cst::Ident::Invalid`]
     #[error("not a valid identifier: `{0}`")]
     InvalidIdentifier(String),
+    /// Returned when a policy uses '=' as a binary operator.
+    /// '=' is not an operator in Cedar; we can suggest '==' instead.
+    #[error("'=' is not a valid operator in Cedar")]
+    #[diagnostic(help("try using '==' instead"))]
+    InvalidSingleEq,
     /// Returned when a policy uses a effect keyword beyond `permit` or `forbid`
     #[error("not a valid policy effect: `{0}`")]
     #[diagnostic(help("effect must be either `permit` or `forbid`"))]
@@ -216,9 +221,9 @@ pub enum ToASTErrorKind {
         /// The variable that was present in this clause
         got: Var,
     },
-    /// Returned when a policy scope clauses uses an operator beyond `==` or `in`.
+    /// Returned when a policy scope clause uses an operator not allowed in scopes.
     #[error("not a valid policy scope constraint: {0}")]
-    #[diagnostic(help("policy scope constraints must either `==`, `in`, `is`, or `_ is _ in _`"))]
+    #[diagnostic(help("policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"))]
     InvalidConstraintOperator(cst::RelOp),
     /// Returned when the right hand side of `==` in a policy scope clause is not a single Entity UID or a template slot.
     /// This is valid in Cedar conditions, but not in the Scope

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -223,7 +223,9 @@ pub enum ToASTErrorKind {
     },
     /// Returned when a policy scope clause uses an operator not allowed in scopes.
     #[error("not a valid policy scope constraint: {0}")]
-    #[diagnostic(help("policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"))]
+    #[diagnostic(help(
+        "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
+    ))]
     InvalidConstraintOperator(cst::RelOp),
     /// Returned when the right hand side of `==` in a policy scope clause is not a single Entity UID or a template slot.
     /// This is valid in Cedar conditions, but not in the Scope

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -224,6 +224,7 @@ impl fmt::Display for RelOp {
             RelOp::NotEq => write!(f, "!="),
             RelOp::Eq => write!(f, "=="),
             RelOp::In => write!(f, "in"),
+            RelOp::InvalidSingleEq => write!(f, "="),
         }
     }
 }

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -57,7 +57,7 @@ match {
     r"[0-9]+" => NUMBER,
     r#""(\\.|[^"\\])*""# => STRINGLIT,
 
-    // other tokens used
+    // other tokens used (or not currently used, in the case of e.g. % and =)
     "@",
     ".", ",", ";", ":", "::",
     "(", ")", "{", "}", "[", "]",
@@ -65,6 +65,7 @@ match {
     "||", "&&",
     "+", "-", "*", "/", "%",
     "!",
+    "=",
 }
 
 Comma<E>: Vec<E> = {
@@ -208,7 +209,7 @@ Relation: Node<Option<cst::Relation>> = {
     <l:@L> <t:Add> IS <n:Add> <e: (IN <Add>)?> <r:@R>
         => Node::with_source_loc(Some(cst::Relation::IsIn{target: t, entity_type: n, in_entity: e}), Loc::new(l..r, Arc::clone(src))),
 }
-// RelOp     := '<' | '<=' | '>=' | '>' | '!=' | '==' | 'in'
+// RelOp     := '<' | '<=' | '>=' | '>' | '!=' | '==' | 'in' | '=' (the '=' is just to provide an error suggesting '==' instead)
 RelOp: cst::RelOp = {
     "<" => cst::RelOp::Less,
     "<=" => cst::RelOp::LessEq,
@@ -216,6 +217,7 @@ RelOp: cst::RelOp = {
     ">" => cst::RelOp::Greater,
     "!=" => cst::RelOp::NotEq,
     "==" => cst::RelOp::Eq,
+    "=" => cst::RelOp::InvalidSingleEq,
     IN => cst::RelOp::In,
 }
 AddOp: cst::AddOp = {


### PR DESCRIPTION
## Description of changes

Improves parse error messages when single `=` is used as a relational operator (ie, anywhere `==` or `<` etc would be expected).  This includes the case #452 was complaining about, but this PR's fix is more general and covers `=` used in `when` clauses as well.  Here's an example of what the error message now looks like for #452's example:

![image](https://github.com/cedar-policy/cedar/assets/4458638/2cdc6280-8e5d-4c14-a94b-5aff1dd4f6dc)

## Issue #, if available

Fixes #452

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
