### PR TITLE
refactor: remove feature gated pub use

### DIFF
--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -34,21 +34,11 @@
     clippy::doc_markdown
 )]
 #![allow(clippy::must_use_candidate, clippy::missing_const_for_fn)]
-// enable doc_auto_cfg feature is docs rs cfg is set and present
+// enable doc_auto_cfg feature if docsrs cfg is present
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Rust public API
 mod api;
-
-// import feature gated enum and struct so top level module show cfg attr.
-#[cfg(feature = "partial-eval")]
-pub use api::PartialResponse;
-#[cfg(feature = "partial-eval")]
-pub use api::RequestBuilder;
-#[cfg(feature = "partial-eval")]
-pub use api::ResidualResponse;
-#[cfg(feature = "partial-eval")]
-pub use api::UnsetSchema;
 
 pub use api::*;
 


### PR DESCRIPTION
## Description of changes
Remove feature gated pub use. It was initially introduced due to bug during documentation generation and feature were not visible at top level. It is now fixed in latest nightly which docs.rs uses to build docs.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
