### PR TITLE
bump version numbers in 3.1 release branch

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.1.0
 
 ### Added
 

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-cli"
 edition = "2021"
 
-version = "3.0.0"
+version = "3.1.0"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "CLI interface for the Cedar Policy language."
@@ -11,8 +11,8 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy = { version = "=3.0.0", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=3.0.0", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=3.1.0", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=3.1.0", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_with = { version = "3.1", features = ["json"] }
+serde_with = { version = "3.0", features = ["json"] }
 serde_json = "1.0"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 lazy_static = "1.4"

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -3,7 +3,7 @@ name = "cedar-policy-core"
 edition = "2021"
 build = "build.rs"
 
-version = "3.0.0"
+version = "3.1.0"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Core implemenation of the Cedar Policy language."
@@ -13,7 +13,7 @@ repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_with = { version = "3.0", features = ["json"] }
+serde_with = { version = "3.1", features = ["json"] }
 serde_json = "1.0"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 lazy_static = "1.4"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cedar-policy-formatter"
-version = "3.0.0"
+version = "3.1.0"
 edition = "2021"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
@@ -10,7 +10,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=3.1.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
 logos = "0.13.0"
 itertools = "0.12"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy-validator"
 edition = "2021"
 
-version = "3.0.0"
+version = "3.1.0"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Validator for the Cedar Policy language."
@@ -11,7 +11,7 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=3.1.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.1.0] - coming soon
+Cedar Language Version: 3.0.0
 
 ### Added
 
@@ -370,7 +371,7 @@ Cedar Language Version: 2.0.0
 Cedar Language Version: 2.0.0
 - Initial release of `cedar-policy`.
 
-[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.0.1...main
+[3.1.0]: https://github.com/cedar-policy/cedar/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/cedar-policy/cedar/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/cedar-policy/cedar/compare/v2.4.3...v3.0.0
 [2.4.3]: https://github.com/cedar-policy/cedar/compare/v2.4.2...v2.4.3

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [3.1.0] - coming soon
-Cedar Language Version: 3.0.0
+Cedar Language Version: 3.1.0
 
 ### Added
 
@@ -371,6 +371,7 @@ Cedar Language Version: 2.0.0
 Cedar Language Version: 2.0.0
 - Initial release of `cedar-policy`.
 
+[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.1.0...main
 [3.1.0]: https://github.com/cedar-policy/cedar/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/cedar-policy/cedar/compare/v3.0.0...v3.0.1
 [3.0.0]: https://github.com/cedar-policy/cedar/compare/v2.4.3...v3.0.0

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cedar-policy"
 edition = "2021"
 
-version = "3.0.0"
+version = "3.1.0"
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Cedar is a language for defining permissions as policies, which describe who should have access to what."
@@ -11,8 +11,8 @@ homepage = "https://cedarpolicy.com"
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=3.0.0", path = "../cedar-policy-validator" }
+cedar-policy-core = { version = "=3.1.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=3.1.0", path = "../cedar-policy-validator" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"


### PR DESCRIPTION
## Description of changes

Update Cargo.toml version numbers and CHANGELOGs on the `release/3.1.x` branch. We need to remember to pull this edit to the `main` branch once the new version is released.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
