### PR TITLE
Bumping dependencies

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -16,7 +16,7 @@ cedar-policy-formatter = { version = "=3.0.0", path = "../cedar-policy-formatter
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-miette = { version = "5.9.0", features = ["fancy"] }
+miette = { version = "7.1.0", features = ["fancy"] }
 thiserror = "1.0"
 
 [features]

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -24,14 +24,14 @@ thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }
-miette = { version = "5.9.0", features = ["serde"] }
+miette = { version = "7.1.0", features = ["serde"] }
 nonempty = "0.9.0"
 
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }
 
 # wasm dependencies
-serde-wasm-bindgen = { version = "0.4", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 tsify = { version = "0.4.5", optional = true }
 wasm-bindgen = { version = "0.2.82", optional = true }
 

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -12,8 +12,8 @@ repository = "https://github.com/cedar-policy/cedar"
 [dependencies]
 cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
-logos = "0.13.0"
+logos = "0.14.0"
 itertools = "0.12"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.9.1", features = ["unicode"] }
-miette = { version = "5.9.0" }
+miette = { version = "7.1.0" }

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -15,7 +15,7 @@ cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
-miette = "5.9.0"
+miette = "7.1.0"
 thiserror = "1.0"
 itertools = "0.12"
 unicode-security = "0.1.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 itertools = "0.12"
-miette = "5.9.0"
+miette = "7.1.0"
 thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true }
@@ -26,7 +26,7 @@ serde_with = "3.3.0"
 nonempty = "0.9"
 
 # wasm dependencies
-serde-wasm-bindgen = { version = "0.4", optional = true }
+serde-wasm-bindgen = { version = "0.6", optional = true }
 tsify = { version = "0.4.5", optional = true }
 wasm-bindgen = { version = "0.2.82", optional = true }
 

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -15,7 +15,7 @@ cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core", feature
 cedar-policy-formatter = { version = "=3.0.0", path = "../cedar-policy-formatter" }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde-wasm-bindgen = "0.4"
+serde-wasm-bindgen = "0.6"
 serde_json = "1.0"
 # wasm support
 wasm-bindgen = { version = "0.2.82" }
@@ -32,8 +32,8 @@ crate_type = ["cdylib", "rlib"]
 wasm-bindgen-test = "0.3.13"
 
 [build-dependencies]
-cargo-lock = "8.0.2"
-itertools = "0.10.4"
+cargo-lock = "9.0.0"
+itertools = "0.12.1"
 
 [profile.release]
 overflow-checks = true


### PR DESCRIPTION
## Description of changes

Updating dependencies based on the output of `cargo outdated`. Afaict this does not break any current behavior.
* `miette` 5.9.0 -> 7.1.0
* `serde-wasm-bindgen` 0.4 -> 0.6
* `logos` 0.13.0 -> 0.14.0
* `cargo-lock` 8.0.2 -> 9.0.0
* `itertools` 0.10.4 -> 0.12.1

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
