### PR TITLE
Adding constructors for ip/decimal

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`, `RestrctedExpression::new_decimal`, (TDB, resolving #659)
 - `PolicyId::new()` (#587, resolving #551)
 - `EntityId::new()` (#583, resolving #553)
 - `AsRef<str>` implementation for `PolicyId` (#504, resolving #503)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`, `RestrctedExpression::new_decimal`, (TDB, resolving #659)
+- `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`, `RestrctedExpression::new_decimal`, (#661, resolving #659)
 - `PolicyId::new()` (#587, resolving #551)
 - `EntityId::new()` (#583, resolving #553)
 - `AsRef<str>` implementation for `PolicyId` (#504, resolving #503)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`, `RestrctedExpression::new_decimal`, (#661, resolving #659)
+- `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`, and `RestrictedExpression::new_decimal` (#661, resolving #659)
 - `PolicyId::new()` (#587, resolving #551)
 - `EntityId::new()` (#583, resolving #553)
 - `AsRef<str>` implementation for `PolicyId` (#504, resolving #503)

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3462,7 +3462,7 @@ impl Expression {
         Self(ast::Expr::set(values.into_iter().map(|v| v.0)))
     }
 
-    /// Create an expression representing an ip address
+    /// Create an expression representing an ip address.
     /// This function does not perform error checking on the source string,
     /// it creates an expression that calls the `ip` constructor.
     pub fn new_ip(src: impl AsRef<str>) -> Self {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3550,7 +3550,7 @@ impl RestrictedExpression {
         Self(ast::RestrictedExpr::set(values.into_iter().map(|v| v.0)))
     }
 
-    /// Create an expression representing an ip address
+    /// Create an expression representing an ip address.
     /// This function does not perform error checking on the source string,
     /// it creates an expression that calls the `ip` constructor.
     pub fn new_ip(src: impl AsRef<str>) -> Self {


### PR DESCRIPTION
## Description of changes
Adds methods to `Expression` and `RestrictedExpression` that allow for constructing `ip` and `decimal` calls.
## Issue #, if available
#659 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
