### PR TITLE
Pull changes from `main` to `release/3.1.x`

### DIFF
--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -3,9 +3,344 @@
 #[cfg(test)]
 mod demo_tests {
 
+    use std::{
+        collections::HashMap,
+        iter::{empty, once},
+    };
+
+    use cool_asserts::assert_matches;
     use smol_str::ToSmolStr;
 
-    use crate::{EntityType, SchemaFragment, SchemaTypeVariant, TypeOfAttribute};
+    use crate::{
+        human_schema::{self, ast::PR, err::ToJsonSchemaError},
+        ActionType, ApplySpec, AttributesOrContext, EntityType, NamespaceDefinition,
+        SchemaFragment, SchemaTypeVariant, TypeOfAttribute,
+    };
+
+    #[test]
+    fn no_applies_to() {
+        let src = r#"
+            action "Foo";
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        assert_matches!(foo,
+            ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), ..}), .. } => assert!(resources.is_empty() && principals.is_empty())
+        );
+    }
+
+    #[test]
+    fn just_context() {
+        let src = r#"
+        action "Foo" appliesTo { context: {} };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        assert_matches!(
+            foo,
+            ActionType {
+                applies_to: Some(ApplySpec {
+                    resource_types: None,
+                    principal_types: None,
+                    ..
+                }),
+                ..
+            }
+        );
+    }
+
+    #[test]
+    fn just_principal() {
+        let src = r#"
+        entity a;
+        action "Foo" appliesTo { principal: a, context: {}  };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        assert_matches!(foo,
+            ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), ..}), .. } =>
+                {
+                    match principals.as_slice() {
+                        [a] if a == &"a".to_smolstr() => (),
+                        _ => panic!("Bad principals")
+                    }
+                }
+        );
+    }
+
+    #[test]
+    fn just_resource() {
+        let src = r#"
+        entity a;
+        action "Foo" appliesTo { resource: a, context: {}  };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        assert_matches!(foo,
+            ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, ..}), .. } =>
+                {
+                    match resources.as_slice() {
+                        [a] if a == &"a".to_smolstr() => (),
+                        _ => panic!("Bad principals")
+                    }
+                }
+        );
+    }
+
+    #[test]
+    fn resource_only() {
+        let src = r#"
+            entity a;
+            action "Foo" appliesTo {
+                resource : [a]
+            };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let unqual = schema.0.get("").unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(foo,
+                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, .. }  ), ..} =>
+                    assert_matches!(resources.as_slice(), [a] => assert_eq!(a.as_ref(), "a"))
+            ,
+        );
+    }
+
+    #[test]
+    fn resources_only() {
+        let src = r#"
+            entity a;
+            entity b;
+            action "Foo" appliesTo {
+                resource : [a, b]
+            };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let unqual = schema.0.get("").unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(foo,
+                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, .. }  ), ..} =>
+                    assert_matches!(resources.as_slice(), [a, b] => {
+                        assert_eq!(a.as_ref(), "a");
+                        assert_eq!(b.as_ref(), "b")
+                    })
+            ,
+        );
+    }
+
+    #[test]
+    fn principal_only() {
+        let src = r#"
+            entity a;
+            action "Foo" appliesTo {
+                principal: [a]
+            };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let unqual = schema.0.get("").unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(foo,
+                ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), .. }  ), ..} =>
+                    assert_matches!(principals.as_slice(), [a] => assert_eq!(a.as_ref(), "a"))
+            ,
+        );
+    }
+
+    #[test]
+    fn principals_only() {
+        let src = r#"
+            entity a;
+            entity b;
+            action "Foo" appliesTo {
+                principal: [a, b]
+            };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let unqual = schema.0.get("").unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(foo,
+                ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), .. }  ), ..} =>
+                    assert_matches!(principals.as_slice(), [a,b] => {
+                        assert_eq!(a.as_ref(), "a");
+                        assert_eq!(b.as_ref(), "b");
+                })
+            ,
+        );
+    }
+
+    #[test]
+    fn both_targets() {
+        let src = r#"
+            entity a;
+            entity b;
+            entity c;
+            entity d;
+            action "Foo" appliesTo {
+                principal: [a, b],
+                resource: [c, d]
+            };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let unqual = schema.0.get("").unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(foo,
+                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), .. }  ), ..} =>
+                {
+                    assert_matches!(principals.as_slice(), [a,b] => {
+                        assert_eq!(a.as_ref(), "a");
+                        assert_eq!(b.as_ref(), "b");
+                });
+                assert_matches!(resources.as_slice(), [c,d] =>  {
+                        assert_eq!(c.as_ref(), "c");
+                        assert_eq!(d.as_ref(), "d");
+
+                })
+            }
+            ,
+        );
+    }
+
+    #[test]
+    fn both_targets_flipped() {
+        let src = r#"
+            entity a;
+            entity b;
+            entity c;
+            entity d;
+            action "Foo" appliesTo {
+                resource: [c, d],
+                principal: [a, b]
+            };
+        "#;
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let unqual = schema.0.get("").unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(foo,
+                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), .. }  ), ..} =>
+                {
+                    assert_matches!(principals.as_slice(), [a,b] => {
+                        assert_eq!(a.as_ref(), "a");
+                        assert_eq!(b.as_ref(), "b");
+                });
+                assert_matches!(resources.as_slice(), [c,d] =>  {
+                        assert_eq!(c.as_ref(), "c");
+                        assert_eq!(d.as_ref(), "d");
+
+                })
+            }
+            ,
+        );
+    }
+
+    #[test]
+    fn duplicate_principal() {
+        let src = r#"
+            entity a;
+            entity b;
+            entity c;
+            entity d;
+            action "Foo" appliesTo {
+                principal: [a, b],
+                principal : [c]
+            };
+        "#;
+        // Can't unwrap here as impl iter doesn't implement debug
+        let err = match SchemaFragment::from_str_natural(src) {
+            Err(e) => e,
+            _ => panic!("Should have failed to parse"),
+        };
+        assert_matches!(err,
+        crate::HumanSchemaError::Parsing(err) => assert_matches!(err,
+            human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
+                assert!(json_errs
+                    .into_iter()
+                    .any(|err| {
+                        matches!(
+                            err,
+                            ToJsonSchemaError::DuplicatePR {
+                                kind: PR::Principal,
+                                ..
+                            }
+                        )
+                    }));
+            }));
+    }
+
+    #[test]
+    fn duplicate_resource() {
+        let src = r#"
+            entity a;
+            entity b;
+            entity c;
+            entity d;
+            action "Foo" appliesTo {
+                resource: [a, b],
+                resource: [c]
+            };
+        "#;
+        // Can't unwrap here as impl iter doesn't implement debug
+        let err = match SchemaFragment::from_str_natural(src) {
+            Err(e) => e,
+            _ => panic!("Should have failed to parse"),
+        };
+        assert_matches!(err,
+        crate::HumanSchemaError::Parsing(err) => assert_matches!(err,
+            human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
+                assert!(json_errs
+                    .into_iter()
+                    .any(|err| {
+                        matches!(
+                            err,
+                            ToJsonSchemaError::DuplicatePR {
+                                kind: PR::Resource,
+                                ..
+                            }
+                        )
+                    }));
+            }));
+    }
+
+    #[test]
+    fn empty_appliesto() {
+        let action = ActionType {
+            attributes: None,
+            applies_to: None,
+            member_of: None,
+        };
+        let namespace = NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
+        let fragment = SchemaFragment(HashMap::from([("bar".to_smolstr(), namespace)]));
+        let as_src = fragment.as_natural_schema().unwrap();
+        let expected = r#"action "foo" ;"#;
+        assert!(as_src.contains(expected), "src was:\n`{as_src}`");
+    }
+
+    #[test]
+    fn print_actions() {
+        let namespace = NamespaceDefinition {
+            common_types: HashMap::new(),
+            entity_types: HashMap::from([(
+                "a".to_smolstr(),
+                EntityType {
+                    member_of_types: vec![],
+                    shape: AttributesOrContext::default(),
+                },
+            )]),
+            actions: HashMap::from([(
+                "j".to_smolstr(),
+                ActionType {
+                    attributes: None,
+                    applies_to: Some(ApplySpec {
+                        resource_types: Some(vec![]),
+                        principal_types: Some(vec!["a".to_smolstr()]),
+                        context: AttributesOrContext::default(),
+                    }),
+                    member_of: None,
+                },
+            )]),
+        };
+        let fragment = SchemaFragment(HashMap::from([("".to_smolstr(), namespace)]));
+        let src = fragment.as_natural_schema().unwrap();
+        assert!(src.contains(r#"action "j" ;"#), "schema was: `{src}`")
+    }
 
     #[test]
     fn test_github() {

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -556,7 +556,6 @@ fn extract_name(n: Node<SmolStr>) -> (SmolStr, Node<()>) {
 }
 
 fn shadows_builtin((name, node): (&SmolStr, &Node<()>)) -> Option<SchemaWarning> {
-    println!("Name: `{name}`");
     if EXTENSIONS.contains(&name.as_ref()) || BUILTIN_TYPES.contains(&name.as_ref()) {
         Some(SchemaWarning::ShadowsBuiltin {
             name: name.clone(),

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1972,4 +1972,72 @@ mod test {
             "ExampleCo::Personnel::Action"
         );
     }
+
+    #[test]
+    fn qualified_undeclared_common_types() {
+        let src = json!(
+            {
+                "Demo": {
+                  "entityTypes": {
+                    "User": {
+                      "memberOfTypes": [],
+                      "shape": {
+                        "type": "Record",
+                        "attributes": {
+                          "id": { "type": "id" },
+                        }
+                      }
+                    }
+                  },
+                  "actions": {}
+                },
+                "": {
+                  "commonTypes": {
+                    "id": {
+                      "type": "String"
+                    },
+                  },
+                  "entityTypes": {},
+                  "actions": {}
+                }
+              }
+        );
+        let schema = ValidatorSchema::from_json_value(src, Extensions::all_available());
+        assert_matches!(schema, Err(SchemaError::UndeclaredCommonTypes(types)) =>
+            assert_eq!(types, HashSet::from(["Demo::id".to_string()])));
+    }
+
+    #[test]
+    fn qualified_undeclared_common_types2() {
+        let src = json!(
+            {
+                "Demo": {
+                  "entityTypes": {
+                    "User": {
+                      "memberOfTypes": [],
+                      "shape": {
+                        "type": "Record",
+                        "attributes": {
+                          "id": { "type": "Demo::id" },
+                        }
+                      }
+                    }
+                  },
+                  "actions": {}
+                },
+                "": {
+                  "commonTypes": {
+                    "id": {
+                      "type": "String"
+                    },
+                  },
+                  "entityTypes": {},
+                  "actions": {}
+                }
+              }
+        );
+        let schema = ValidatorSchema::from_json_value(src, Extensions::all_available());
+        assert_matches!(schema, Err(SchemaError::UndeclaredCommonTypes(types)) =>
+            assert_eq!(types, HashSet::from(["Demo::id".to_string()])));
+    }
 }

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -722,7 +722,9 @@ impl ValidatorNamespaceDef {
                 .map_err(SchemaError::ParseCommonType)?;
                 Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
                     typ_defs.get(&defined_type_name).cloned().ok_or(
-                        SchemaError::UndeclaredCommonTypes(HashSet::from([type_name.to_string()])),
+                        SchemaError::UndeclaredCommonTypes(HashSet::from([
+                            defined_type_name.to_string()
+                        ])),
                     )
                 }))
             }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -35,7 +35,7 @@ use crate::{
 /// schema fragment is split into multiple namespace definitions, eac including
 /// a namespace name which is applied to all entity types (and the implicit
 /// `Action` entity type for all actions) in the schema.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct SchemaFragment(
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,8 @@ Cedar Language Version: 3.1.0
 
 ### Changed
 
+- Changed error message on `SchemaError::UndeclaredCommonTypes` to report
+  fully qualified type names. (#652, resolving #580)
 - Better integration with `miette` for various error types. If you have
   previously been just using the `Display` trait to get the error message from a
   Cedar error type, you may want to consider also examining other data provided

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,8 +22,6 @@ Cedar Language Version: 3.1.0
 
 ### Changed
 
-- Changed error message on `SchemaError::UndeclaredCommonTypes` to report
-  fully qualified type names. (#652, resolving #580)
 - Better integration with `miette` for various error types. If you have
   previously been just using the `Display` trait to get the error message from a
   Cedar error type, you may want to consider also examining other data provided
@@ -32,7 +30,6 @@ Cedar Language Version: 3.1.0
   and all associated information in a pretty human-readable format or as JSON.
   For more details, see `miette`'s
   [documentation](https://docs.rs/miette/latest/miette/index.html). (#477)
-- Moved `<PolicyId as FromStr>::Err` to `Infallible` (#588, resolving #551)
 - Cedar reserved words like `if`, `has`, and `true` are now allowed as policy
   annotation keys. (#634, resolving #623)
 - Add hints suggesting how to fix some type errors. (#513)
@@ -48,6 +45,8 @@ Cedar Language Version: 3.1.0
   using the wrong call style. (#482)
 - Include source spans on more parse error messages. (#471, resolving #465)
 - Include source spans on more evaluation error messages. (#582)
+- Changed error message on `SchemaError::UndeclaredCommonTypes` to report
+  fully qualified type names. (#652, resolving #580)
 - For the `partial-eval` experimental feature: make the return values of
   `RequestBuilder`'s `principal`, `action`, `resource`, `context` and
   `schema` functions `#[must_use]`. (#502)


### PR DESCRIPTION
## Description of changes

Cherry picking a few PRs from `main` to the pre-release branch `release/3.1.x`:
* #652: improves an error message
* #655: removes a print
* #658 (the important one!): bug fixes for the new schema format

There are also several other harmless PRs on `main` that I didn't pull back, assuming that we don't want to change too much just before release. Lmk in the comments if you think I should cherry pick these too 🙂
* #653: fixes for clippy lints
* #662, #663, #664, #665, 667: dependabot dependency update
* #661: adds some constructors (ok because 3.1 is a minor release)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
