### PR TITLE
Fixing 2 bugs with IDs

### DIFF
--- a/cedar-policy-validator/src/human_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/human_schema/grammar.lalrpop
@@ -178,10 +178,8 @@ Ident: Node<Id> = {
         => Node::with_source_loc("namespace".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> ENTITY <r:@R>
         => Node::with_source_loc("entity".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
-    <l:@L> IN <r:@R>
-        => Node::with_source_loc("in".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> SET <r:@R>
-        => Node::with_source_loc("set".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
+        => Node::with_source_loc("Set".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> APPLIESTO <r:@R>
         => Node::with_source_loc("appliesTo".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> PRINCIPAL <r:@R>

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -948,6 +948,7 @@ mod parser_tests {
 #[cfg(test)]
 mod translator_tests {
     use cedar_policy_core::FromNormalizedStr;
+    use smol_str::ToSmolStr;
 
     use crate::{SchemaError, SchemaFragment, SchemaTypeVariant, TypeOfAttribute, ValidatorSchema};
 
@@ -1266,5 +1267,159 @@ mod translator_tests {
                     SchemaError::UndeclaredCommonTypes(_)
                 )
         );
+    }
+
+    #[test]
+    fn entity_named_namespace() {
+        let src = r#"
+        entity namespace = {};
+        entity Foo in [namespace] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["namespace".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_in() {
+        // This fails because `in` is reserved
+        let src = r#"
+        entity in = {};
+        entity Foo in [in] = {};
+        "#;
+
+        assert!(SchemaFragment::from_str_natural(src).is_err());
+    }
+
+    #[test]
+    fn entity_named_set() {
+        let src = r#"
+        entity Set = {};
+        entity Foo in [Set] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["Set".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_applies_to() {
+        let src = r#"
+        entity appliesTo = {};
+        entity Foo in [appliesTo] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["appliesTo".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_principal() {
+        let src = r#"
+        entity principal = {};
+        entity Foo in [principal ] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["principal".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_resource() {
+        let src = r#"
+        entity resource= {};
+        entity Foo in [resource] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["resource".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_action() {
+        let src = r#"
+        entity action= {};
+        entity Foo in [action] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["action".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_context() {
+        let src = r#"
+        entity context= {};
+        entity Foo in [context] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["context".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_attributes() {
+        let src = r#"
+        entity attributes= {};
+        entity Foo in [attributes] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["attributes".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_bool() {
+        let src = r#"
+        entity Bool= {};
+        entity Foo in [Bool] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["Bool".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_long() {
+        let src = r#"
+        entity Long= {};
+        entity Foo in [Long] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["Long".to_smolstr()]);
+    }
+
+    #[test]
+    fn entity_named_string() {
+        let src = r#"
+        entity String= {};
+        entity Foo in [String] = {};
+        "#;
+
+        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let ns = schema.0.get("").unwrap();
+        let foo = ns.entity_types.get("Foo").unwrap();
+        assert_eq!(foo.member_of_types, vec!["String".to_smolstr()]);
     }
 }


### PR DESCRIPTION
## Description of changes
1. Entity types with the id `Set` were mistakenly interpreted as having the id `set`
2. A mistake the CFG could lead to a panic when parsing a schema that used `in` as an entity type name
## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):


- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
