### PR TITLE
Backport #581

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -4925,6 +4925,135 @@ mod schema_based_parsing_tests {
             .unwrap()
         );
     }
+
+    /// If a user passes actions through both the schema and the entities, then
+    /// those actions should exactly match _unless_ the `TCComputation::ComputeNow`
+    /// option is used, in which case only the TC has to match.
+    #[test]
+    fn issue_285() {
+        let schema = Schema::from_json_value(json!(
+        {"": {
+            "entityTypes": {},
+            "actions": {
+                "A": {},
+                "B": {
+                    "memberOf": [{"id": "A"}]
+                },
+                "C": {
+                    "memberOf": [{"id": "B"}]
+                }
+            }
+        }}
+        ))
+        .expect("should be a valid schema");
+
+        let entitiesjson_tc = json!(
+            [
+                {
+                    "uid": { "type": "Action", "id": "A" },
+                    "attrs": {},
+                    "parents": []
+                },
+                {
+                    "uid": { "type": "Action", "id": "B" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "Action", "id": "A" }
+                    ]
+                },
+                {
+                    "uid": { "type": "Action", "id": "C" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "Action", "id": "A" },
+                        { "type": "Action", "id": "B" }
+                    ]
+                }
+            ]
+        );
+
+        let entitiesjson_no_tc = json!(
+            [
+                {
+                    "uid": { "type": "Action", "id": "A" },
+                    "attrs": {},
+                    "parents": []
+                },
+                {
+                    "uid": { "type": "Action", "id": "B" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "Action", "id": "A" }
+                    ]
+                },
+                {
+                    "uid": { "type": "Action", "id": "C" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "Action", "id": "B" }
+                    ]
+                }
+            ]
+        );
+
+        // Both entity jsons are ok (the default TC setting is `ComputeNow`)
+        assert!(Entities::from_json_value(entitiesjson_tc.clone(), Some(&schema)).is_ok());
+        assert!(Entities::from_json_value(entitiesjson_no_tc.clone(), Some(&schema)).is_ok());
+
+        // Parsing will fail if the TC doesn't match
+        let entitiesjson_bad = json!(
+            [
+                {
+                    "uid": { "type": "Action", "id": "A" },
+                    "attrs": {},
+                    "parents": []
+                },
+                {
+                    "uid": { "type": "Action", "id": "B" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "Action", "id": "A" }
+                    ]
+                },
+                {
+                    "uid": { "type": "Action", "id": "C" },
+                    "attrs": {},
+                    "parents": [
+                        { "type": "Action", "id": "A" }
+                    ]
+                }
+            ]
+        );
+        assert!(matches!(
+            Entities::from_json_value(entitiesjson_bad, Some(&schema)),
+            Err(EntitiesError::Deserialization(
+                entities::JsonDeserializationError::ActionDeclarationMismatch { uid: _ }
+            ))
+        ));
+
+        // Parsing will fail if we change the TC setting
+        let parser_assume_computed = entities::EntityJsonParser::new(
+            Some(cedar_policy_validator::CoreSchema::new(&schema.0)),
+            Extensions::all_available(),
+            entities::TCComputation::AssumeAlreadyComputed,
+        );
+        assert!(matches!(
+            parser_assume_computed.from_json_value(entitiesjson_no_tc.clone()),
+            Err(EntitiesError::Deserialization(
+                entities::JsonDeserializationError::ActionDeclarationMismatch { uid: _ }
+            ))
+        ));
+
+        let parser_enforce_computed = entities::EntityJsonParser::new(
+            Some(cedar_policy_validator::CoreSchema::new(&schema.0)),
+            extensions::Extensions::all_available(),
+            entities::TCComputation::EnforceAlreadyComputed,
+        );
+        assert!(matches!(
+            parser_enforce_computed.from_json_value(entitiesjson_no_tc),
+            Err(EntitiesError::TransitiveClosureError(_))
+        ));
+    }
 }
 #[cfg(test)]
 // PANIC SAFETY: unit tests


### PR DESCRIPTION
## Description of changes

Backport bugfix #581 to the `release/2.4.x` branch. The structure of the change is different from the fix on `main` because the structure of this code has changed significantly since 2.4. But the idea is the same: I moved the code to check the action hierarchy until after TC computation.

I did not add an entry for this bugfix to the CHANGELOG because we haven't added entries for the other bugfixes yet. That will come in a separate PR.

## Issue #, if available

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
