### PR TITLE
Revert breaking changes introduced by #557

### DIFF
--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -19,7 +19,6 @@ use crate::entities::JsonDeserializationError;
 use crate::parser::err::ParseErrors;
 use crate::parser::unescape;
 use miette::Diagnostic;
-use nonempty::NonEmpty;
 use smol_str::SmolStr;
 use thiserror::Error;
 
@@ -74,8 +73,8 @@ pub enum FromJsonError {
     },
     /// Error thrown while processing string escapes
     // show just the first error in the main error message, like in [`ParseErrors`]; see #326 and discussion on #477
-    #[error("{}", .0.first())]
-    UnescapeError(#[related] NonEmpty<unescape::UnescapeError>),
+    #[error("{}", match .0.first() { Some(err) => format!("{err}"), None => "invalid escape".into() })]
+    UnescapeError(#[related] Vec<unescape::UnescapeError>),
     /// Error reported when the entity type tested by an `is` expression cannot be parsed.
     #[error("invalid entity type: {0}")]
     #[diagnostic(transparent)]

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -607,7 +607,7 @@ impl Expr {
             Expr::ExprNoExt(ExprNoExt::Like { left, pattern }) => {
                 match unescape::to_pattern(&pattern) {
                     Ok(pattern) => Ok(ast::Expr::like((*left).clone().try_into_ast(id)?, pattern)),
-                    Err(errs) => Err(FromJsonError::UnescapeError(errs)),
+                    Err(errs) => Err(FromJsonError::UnescapeError(errs.into())),
                 }
             }
             Expr::ExprNoExt(ExprNoExt::Is {


### PR DESCRIPTION
`FromJsonError::UnescapeError`'s signature is reverted.

## Description of changes

## Issue #, if available

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
