### PR TITLE
tsify ValidateCall and schema types for cedar-wasm, add wasm build to CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -70,3 +70,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: EmbarkStudios/cargo-deny-action@v1
+
+  wasm-build:
+    name: run wasm build script
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - run: cd ./cedar-wasm && cargo install wasm-pack && ./build-wasm.sh

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -26,6 +26,11 @@ lalrpop-util = { version = "0.20.0", features = ["lexer", "unicode"] }
 lazy_static = "1.4.0"
 nonempty = "0.10.0"
 
+# wasm dependencies
+serde-wasm-bindgen = { version = "0.6", optional = true }
+tsify = { version = "0.4.5", optional = true }
+wasm-bindgen = { version = "0.2.82", optional = true }
+
 [features]
 # by default, enable all Cedar extensions
 default = ["ipaddr", "decimal"]
@@ -38,6 +43,7 @@ arbitrary = ["dep:arbitrary"]
 
 # Experimental features.
 partial-validate = []
+wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -30,6 +30,9 @@ use crate::{
     HumanSchemaError, Result,
 };
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 /// A SchemaFragment describe the types for a given instance of Cedar.
 /// SchemaFragments are composed of Entity Types and Action Types. The
 /// schema fragment is split into multiple namespace definitions, eac including
@@ -37,6 +40,8 @@ use crate::{
 /// `Action` entity type for all actions) in the schema.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SchemaFragment(
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     pub  HashMap<SmolStr, NamespaceDefinition>,
@@ -83,6 +88,8 @@ impl SchemaFragment {
 #[serde_as]
 #[serde(deny_unknown_fields)]
 #[doc(hidden)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct NamespaceDefinition {
     #[serde(default)]
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
@@ -113,6 +120,8 @@ impl NamespaceDefinition {
 /// can/should be included on entities of each type.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EntityType {
     #[serde(default)]
     #[serde(rename = "memberOfTypes")]
@@ -123,6 +132,8 @@ pub struct EntityType {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(transparent)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct AttributesOrContext(
     // We use the usual `SchemaType` deserialization, but it will ultimately
     // need to be a `Record` or type def which resolves to a `Record`.
@@ -148,6 +159,8 @@ impl Default for AttributesOrContext {
 /// kinds of entities it can be used on.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionType {
     /// This maps attribute names to
     /// `cedar_policy_core::entities::json::value::CedarValueJson` which is the
@@ -172,6 +185,8 @@ pub struct ActionType {
 /// applies to.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ApplySpec {
     #[serde(default)]
     #[serde(rename = "resourceTypes")]
@@ -185,6 +200,8 @@ pub struct ApplySpec {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionEntityUID {
     pub id: SmolStr,
 
@@ -218,6 +235,8 @@ impl std::fmt::Display for ActionEntityUID {
 // then, have catch-all variant for any unrecognized tag in the same enum that
 // captures the name of the unrecognized tag.
 #[serde(untagged)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SchemaType {
     Type(SchemaTypeVariant),
     TypeDef {
@@ -492,8 +511,10 @@ impl From<SchemaTypeVariant> for SchemaType {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "type")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum SchemaTypeVariant {
     String,
     Long,

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -299,7 +299,7 @@ struct AuthorizationCall {
     /// `__entity` and `__extn` escapes to be implicit, and it will error if
     /// attributes have the wrong types (e.g., string instead of integer).
     #[serde(rename = "schema")]
-    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, any>"))]
+    #[cfg_attr(feature = "wasm", tsify(type = "Schema"))]
     schema: Option<JsonValueWithNoDuplicateKeys>,
     /// If this is `true` and a schema is provided, perform request validation.
     /// If this is `false`, the schema will only be used for schema-based

--- a/cedar-policy/src/frontend/validate.rs
+++ b/cedar-policy/src/frontend/validate.rs
@@ -25,6 +25,9 @@ use cedar_policy_core::{
 use cedar_policy_validator::Validator;
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 fn validate(call: &ValidateCall) -> Result<ValidateAnswer, String> {
     let mut policy_set = PolicySet::new();
     let mut parse_errors: Vec<String> = vec![];
@@ -99,6 +102,8 @@ pub fn json_validate(input: &str) -> InterfaceResult {
 }
 
 #[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 struct ValidateCall {
     #[serde(default)]
     #[serde(rename = "validationSettings")]
@@ -109,11 +114,15 @@ struct ValidateCall {
 }
 
 #[derive(Default, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 struct ValidationSettings {
     mode: ValidationMode,
 }
 
 #[derive(Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 enum ValidationMode {
     #[serde(rename = "regular")]
     Regular,

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -13,3 +13,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `policy_text_to_json`, and `policy_text_from_json`. (#616)
 - Exposed cedar-wasm functionality for authorization and validation: `wasm_is_authorized`
   and `wasm_validate`. (#657)
+- Exposed types through `tsify` for `ValidateCall` and the schema. (#692)

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ['/build']
 cedar-policy = { version = "=3.0.0", path = "../cedar-policy", features = ["wasm"] }
 cedar-policy-core = { version = "=3.0.0", path = "../cedar-policy-core", features = ["wasm"] }
 cedar-policy-formatter = { version = "=3.0.0", path = "../cedar-policy-formatter" }
+cedar-policy-validator = {version = "=3.0.0", path = "../cedar-policy-validator", features = ["wasm"]}
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# This script calls wasm-pack build and post-processes the generated TS types to fix them.
+# Without this, the built wasm still works, but the Typescript definitions made by tsify don't.
 set -e
 cargo build
 wasm-pack build --scope amzn --target web
@@ -17,6 +19,8 @@ sed -i "s/[{]\s*-: /{ \"-\": /g" pkg/cedar_wasm.d.ts
 sed -i "s/[{]\s*[*]: /{ \"*\": /g" pkg/cedar_wasm.d.ts
 sed -i "s/[{]\s*\.: /{ \".\": /g" pkg/cedar_wasm.d.ts
 sed -i "s/ | __skip//g" pkg/cedar_wasm.d.ts
+sed -i "s/SchemaFragment/Schema/g" pkg/cedar_wasm.d.ts
 
 echo "type SmolStr = string;" >> pkg/cedar_wasm.d.ts
+echo "export type TypeOfAttribute = SchemaType & { required?: boolean };" >> pkg/cedar_wasm.d.ts
 echo "Finished post-processing types file"


### PR DESCRIPTION
## Description of changes
Expose the types for ValidateCall (JSON input to wasm_validate) and the schema. Update previous `Record<string, any>` types for the schema to use the exported `Schema` type.

Added `cedar-wasm/build-wasm.sh` to the CI workflow.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
