### PR TITLE
Translate Schema --schema short option form should be -s

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -107,7 +107,7 @@ pub struct TranslateSchemaArgs {
     pub direction: TranslationDirection,
     /// Filename to read the schema from.
     /// If not provided, will default to reading stdin.
-    #[arg(short, long = "schema", value_name = "FILE")]
+    #[arg(short = 's', long = "schema", value_name = "FILE")]
     pub input_file: Option<String>,
 }
 


### PR DESCRIPTION
The macro took the short option from the field name, not the long option, so it  was `-i`.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
