### PR TITLE
Improve parser errors on unexpected tokens

### DIFF
--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -1100,6 +1100,8 @@ mod parse_tests {
         assert_labeled_span("permit(,,);", "expected `)` or identifier");
         assert_labeled_span("permit(principal,", "expected identifier");
         assert_labeled_span("permit(principal,action,", "expected identifier");
+        // Nothing will actually convert to an AST here.
+        assert_labeled_span("permit(principal,action,resource,", "expected identifier");
         // We still list out `if` as an expected token because it doesn't get
         // parsed as an ident in this position.
         assert_labeled_span(

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -689,6 +689,7 @@ mod parse_tests {
     use super::*;
     use crate::test_utils::*;
     use cool_asserts::assert_matches;
+    use itertools::Itertools;
     use miette::Diagnostic;
 
     #[test]
@@ -1058,5 +1059,50 @@ mod parse_tests {
                 itertools::assert_equal(err.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
             }
         })
+    }
+
+    #[test]
+    fn unexpected_token_errors() {
+        #[track_caller]
+        fn assert_labeled_span(policy: &str, label: impl Into<String>) {
+            assert_matches!(parse_policy(None, policy), Err(e) => {
+                let actual_label = e.labels().and_then(|l| {
+                    l.exactly_one()
+                        .ok()
+                        .expect("Assumed that there would be exactly one label if labels are present")
+                        .label()
+                        .map(|l| l.to_string())
+                });
+                assert_eq!(Some(label.into()), actual_label, "Did not see expected labeled span.");
+            });
+        }
+
+        // Don't list out all the special case identifiers
+        assert_labeled_span("@", "expected identifier");
+        assert_labeled_span(
+            "permit(principal, action, resource) when { principal.",
+            "expected identifier",
+        );
+
+        // We specifically want `when` or `unless`, but we previously listed all
+        // identifier tokens, so this is an improvement.
+        assert_labeled_span(
+            "permit(principal, action, resource)",
+            "expected `;` or identifier",
+        );
+        assert_labeled_span("@if(\"a\")", "expected `@` or identifier");
+        assert_labeled_span("permit(", "expected `)` or identifier");
+        // We still list out `if` as an expected token because it doesn't get
+        // parsed as an ident in this position.
+        assert_labeled_span(
+            "permit(principal, action, resource) when {",
+            "expected `!`, `(`, `-`, `[`, `{`, `}`, `false`, identifier, `if`, number, `?principal`, `?resource`, string literal, or `true`",
+        );
+
+        // We expect binary operators, but don't claim to expect `=`, `%` or `/`.
+        assert_labeled_span(
+            "permit(principal, action, resource) when { if true",
+            "expected `!=`, `&&`, `(`, `*`, `+`, `-`, `.`, `::`, `<`, `<=`, `==`, `>`, `>=`, `[`, `||`, `has`, `in`, `is`, `like`, or `then`",
+        )
     }
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -590,7 +590,7 @@ pub struct ExpectedTokenConfig {
     /// constructs. It is very often not useful to explicitly list out all of
     /// these special identifier because the parser really just wants any
     /// generic identifier. That it would accept these does not give any
-    /// usefully information.
+    /// useful information.
     pub special_identifier_tokens: HashSet<&'static str>,
 
     /// If this token is expected, then the parser expected a generic identifier, so

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -575,7 +575,7 @@ impl Diagnostic for ToCSTError {
 #[derive(Debug)]
 pub struct ExpectedTokenConfig {
     /// Defines user-friendly names for tokens used by our parser. Keys are the
-    /// names ok tokens as defined in the `.lalrpop` grammar file. A token may
+    /// names of tokens as defined in the `.lalrpop` grammar file. A token may
     /// be omitted from this map if the name is already friendly enough.
     pub friendly_token_names: HashMap<&'static str, &'static str>,
 
@@ -585,7 +585,7 @@ pub struct ExpectedTokenConfig {
     /// these from the list of expected tokens in an error message.
     pub impossible_tokens: HashSet<&'static str>,
 
-    /// In both our policy and schema grammar have a generic identifier token
+    /// Both our policy and schema grammar have a generic identifier token
     /// and some more specific identifier tokens that we use to parse specific
     /// constructs. It is very often not useful to explicitly list out all of
     /// these special identifier because the parser really just wants any

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -556,11 +556,11 @@ impl Diagnostic for ToCSTError {
         let labeled_span = match &self.err {
             OwnedRawParseError::InvalidToken { .. } => LabeledSpan::underline(primary_source_span),
             OwnedRawParseError::UnrecognizedEof { expected, .. } => LabeledSpan::new_with_span(
-                expected_to_string(expected, &FRIENDLY_TOKEN_NAMES),
+                expected_to_string(expected, &POLICY_TOKEN_CONFIG),
                 primary_source_span,
             ),
             OwnedRawParseError::UnrecognizedToken { expected, .. } => LabeledSpan::new_with_span(
-                expected_to_string(expected, &FRIENDLY_TOKEN_NAMES),
+                expected_to_string(expected, &POLICY_TOKEN_CONFIG),
                 primary_source_span,
             ),
             OwnedRawParseError::ExtraToken { .. } => LabeledSpan::underline(primary_source_span),
@@ -570,84 +570,107 @@ impl Diagnostic for ToCSTError {
     }
 }
 
-lazy_static! {
-    /// Keys mirror the token names defined in the `match` block of
-    /// `grammar.lalrpop`.
-    static ref FRIENDLY_TOKEN_NAMES: HashMap<&'static str, &'static str> = HashMap::from([
-        ("TRUE", "`true`"),
-        ("FALSE", "`false`"),
-        ("IF", "`if`"),
-        ("PERMIT", "`permit`"),
-        ("FORBID", "`forbid`"),
-        ("WHEN", "`when`"),
-        ("UNLESS", "`unless`"),
-        ("IN", "`in`"),
-        ("HAS", "`has`"),
-        ("LIKE", "`like`"),
-        ("IS", "`is`"),
-        ("THEN", "`then`"),
-        ("ELSE", "`else`"),
-        ("PRINCIPAL", "`principal`"),
-        ("ACTION", "`action`"),
-        ("RESOURCE", "`resource`"),
-        ("CONTEXT", "`context`"),
-        ("PRINCIPAL_SLOT", "`?principal`"),
-        ("RESOURCE_SLOT", "`?resource`"),
-        ("IDENTIFIER", "identifier"),
-        ("NUMBER", "number"),
-        ("STRINGLIT", "string literal"),
-    ]);
+/// Defines configurable rules for how tokens in an `UnrecognizedToken` or
+/// `UnrecognizedEof` error should be displayed to users.
+#[derive(Debug)]
+pub struct ExpectedTokenConfig {
+    /// Defines user-friendly names for tokens used by our parser. Keys are the
+    /// names ok tokens as defined in the `.lalrpop` grammar file. A token may
+    /// be omitted from this map if the name is already friendly enough.
+    pub friendly_token_names: HashMap<&'static str, &'static str>,
 
-    /// Some tokens defined in our grammar always cause conversion to CST to
-    /// fail, so they can never occur in any policy. E.g., Our grammar defines a
-    /// token for the mod operator `%`, but we reject any CST that uses the
-    /// operator. To reduce confusion we filter these from the list of expected
-    /// tokens in an error message.
-    static ref IMPOSSIBLE_TOKEN_NAMES: HashSet<&'static str> = HashSet::from([
-        "\"=\"", "\"%\"", "\"/\"", "OTHER_SLOT",
-    ]);
+    /// Some tokens defined in our grammar always cause later processing to fail.
+    /// Our policy grammar defines a token for the mod operator `%`, but we
+    /// reject any CST that uses the operator. To reduce confusion we filter
+    /// these from the list of expected tokens in an error message.
+    pub impossible_tokens: HashSet<&'static str>,
 
-    /// Tokens for (most of) our identifiers. Used to remove these from the
-    /// expected tokens list when they're not useful.
-    static ref IDENTIFIER_TOKEN_NAMES: HashSet<&'static str> = HashSet::from([
-        "PERMIT", "FORBID", "WHEN", "UNLESS", "IN", "HAS", "LIKE", "IS", "THEN",
-        "ELSE", "PRINCIPAL", "ACTION", "RESOURCE", "CONTEXT",
-    ]);
+    /// In both our policy and schema grammar have a generic identifier token
+    /// and some more specific identifier tokens that we use to parse specific
+    /// constructs. It is very often not useful to explicitly list out all of
+    /// these special identifier because the parser really just wants any
+    /// generic identifier. That it would accept these does not give any
+    /// usefully information.
+    pub special_identifier_tokens: HashSet<&'static str>,
 
-    /// Tokens for the remaining identifiers. These will be parsed as something
-    /// other than an identifier when they occur at the start of an expression,
-    /// so we want to keep these in the error message if the parser was looking
-    /// for the first token of an expression.
-    static ref EXPR_FIRST_SET_IDENTIFIER_TOKEN_NAMES: HashSet<&'static str> =
-    HashSet::from([
-        "TRUE", "FALSE", "IF",
-    ]);
+    /// If this token is expected, then the parser expected a generic identifier, so
+    /// we omit the specific identifiers favor of saying we expect an "identifier".
+    pub identifier_sentinel: &'static str,
+
+    /// Special identifiers that may be worth displaying even if the parser
+    /// wants a generic identifier. These can tokens will be parsed as something
+    /// other than an identifier when they occur as the first token in an
+    /// expression (or a type, in the case of the schema grammar).
+    pub first_set_identifier_tokens: HashSet<&'static str>,
+
+    /// If this token is expected, then the parser was looking to start parsing
+    /// an expression (or type, in the schema). We know that we should report the
+    /// tokens that aren't parsed as identifiers at the start of an expression.
+    pub first_set_sentinel: &'static str,
 }
 
-// If this token is expected, then the parser expected a generic identifier, so
-// we omit the specific identifiers favor of saying we expect an "identifier".
-static IDENTIFIER_SENTINEL: &'static str = "IDENTIFIER";
-
-// If this token is expected, then the parser was looking to start parsing an
-// expression.
-static EXPR_FIRST_SET_SENTINEL: &'static str = "\"!\"";
+lazy_static! {
+    static ref POLICY_TOKEN_CONFIG: ExpectedTokenConfig = ExpectedTokenConfig {
+        friendly_token_names: HashMap::from([
+            ("TRUE", "`true`"),
+            ("FALSE", "`false`"),
+            ("IF", "`if`"),
+            ("PERMIT", "`permit`"),
+            ("FORBID", "`forbid`"),
+            ("WHEN", "`when`"),
+            ("UNLESS", "`unless`"),
+            ("IN", "`in`"),
+            ("HAS", "`has`"),
+            ("LIKE", "`like`"),
+            ("IS", "`is`"),
+            ("THEN", "`then`"),
+            ("ELSE", "`else`"),
+            ("PRINCIPAL", "`principal`"),
+            ("ACTION", "`action`"),
+            ("RESOURCE", "`resource`"),
+            ("CONTEXT", "`context`"),
+            ("PRINCIPAL_SLOT", "`?principal`"),
+            ("RESOURCE_SLOT", "`?resource`"),
+            ("IDENTIFIER", "identifier"),
+            ("NUMBER", "number"),
+            ("STRINGLIT", "string literal"),
+        ]),
+        impossible_tokens: HashSet::from(["\"=\"", "\"%\"", "\"/\"", "OTHER_SLOT"]),
+        special_identifier_tokens: HashSet::from([
+            "PERMIT",
+            "FORBID",
+            "WHEN",
+            "UNLESS",
+            "IN",
+            "HAS",
+            "LIKE",
+            "IS",
+            "THEN",
+            "ELSE",
+            "PRINCIPAL",
+            "ACTION",
+            "RESOURCE",
+            "CONTEXT",
+        ]),
+        identifier_sentinel: "IDENTIFIER",
+        first_set_identifier_tokens: HashSet::from(["TRUE", "FALSE", "IF"]),
+        first_set_sentinel: "\"!\"",
+    };
+}
 
 /// Format lalrpop expected error messages
-pub fn expected_to_string(
-    expected: &[String],
-    token_map: &HashMap<&'static str, &'static str>,
-) -> Option<String> {
+pub fn expected_to_string(expected: &[String], config: &ExpectedTokenConfig) -> Option<String> {
     let mut expected = expected
         .iter()
-        .filter(|e| !IMPOSSIBLE_TOKEN_NAMES.contains(e.as_str()))
+        .filter(|e| !config.impossible_tokens.contains(e.as_str()))
         .map(|e| e.as_str())
         .collect::<BTreeSet<_>>();
-    if expected.contains(IDENTIFIER_SENTINEL) {
-        for token in IDENTIFIER_TOKEN_NAMES.iter() {
+    if expected.contains(config.identifier_sentinel) {
+        for token in config.special_identifier_tokens.iter() {
             expected.remove(*token);
         }
-        if !expected.contains(EXPR_FIRST_SET_SENTINEL) {
-            for token in EXPR_FIRST_SET_IDENTIFIER_TOKEN_NAMES.iter() {
+        if !expected.contains(config.first_set_sentinel) {
+            for token in config.first_set_identifier_tokens.iter() {
                 expected.remove(*token);
             }
         }
@@ -663,7 +686,7 @@ pub fn expected_to_string(
         &mut expected_string,
         "or",
         expected,
-        |f, token| match token_map.get(token) {
+        |f, token| match config.friendly_token_names.get(token) {
             Some(friendly_token_name) => write!(f, "{}", friendly_token_name),
             None => write!(f, "{}", token.replace('"', "`")),
         },

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -35,6 +35,7 @@ pub enum HumanSchemaError {
     #[error("{0}")]
     IO(#[from] std::io::Error),
     #[error("{0}")]
+    #[diagnostic(transparent)]
     Parsing(#[from] HumanSyntaxParseErrors),
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 return a `RequestBuilder<&Schema>` so the `RequestBuilder<&Schema>::build`
 method checks the request against the schema provided and the
 `RequestBuilder<UnsetSchema>::build` method becomes infallible. (#559)
+* Improved "unexpected token" parse errors when the parsers expects an identifier. (#698)
 
 ### Fixed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -57,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 return a `RequestBuilder<&Schema>` so the `RequestBuilder<&Schema>::build`
 method checks the request against the schema provided and the
 `RequestBuilder<UnsetSchema>::build` method becomes infallible. (#559)
-* Improved "unexpected token" parse errors when the parsers expects an identifier. (#698)
+- Improved "unexpected token" parse errors when the schema or policy parsers
+  expect an identifier. (#698)
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

Improve the parser error reported for unexpected tokens/end-of-input when the parser expects an identifier. The error message used to list out the token for every special identifier. Also ensures we don't claim to expect some tokens that can never be in a valid AST. The `=`, `/`, and `%` tokens are always invalid, so we shouldn't claim to expect them even if they grammar seems to allow it.

New error:
```
  × failed to parse policy set
  ╰─▶ unexpected end of input
   ╭─[<stdin>:1:36]
 1 │ permit(principal, action, resource)
   ·                                    ▲
   ·                                    ╰── expected `;` or identifier
   ╰────
```


Old error: 

```
  × failed to parse policy set
  ╰─▶ unexpected end of input
   ╭─[<stdin>:1:1]
 1 │ permit(principal, action, resource)
   ·                                    ▲
   ·                                    ╰── expected `;`, `action`, `context`, `else`, `false`, `forbid`, `has`, identifier, `if`, `in`, `is`, `like`, `permit`, `principal`, `resource`, `then`, `true`, `unless`, or `when`
   ╰────
```

Improves on #176. There are sill some odd parse errors of this sort. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` 

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or 
