### PR TITLE
Fix typechecking `in` for action in different namespaces

### DIFF
--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1865,7 +1865,14 @@ impl<'a> Typechecker<'a> {
                                             .get_entity_type(&rhs_name)
                                             .map(|ety| ety.descendants.contains(&lhs_name))
                                             .unwrap_or(false);
-                                        if lhs_name == rhs_name || lhs_ty_in_rhs_ty {
+                                        // A schema may always declare that an action entity is a member of another action entity,
+                                        // regardless of their exact types (i.e., their namespaces), so we shouldn't treat it as an error.
+                                        let action_in_action = is_action_entity_type(&lhs_name)
+                                            && is_action_entity_type(&rhs_name);
+                                        if lhs_name == rhs_name
+                                            || action_in_action
+                                            || lhs_ty_in_rhs_ty
+                                        {
                                             TypecheckAnswer::success(type_of_in)
                                         } else {
                                             // We could actually just return `Type::False`, but this is incurs a larger Dafny proof update.

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -19,6 +19,7 @@
 #![cfg(test)]
 // GRCOV_STOP_COVERAGE
 
+use cool_asserts::assert_matches;
 use serde_json::json;
 use std::str::FromStr;
 use std::vec;
@@ -35,7 +36,7 @@ use super::test_utils::{
 use crate::{
     type_error::TypeError,
     types::{EntityLUB, Type},
-    AttributeAccess, SchemaFragment, ValidatorSchema,
+    AttributeAccess, SchemaError, SchemaFragment, ValidatorSchema,
 };
 
 fn namespaced_entity_type_schema() -> SchemaFragment {
@@ -525,4 +526,120 @@ fn namespaced_entity_is_wrong_type_when() {
             None,
         )],
     );
+}
+
+#[test]
+fn multi_namespace_action_eq() {
+    let (schema, _) = SchemaFragment::from_str_natural(
+        r#"
+            action "Action" appliesTo { context: {} };
+            namespace NS1 { action "Action" appliesTo { context: {} }; }
+            namespace NS2 { action "Action" appliesTo { context: {} }; }
+        "#,
+    )
+    .unwrap();
+
+    assert_policy_typechecks(
+        schema.clone(),
+        parse_policy(
+            None,
+            r#"permit(principal, action == Action::"Action", resource);"#,
+        )
+        .unwrap(),
+    );
+    assert_policy_typechecks(
+        schema.clone(),
+        parse_policy(
+            None,
+            r#"permit(principal, action == NS1::Action::"Action", resource);"#,
+        )
+        .unwrap(),
+    );
+
+    let policy = parse_policy(
+        None,
+        r#"permit(principal, action, resource) when { NS1::Action::"Action" == NS2::Action::"Action" };"#,
+    )
+    .unwrap();
+    assert_policy_typecheck_fails(
+        schema.clone(),
+        policy.clone(),
+        vec![TypeError::impossible_policy(policy.condition())],
+    );
+}
+
+#[test]
+fn multi_namespace_action_in() {
+    let (schema, _) = SchemaFragment::from_str_natural(
+        r#"
+            namespace NS1 { action "Group"; }
+            namespace NS2 { action "Group" in [NS1::Action::"Group"]; }
+            namespace NS3 {
+                action "Group" in [NS2::Action::"Group"];
+                action "Action" in [Action::"Group"] appliesTo { context: {} };
+            }
+            namespace NS4 { action "Group"; }
+        "#,
+    )
+    .unwrap();
+
+    assert_policy_typechecks(
+        schema.clone(),
+        parse_policy(
+            None,
+            r#"permit(principal, action in NS1::Action::"Group", resource);"#,
+        )
+        .unwrap(),
+    );
+    assert_policy_typechecks(
+        schema.clone(),
+        parse_policy(
+            None,
+            r#"permit(principal, action in NS2::Action::"Group", resource);"#,
+        )
+        .unwrap(),
+    );
+    assert_policy_typechecks(
+        schema.clone(),
+        parse_policy(
+            None,
+            r#"permit(principal, action in NS3::Action::"Group", resource);"#,
+        )
+        .unwrap(),
+    );
+    assert_policy_typechecks(
+        schema.clone(),
+        parse_policy(
+            None,
+            r#"permit(principal, action in NS3::Action::"Action", resource);"#,
+        )
+        .unwrap(),
+    );
+
+    let policy = parse_policy(
+        None,
+        r#"permit(principal, action in NS4::Action::"Group", resource);"#,
+    )
+    .unwrap();
+    assert_policy_typecheck_fails(
+        schema.clone(),
+        policy.clone(),
+        vec![TypeError::impossible_policy(policy.condition())],
+    );
+}
+
+#[test]
+fn multi_namespace_action_group_cycle() {
+    let (schema, _) = SchemaFragment::from_str_natural(
+        r#"
+            namespace A { action "Act" in C::Action::"Act"; }
+            namespace B { action "Act" in A::Action::"Act"; }
+            namespace C { action "Act" in B::Action::"Act"; }
+        "#,
+    )
+    .unwrap();
+    assert_matches!(
+        ValidatorSchema::try_from(schema),
+        Err(SchemaError::CycleInActionHierarchy(_))
+    )
 }

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -658,7 +658,7 @@ fn test_cedar_policy_642() {
                 principal in NS1::PrincipalEntity::"user1",
                 action in NS1::Action::"Group1",
                 resource in NS1::SystemEntity1::"entity1"
-            );"#
+            );"#,
         )
         .unwrap(),
     );

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Validation for the `in` operator to no longer reports an error when comparing actions
+  in different namespaces. (#704, resolving #642)
+
 ## [3.1.0] - 2024-03-08
 Cedar Language Version: 3.1.0
 


### PR DESCRIPTION
## Description of changes

Makes the easy fix to #642. Actions in different namespaces were incorrectly considered incomparable by the typechecking rule for `in`. Update that function so that the comparison is allowed.

This can be released in the next patch/minor release. Per #638, we might be able to get rid of this error variant entirely, but that would likely wait for 4.0.  

This changes a typechecking rule, so it might seem to require a spec update, but IIRC, the Lean spec would already allow these policies, and DRT allows for this difference. Also, we don't generate schema with multiple namespaces, so DRT couldn't fail anyways. 

This bug was introduced by #282 which was released with version 3.0, so we don't need to backport the fix.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
