### PR TITLE
Use human friendly type format for type error display

### DIFF
--- a/cedar-policy-validator/src/human_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/human_schema/grammar.lalrpop
@@ -146,7 +146,7 @@ AppDecls: Node<NonEmpty<Node<AppDecl>>> = {
 // SetType := 'Set' '<' Type '>'
 // RecType := '{' [AttrDecls] '}'
 // Type := PRIMTYPE | Path | SetType | RecType
-Type: Node<SType> = {
+pub Type: Node<SType> = {
     <p:Path>
         => { let loc = p.loc().clone(); Node::with_source_loc(SType::Ident(p), loc) },
     <l:@L> SET "<" <t:Type> ">" <r:@R>

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -47,6 +47,20 @@ pub fn custom_schema_to_json_schema(
     Ok((SchemaFragment(fragment), warnings.into_iter()))
 }
 
+/// Convert a custom type AST into the JSON representation of the type.
+/// Conversion is done in an empty context.
+pub fn custom_type_to_json_type(ty: Node<Type>) -> Result<SchemaType, ToJsonSchemaErrors> {
+    let names = HashMap::from([("".into(), NamespaceRecord::default())]);
+    let context = ConversionContext::new(
+        &names,
+        &Namespace {
+            name: None,
+            decls: vec![],
+        },
+    );
+    context.convert_type(ty)
+}
+
 fn split_unqualified_namespace(
     namespaces: impl IntoIterator<Item = Namespace>,
 ) -> (impl Iterator<Item = Namespace>, Option<Namespace>) {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   expect an identifier. (#698)
 - Deprecated the integration testing harness code. It will be removed from the
   `cedar-policy` crate in the next major version.
+- Validation error messages render types in the new, more readable, schema
+  syntax. (#708, resolving #242)
 
 ### Fixed
 


### PR DESCRIPTION
Fix #242

This required a way to print out internal types that aren't accepted by the parser. I used a namespace `__cedar::internal` for this, so, for example, a type error that expects any set will say that it expects `Set<__cedar::internal::Any>`.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
