### PR TITLE
fix: unsoundness issue caught in recent nightly

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Validation for the `in` operator to no longer reports an error when comparing actions
   in different namespaces. (#704, resolving #642)
+- `ValidationResult` methods `validation_errors` and `validation_warnings`, along with
+  `confusable_string_checker`, now return iterators with static lifetimes instead of
+  custom lifetimes, addressing potential unsoundness. (#712)
 
 ## [3.1.0] - 2024-03-08
 Cedar Language Version: 3.1.0

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1673,12 +1673,12 @@ impl<'a> ValidationResult<'a> {
     }
 
     /// Get an iterator over the errors found by the validator.
-    pub fn validation_errors<'b>(&self) -> impl Iterator<Item = &ValidationError<'b>> {
+    pub fn validation_errors(&self) -> impl Iterator<Item = &ValidationError<'static>> {
         self.validation_errors.iter()
     }
 
     /// Get an iterator over the warnings found by the validator.
-    pub fn validation_warnings<'b>(&self) -> impl Iterator<Item = &ValidationWarning<'b>> {
+    pub fn validation_warnings(&self) -> impl Iterator<Item = &ValidationWarning<'static>> {
         self.validation_warnings.iter()
     }
 
@@ -1911,12 +1911,9 @@ impl<'a> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation<'st
 /// checks are also provided through [`Validator::validate`] which provides more
 /// comprehensive error detection, but this function can be used to check for
 /// confusable strings without defining a schema.
-pub fn confusable_string_checker<'a, 'b>(
+pub fn confusable_string_checker<'a>(
     templates: impl Iterator<Item = &'a Template> + 'a,
-) -> impl Iterator<Item = ValidationWarning<'b>> + 'a
-where
-    'b: 'a,
-{
+) -> impl Iterator<Item = ValidationWarning<'static>> + 'a {
     cedar_policy_validator::confusable_string_checks(templates.map(|t| &t.ast))
         .map(std::convert::Into::into)
 }


### PR DESCRIPTION
## Description of changes
Return static lifetime for `ValidationError` and `ValidationWarning` so lifetime will live enough. 3.1.0 is not working with latest nightly version this PR fix that issue by returning static lifetime instead of custom lifetime
Latest nightly error message
```
error: lifetime may not live long enough
    --> cedar-policy/src/api.rs:1677:9
     |
1676 |     pub fn validation_errors<'b>(&self) -> impl Iterator<Item = &ValidationError<'b>> {
     |                              --  - let's call the lifetime of this reference `'1`
     |                              |
     |                              lifetime `'b` defined here
1677 |         self.validation_errors.iter()
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'b`

error: lifetime may not live long enough
    --> cedar-policy/src/api.rs:1682:9
     |
1681 |     pub fn validation_warnings<'b>(&self) -> impl Iterator<Item = &ValidationWarning<'b>> {
     |                                --  - let's call the lifetime of this reference `'1`
     |                                |
     |                                lifetime `'b` defined here
1682 |         self.validation_warnings.iter()
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method was supposed to return data with lifetime `'1` but it is returning data with lifetime `'b`

error: lifetime may not live long enough
    --> cedar-policy/src/api.rs:1920:5
     |
1914 |   pub fn confusable_string_checker<'a, 'b>(
     |                                        -- lifetime `'b` defined here
...
1920 | /     cedar_policy_validator::confusable_string_checks(templates.map(|t| &t.ast))
1921 | |         .map(std::convert::Into::into)
     | |______________________________________^ returning this value requires that `'b` must outlive `'static`

error: could not compile `cedar-policy` (lib) due to 3 previous errors
```

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
