### PR TITLE
Expose formatter and schema/entity/context parsing to wasm

### DIFF
--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -52,7 +52,7 @@ pub struct EntityJson {
     /// any duplicate keys in any records that may occur in an attribute value
     /// (even nested).)
     #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
-    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, any>"))]
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson>"))]
     // the annotation covers duplicates in this `HashMap` itself, while the `JsonValueWithNoDuplicateKeys` covers duplicates in any records contained in attribute values (including recursively)
     attrs: HashMap<SmolStr, JsonValueWithNoDuplicateKeys>,
     /// Parents of the entity, specified in any form accepted by `EntityUidJson`

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -292,7 +292,10 @@ struct AuthorizationCall {
     #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
     resource: Option<JsonValueWithNoDuplicateKeys>,
     #[serde_as(as = "MapPreventDuplicates<_, _>")]
-    #[cfg_attr(feature = "wasm", tsify(optional, type = "Record<string, any>"))]
+    #[cfg_attr(
+        feature = "wasm",
+        tsify(optional, type = "Record<string, CedarValueJson>")
+    )]
     context: HashMap<String, JsonValueWithNoDuplicateKeys>,
     /// Optional schema in JSON format.
     /// If present, this will inform the parsing: for instance, it will allow

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exposed cedar-wasm functionality for authorization and validation: `wasm_is_authorized`
   and `wasm_validate`. (#657)
 - Exposed types through `tsify` for `ValidateCall` and the schema. (#692)
+- Exposed cedar-wasm functionality for formatter and schema, context, and entity parsing: `wasm_format_policies`, `check_parse_schema`, `check_parse_context`, `check_parse_entities`. (#718)

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -23,4 +23,5 @@ sed -i "s/SchemaFragment/Schema/g" pkg/cedar_wasm.d.ts
 
 echo "type SmolStr = string;" >> pkg/cedar_wasm.d.ts
 echo "export type TypeOfAttribute = SchemaType & { required?: boolean };" >> pkg/cedar_wasm.d.ts
+echo "export type Context = Record<string, CedarValueJson>;" >> pkg/cedar_wasm.d.ts
 echo "Finished post-processing types file"

--- a/cedar-wasm/src/formatter.rs
+++ b/cedar-wasm/src/formatter.rs
@@ -1,0 +1,76 @@
+use cedar_policy_formatter::{policies_str_to_pretty, Config};
+use serde::{Deserialize, Serialize};
+
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[tsify(from_wasm_abi, into_wasm_abi)]
+pub struct FormattingResult {
+    success: bool,
+    #[serde(rename = "formattedPolicy", skip_serializing_if = "Option::is_none")]
+    formatted_policy: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+#[wasm_bindgen(js_name = "formatPolicies")]
+pub fn wasm_format_policies(
+    policies_str: &str,
+    line_width: i32,
+    indent_width: i32,
+) -> FormattingResult {
+    let line_width: usize = match line_width.try_into() {
+        Ok(width) => width,
+        Err(_) => {
+            return FormattingResult {
+                success: false,
+                formatted_policy: None,
+                error: Some("Input size error (line width)".to_string()),
+            }
+        }
+    };
+    let indent_width: isize = match indent_width.try_into() {
+        Ok(width) => width,
+        Err(_) => {
+            return FormattingResult {
+                success: false,
+                formatted_policy: None,
+                error: Some("Input size error (indent width)".to_string()),
+            }
+        }
+    };
+    let config = Config {
+        line_width,
+        indent_width,
+    };
+    match policies_str_to_pretty(policies_str, &config) {
+        Ok(prettified_policy) => FormattingResult {
+            success: true,
+            formatted_policy: Some(prettified_policy),
+            error: None,
+        },
+        Err(err) => FormattingResult {
+            success: false,
+            formatted_policy: None,
+            error: Some(err.to_string()),
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_format_policies() {
+        let policy = r#"permit(principal, action == Action::"view", resource in Albums::"gangsta rap") when {principal.is_gangsta == true};"#;
+        let expected = "permit (\n    principal,\n    action == Action::\"view\",\n    resource in Albums::\"gangsta rap\"\n)\nwhen { principal.is_gangsta == true };";
+        assert_eq!(
+            wasm_format_policies(policy, 80, 4)
+                .formatted_policy
+                .unwrap(),
+            expected
+        );
+    }
+}

--- a/cedar-wasm/src/lib.rs
+++ b/cedar-wasm/src/lib.rs
@@ -3,12 +3,18 @@
 use wasm_bindgen::prelude::*;
 
 mod authorizer;
+mod formatter;
 mod policies_and_templates;
+mod schema_and_entities_and_context;
 mod validator;
 
 pub use authorizer::wasm_is_authorized;
+pub use formatter::wasm_format_policies;
 pub use policies_and_templates::{
     check_parse_policy_set, policy_text_from_json, policy_text_to_json,
+};
+pub use schema_and_entities_and_context::{
+    check_parse_context, check_parse_entities, check_parse_schema,
 };
 pub use validator::wasm_validate;
 

--- a/cedar-wasm/src/schema_and_entities_and_context.rs
+++ b/cedar-wasm/src/schema_and_entities_and_context.rs
@@ -1,0 +1,251 @@
+use std::str::FromStr;
+
+use cedar_policy::{Context, Entities, EntityUid, Schema};
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[serde(tag = "success")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+/// struct that defines the result for the syntax validation function
+pub enum CheckParseResult {
+    #[serde(rename = "true")]
+    /// represents successful syntax validation
+    Success,
+    #[serde(rename = "false")]
+    /// represents a syntax error and encloses a vector of the errors
+    SyntaxError { errors: Vec<String> },
+}
+
+#[wasm_bindgen(js_name = "checkParseSchema")]
+pub fn check_parse_schema(input_schema: &str) -> CheckParseResult {
+    match Schema::from_str(input_schema) {
+        Ok(_schema) => CheckParseResult::Success,
+        Err(err) => CheckParseResult::SyntaxError {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[wasm_bindgen(js_name = "checkParseEntities")]
+pub fn check_parse_entities(entities_str: &str, schema_str: &str) -> CheckParseResult {
+    let parsed_schema = match Schema::from_str(schema_str) {
+        Ok(schema) => schema,
+        Err(err) => {
+            return CheckParseResult::SyntaxError {
+                errors: vec![err.to_string()],
+            }
+        }
+    };
+    match Entities::from_json_str(entities_str, Some(&parsed_schema)) {
+        Ok(_) => CheckParseResult::Success,
+        Err(err) => CheckParseResult::SyntaxError {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[wasm_bindgen(js_name = "checkParseContext")]
+pub fn check_parse_context(
+    context_str: &str,
+    action_str: &str,
+    schema_str: &str,
+) -> CheckParseResult {
+    let parsed_schema = match Schema::from_str(schema_str) {
+        Ok(schema) => schema,
+        Err(err) => {
+            return CheckParseResult::SyntaxError {
+                errors: vec![err.to_string()],
+            }
+        }
+    };
+    let parsed_action = match EntityUid::from_str(action_str) {
+        Ok(action) => action,
+        Err(err) => {
+            return CheckParseResult::SyntaxError {
+                errors: vec![err.to_string()],
+            }
+        }
+    };
+    match Context::from_json_str(context_str, Some((&parsed_schema, &parsed_action))) {
+        Ok(_entities) => CheckParseResult::Success,
+        Err(err) => CheckParseResult::SyntaxError {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Schema validator
+    #[test]
+    fn validate_schema_syntax_succeeds_empty_schema() {
+        let schema_str = "{}";
+        assert_syntax_result_is_ok(&check_parse_schema(schema_str))
+    }
+    #[test]
+    fn validate_schema_syntax_succeeds_nonempty_schema() {
+        let schema_str = r#"{
+          "MyNamespace": {
+            "entityTypes": {},
+            "actions": {}
+          }
+        }"#;
+        assert_syntax_result_is_ok(&check_parse_schema(schema_str))
+    }
+
+    #[test]
+    fn validate_schema_bad_syntax_fails() {
+        let schema_str = r#"{
+            "MyNamespace": {
+              "entityTypes": {}
+            }
+          }"#;
+        assert_syntax_result_has_errors(&check_parse_schema(schema_str))
+    }
+
+    // Entities
+
+    #[test]
+    fn validate_entities_succeeds() {
+        let entities_str = r#"[
+            {
+                "uid": {
+                    "type": "TheNamespace::User",
+                    "id": "alice"
+                },
+                "attrs": {
+                    "department": "HardwareEngineering",
+                    "jobLevel": 5
+                },
+                "parents": []
+              }
+        ]"#;
+        let schema_str = r#"{
+            "TheNamespace": {
+                "entityTypes": {
+                    "User": {
+                        "memberOfTypes": [],
+                        "shape": {
+                            "attributes": {
+                                "department": {
+                                    "type": "String"
+                                },
+                                "jobLevel": {
+                                    "type": "Long"
+                                }
+                            },
+                            "type": "Record"
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        }"#;
+        assert_syntax_result_is_ok(&check_parse_entities(entities_str, schema_str));
+    }
+
+    #[test]
+    fn validate_entities_fails_on_bad_entity() {
+        let entities_str = r#"[
+            {
+                "uid": "TheNamespace::User::\"alice\"",
+                "attrs": {
+                    "benchPress": "doesn'tevenlift"
+                },
+                "parents": []
+              }
+        ]"#;
+        let schema_str = r#"{
+            "TheNamespace": {
+                "entityTypes": {
+                    "User": {
+                        "memberOfTypes": [],
+                        "shape": {
+                            "attributes": {
+                                "department": {
+                                    "type": "String"
+                                }
+                            },
+                            "type": "Record"
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        }"#;
+        assert_syntax_result_has_errors(&check_parse_entities(entities_str, schema_str));
+    }
+
+    #[test]
+    fn validate_context_succeeds() {
+        let context_str = r#"{
+            "referrer": "Morpheus"
+        }"#;
+        let action_str = r#"Ex::Action::"Join""#;
+        let schema_str = r#"{
+            "Ex": {
+                "entityTypes": {},
+                "actions": {
+                    "Join": {
+                        "appliesTo": {
+                            "context": {
+                                "type": "Record",
+                                "attributes": {
+                                    "referrer": {
+                                        "type": "String",
+                                        "required": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        assert_syntax_result_is_ok(&check_parse_context(context_str, action_str, schema_str));
+    }
+
+    #[test]
+    fn validate_context_fails_for_bad_context() {
+        let context_str = r#"{
+            "wrongAttr": true
+        }"#;
+        let action_str = r#"Ex::Action::"Join""#;
+        let schema_str = r#"{
+            "Ex": {
+                "entityTypes": {},
+                "actions": {
+                    "Join": {
+                        "appliesTo": {
+                            "context": {
+                                "type": "Record",
+                                "attributes": {
+                                    "referrer": {
+                                        "type": "String",
+                                        "required": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        assert_syntax_result_has_errors(&check_parse_context(context_str, action_str, schema_str));
+    }
+
+    fn assert_syntax_result_is_ok(parse_result: &CheckParseResult) {
+        assert!(matches!(parse_result, CheckParseResult::Success))
+    }
+
+    fn assert_syntax_result_has_errors(parse_result: &CheckParseResult) {
+        assert!(matches!(
+            parse_result,
+            CheckParseResult::SyntaxError { errors: _ }
+        ))
+    }
+}


### PR DESCRIPTION
## Description of changes

Broken off of/added to the changes under this larger CR: https://github.com/Swolebrain/cedar/commit/a1b511923e30020cd0e26b4bed6ab7cd3e8b2402

- Added policy formatting to wasm: `wasm_format_policies`
- Added and `check_parse_<schema/context/entities>` functions to wasm to allow schema to be parsed and checked for errors, as well as for entities and context to be checked against the schema.

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
