### PR TITLE
Fix build warning and avoid unnecessary rebuilds of cedar-wasm

### DIFF
--- a/cedar-wasm/.cargo/config.toml
+++ b/cedar-wasm/.cargo/config.toml
@@ -1,0 +1,4 @@
+[profile.release]
+overflow-checks = true
+# Tell `rustc` to optimize for small code size
+opt-level = "s"

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -34,8 +34,3 @@ wasm-bindgen-test = "0.3.13"
 [build-dependencies]
 cargo-lock = "9.0.0"
 itertools = "0.12.1"
-
-[profile.release]
-overflow-checks = true
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"

--- a/cedar-wasm/build.rs
+++ b/cedar-wasm/build.rs
@@ -3,7 +3,7 @@ use cargo_lock::Lockfile;
 /// PANIC SAFETY: This is a build script so it's okay for it to panic. Build should fail if underlying assumptions of this script fail
 #[allow(clippy::expect_used)]
 fn main() {
-    println!("cargo:rerun-if-changed=Cargo.lock");
+    println!("cargo:rerun-if-changed=../Cargo.lock");
     let lockfile = Lockfile::load("../Cargo.lock").expect("a valid lockfile");
     let mut iter = lockfile
         .packages


### PR DESCRIPTION
## Description of changes

* Fix `build.rs` to rebuild on change to `../Cargo.lock` instead of `Cargo.lock`. There is no `cedar-wasm/Cargo.lock` so this caused a rebuild of `cedar-wasm` on every `cargo build`. (Fix #649) 
* Build profiles in subdirectory `Cargo.toml` files are ignored according to a `cargo build` warning message. Fix the warning, by moving the profile to a `.cargo/config.toml` file which [should override the root profiles](https://doc.rust-lang.org/cargo/reference/profiles.html).

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
