### PR TITLE
Backport PRs to 3.1.x release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -16,7 +16,7 @@ cedar-policy-formatter = { version = "=3.1.0", path = "../cedar-policy-formatter
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-miette = { version = "5.9.0", features = ["fancy"] }
+miette = { version = "7.1.0", features = ["fancy"] }
 thiserror = "1.0"
 
 [features]

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -24,7 +24,7 @@ thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }
-miette = { version = "5.9.0", features = ["serde"] }
+miette = { version = "7.1.0", features = ["serde"] }
 
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -32,7 +32,6 @@ lalrpop_mod!(
 );
 
 use super::*;
-use node::Node;
 use std::sync::Arc;
 
 /// This helper function calls a generated parser, collects errors that could be

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -17,7 +17,6 @@
 //! Module containing code to compute the transitive closure of a graph.
 //! This is a generic utility, and not specific to Cedar.
 
-use std::cmp::Eq;
 use std::collections::{HashMap, HashSet};
 use std::fmt::{Debug, Display};
 use std::hash::Hash;

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/cedar-policy/cedar"
 [dependencies]
 cedar-policy-core = { version = "=3.1.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
-logos = "0.13.0"
+logos = "0.14.0"
 itertools = "0.12"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.9.1", features = ["unicode"] }

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -16,4 +16,4 @@ logos = "0.14.0"
 itertools = "0.12"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.9.1", features = ["unicode"] }
-miette = { version = "5.9.0" }
+miette = { version = "7.1.0" }

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -15,7 +15,7 @@ cedar-policy-core = { version = "=3.1.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
-miette = "5.9.0"
+miette = "7.1.0"
 thiserror = "1.0"
 itertools = "0.12"
 unicode-security = "0.1.0"

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1865,7 +1865,14 @@ impl<'a> Typechecker<'a> {
                                             .get_entity_type(&rhs_name)
                                             .map(|ety| ety.descendants.contains(&lhs_name))
                                             .unwrap_or(false);
-                                        if lhs_name == rhs_name || lhs_ty_in_rhs_ty {
+                                        // A schema may always declare that an action entity is a member of another action entity,
+                                        // regardless of their exact types (i.e., their namespaces), so we shouldn't treat it as an error.
+                                        let action_in_action = is_action_entity_type(&lhs_name)
+                                            && is_action_entity_type(&rhs_name);
+                                        if lhs_name == rhs_name
+                                            || action_in_action
+                                            || lhs_ty_in_rhs_ty
+                                        {
                                             TypecheckAnswer::success(type_of_in)
                                         } else {
                                             // We could actually just return `Type::False`, but this is incurs a larger Dafny proof update.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ValidationResult` methods `validation_errors` and `validation_warnings`, along with
   `confusable_string_checker`, now return iterators with static lifetimes instead of
   custom lifetimes, fixing build for latest nightly Rust. (#712)
+- Validation for the `in` operator to no longer reports an error when comparing actions
+  in different namespaces. (#704, resolving #642)
 
 ## [3.1.0] - 2024-03-08
 Cedar Language Version: 3.1.0

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 lalrpop-util = { version = "0.20.0", features = ["lexer"] }
 itertools = "0.12"
-miette = "5.9.0"
+miette = "7.1.0"
 thiserror = "1.0"
 smol_str = { version = "0.2", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true }


### PR DESCRIPTION
## Description of changes

Backports the following PRs to the `release/3.1.x` branch in preparation for a 3.1.1 patch release. The only non-trivial one is #704.
* #662 
* #663 
* #664 
* #684 
* #704

## Issue #, if available
