### PR TITLE
refactor: return specific error type instead of using impl

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validation error messages render types in the new, more readable, schema
   syntax. (#708, resolving #242)
 - Removed unnecessary lifetimes from some validation related structs (#715)
+- Return specific error type instead of using `impl miette::Diagnostic` (#724, resolving #723)
 
 ## [3.1.1] - 2024-03-14
 


### PR DESCRIPTION
## Description of changes
Return specific error types instead of using `impl miette::Diagnostic`. This improves error handling and maintains consistency across the codebase. This PR is not breaking change since all specific error types implement `miette::Diagnostic`

## Issue #, if available
Fixes #723

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
