### PR TITLE
More integration test refactoring

### DIFF
--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -51,6 +51,14 @@ impl<T> TestResult<T> {
             Self::Failure(err) => panic!("{msg}: {err}"),
         }
     }
+
+    /// Apply a function to the success value.
+    pub fn map<F: FnOnce(T) -> T>(self, f: F) -> Self {
+        match self {
+            Self::Success(t) => Self::Success(f(t)),
+            Self::Failure(err) => Self::Failure(err),
+        }
+    }
 }
 
 /// Simple wrapper around u128 to remind ourselves that timing info is in microseconds.

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -141,7 +141,7 @@ pub enum ErrorComparisonMode {
 }
 
 /// Specifies how validation results from this [`CedarTestImplementation`] should
-/// compared against validation results from another implementation.
+/// be compared against validation results from another implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ValidationComparisonMode {
     /// When comparing this [`CedarTestImplementation`] against another

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -15,7 +15,9 @@
  */
 
 //! Definition of a `CedarTestImplementation` trait that describes an
-//! implementation of Cedar to use during testing.
+//! implementation of Cedar to use during testing. This trait is used for
+//! running the integration tests and for performing randomized differential
+//! testing (see <https://github.com/cedar-policy/cedar-spec>).
 
 pub use cedar_policy::frontend::is_authorized::InterfaceResponse;
 use cedar_policy_core::ast::{Expr, PolicySet, Request, Value};
@@ -116,26 +118,41 @@ pub trait CedarTestImplementation {
 
     /// `ErrorComparisonMode` that should be used for this `CedarTestImplementation`
     fn error_comparison_mode(&self) -> ErrorComparisonMode;
+
+    /// `ValidationComparisonMode` that should be used for this `CedarTestImplementation`
+    fn validation_comparison_mode(&self) -> ValidationComparisonMode;
 }
 
-/// Specifies how errors coming from a `CedarTestImplementation` should be
-/// compared against errors coming from the Rust implementation.
+/// Specifies how authorization errors coming from this `CedarTestImplementation`
+///  should be compared against errors coming from another implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorComparisonMode {
-    /// Don't compare errors at all; the `CedarTestImplementation` is not
-    /// expected to produce errors matching the Rust implementation's errors in
-    /// any way.
-    /// In fact, the `CedarTestImplementation` will be expected to never report
-    /// errors.
+    /// Don't compare errors at all.
     Ignore,
-    /// The `CedarTestImplementation` is expected to produce "error messages" that
-    /// are actually just the id of the erroring policy. This will be compared to
-    /// ensure that the `CedarTestImplementation` agrees with the Rust
-    /// implementation on which policies produce errors.
+    /// The `CedarTestImplementation` is expected to produce "error messages"
+    /// that are actually just the id of the erroring policy. This will used to
+    /// ensure that different `CedarTestImplementation`s agree on which policies
+    /// produce errors.
     PolicyIds,
     /// The `CedarTestImplementation` is expected to produce error messages that
     /// exactly match the Rust implementation's error messages' `Display` text.
     Full,
+}
+
+/// Specifies how validation results from this `CedarTestImplementation` should
+/// compared against validation results from another implementation.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ValidationComparisonMode {
+    /// When comparing this `CedarTestImplementation` against another
+    /// implementation, `validate` should return a `validation_passed` result
+    /// for any input that the other implementation says is valid. This allows
+    /// for flexibility in cases where the other implementation (incorrectly)
+    /// says the input is invalid due to weaker typing precision.
+    AgreeOnValid,
+    /// When comparing this `CedarTestImplementation` against another
+    /// implementation, the valid / not valid decision should agree for all
+    /// inputs, although the exact validation errors may differ.
+    AgreeOnAll,
 }
 
 /// Basic struct to support implementing the `CedarTestImplementation` trait
@@ -230,5 +247,9 @@ impl CedarTestImplementation for RustEngine {
 
     fn error_comparison_mode(&self) -> ErrorComparisonMode {
         ErrorComparisonMode::PolicyIds
+    }
+
+    fn validation_comparison_mode(&self) -> ValidationComparisonMode {
+        ValidationComparisonMode::AgreeOnAll
     }
 }

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -123,33 +123,34 @@ pub trait CedarTestImplementation {
     fn validation_comparison_mode(&self) -> ValidationComparisonMode;
 }
 
-/// Specifies how authorization errors coming from this `CedarTestImplementation`
+/// Specifies how authorization errors coming from this [`CedarTestImplementation`]
 ///  should be compared against errors coming from another implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ErrorComparisonMode {
-    /// Don't compare errors at all.
+    /// Don't compare errors at all. The [`CedarTestImplementation`] will be
+    /// expected to never report errors.
     Ignore,
-    /// The `CedarTestImplementation` is expected to produce "error messages"
+    /// The [`CedarTestImplementation`] is expected to produce "error messages"
     /// that are actually just the id of the erroring policy. This will used to
-    /// ensure that different `CedarTestImplementation`s agree on which policies
-    /// produce errors.
+    /// ensure that different implementations agree on which policies produce
+    /// errors.
     PolicyIds,
-    /// The `CedarTestImplementation` is expected to produce error messages that
+    /// The [`CedarTestImplementation`] is expected to produce error messages that
     /// exactly match the Rust implementation's error messages' `Display` text.
     Full,
 }
 
-/// Specifies how validation results from this `CedarTestImplementation` should
+/// Specifies how validation results from this [`CedarTestImplementation`] should
 /// compared against validation results from another implementation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ValidationComparisonMode {
-    /// When comparing this `CedarTestImplementation` against another
+    /// When comparing this [`CedarTestImplementation`] against another
     /// implementation, `validate` should return a `validation_passed` result
     /// for any input that the other implementation says is valid. This allows
     /// for flexibility in cases where the other implementation (incorrectly)
     /// says the input is invalid due to weaker typing precision.
     AgreeOnValid,
-    /// When comparing this `CedarTestImplementation` against another
+    /// When comparing this [`CedarTestImplementation`] against another
     /// implementation, the valid / not valid decision should agree for all
     /// inputs, although the exact validation errors may differ.
     AgreeOnAll,

--- a/cedar-testing/src/integration_testing.rs
+++ b/cedar-testing/src/integration_testing.rs
@@ -312,7 +312,13 @@ pub fn perform_integration_test_from_json_custom(
             "Unexpected validation errors in {test_name}: {:?}",
             validation_result.errors
         );
-    } else {
+    }
+    if !test.should_validate
+        && matches!(
+            test_impl.validation_comparison_mode(),
+            ValidationComparisonMode::AgreeOnAll
+        )
+    {
         assert!(
             !validation_result.validation_passed(),
             "Expected that validation would fail in {test_name}, but it did not.",

--- a/cedar-testing/src/integration_testing.rs
+++ b/cedar-testing/src/integration_testing.rs
@@ -312,17 +312,16 @@ pub fn perform_integration_test_from_json_custom(
             "Unexpected validation errors in {test_name}: {:?}",
             validation_result.errors
         );
-    }
-    if !test.should_validate
-        && matches!(
-            test_impl.validation_comparison_mode(),
-            ValidationComparisonMode::AgreeOnAll
-        )
-    {
-        assert!(
-            !validation_result.validation_passed(),
-            "Expected that validation would fail in {test_name}, but it did not.",
-        );
+    } else {
+        match test_impl.validation_comparison_mode() {
+            ValidationComparisonMode::AgreeOnAll => {
+                assert!(
+                    !validation_result.validation_passed(),
+                    "Expected that validation would fail in {test_name}, but it did not.",
+                );
+            }
+            ValidationComparisonMode::AgreeOnValid => {} // ignore
+        }
     }
 
     for json_request in test.requests {

--- a/cedar-testing/tests/cedar-policy-cli/main.rs
+++ b/cedar-testing/tests/cedar-policy-cli/main.rs
@@ -20,10 +20,17 @@
 #![allow(clippy::expect_used)]
 // PANIC SAFETY tests
 #![allow(clippy::panic)]
+
 mod corpus_tests;
+
+#[cfg(feature = "decimal")]
 mod decimal;
+
 mod example_use_cases;
+
+#[cfg(feature = "ipaddr")]
 mod ip;
+
 mod multi;
 
 use cedar_policy::Decision;

--- a/cedar-testing/tests/cedar-policy-cli/main.rs
+++ b/cedar-testing/tests/cedar-policy-cli/main.rs
@@ -22,15 +22,11 @@
 #![allow(clippy::panic)]
 
 mod corpus_tests;
-
 #[cfg(feature = "decimal")]
 mod decimal;
-
 mod example_use_cases;
-
 #[cfg(feature = "ipaddr")]
 mod ip;
-
 mod multi;
 
 use cedar_policy::Decision;

--- a/cedar-testing/tests/cedar-policy/corpus_tests.rs
+++ b/cedar-testing/tests/cedar-policy/corpus_tests.rs
@@ -16,8 +16,8 @@
 
 //! Integration tests auto-generated using the differential tester.
 
-use crate::integration_testing::perform_integration_test_from_json;
-use crate::integration_testing::resolve_integration_test_path;
+use cedar_testing::integration_testing::perform_integration_test_from_json;
+use cedar_testing::integration_testing::resolve_integration_test_path;
 use std::path::Path;
 
 /// Path of the folder containing the corpus tests

--- a/cedar-testing/tests/cedar-policy/decimal.rs
+++ b/cedar-testing/tests/cedar-policy/decimal.rs
@@ -16,7 +16,7 @@
 
 //! Integration tests targeting the decimal extension
 
-use crate::integration_testing::perform_integration_test_from_json;
+use cedar_testing::integration_testing::perform_integration_test_from_json;
 use std::path::Path;
 
 /// Path of the folder containing the JSON tests

--- a/cedar-testing/tests/cedar-policy/decimal.rs
+++ b/cedar-testing/tests/cedar-policy/decimal.rs
@@ -25,13 +25,11 @@ fn folder() -> &'static Path {
 }
 
 #[test]
-#[cfg(feature = "decimal")]
 fn decimal_1() {
     perform_integration_test_from_json(folder().join("1.json"));
 }
 
 #[test]
-#[cfg(feature = "decimal")]
 fn decimal_2() {
     perform_integration_test_from_json(folder().join("2.json"));
 }

--- a/cedar-testing/tests/cedar-policy/example_use_cases.rs
+++ b/cedar-testing/tests/cedar-policy/example_use_cases.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::integration_testing::perform_integration_test_from_json;
+use cedar_testing::integration_testing::perform_integration_test_from_json;
 use std::path::Path;
 
 /// Path of the folder containing the JSON tests

--- a/cedar-testing/tests/cedar-policy/ip.rs
+++ b/cedar-testing/tests/cedar-policy/ip.rs
@@ -25,19 +25,16 @@ fn folder() -> &'static Path {
 }
 
 #[test]
-#[cfg(feature = "ipaddr")]
 fn ip_1() {
     perform_integration_test_from_json(folder().join("1.json"));
 }
 
 #[test]
-#[cfg(feature = "ipaddr")]
 fn ip_2() {
     perform_integration_test_from_json(folder().join("2.json"));
 }
 
 #[test]
-#[cfg(feature = "ipaddr")]
 fn ip_3() {
     perform_integration_test_from_json(folder().join("3.json"));
 }

--- a/cedar-testing/tests/cedar-policy/main.rs
+++ b/cedar-testing/tests/cedar-policy/main.rs
@@ -14,30 +14,12 @@
  * limitations under the License.
  */
 
-//! Integration tests targeting the ipaddr extension
-
-use cedar_testing::integration_testing::perform_integration_test_from_json;
-use std::path::Path;
-
-/// Path of the folder containing the JSON tests
-fn folder() -> &'static Path {
-    Path::new("tests/ip")
-}
-
-#[test]
-#[cfg(feature = "ipaddr")]
-fn ip_1() {
-    perform_integration_test_from_json(folder().join("1.json"));
-}
-
-#[test]
-#[cfg(feature = "ipaddr")]
-fn ip_2() {
-    perform_integration_test_from_json(folder().join("2.json"));
-}
-
-#[test]
-#[cfg(feature = "ipaddr")]
-fn ip_3() {
-    perform_integration_test_from_json(folder().join("3.json"));
-}
+// PANIC SAFETY tests
+#![allow(clippy::expect_used)]
+// PANIC SAFETY tests
+#![allow(clippy::panic)]
+mod corpus_tests;
+mod decimal;
+mod example_use_cases;
+mod ip;
+mod multi;

--- a/cedar-testing/tests/cedar-policy/main.rs
+++ b/cedar-testing/tests/cedar-policy/main.rs
@@ -20,13 +20,9 @@
 #![allow(clippy::panic)]
 
 mod corpus_tests;
-
 #[cfg(feature = "decimal")]
 mod decimal;
-
 mod example_use_cases;
-
 #[cfg(feature = "ipaddr")]
 mod ip;
-
 mod multi;

--- a/cedar-testing/tests/cedar-policy/main.rs
+++ b/cedar-testing/tests/cedar-policy/main.rs
@@ -18,8 +18,15 @@
 #![allow(clippy::expect_used)]
 // PANIC SAFETY tests
 #![allow(clippy::panic)]
+
 mod corpus_tests;
+
+#[cfg(feature = "decimal")]
 mod decimal;
+
 mod example_use_cases;
+
+#[cfg(feature = "ipaddr")]
 mod ip;
+
 mod multi;

--- a/cedar-testing/tests/cedar-policy/multi.rs
+++ b/cedar-testing/tests/cedar-policy/multi.rs
@@ -16,7 +16,7 @@
 
 //! Integration tests that involve interactions between multiple policies
 
-use crate::integration_testing::perform_integration_test_from_json;
+use cedar_testing::integration_testing::perform_integration_test_from_json;
 use std::path::Path;
 
 /// Path of the folder containing the JSON tests


### PR DESCRIPTION
## Description of changes

* While working on #716 I noticed that the cedar-policy integration tests weren't actually running after #707 (oops). Added a main file to fix this.
* Added a `ValidationComparisonMode` to `CedarTestImplementation` that controls how validation results are used during testing. This should allow me to easily fix the CI failure in #716, which is caused by validation differences in the corpus tests. I can also reuse this to clean up the implementation of [cedar-spec#210](https://github.com/cedar-policy/cedar-spec/pull/210), which updated the property tested in validation DRT.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
