### PR TITLE
Expose template parsing to wasm, align wasm result structs with Inter…

### DIFF
--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and `wasm_validate`. (#657)
 - Exposed types through `tsify` for `ValidateCall` and the schema. (#692)
 - Exposed cedar-wasm functionality for formatter and schema, context, and entity parsing: `wasm_format_policies`, `check_parse_schema`, `check_parse_context`, `check_parse_entities`. (#718)
+- Exposed cedar-wasm functionality for template parsing: `check_parse_template`.

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -30,6 +30,7 @@ crate_type = ["cdylib", "rlib"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
+cool_asserts = "2.0"
 
 [build-dependencies]
 cargo-lock = "9.0.0"

--- a/cedar-wasm/src/formatter.rs
+++ b/cedar-wasm/src/formatter.rs
@@ -5,13 +5,14 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[tsify(from_wasm_abi, into_wasm_abi)]
-pub struct FormattingResult {
-    success: bool,
-    #[serde(rename = "formattedPolicy", skip_serializing_if = "Option::is_none")]
-    formatted_policy: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<String>,
+#[serde(tag = "success")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum FormattingResult {
+    #[serde(rename = "true")]
+    Success { formatted_policy: String },
+    #[serde(rename = "false")]
+    Error { error: String },
 }
 
 #[wasm_bindgen(js_name = "formatPolicies")]
@@ -23,20 +24,16 @@ pub fn wasm_format_policies(
     let line_width: usize = match line_width.try_into() {
         Ok(width) => width,
         Err(_) => {
-            return FormattingResult {
-                success: false,
-                formatted_policy: None,
-                error: Some("Input size error (line width)".to_string()),
+            return FormattingResult::Error {
+                error: "Input size error (line width)".to_string(),
             }
         }
     };
     let indent_width: isize = match indent_width.try_into() {
         Ok(width) => width,
         Err(_) => {
-            return FormattingResult {
-                success: false,
-                formatted_policy: None,
-                error: Some("Input size error (indent width)".to_string()),
+            return FormattingResult::Error {
+                error: "Input size error (indent width)".to_string(),
             }
         }
     };
@@ -45,15 +42,11 @@ pub fn wasm_format_policies(
         indent_width,
     };
     match policies_str_to_pretty(policies_str, &config) {
-        Ok(prettified_policy) => FormattingResult {
-            success: true,
-            formatted_policy: Some(prettified_policy),
-            error: None,
+        Ok(prettified_policy) => FormattingResult::Success {
+            formatted_policy: prettified_policy,
         },
-        Err(err) => FormattingResult {
-            success: false,
-            formatted_policy: None,
-            error: Some(err.to_string()),
+        Err(err) => FormattingResult::Error {
+            error: err.to_string(),
         },
     }
 }
@@ -61,16 +54,15 @@ pub fn wasm_format_policies(
 #[cfg(test)]
 mod test {
     use super::*;
+    use cool_asserts::assert_matches;
 
     #[test]
     fn test_format_policies() {
         let policy = r#"permit(principal, action == Action::"view", resource in Albums::"gangsta rap") when {principal.is_gangsta == true};"#;
         let expected = "permit (\n    principal,\n    action == Action::\"view\",\n    resource in Albums::\"gangsta rap\"\n)\nwhen { principal.is_gangsta == true };";
-        assert_eq!(
-            wasm_format_policies(policy, 80, 4)
-                .formatted_policy
-                .unwrap(),
-            expected
-        );
+        let result = wasm_format_policies(policy, 80, 4);
+        assert_matches!(result, FormattingResult::Success { formatted_policy } => {
+            assert_eq!(formatted_policy, expected.to_string());
+        });
     }
 }

--- a/cedar-wasm/src/lib.rs
+++ b/cedar-wasm/src/lib.rs
@@ -11,7 +11,7 @@ mod validator;
 pub use authorizer::wasm_is_authorized;
 pub use formatter::wasm_format_policies;
 pub use policies_and_templates::{
-    check_parse_policy_set, policy_text_from_json, policy_text_to_json,
+    check_parse_policy_set, check_parse_template, policy_text_from_json, policy_text_to_json,
 };
 pub use schema_and_entities_and_context::{
     check_parse_context, check_parse_entities, check_parse_schema,


### PR DESCRIPTION
Expose template parsing to wasm, align wasm result structs with InterfaceResult

## Description of changes
- Added a template parsing method to wasm, `check_parse_template`, which parses a template and returns what slots it contains.
- Changed tagging on `Result` enums used for wasm function returns in order to better align with `cedar-policy`'s `InterfaceResult`, which is also directly used in wasm.


## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
## Disclaimer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
