### PR TITLE
[DRAFT] Update integration test CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,33 +31,8 @@ jobs:
       - run: cargo test --verbose --features "experimental"
       - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
 
-  integration_testing:
-    name: Integration tests
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-
-    # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
-    # doesn't trigger a fresh build.
-    env:
-      RUSTFLAGS: '-D warnings -F unsafe-code'
-
-    steps:
-      - name: Checkout cedar
-        uses: actions/checkout@v4
-      - run: rm -rf cedar-integration-tests # blast the current content
-      - name: Checkout cedar-integration-tests
-        uses: actions/checkout@v4
-        with:
-          repository: cedar-policy/cedar-integration-tests
-          ref: main
-          path: ./cedar-integration-tests
-      - run: cd cedar-integration-tests && tar xzf corpus-tests.tar.gz
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo test --verbose --features "integration-testing"
-      - run: cargo test --verbose --features "integration-testing" -- --ignored
+  run-integration-tests:
+    uses: ./.github/workflows/run_integration_tests_reusable.yml
 
   # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
   # don't effect it. As a side effect, this will run in parallel, saving some

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -76,10 +76,14 @@ jobs:
         run: cargo fmt --all --check
       - name: Install Zig
         run: sudo snap install zig --beta --classic
+      - name: Setup Java JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'corretto'
+          cache: 'gradle'
       - name: Build FFI and Java Libraries
         working-directory: cedar-java/CedarJava
-        env:
-          MUST_RUN_CEDAR_INTEGRATION_TESTS: 1
         run: ./gradlew build
       - name: Generate Java Documentation
         working-directory: cedar-java/CedarJava

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -1,0 +1,36 @@
+name: Run Integration Tests
+
+on:
+  workflow_call:
+
+jobs:
+  run_integration_testing:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+
+    # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
+    # doesn't trigger a fresh build.
+    env:
+      RUSTFLAGS: '-D warnings -F unsafe-code'
+
+    steps:
+      - name: Checkout cedar
+        uses: actions/checkout@v4
+      - run: rm -rf cedar-integration-tests # blast the current content
+      - name: Checkout cedar-integration-tests
+        uses: actions/checkout@v4
+        with:
+          repository: cedar-policy/cedar-integration-tests
+          ref: main
+          path: ./cedar-integration-tests
+      - name: Decompress corpus tests
+        working-directory: ./cedar-integration-tests
+        run: tar xzf corpus-tests.tar.gz
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo test --verbose --features "integration-testing"
+      - run: cargo test --verbose --features "integration-testing" -- --ignored
+      

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -30,7 +30,12 @@ jobs:
       - name: Decompress corpus tests
         working-directory: ./cedar-integration-tests
         run: tar xzf corpus-tests.tar.gz
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo test --verbose --features "integration-testing"
-      - run: cargo test --verbose --features "integration-testing" -- --ignored
+      - name: Prepare Rust build
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Setup upterm session
+        uses: lhotari/action-upterm@v1
+      - name: Run handwritten integration tests
+        run: cargo test --verbose --features "integration-testing"
+      - name: Run corpus tests
+        run: cargo test --verbose --features "integration-testing" -- --ignored
       

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -20,7 +20,13 @@ jobs:
     steps:
       - name: Checkout cedar
         uses: actions/checkout@v4
-      - run: rm -rf cedar-integration-tests # blast the current content
+        with:
+          repository: cedar-policy/cedar
+          ref: main
+          path: ./cedar
+      - name: Delete old integration tests
+        working-directory: ./cedar
+        run: rm -rf cedar-integration-tests # blast the current content
       - name: Checkout cedar-integration-tests
         uses: actions/checkout@v4
         with:
@@ -32,10 +38,10 @@ jobs:
         run: tar xzf corpus-tests.tar.gz
       - name: Prepare Rust build
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Setup upterm session
-        uses: lhotari/action-upterm@v1
       - name: Run handwritten integration tests
+        working-directory: ./cedar
         run: cargo test --verbose --features "integration-testing"
       - name: Run corpus tests
+        working-directory: ./cedar
         run: cargo test --verbose --features "integration-testing" -- --ignored
       


### PR DESCRIPTION
## Description of changes

Updates to CI to enable running the integration tests from the `cedar-integration-tests` repository.

(Currently a draft because more debugging is required.)

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
