### PR TITLE
cedar#745 for PolicyToJsonError

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3400,9 +3400,9 @@ impl From<serde_json::Error> for PolicyToJsonError {
 
 /// Error types related to JSON processing
 pub mod json_errors {
+    use cedar_policy_core::est;
     use miette::Diagnostic;
     use thiserror::Error;
-    use cedar_policy_core::est;
 
     /// Error linking the JSON representation of a linked policy
     #[derive(Debug, Diagnostic, Error)]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3380,41 +3380,48 @@ pub enum PolicyToJsonError {
     /// For linked policies, error linking the JSON representation
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Link(#[from] JsonLinkError),
+    Link(#[from] json_errors::JsonLinkError),
     /// Error in the JSON serialization
     #[error(transparent)]
-    JsonSerialization(#[from] PolicyJsonSerializationError),
+    JsonSerialization(#[from] json_errors::PolicyJsonSerializationError),
 }
 
 impl From<est::InstantiationError> for PolicyToJsonError {
     fn from(e: est::InstantiationError) -> Self {
-        JsonLinkError::from(e).into()
+        json_errors::JsonLinkError::from(e).into()
     }
 }
 
 impl From<serde_json::Error> for PolicyToJsonError {
     fn from(e: serde_json::Error) -> Self {
-        PolicyJsonSerializationError::from(e).into()
+        json_errors::PolicyJsonSerializationError::from(e).into()
     }
 }
 
-/// Error linking the JSON representation of a linked policy
-#[derive(Debug, Diagnostic, Error)]
-#[error(transparent)]
-#[diagnostic(transparent)]
-pub struct JsonLinkError {
-    /// Underlying error
-    #[from]
-    err: est::InstantiationError,
-}
+/// Error types related to JSON processing
+pub mod json_errors {
+    use miette::Diagnostic;
+    use thiserror::Error;
+    use cedar_policy_core::est;
 
-/// Error serializing a policy as JSON
-#[derive(Debug, Diagnostic, Error)]
-#[error(transparent)]
-pub struct PolicyJsonSerializationError {
-    /// Underlying error
-    #[from]
-    err: serde_json::Error,
+    /// Error linking the JSON representation of a linked policy
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    pub struct JsonLinkError {
+        /// Underlying error
+        #[from]
+        err: est::InstantiationError,
+    }
+
+    /// Error serializing a policy as JSON
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    pub struct PolicyJsonSerializationError {
+        /// Underlying error
+        #[from]
+        err: serde_json::Error,
+    }
 }
 
 /// Expressions to be evaluated


### PR DESCRIPTION
## Description of changes

Applies the recommendations in #745 for `PolicyToJsonError`.

Questions:

- Do we like how this looks? Do we want to change the recommendations in any way?
- We'll end up with a large number of these member structs that are `pub` but with private fields.  Should we organize them into submodules?  One submodule per error enum or something?

## Issue #, if available

#745

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

No changelog update, let's do one at the end for all of #745.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

