### PR TITLE
reorg how advice is stored on `EvaluationError`

### DIFF
--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -465,12 +465,15 @@ impl<'e> Evaluator<'e> {
                                 // If arg1 is not an entity and arg2 is a set, then possibly
                                 // the user intended `arg2.contains(arg1)` rather than `arg1 in arg2`.
                                 // If arg2 is a record, then possibly they intended `arg2 has arg1`.
-                                if matches!(e.error_kind(), EvaluationErrorKind::TypeError { .. }) {
-                                    match arg2.type_of() {
-                                        Type::Set => e.set_advice("`in` is for checking the entity hierarchy; use `.contains()` to test set membership".into()),
-                                        Type::Record => e.set_advice("`in` is for checking the entity hierarchy; use `has` to test if a record has a key".into()),
-                                        _ => {}
+                                match e.error_kind_mut() {
+                                    EvaluationErrorKind::TypeError { advice, .. } => {
+                                        match arg2.type_of() {
+                                            Type::Set => *advice = Some("`in` is for checking the entity hierarchy; use `.contains()` to test set membership".into()),
+                                            Type::Record => *advice = Some("`in` is for checking the entity hierarchy; use `has` to test if a record has a key".into()),
+                                            _ => {}
+                                        }
                                     }
+                                    _ => {}
                                 };
                                 e
                             })?;
@@ -1446,6 +1449,7 @@ pub mod test {
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Bool],
                     actual: Type::String,
+                    advice: None,
                 },
             )
         );
@@ -1462,6 +1466,7 @@ pub mod test {
                     actual: Type::Entity {
                         ty: EntityUID::test_entity_type(),
                     },
+                    advice: None,
                 },
             )
         );
@@ -1656,6 +1661,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -1672,6 +1678,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -1721,6 +1728,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -1784,6 +1792,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -1803,6 +1812,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -2072,6 +2082,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -2088,6 +2099,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2104,6 +2116,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -2120,6 +2133,7 @@ pub mod test {
                         ),
                     ],
                     actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2148,6 +2162,7 @@ pub mod test {
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Bool],
                     actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -2160,6 +2175,7 @@ pub mod test {
                     actual: Type::Entity {
                         ty: EntityUID::test_entity_type(),
                     },
+                    advice: None,
                 }
             )
         );
@@ -2240,7 +2256,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2254,7 +2271,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Set
+                    actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -2563,7 +2581,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2573,7 +2592,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2583,7 +2603,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2593,7 +2614,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2603,7 +2625,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2613,7 +2636,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2623,7 +2647,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2633,7 +2658,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2643,7 +2669,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2653,7 +2680,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2663,7 +2691,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2673,7 +2702,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2683,7 +2713,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2693,7 +2724,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2703,7 +2735,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2713,7 +2746,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2723,7 +2757,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2733,7 +2768,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2743,7 +2779,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2756,7 +2793,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2766,7 +2804,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2776,7 +2815,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2786,7 +2826,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2796,7 +2837,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2806,7 +2848,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2816,7 +2859,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2826,7 +2870,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Bool
+                    actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -2839,7 +2884,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::Set
+                    actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -2863,7 +2909,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2876,7 +2923,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2889,7 +2937,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2902,7 +2951,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2947,7 +2997,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2979,7 +3030,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -2999,7 +3051,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Long],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -3165,7 +3218,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::Long
+                    actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -3178,7 +3232,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::Record
+                    actual: Type::Record,
+                    advice: None,
                 }
             )
         );
@@ -3191,7 +3246,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::Long
+                    actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -3392,6 +3448,7 @@ pub mod test {
                             .expect("should be a valid identifier")
                     )],
                     actual: Type::Bool,
+                    advice: None,
                 }
             )
         );
@@ -3449,6 +3506,7 @@ pub mod test {
                             .expect("should be a valid identifier")
                     )],
                     actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -3465,6 +3523,7 @@ pub mod test {
                             .expect("should be a valid identifier")
                     )],
                     actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -3483,11 +3542,8 @@ pub mod test {
                                 .expect("should be a valid identifier")
                         )],
                         actual: Type::Long,
+                        advice: Some("`in` is for checking the entity hierarchy; use `.contains()` to test set membership".into()),
                     }
-                );
-                assert_eq!(
-                    e.advice(),
-                    Some("`in` is for checking the entity hierarchy; use `.contains()` to test set membership")
                 );
             }
         );
@@ -3509,11 +3565,8 @@ pub mod test {
                                 .expect("should be a valid identifier")
                         )],
                         actual: Type::String,
+                        advice: Some("`in` is for checking the entity hierarchy; use `has` to test if a record has a key".into()),
                     }
-                );
-                assert_eq!(
-                    e.advice(),
-                    Some("`in` is for checking the entity hierarchy; use `has` to test if a record has a key")
                 );
             }
         );
@@ -3537,6 +3590,7 @@ pub mod test {
                         )
                     ],
                     actual: Type::Record,
+                    advice: None,
                 }
             )
         );
@@ -3753,7 +3807,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::String],
-                    actual: Type::Long
+                    actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -3766,7 +3821,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -3890,6 +3946,7 @@ pub mod test {
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
                     actual: Type::Long,
+                    advice: None,
                 }
             )
         );
@@ -4017,7 +4074,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -4034,7 +4092,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::Record
+                    actual: Type::Record,
+                    advice: None,
                 }
             )
         );
@@ -4141,7 +4200,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::String
+                    actual: Type::String,
+                    advice: None,
                 }
             )
         );
@@ -4158,7 +4218,8 @@ pub mod test {
             Err(e) => assert_eq!(e.error_kind(),
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::Set],
-                    actual: Type::Record
+                    actual: Type::Record,
+                    advice: None,
                 }
             )
         );

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -29,8 +29,6 @@ use thiserror::Error;
 pub struct EvaluationError {
     /// The kind of error that occurred
     error_kind: EvaluationErrorKind,
-    /// Optional advice on how to fix the error
-    advice: Option<String>,
     /// Source location of the error. (This overrides other sources if present,
     /// but if this is `None`, we'll check for location info in the
     /// `.error_kind`.)
@@ -40,12 +38,7 @@ pub struct EvaluationError {
 // custom impl of `Diagnostic`
 impl Diagnostic for EvaluationError {
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        match (self.error_kind.help(), self.advice.as_ref()) {
-            (Some(help), None) => Some(help),
-            (None, Some(advice)) => Some(Box::new(advice)),
-            (Some(help), Some(advice)) => Some(Box::new(format!("{help}; {advice}"))),
-            (None, None) => None,
-        }
+        self.error_kind.help()
     }
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
@@ -92,19 +85,14 @@ impl EvaluationError {
         &self.error_kind
     }
 
+    /// (internal only) mutable access to the `EvaluationErrorKind`
+    pub(super) fn error_kind_mut(&mut self) -> &mut EvaluationErrorKind {
+        &mut self.error_kind
+    }
+
     /// Extract the source location of the error, if one is attached
     pub fn source_loc(&self) -> Option<&Loc> {
         self.source_loc.as_ref()
-    }
-
-    /// Extract the advice attached to the error, if any
-    pub fn advice(&self) -> Option<&str> {
-        self.advice.as_deref()
-    }
-
-    /// Set the advice field of an error
-    pub fn set_advice(&mut self, advice: String) {
-        self.advice = Some(advice);
     }
 
     /// Return the `EvaluationError`, but with the new `source_loc` (or `None`).
@@ -116,7 +104,6 @@ impl EvaluationError {
     pub(crate) fn entity_does_not_exist(euid: Arc<EntityUID>, source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: EvaluationErrorKind::EntityDoesNotExist(euid),
-            advice: None,
             source_loc,
         }
     }
@@ -129,7 +116,6 @@ impl EvaluationError {
     ) -> Self {
         Self {
             error_kind: EvaluationErrorKind::EntityAttrDoesNotExist { entity, attr },
-            advice: None,
             source_loc,
         }
     }
@@ -138,7 +124,6 @@ impl EvaluationError {
     pub(crate) fn unspecified_entity_access(attr: SmolStr, source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: EvaluationErrorKind::UnspecifiedEntityAccess(attr),
-            advice: None,
             source_loc,
         }
     }
@@ -151,7 +136,6 @@ impl EvaluationError {
     ) -> Self {
         Self {
             error_kind: EvaluationErrorKind::RecordAttrDoesNotExist(attr, alternatives),
-            advice: None,
             source_loc,
         }
     }
@@ -162,8 +146,8 @@ impl EvaluationError {
             error_kind: EvaluationErrorKind::TypeError {
                 expected,
                 actual: actual.type_of(),
+                advice: None,
             },
-            advice: None,
             source_loc: actual.source_loc().cloned(),
         }
     }
@@ -182,8 +166,8 @@ impl EvaluationError {
             error_kind: EvaluationErrorKind::TypeError {
                 expected,
                 actual: actual.type_of(),
+                advice: Some(advice),
             },
-            advice: Some(advice),
             source_loc: actual.source_loc().cloned(),
         }
     }
@@ -209,7 +193,6 @@ impl EvaluationError {
                 expected,
                 actual,
             },
-            advice: None,
             source_loc,
         }
     }
@@ -218,7 +201,6 @@ impl EvaluationError {
     pub(crate) fn unlinked_slot(id: SlotId, source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: EvaluationErrorKind::UnlinkedSlot(id),
-            advice: None,
             source_loc,
         }
     }
@@ -234,7 +216,6 @@ impl EvaluationError {
                 extension_name,
                 msg,
             },
-            advice: None,
             source_loc,
         }
     }
@@ -244,7 +225,6 @@ impl EvaluationError {
         let source_loc = e.source_loc().cloned();
         Self {
             error_kind: EvaluationErrorKind::NonValue(e),
-            advice: Some("consider using the partial evaluation APIs".into()),
             source_loc,
         }
     }
@@ -253,7 +233,6 @@ impl EvaluationError {
     pub(crate) fn recursion_limit(source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: EvaluationErrorKind::RecursionLimit,
-            advice: None,
             source_loc,
         }
     }
@@ -264,7 +243,6 @@ impl EvaluationError {
     ) -> Self {
         Self {
             error_kind: err.into(),
-            advice: None,
             source_loc,
         }
     }
@@ -272,7 +250,6 @@ impl EvaluationError {
     pub(crate) fn integer_overflow(err: IntegerOverflowError, source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: err.into(),
-            advice: None,
             source_loc,
         }
     }
@@ -282,7 +259,6 @@ impl From<RestrictedExprError> for EvaluationError {
     fn from(err: RestrictedExprError) -> Self {
         Self {
             error_kind: err.into(),
-            advice: None,
             source_loc: None, // defer to the source information embedded in the `RestrictedExprError` and thus stored in `error_kind`
         }
     }
@@ -329,6 +305,9 @@ pub enum EvaluationErrorKind {
         expected: NonEmpty<Type>,
         /// Encountered this type instead
         actual: Type,
+        /// Optional advice for how to fix this error
+        #[help]
+        advice: Option<String>,
     },
 
     /// Wrong number of arguments provided to an extension function
@@ -370,6 +349,7 @@ pub enum EvaluationErrorKind {
     /// reduced to a [`Value`]. In order to return partial results, use the
     /// partial evaluation APIs instead.
     #[error("the expression contains unknown(s): `{0}`")]
+    #[diagnostic(help("consider using the partial evaluation APIs"))]
     NonValue(Expr),
 
     /// Maximum recursion limit reached for expression evaluation

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -625,6 +625,7 @@ mod tests {
                         name: Name::parse_unqualified_name("decimal")
                             .expect("should be a valid identifier")
                     },
+                    advice: None,
                 }
             )
         );
@@ -641,9 +642,9 @@ mod tests {
                                 .expect("should be a valid identifier")
                         }],
                         actual: Type::String,
+                        advice: Some(ADVICE_MSG.into()),
                     }
                 );
-                assert_eq!(e.advice(), Some(ADVICE_MSG));
             }
         );
         // bad use of `lessThan` as function

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -566,6 +566,7 @@ mod tests {
                 &EvaluationErrorKind::TypeError {
                     expected: nonempty![Type::String],
                     actual: Type::Set,
+                    advice: None,
                 }
             )
         );
@@ -580,6 +581,7 @@ mod tests {
                         name: Name::parse_unqualified_name("ipaddr")
                             .expect("should be a valid identifier")
                     },
+                    advice: None,
                 }
             )
         );
@@ -598,9 +600,9 @@ mod tests {
                                 .expect("should be a valid identifier")
                         }],
                         actual: Type::String,
+                        advice: Some(ADVICE_MSG.into()),
                     },
                 );
-                assert_eq!(e.advice(), Some(ADVICE_MSG));
             }
         );
 


### PR DESCRIPTION
## Description of changes

Pushes the `advice` down from `EvaluationError` into `EvaluationErrorKind`.  Only `TypeError` was using the dynamic capability, everyone else is fine with static.  This comes out from @khieta's comment https://github.com/cedar-policy/cedar/issues/745#issuecomment-2018696491; I'll do source_loc next.

Unfortunately, this change is breaking, because `EvaluationErrorKind` is public and `TypeError`'s fields are public.  After #745, this kind of change would not be breaking.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
