### PR TITLE
Strengthen the types of `SchemaFragment`

### DIFF
--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -90,6 +90,9 @@ impl Name {
         self.path.iter().join("::")
     }
 
+    /// Prefix the name with a optional namespace
+    /// e.g., prefix `A::B`` with `Some(C)` produces `C::A::B`
+    /// prefix `A::B` with `None` yields itself
     pub fn prefix_namespace(&self, namespace: Option<Name>) -> Name {
         match namespace {
             Some(namespace) => Self::new(
@@ -104,6 +107,7 @@ impl Name {
         }
     }
 
+    /// Test if a `Name` is an `Id`
     pub fn is_singleton(&self) -> bool {
         self.path.is_empty()
     }

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -36,10 +36,24 @@ pub struct Name {
     pub(crate) path: Arc<Vec<Id>>,
 }
 
-// A shortcut for `Name::unqualified_name`
+/// A shortcut for `Name::unqualified_name`
 impl From<Id> for Name {
     fn from(value: Id) -> Self {
         Self::unqualified_name(value)
+    }
+}
+
+/// Convert a `Name` to an `Id`
+/// The error type is the unit type because the reason the conversion fails
+/// is obvious
+impl TryFrom<Name> for Id {
+    type Error = ();
+    fn try_from(value: Name) -> Result<Self, Self::Error> {
+        if value.is_unqualified() {
+            Ok(value.id)
+        } else {
+            Err(())
+        }
     }
 }
 

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -103,8 +103,8 @@ impl Name {
     /// When the name is an `Id`, prefix it with the optional namespace
     /// e.g., prefix `A::B`` with `Some(C)` or `None` produces `A::B`
     /// prefix `A` with `Some(B::C)` yields `B::C::A`
-    pub fn prefix_namespace(&self, namespace: Option<Name>) -> Name {
-        if self.is_singleton() {
+    pub fn prefix_namespace_if_unqualified(&self, namespace: Option<Name>) -> Name {
+        if self.is_unqualified() {
             // Ideally, we want to implement `IntoIterator` for `Name`
             match namespace {
                 Some(namespace) => Self::new(
@@ -122,7 +122,7 @@ impl Name {
     }
 
     /// Test if a `Name` is an `Id`
-    pub fn is_singleton(&self) -> bool {
+    pub fn is_unqualified(&self) -> bool {
         self.path.is_empty()
     }
 }
@@ -234,7 +234,6 @@ mod vars_test {
 
 #[cfg(test)]
 mod test {
-
     use smol_str::ToSmolStr;
 
     use super::*;
@@ -256,28 +255,28 @@ mod test {
             "foo::bar::baz",
             Name::from_normalized_str("baz")
                 .unwrap()
-                .prefix_namespace(Some("foo::bar".parse().unwrap()))
+                .prefix_namespace_if_unqualified(Some("foo::bar".parse().unwrap()))
                 .to_smolstr()
         );
         assert_eq!(
             "C::D",
             Name::from_normalized_str("C::D")
                 .unwrap()
-                .prefix_namespace(Some("A::B".parse().unwrap()))
+                .prefix_namespace_if_unqualified(Some("A::B".parse().unwrap()))
                 .to_smolstr()
         );
         assert_eq!(
             "A::B::C::D",
             Name::from_normalized_str("D")
                 .unwrap()
-                .prefix_namespace(Some("A::B::C".parse().unwrap()))
+                .prefix_namespace_if_unqualified(Some("A::B::C".parse().unwrap()))
                 .to_smolstr()
         );
         assert_eq!(
             "B::C::D",
             Name::from_normalized_str("B::C::D")
                 .unwrap()
-                .prefix_namespace(Some("A".parse().unwrap()))
+                .prefix_namespace_if_unqualified(Some("A".parse().unwrap()))
                 .to_smolstr()
         );
     }

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -44,7 +44,7 @@ impl<'a> entities::Schema for CoreSchema<'a> {
     }
 
     fn action(&self, action: &ast::EntityUID) -> Option<Arc<ast::Entity>> {
-        self.actions.get(action).map(Arc::clone)
+        self.actions.get(action).cloned()
     }
 
     fn entity_types_with_basename<'b>(

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -18,7 +18,6 @@ use std::collections::HashSet;
 
 use cedar_policy_core::{
     ast::{EntityAttrEvaluationError, EntityUID, Name},
-    parser::err::{ParseError, ParseErrors},
     transitive_closure,
 };
 use itertools::Itertools;
@@ -91,23 +90,6 @@ pub enum SchemaError {
     /// Cycle in the schema's action hierarchy.
     #[error("cycle in action hierarchy containing `{0}`")]
     CycleInActionHierarchy(EntityUID),
-    /// Parse errors occurring while parsing an entity type.
-    #[error("parse error in entity type: {}", Self::format_parse_errs(.0))]
-    #[diagnostic(transparent)]
-    ParseEntityType(ParseErrors),
-    /// Parse errors occurring while parsing a namespace identifier.
-    #[error("parse error in namespace identifier: {}", Self::format_parse_errs(.0))]
-    #[diagnostic(transparent)]
-    ParseNamespace(ParseErrors),
-    /// Parse errors occurring while parsing an extension type.
-    #[error("parse error in extension type: {}", Self::format_parse_errs(.0))]
-    #[diagnostic(transparent)]
-    ParseExtensionType(ParseErrors),
-    /// Parse errors occurring while parsing the name of one of reusable
-    /// declared types.
-    #[error("parse error in common type identifier: {}", Self::format_parse_errs(.0))]
-    #[diagnostic(transparent)]
-    ParseCommonType(ParseErrors),
     /// The schema file included an entity type `Action` in the entity type
     /// list. The `Action` entity type is always implicitly declared, and it
     /// cannot currently have attributes or be in any groups, so there is no
@@ -161,12 +143,6 @@ impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
 }
 
 pub type Result<T> = std::result::Result<T, SchemaError>;
-
-impl SchemaError {
-    fn format_parse_errs(errs: &[ParseError]) -> String {
-        errs.iter().map(|e| e.to_string()).join(", ")
-    }
-}
 
 #[derive(Debug)]
 pub enum ContextOrShape {

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -1,7 +1,7 @@
 use std::iter::once;
 
 use cedar_policy_core::{
-    ast::Id,
+    ast::{Id, Name},
     parser::{Loc, Node},
 };
 use itertools::{Either, Itertools};
@@ -95,10 +95,22 @@ impl std::fmt::Display for Path {
     }
 }
 
+impl From<Path> for Name {
+    fn from(value: Path) -> Self {
+        value.0.node.into()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct PathInternal {
     basename: Id,
     namespace: Vec<Id>,
+}
+
+impl From<PathInternal> for Name {
+    fn from(value: PathInternal) -> Self {
+        Self::new(value.basename, value.namespace.into_iter())
+    }
 }
 
 impl PathInternal {
@@ -192,16 +204,6 @@ pub enum Declaration {
     Type(TypeDecl),
 }
 
-impl Decl for Declaration {
-    fn names(&self) -> Vec<Node<SmolStr>> {
-        match self {
-            Declaration::Entity(e) => e.names(),
-            Declaration::Action(a) => a.names(),
-            Declaration::Type(t) => t.names(),
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct TypeDecl {
     pub name: Node<Id>,
@@ -224,15 +226,6 @@ pub struct EntityDecl {
     pub member_of_types: Vec<Path>,
     /// Attributes this entity has
     pub attrs: Vec<Node<AttrDecl>>,
-}
-
-impl Decl for EntityDecl {
-    fn names(&self) -> Vec<Node<SmolStr>> {
-        self.names
-            .iter()
-            .map(|n| n.clone().map(|id| id.to_smolstr()))
-            .collect()
-    }
 }
 
 /// Type definitions

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -109,7 +109,7 @@ struct PathInternal {
 
 impl From<PathInternal> for Name {
     fn from(value: PathInternal) -> Self {
-        Self::new(value.basename, value.namespace.into_iter())
+        Self::new(value.basename, value.namespace)
     }
 }
 

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -353,6 +353,8 @@ pub enum ToJsonSchemaError {
     UnknownTypeName(Node<SmolStr>),
     #[error("Use reserved namespace `__cedar`")]
     UseReservedNamespace(Loc),
+    #[error("Invalid name: `{0}`")]
+    InvalidName(SmolStr),
 }
 
 impl ToJsonSchemaError {
@@ -395,6 +397,7 @@ impl Diagnostic for ToJsonSchemaError {
             ToJsonSchemaError::UseReservedNamespace(loc) => {
                 Some(Box::new(std::iter::once(LabeledSpan::underline(loc.span))))
             }
+            Self::InvalidName(name) => None,
         }
     }
 }

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -353,8 +353,6 @@ pub enum ToJsonSchemaError {
     UnknownTypeName(Node<SmolStr>),
     #[error("Use reserved namespace `__cedar`")]
     UseReservedNamespace(Loc),
-    #[error("Invalid name: `{0}`")]
-    InvalidName(SmolStr),
 }
 
 impl ToJsonSchemaError {
@@ -397,7 +395,6 @@ impl Diagnostic for ToJsonSchemaError {
             ToJsonSchemaError::UseReservedNamespace(loc) => {
                 Some(Box::new(std::iter::once(LabeledSpan::underline(loc.span))))
             }
-            Self::InvalidName(name) => None,
         }
     }
 }

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -332,21 +332,21 @@ impl Diagnostic for ToJsonSchemaErrors {
 pub enum ToJsonSchemaError {
     /// Error raised when there are duplicate keys
     #[error("Duplicate keys: `{key}`")]
-    DuplicateKeys { key: SmolStr, start: Loc, end: Loc },
+    DuplicateKeys { key: SmolStr, loc1: Loc, loc2: Loc },
     /// Error raised when there are duplicate declarations
     #[error("Duplicate declarations: `{decl}`")]
-    DuplicateDeclarations { decl: SmolStr, start: Loc, end: Loc },
+    DuplicateDeclarations { decl: SmolStr, loc1: Loc, loc2: Loc },
     #[error("Duplicate context declaration. Action may have at most one context declaration")]
-    DuplicateContext { start: Loc, end: Loc },
+    DuplicateContext { loc1: Loc, loc2: Loc },
     #[error("Duplicate {kind} decleration. Action may have at most once {kind} declaration")]
-    DuplicatePR { kind: PR, start: Loc, end: Loc },
+    DuplicatePR { kind: PR, loc1: Loc, loc2: Loc },
 
     /// Error raised when there are duplicate namespace IDs
     #[error("Duplicate namespace IDs: `{namespace_id}`")]
     DuplicateNameSpaces {
         namespace_id: SmolStr,
-        start: Option<Loc>,
-        end: Option<Loc>,
+        loc1: Option<Loc>,
+        loc2: Option<Loc>,
     },
     /// Invalid type name
     #[error("Unknown type name: `{}`", .0.node)]
@@ -356,17 +356,17 @@ pub enum ToJsonSchemaError {
 }
 
 impl ToJsonSchemaError {
-    pub fn duplicate_keys(key: SmolStr, start: Loc, end: Loc) -> Self {
-        Self::DuplicateKeys { key, start, end }
+    pub fn duplicate_keys(key: SmolStr, loc1: Loc, loc2: Loc) -> Self {
+        Self::DuplicateKeys { key, loc1, loc2 }
     }
-    pub fn duplicate_decls(decl: SmolStr, start: Loc, end: Loc) -> Self {
-        Self::DuplicateDeclarations { decl, start, end }
+    pub fn duplicate_decls(decl: SmolStr, loc1: Loc, loc2: Loc) -> Self {
+        Self::DuplicateDeclarations { decl, loc1, loc2 }
     }
-    pub fn duplicate_namespace(namespace_id: SmolStr, start: Loc, end: Loc) -> Self {
+    pub fn duplicate_namespace(namespace_id: SmolStr, loc1: Loc, loc2: Loc) -> Self {
         Self::DuplicateNameSpaces {
             namespace_id,
-            start: Some(start),
-            end: Some(end),
+            loc1: Some(loc1),
+            loc2: Some(loc2),
         }
     }
 }
@@ -374,18 +374,18 @@ impl ToJsonSchemaError {
 impl Diagnostic for ToJsonSchemaError {
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
         match self {
-            ToJsonSchemaError::DuplicateDeclarations { start, end, .. }
-            | ToJsonSchemaError::DuplicateContext { start, end }
-            | ToJsonSchemaError::DuplicatePR { start, end, .. }
-            | ToJsonSchemaError::DuplicateKeys { start, end, .. } => Some(Box::new(
+            ToJsonSchemaError::DuplicateDeclarations { loc1, loc2, .. }
+            | ToJsonSchemaError::DuplicateContext { loc1, loc2 }
+            | ToJsonSchemaError::DuplicatePR { loc1, loc2, .. }
+            | ToJsonSchemaError::DuplicateKeys { loc1, loc2, .. } => Some(Box::new(
                 vec![
-                    LabeledSpan::underline(start.span),
-                    LabeledSpan::underline(end.span),
+                    LabeledSpan::underline(loc1.span),
+                    LabeledSpan::underline(loc2.span),
                 ]
                 .into_iter(),
             )),
-            ToJsonSchemaError::DuplicateNameSpaces { start, end, .. } => {
-                Some(Box::new([start, end].into_iter().filter_map(|loc| {
+            ToJsonSchemaError::DuplicateNameSpaces { loc1, loc2, .. } => {
+                Some(Box::new([loc1, loc2].into_iter().filter_map(|loc| {
                     Some(LabeledSpan::underline(loc.as_ref()?.span))
                 })))
             }

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -180,7 +180,7 @@ pub fn json_schema_to_custom_schema_str(
             .keys()
             .map(|ty_name| {
                 Name::unqualified_name(ty_name.clone())
-                    .prefix_namespace(name.clone())
+                    .prefix_namespace_if_unqualified(name.clone())
                     .to_smolstr()
             })
             .collect();
@@ -189,7 +189,7 @@ pub fn json_schema_to_custom_schema_str(
             .keys()
             .map(|ty_name| {
                 Name::unqualified_name(ty_name.clone())
-                    .prefix_namespace(name.clone())
+                    .prefix_namespace_if_unqualified(name.clone())
                     .to_smolstr()
             })
             .collect();

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -1,9 +1,10 @@
 use std::{collections::HashSet, fmt::Display};
 
+use cedar_policy_core::ast::Name;
 use itertools::Itertools;
 use miette::Diagnostic;
 use nonempty::NonEmpty;
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 use thiserror::Error;
 
 use crate::{
@@ -177,12 +178,20 @@ pub fn json_schema_to_custom_schema_str(
         let entity_types: HashSet<SmolStr> = ns
             .entity_types
             .keys()
-            .map(|ty_name| format!("{}::{ty_name}", name.as_ref().unwrap()).into())
+            .map(|ty_name| {
+                Name::unqualified_name(ty_name.clone())
+                    .prefix_namespace(name.clone())
+                    .to_smolstr()
+            })
             .collect();
         let common_types: HashSet<SmolStr> = ns
             .common_types
             .keys()
-            .map(|ty_name| format!("{}::{ty_name}", name.as_ref().unwrap()).into())
+            .map(|ty_name| {
+                Name::unqualified_name(ty_name.clone())
+                    .prefix_namespace(name.clone())
+                    .to_smolstr()
+            })
             .collect();
         name_collisions.extend(entity_types.intersection(&common_types).cloned());
     }

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -1641,4 +1641,69 @@ mod translator_tests {
 
         assert!(SchemaFragment::from_str_natural(src).is_err());
     }
+
+    #[test]
+    fn multiple_principal_decls() {
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { principal: A, principal: A };
+        "#,
+        );
+        assert!(schema.is_err());
+
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { principal: A, resource: B, principal: A };
+        "#,
+        );
+        assert!(schema.is_err());
+    }
+
+    #[test]
+    fn multiple_resource_decls() {
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { resource: A, resource: A };
+        "#,
+        );
+        assert!(schema.is_err());
+
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { resource: A, principal: B, resource: A };
+        "#,
+        );
+        assert!(schema.is_err());
+    }
+
+    #[test]
+    fn multiple_context_decls() {
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { context: A, context: A };
+        "#,
+        );
+        assert!(schema.is_err());
+
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { principal: C, context: A, context: A };
+        "#,
+        );
+        assert!(schema.is_err());
+
+        let schema = SchemaFragment::from_str_natural(
+            r#"
+        entity foo;
+        action a appliesTo { resource: C, context: A, context: A };
+        "#,
+        );
+        assert!(schema.is_err());
+    }
 }

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -26,7 +26,7 @@ mod demo_tests {
             action "Foo";
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
             ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), ..}), .. } => assert!(resources.is_empty() && principals.is_empty())
         );
@@ -38,7 +38,7 @@ mod demo_tests {
         action "Foo" appliesTo { context: {} };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(
             foo,
             ActionType {
@@ -59,12 +59,12 @@ mod demo_tests {
         action "Foo" appliesTo { principal: a, context: {}  };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
             ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), ..}), .. } =>
                 {
                     match principals.as_slice() {
-                        [a] if a == &"a".to_smolstr() => (),
+                        [a] if a == &"a".parse().unwrap() => (),
                         _ => panic!("Bad principals")
                     }
                 }
@@ -78,12 +78,12 @@ mod demo_tests {
         action "Foo" appliesTo { resource: a, context: {}  };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get("").unwrap().actions.get("Foo").unwrap();
+        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
             ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, ..}), .. } =>
                 {
                     match resources.as_slice() {
-                        [a] if a == &"a".to_smolstr() => (),
+                        [a] if a == &"a".parse().unwrap() => (),
                         _ => panic!("Bad principals")
                     }
                 }
@@ -99,11 +99,11 @@ mod demo_tests {
             };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get("").unwrap();
+        let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
                 ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, .. }  ), ..} =>
-                    assert_matches!(resources.as_slice(), [a] => assert_eq!(a.as_ref(), "a"))
+                    assert_matches!(resources.as_slice(), [a] => assert_eq!(a, &"a".parse().unwrap()))
             ,
         );
     }
@@ -118,13 +118,13 @@ mod demo_tests {
             };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get("").unwrap();
+        let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
                 ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, .. }  ), ..} =>
                     assert_matches!(resources.as_slice(), [a, b] => {
-                        assert_eq!(a.as_ref(), "a");
-                        assert_eq!(b.as_ref(), "b")
+                        assert_eq!(a, &"a".parse().unwrap());
+                        assert_eq!(b, &"b".parse().unwrap())
                     })
             ,
         );
@@ -139,11 +139,11 @@ mod demo_tests {
             };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get("").unwrap();
+        let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
                 ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), .. }  ), ..} =>
-                    assert_matches!(principals.as_slice(), [a] => assert_eq!(a.as_ref(), "a"))
+                    assert_matches!(principals.as_slice(), [a] => assert_eq!(a, &"a".parse().unwrap()))
             ,
         );
     }
@@ -158,13 +158,13 @@ mod demo_tests {
             };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get("").unwrap();
+        let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
                 ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), .. }  ), ..} =>
                     assert_matches!(principals.as_slice(), [a,b] => {
-                        assert_eq!(a.as_ref(), "a");
-                        assert_eq!(b.as_ref(), "b");
+                        assert_eq!(a, &"a".parse().unwrap());
+                        assert_eq!(b, &"b".parse().unwrap());
                 })
             ,
         );
@@ -183,18 +183,18 @@ mod demo_tests {
             };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get("").unwrap();
+        let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
                 ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), .. }  ), ..} =>
                 {
                     assert_matches!(principals.as_slice(), [a,b] => {
-                        assert_eq!(a.as_ref(), "a");
-                        assert_eq!(b.as_ref(), "b");
+                        assert_eq!(a, &"a".parse().unwrap());
+                        assert_eq!(b, &"b".parse().unwrap());
                 });
                 assert_matches!(resources.as_slice(), [c,d] =>  {
-                        assert_eq!(c.as_ref(), "c");
-                        assert_eq!(d.as_ref(), "d");
+                        assert_eq!(c, &"c".parse().unwrap());
+                        assert_eq!(d, &"d".parse().unwrap());
 
                 })
             }
@@ -215,18 +215,18 @@ mod demo_tests {
             };
         "#;
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get("").unwrap();
+        let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
                 ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), .. }  ), ..} =>
                 {
                     assert_matches!(principals.as_slice(), [a,b] => {
-                        assert_eq!(a.as_ref(), "a");
-                        assert_eq!(b.as_ref(), "b");
+                        assert_eq!(a, &"a".parse().unwrap());
+                        assert_eq!(b, &"b".parse().unwrap());
                 });
                 assert_matches!(resources.as_slice(), [c,d] =>  {
-                        assert_eq!(c.as_ref(), "c");
-                        assert_eq!(d.as_ref(), "d");
+                        assert_eq!(c, &"c".parse().unwrap());
+                        assert_eq!(d, &"d".parse().unwrap());
 
                 })
             }
@@ -310,7 +310,7 @@ mod demo_tests {
             member_of: None,
         };
         let namespace = NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
-        let fragment = SchemaFragment(HashMap::from([("bar".to_smolstr(), namespace)]));
+        let fragment = SchemaFragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
         let as_src = fragment.as_natural_schema().unwrap();
         let expected = r#"action "foo" appliesTo {  context: {}
 };"#;
@@ -379,7 +379,7 @@ namespace Baz {action "Foo" appliesTo {
         let namespace = NamespaceDefinition {
             common_types: HashMap::new(),
             entity_types: HashMap::from([(
-                "a".to_smolstr(),
+                "a".parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -391,14 +391,14 @@ namespace Baz {action "Foo" appliesTo {
                     attributes: None,
                     applies_to: Some(ApplySpec {
                         resource_types: Some(vec![]),
-                        principal_types: Some(vec!["a".to_smolstr()]),
+                        principal_types: Some(vec!["a".parse().unwrap()]),
                         context: AttributesOrContext::default(),
                     }),
                     member_of: None,
                 },
             )]),
         };
-        let fragment = SchemaFragment(HashMap::from([("".to_smolstr(), namespace)]));
+        let fragment = SchemaFragment(HashMap::from([(None, namespace)]));
         let src = fragment.as_natural_schema().unwrap();
         assert!(src.contains(r#"action "j" ;"#), "schema was: `{src}`")
     }
@@ -473,26 +473,32 @@ namespace Baz {action "Foo" appliesTo {
         assert!(warnings.collect::<Vec<_>>().is_empty());
         let github = fragment
             .0
-            .get("GitHub")
+            .get(&Some("GitHub".parse().unwrap()))
             .expect("`Github` name space did not exist");
         // User
-        let user = github.entity_types.get("User").expect("No `User`");
+        let user = github
+            .entity_types
+            .get(&"User".parse().unwrap())
+            .expect("No `User`");
         assert_empty_records(user);
         assert_eq!(
             &user.member_of_types,
-            &vec!["UserGroup".to_smolstr(), "Team".to_smolstr()]
+            &vec!["UserGroup".parse().unwrap(), "Team".parse().unwrap()]
         );
         // UserGroup
         let usergroup = github
             .entity_types
-            .get("UserGroup")
+            .get(&"UserGroup".parse().unwrap())
             .expect("No `UserGroup`");
         assert_empty_records(usergroup);
-        assert_eq!(&usergroup.member_of_types, &vec!["UserGroup".to_smolstr()]);
+        assert_eq!(
+            &usergroup.member_of_types,
+            &vec!["UserGroup".parse().unwrap()]
+        );
         // Repository
         let repo = github
             .entity_types
-            .get("Repository")
+            .get(&"Repository".parse().unwrap())
             .expect("No `Repository`");
         assert!(repo.member_of_types.is_empty());
         let groups = ["readers", "writers", "triagers", "admins", "maintainers"];
@@ -503,7 +509,7 @@ namespace Baz {action "Foo" appliesTo {
                     additional_attributes: false,
                 }) => {
                     let expected = SchemaTypeVariant::Entity {
-                        name: "UserGroup".into(),
+                        name: "UserGroup".parse().unwrap(),
                     };
                     let attribute = attributes.get(group).expect("No attribute `{group}`");
                     assert_has_type(attribute, expected);
@@ -511,7 +517,10 @@ namespace Baz {action "Foo" appliesTo {
                 _ => panic!("Shape was not a record"),
             }
         }
-        let issue = github.entity_types.get("Issue").expect("No `Issue`");
+        let issue = github
+            .entity_types
+            .get(&"Issue".parse().unwrap())
+            .expect("No `Issue`");
         assert!(issue.member_of_types.is_empty());
         match &issue.shape.0 {
             crate::SchemaType::Type(SchemaTypeVariant::Record {
@@ -522,20 +531,23 @@ namespace Baz {action "Foo" appliesTo {
                 assert_has_type(
                     attribute,
                     SchemaTypeVariant::Entity {
-                        name: "Repository".into(),
+                        name: "Repository".parse().unwrap(),
                     },
                 );
                 let attribute = attributes.get("reporter").expect("No `repo`");
                 assert_has_type(
                     attribute,
                     SchemaTypeVariant::Entity {
-                        name: "User".into(),
+                        name: "User".parse().unwrap(),
                     },
                 );
             }
             _ => panic!("bad type on `Issue`"),
         }
-        let org = github.entity_types.get("Org").expect("No `Org`");
+        let org = github
+            .entity_types
+            .get(&"Org".parse().unwrap())
+            .expect("No `Org`");
         assert!(org.member_of_types.is_empty());
         let groups = ["members", "owners", "memberOfTypes"];
         for group in groups {
@@ -545,7 +557,7 @@ namespace Baz {action "Foo" appliesTo {
                     additional_attributes: false,
                 }) => {
                     let expected = SchemaTypeVariant::Entity {
-                        name: "UserGroup".into(),
+                        name: "UserGroup".parse().unwrap(),
                     };
                     let attribute = attributes.get(group).expect("No attribute `{group}`");
                     assert_has_type(attribute, expected);
@@ -599,9 +611,15 @@ namespace Baz {action "Foo" appliesTo {
         )
         .expect("failed to parse");
         assert!(warnings.collect::<Vec<_>>().is_empty());
-        let doccloud = fragment.0.get("DocCloud").expect("No `DocCloud` namespace");
-        let user = doccloud.entity_types.get("User").expect("No `User`");
-        assert_eq!(&user.member_of_types, &vec!["Group".to_smolstr()]);
+        let doccloud = fragment
+            .0
+            .get(&Some("DocCloud".parse().unwrap()))
+            .expect("No `DocCloud` namespace");
+        let user = doccloud
+            .entity_types
+            .get(&"User".parse().unwrap())
+            .expect("No `User`");
+        assert_eq!(&user.member_of_types, &vec!["Group".parse().unwrap()]);
         match &user.shape.0 {
             crate::SchemaType::Type(SchemaTypeVariant::Record {
                 attributes,
@@ -610,22 +628,28 @@ namespace Baz {action "Foo" appliesTo {
                 assert_has_type(
                     attributes.get("personalGroup").unwrap(),
                     SchemaTypeVariant::Entity {
-                        name: "Group".into(),
+                        name: "Group".parse().unwrap(),
                     },
                 );
                 assert_has_type(
                     attributes.get("blocked").unwrap(),
                     SchemaTypeVariant::Set {
                         element: Box::new(crate::SchemaType::Type(SchemaTypeVariant::Entity {
-                            name: "User".into(),
+                            name: "User".parse().unwrap(),
                         })),
                     },
                 );
             }
             _ => panic!("Wrong type"),
         }
-        let group = doccloud.entity_types.get("Group").expect("No `Group`");
-        assert_eq!(&group.member_of_types, &vec!["DocumentShare".to_smolstr()]);
+        let group = doccloud
+            .entity_types
+            .get(&"Group".parse().unwrap())
+            .expect("No `Group`");
+        assert_eq!(
+            &group.member_of_types,
+            &vec!["DocumentShare".parse().unwrap()]
+        );
         match &group.shape.0 {
             crate::SchemaType::Type(SchemaTypeVariant::Record {
                 attributes,
@@ -634,13 +658,16 @@ namespace Baz {action "Foo" appliesTo {
                 assert_has_type(
                     attributes.get("owner").unwrap(),
                     SchemaTypeVariant::Entity {
-                        name: "User".into(),
+                        name: "User".parse().unwrap(),
                     },
                 );
             }
             _ => panic!("Wrong type"),
         }
-        let document = doccloud.entity_types.get("Document").expect("No `Group`");
+        let document = doccloud
+            .entity_types
+            .get(&"Document".parse().unwrap())
+            .expect("No `Group`");
         assert!(document.member_of_types.is_empty());
         match &document.shape.0 {
             crate::SchemaType::Type(SchemaTypeVariant::Record {
@@ -650,7 +677,7 @@ namespace Baz {action "Foo" appliesTo {
                 assert_has_type(
                     attributes.get("owner").unwrap(),
                     SchemaTypeVariant::Entity {
-                        name: "User".into(),
+                        name: "User".parse().unwrap(),
                     },
                 );
                 assert_has_type(
@@ -664,19 +691,19 @@ namespace Baz {action "Foo" appliesTo {
                 assert_has_type(
                     attributes.get("viewACL").unwrap(),
                     SchemaTypeVariant::Entity {
-                        name: "DocumentShare".into(),
+                        name: "DocumentShare".parse().unwrap(),
                     },
                 );
                 assert_has_type(
                     attributes.get("modifyACL").unwrap(),
                     SchemaTypeVariant::Entity {
-                        name: "DocumentShare".into(),
+                        name: "DocumentShare".parse().unwrap(),
                     },
                 );
                 assert_has_type(
                     attributes.get("manageACL").unwrap(),
                     SchemaTypeVariant::Entity {
-                        name: "DocumentShare".into(),
+                        name: "DocumentShare".parse().unwrap(),
                     },
                 );
             }
@@ -684,16 +711,25 @@ namespace Baz {action "Foo" appliesTo {
         }
         let document_share = doccloud
             .entity_types
-            .get("DocumentShare")
+            .get(&"DocumentShare".parse().unwrap())
             .expect("No `DocumentShare`");
         assert!(document_share.member_of_types.is_empty());
         assert_empty_records(document_share);
 
-        let public = doccloud.entity_types.get("Public").expect("No `Public`");
-        assert_eq!(&public.member_of_types, &vec!["DocumentShare".to_smolstr()]);
+        let public = doccloud
+            .entity_types
+            .get(&"Public".parse().unwrap())
+            .expect("No `Public`");
+        assert_eq!(
+            &public.member_of_types,
+            &vec!["DocumentShare".parse().unwrap()]
+        );
         assert_empty_records(public);
 
-        let drive = doccloud.entity_types.get("Drive").expect("No `Drive`");
+        let drive = doccloud
+            .entity_types
+            .get(&"Drive".parse().unwrap())
+            .expect("No `Drive`");
         assert!(drive.member_of_types.is_empty());
         assert_empty_records(drive);
     }
@@ -796,8 +832,11 @@ namespace Baz {action "Foo" appliesTo {
         "#;
         let (fragment, warnings) = SchemaFragment::from_str_natural(src).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
-        let service = fragment.0.get("Service").unwrap();
-        let resource = service.entity_types.get("Resource").unwrap();
+        let service = fragment.0.get(&Some("Service".parse().unwrap())).unwrap();
+        let resource = service
+            .entity_types
+            .get(&"Resource".parse().unwrap())
+            .unwrap();
         match &resource.shape.0 {
             crate::SchemaType::Type(SchemaTypeVariant::Record {
                 attributes,
@@ -808,7 +847,7 @@ namespace Baz {action "Foo" appliesTo {
                 assert!(required);
                 match ty {
                     crate::SchemaType::TypeDef { type_name } => {
-                        assert_eq!(type_name, &"AWS::Tag".to_smolstr())
+                        assert_eq!(type_name, &"AWS::Tag".parse().unwrap())
                     }
                     _ => panic!("Wrong type for attribute"),
                 }
@@ -1319,8 +1358,8 @@ mod translator_tests {
           }"#,
         )
         .unwrap();
-        let demo = schema.0.get("Demo").unwrap();
-        let user = demo.entity_types.get("User").unwrap();
+        let demo = schema.0.get(&Some("Demo".parse().unwrap())).unwrap();
+        let user = demo.entity_types.get(&"User".parse().unwrap()).unwrap();
         match &user.shape.0 {
             crate::SchemaType::Type(SchemaTypeVariant::Record {
                 attributes,
@@ -1331,7 +1370,7 @@ mod translator_tests {
                 {
                     assert!(required);
                     let expected = crate::SchemaType::TypeDef {
-                        type_name: "id".into(),
+                        type_name: "id".parse().unwrap(),
                     };
                     assert_eq!(ty, &expected);
                 }
@@ -1339,7 +1378,7 @@ mod translator_tests {
                 {
                     assert!(required);
                     let expected = crate::SchemaType::Type(SchemaTypeVariant::Entity {
-                        name: "email_address".into(),
+                        name: "email_address".parse().unwrap(),
                     });
                     assert_eq!(ty, &expected);
                 }
@@ -1408,9 +1447,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["namespace".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["namespace".parse().unwrap()]);
     }
 
     #[test]
@@ -1432,9 +1471,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["Set".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["Set".parse().unwrap()]);
     }
 
     #[test]
@@ -1445,9 +1484,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["appliesTo".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["appliesTo".parse().unwrap()]);
     }
 
     #[test]
@@ -1458,9 +1497,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["principal".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["principal".parse().unwrap()]);
     }
 
     #[test]
@@ -1471,9 +1510,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["resource".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["resource".parse().unwrap()]);
     }
 
     #[test]
@@ -1484,9 +1523,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["action".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["action".parse().unwrap()]);
     }
 
     #[test]
@@ -1497,9 +1536,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["context".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["context".parse().unwrap()]);
     }
 
     #[test]
@@ -1510,9 +1549,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["attributes".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["attributes".parse().unwrap()]);
     }
 
     #[test]
@@ -1523,9 +1562,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["Bool".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["Bool".parse().unwrap()]);
     }
 
     #[test]
@@ -1536,9 +1575,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["Long".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["Long".parse().unwrap()]);
     }
 
     #[test]
@@ -1549,9 +1588,9 @@ mod translator_tests {
         "#;
 
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let ns = schema.0.get("").unwrap();
-        let foo = ns.entity_types.get("Foo").unwrap();
-        assert_eq!(foo.member_of_types, vec!["String".to_smolstr()]);
+        let ns = schema.0.get(&None).unwrap();
+        let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
+        assert_eq!(foo.member_of_types, vec!["String".parse().unwrap()]);
     }
 
     #[test]

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -1118,7 +1118,6 @@ mod parser_tests {
 #[cfg(test)]
 mod translator_tests {
     use cedar_policy_core::FromNormalizedStr;
-    use smol_str::ToSmolStr;
 
     use crate::{SchemaError, SchemaFragment, SchemaTypeVariant, TypeOfAttribute, ValidatorSchema};
 

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -3,9 +3,8 @@ use std::collections::HashMap;
 use cedar_policy_core::{
     ast::{Id, Name},
     parser::{Loc, Node},
-    FromNormalizedStr,
 };
-use itertools::{Either, ExactlyOneError, Itertools};
+use itertools::{Either, Itertools};
 use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::hash_map::Entry;
@@ -238,12 +237,12 @@ impl<'a> ConversionContext<'a> {
         let principal_types = principals
             .into_iter()
             .at_most_one()
-            .map_err(|e| convert_pr_error(PR::Principal, loc.clone()))?;
+            .map_err(|_| convert_pr_error(PR::Principal, loc.clone()))?;
         // Ensure we have at most one resource decl, then convert it
         let resource_types = resources
             .into_iter()
             .at_most_one()
-            .map_err(|e| convert_pr_error(PR::Resource, loc.clone()))?;
+            .map_err(|_| convert_pr_error(PR::Resource, loc.clone()))?;
         Ok(ApplySpec {
             resource_types,
             principal_types,

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -223,12 +223,20 @@ impl<'a> ConversionContext<'a> {
         let (decls, _) = decls.into_inner();
         let principals_decl = decls.iter().filter(|decl| matches!(&decl.node, AppDecl::PR(pr) if matches!(pr.kind.node, PR::Principal))).at_most_one().map_err(|mut err| ToJsonSchemaError::DuplicatePR {
             kind: PR::Principal,
+            // PANIC SAFETY: there are at least two elements, so `err` should be able to yield twice
+            #[allow(clippy::unwrap_used)]
             start: err.next().unwrap().loc.clone(),
+            // PANIC SAFETY: there are at least two elements, so `err` should be able to yield twice
+            #[allow(clippy::unwrap_used)]
             end: err.next().unwrap().loc.clone(),
         })?;
         let resources_decl = decls.iter().filter(|decl| matches!(&decl.node, AppDecl::PR(pr) if matches!(pr.kind.node, PR::Resource))).at_most_one().map_err(|mut err| ToJsonSchemaError::DuplicatePR {
             kind: PR::Resource,
+            // PANIC SAFETY: there are at least two elements, so `err` should be able to yield twice
+            #[allow(clippy::unwrap_used)]
             start: err.next().unwrap().loc.clone(),
+            // PANIC SAFETY: there are at least two elements, so `err` should be able to yield twice
+            #[allow(clippy::unwrap_used)]
             end: err.next().unwrap().loc.clone(),
         })?;
         let context_decl = decls
@@ -236,20 +244,30 @@ impl<'a> ConversionContext<'a> {
             .filter(|decl| matches!(decl.node, AppDecl::Context(_)))
             .at_most_one()
             .map_err(|mut err| ToJsonSchemaError::DuplicateContext {
+                // PANIC SAFETY: there are at least two elements, so `err` should be able to yield twice
+                #[allow(clippy::unwrap_used)]
                 start: err.next().unwrap().loc.clone(),
+                // PANIC SAFETY: there are at least two elements, so `err` should be able to yield twice
+                #[allow(clippy::unwrap_used)]
                 end: err.next().unwrap().loc.clone(),
             })?;
         let resource_types = resources_decl.map(|decl| match &decl.node {
             AppDecl::PR(decl) => decl.entity_tys.iter().map(|n| n.clone().into()).collect(),
+            // PANIC SAFETY: see the message below
+            #[allow(clippy::unreachable)]
             _ => unreachable!("this declaration has been deemed to be a resource declaration"),
         });
         let principal_types = principals_decl.map(|decl| match &decl.node {
             AppDecl::PR(decl) => decl.entity_tys.iter().map(|n| n.clone().into()).collect(),
+            // PANIC SAFETY: see the message below
+            #[allow(clippy::unreachable)]
             _ => unreachable!("this declaration has been deemed to be a resource declaration"),
         });
         let context = context_decl
             .map(|decl| match &decl.node {
                 AppDecl::Context(decl) => self.convert_context_decl(decl.clone()),
+                // PANIC SAFETY: see the message below
+                #[allow(clippy::unreachable)]
                 _ => unreachable!("this declaration has been deemed to be a context declaration"),
             })
             .transpose()?
@@ -370,6 +388,8 @@ impl<'a> ConversionContext<'a> {
             // We search the current namespace
             self.lookup_namespace(loc.clone(), &self.current_namespace_name)
         } else {
+            // PANIC SAFETY: `name`'s namespace is not empty because its prefix is not
+            #[allow(clippy::unwrap_used)]
             self.lookup_namespace(loc.clone(), &Some(name.namespace().parse().unwrap()))
         }?;
         // Now we search that namespace according to Rule 3

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -238,14 +238,14 @@ mod test {
         let schema_file = NamespaceDefinition::new(
             [
                 (
-                    foo_type.into(),
+                    foo_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    bar_type.into(),
+                    bar_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -482,28 +482,28 @@ mod test {
         let schema_file = NamespaceDefinition::new(
             [
                 (
-                    user_type.into(),
+                    user_type.parse().unwrap(),
                     EntityType {
-                        member_of_types: vec![group_type.into()],
+                        member_of_types: vec![group_type.parse().unwrap()],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    group_type.into(),
+                    group_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    widget_type.into(),
+                    widget_type.parse().unwrap(),
                     EntityType {
-                        member_of_types: vec![bin_type.into()],
+                        member_of_types: vec![bin_type.parse().unwrap()],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    bin_type.into(),
+                    bin_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
@@ -514,8 +514,8 @@ mod test {
                 action_name.into(),
                 ActionType {
                     applies_to: Some(ApplySpec {
-                        resource_types: Some(vec![widget_type.into()]),
-                        principal_types: Some(vec![user_type.into()]),
+                        resource_types: Some(vec![widget_type.parse().unwrap()]),
+                        principal_types: Some(vec![user_type.parse().unwrap()]),
                         context: AttributesOrContext::default(),
                     }),
                     member_of: None,
@@ -558,7 +558,7 @@ mod test {
         let foo_type = "foo_type";
         let schema_file = NamespaceDefinition::new(
             [(
-                foo_type.into(),
+                foo_type.parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -593,7 +593,7 @@ mod test {
     fn validate_entity_type_not_in_singleton_schema() -> Result<()> {
         let schema_file = NamespaceDefinition::new(
             [(
-                "foo_type".into(),
+                "foo_type".parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -714,7 +714,7 @@ mod test {
         let p_name = "User";
         let schema_file = NamespaceDefinition::new(
             [(
-                p_name.into(),
+                p_name.parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -738,7 +738,7 @@ mod test {
         let p_name = "Package";
         let schema_file = NamespaceDefinition::new(
             [(
-                p_name.into(),
+                p_name.parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -762,7 +762,7 @@ mod test {
         let p_name = "User";
         let schema_file = NamespaceDefinition::new(
             [(
-                p_name.into(),
+                p_name.parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -1082,7 +1082,7 @@ mod test {
 
         let schema_file = NamespaceDefinition::new(
             [(
-                foo_type.into(),
+                foo_type.parse().unwrap(),
                 EntityType {
                     member_of_types: vec![],
                     shape: AttributesOrContext::default(),
@@ -1118,14 +1118,14 @@ mod test {
         let schema = NamespaceDefinition::new(
             [
                 (
-                    principal_type.into(),
+                    principal_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    resource_type.into(),
+                    resource_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
@@ -1136,8 +1136,8 @@ mod test {
                 action_name.into(),
                 ActionType {
                     applies_to: Some(ApplySpec {
-                        resource_types: Some(vec![resource_type.into()]),
-                        principal_types: Some(vec![principal_type.into()]),
+                        resource_types: Some(vec![resource_type.parse().unwrap()]),
+                        principal_types: Some(vec![principal_type.parse().unwrap()]),
                         context: AttributesOrContext::default(),
                     }),
                     member_of: Some(vec![]),
@@ -1518,28 +1518,28 @@ mod test {
         let schema_file = NamespaceDefinition::new(
             [
                 (
-                    principal_type.into(),
+                    principal_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    resource_type.into(),
+                    resource_type.parse().unwrap(),
                     EntityType {
-                        member_of_types: vec![resource_parent_type.into()],
+                        member_of_types: vec![resource_parent_type.parse().unwrap()],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    resource_parent_type.into(),
+                    resource_parent_type.parse().unwrap(),
                     EntityType {
-                        member_of_types: vec![resource_grandparent_type.into()],
+                        member_of_types: vec![resource_grandparent_type.parse().unwrap()],
                         shape: AttributesOrContext::default(),
                     },
                 ),
                 (
-                    resource_grandparent_type.into(),
+                    resource_grandparent_type.parse().unwrap(),
                     EntityType {
                         member_of_types: vec![],
                         shape: AttributesOrContext::default(),
@@ -1551,8 +1551,8 @@ mod test {
                     action_name.into(),
                     ActionType {
                         applies_to: Some(ApplySpec {
-                            resource_types: Some(vec![resource_type.into()]),
-                            principal_types: Some(vec![principal_type.into()]),
+                            resource_types: Some(vec![resource_type.parse().unwrap()]),
+                            principal_types: Some(vec![principal_type.parse().unwrap()]),
                             context: AttributesOrContext::default(),
                         }),
                         member_of: Some(vec![ActionEntityUID {

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -1154,7 +1154,7 @@ mod test {
     fn assert_validate_policy_succeeds(validator: &Validator, policy: &Template) {
         assert!(
             validator
-                .validate_policy(&policy, ValidationMode::default())
+                .validate_policy(policy, ValidationMode::default())
                 .0
                 .next()
                 .is_none(),
@@ -1162,7 +1162,7 @@ mod test {
         );
         assert!(
             validator
-                .validate_policy(&policy, ValidationMode::default())
+                .validate_policy(policy, ValidationMode::default())
                 .1
                 .next()
                 .is_none(),

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -92,7 +92,7 @@ impl ValidatorSchemaFragment {
                 .into_iter()
                 .map(|(fragment_ns, ns_def)| {
                     ValidatorNamespaceDef::from_namespace_definition(
-                        Some(fragment_ns),
+                        fragment_ns,
                         ns_def,
                         action_behavior,
                         extensions,
@@ -1179,7 +1179,9 @@ mod test {
         let schema_ty: SchemaType = serde_json::from_value(src).expect("Parse Error");
         assert_eq!(
             schema_ty,
-            SchemaType::Type(SchemaTypeVariant::Entity { name: "Foo".into() })
+            SchemaType::Type(SchemaTypeVariant::Entity {
+                name: "Foo".parse().unwrap()
+            })
         );
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
             Some(&Name::parse_unqualified_name("NS").expect("Expected namespace.")),
@@ -1198,7 +1200,7 @@ mod test {
         assert_eq!(
             schema_ty,
             SchemaType::Type(SchemaTypeVariant::Entity {
-                name: "NS::Foo".into()
+                name: "NS::Foo".parse().unwrap()
             })
         );
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
@@ -1218,7 +1220,7 @@ mod test {
         assert_eq!(
             schema_ty,
             SchemaType::Type(SchemaTypeVariant::Entity {
-                name: "::Foo".into()
+                name: "::Foo".parse().unwrap()
             })
         );
         match ValidatorNamespaceDef::try_schema_type_into_validator_type(

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -652,15 +652,12 @@ impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes {
 #[allow(clippy::indexing_slicing)]
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
     use std::{collections::BTreeMap, str::FromStr};
 
     use crate::types::Type;
     use crate::{SchemaType, SchemaTypeVariant};
 
     use cedar_policy_core::ast::RestrictedExpr;
-    use cedar_policy_core::parser::err::{ParseError, ToASTError, ToASTErrorKind};
-    use cedar_policy_core::parser::Loc;
     use cool_asserts::assert_matches;
     use serde_json::json;
 
@@ -1024,10 +1021,8 @@ mod test {
             "actions": {}
         }
         "#;
-        let schema_file: NamespaceDefinition = serde_json::from_str(src).expect("Parse Error");
-        assert!(
-            matches!(TryInto::<ValidatorSchema>::try_into(schema_file), Err(SchemaError::ParseEntityType(_))),
-            "Expected that namespace in the entity type NS::User would cause a EntityType parse error.");
+        let schema_file: std::result::Result<NamespaceDefinition, _> = serde_json::from_str(src);
+        assert!(schema_file.is_err());
     }
 
     #[test]
@@ -1216,20 +1211,8 @@ mod test {
     #[test]
     fn test_entity_type_namespace_parse_error() {
         let src = json!({"type": "Entity", "name": "::Foo"});
-        let schema_ty: SchemaType = serde_json::from_value(src).expect("Parse Error");
-        assert_eq!(
-            schema_ty,
-            SchemaType::Type(SchemaTypeVariant::Entity {
-                name: "::Foo".parse().unwrap()
-            })
-        );
-        match ValidatorNamespaceDef::try_schema_type_into_validator_type(
-            Some(&Name::parse_unqualified_name("NS").expect("Expected namespace.")),
-            schema_ty,
-        ) {
-            Err(SchemaError::ParseEntityType(_)) => (),
-            _ => panic!("Did not see expected entity type parse error."),
-        }
+        let schema_ty: std::result::Result<SchemaType, _> = serde_json::from_value(src);
+        assert!(schema_ty.is_err());
     }
 
     #[test]
@@ -1721,25 +1704,9 @@ mod test {
                 "actions": {}
             }
         });
-        let fragment = serde_json::from_value::<SchemaFragment>(bad1)
-            .expect("constructing the fragment itself should succeed"); // should this fail in the future?
-        let err = ValidatorSchema::try_from(fragment)
-            .expect_err("should error due to invalid entity type name");
-        let problem_field = "User // comment";
-        let expected_err = ParseError::ToAST(ToASTError::new(
-            ToASTErrorKind::NonNormalizedString {
-                kind: "Id",
-                src: problem_field.to_string(),
-                normalized_src: "User".to_string(),
-            },
-            Loc::new(4, Arc::from(problem_field)),
-        ))
-        .into();
-
-        match err {
-            SchemaError::ParseEntityType(parse_error) => assert_eq!(parse_error, expected_err),
-            err => panic!("Incorrect error {err}"),
-        }
+        let fragment = serde_json::from_value::<SchemaFragment>(bad1); // should this fail in the future?
+                                                                       // The future has come?
+        assert!(fragment.is_err());
 
         // non-normalized schema namespace
         let bad2 = json!({
@@ -1752,24 +1719,9 @@ mod test {
                 "actions": {}
             }
         });
-        let fragment = serde_json::from_value::<SchemaFragment>(bad2)
-            .expect("constructing the fragment itself should succeed"); // should this fail in the future?
-        let err = ValidatorSchema::try_from(fragment)
-            .expect_err("should error due to invalid schema namespace");
-        let problem_field = "ABC     :: //comment \n XYZ  ";
-        let expected_err = ParseError::ToAST(ToASTError::new(
-            ToASTErrorKind::NonNormalizedString {
-                kind: "Name",
-                src: problem_field.to_string(),
-                normalized_src: "ABC::XYZ".to_string(),
-            },
-            Loc::new(3, Arc::from(problem_field)),
-        ))
-        .into();
-        match err {
-            SchemaError::ParseNamespace(parse_error) => assert_eq!(parse_error, expected_err),
-            err => panic!("Incorrect error {:?}", err),
-        };
+        let fragment = serde_json::from_value::<SchemaFragment>(bad2); // should this fail in the future?
+                                                                       // The future has come?
+        assert!(fragment.is_err());
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -14,7 +14,7 @@ use cedar_policy_core::{
     parser::err::ParseErrors,
     FromNormalizedStr,
 };
-use smol_str::SmolStr;
+use smol_str::{SmolStr, ToSmolStr};
 
 use super::ValidatorApplySpec;
 use crate::types::OpenTag;
@@ -191,13 +191,13 @@ impl ValidatorNamespaceDef {
     // the file format. However, our fuzzing library currently needs it to be public.
     /// Construct a new `ValidatorSchema` from the underlying `SchemaFragment`.
     pub fn from_namespace_definition(
-        namespace: Option<SmolStr>,
+        namespace: Option<Name>,
         namespace_def: NamespaceDefinition,
         action_behavior: ActionBehavior,
         extensions: Extensions<'_>,
     ) -> Result<ValidatorNamespaceDef> {
         // Check that each entity types and action is only declared once.
-        let mut e_types_ids: HashSet<SmolStr> = HashSet::new();
+        let mut e_types_ids: HashSet<Id> = HashSet::new();
         for name in namespace_def.entity_types.keys() {
             if !e_types_ids.insert(name.clone()) {
                 // insert returns false for duplicates
@@ -212,27 +212,20 @@ impl ValidatorNamespaceDef {
             }
         }
 
-        let schema_namespace = match namespace.as_deref() {
-            None => None,
-            Some("") => None, // we consider "" to be the same as the empty namespace for this purpose
-            Some(ns) => Some(Name::from_normalized_str(ns).map_err(SchemaError::ParseNamespace)?),
-        };
-
         // Return early with an error if actions cannot be in groups or have
         // attributes, but the schema contains action groups or attributes.
         Self::check_action_behavior(&namespace_def, action_behavior)?;
 
         // Convert the type defs, actions and entity types from the schema file
         // into the representation used by the validator.
-        let type_defs =
-            Self::build_type_defs(namespace_def.common_types, schema_namespace.as_ref())?;
+        let type_defs = Self::build_type_defs(namespace_def.common_types, namespace.as_ref())?;
         let actions =
-            Self::build_action_ids(namespace_def.actions, schema_namespace.as_ref(), extensions)?;
+            Self::build_action_ids(namespace_def.actions, namespace.as_ref(), extensions)?;
         let entity_types =
-            Self::build_entity_types(namespace_def.entity_types, schema_namespace.as_ref())?;
+            Self::build_entity_types(namespace_def.entity_types, namespace.as_ref())?;
 
         Ok(ValidatorNamespaceDef {
-            namespace: schema_namespace,
+            namespace,
             type_defs,
             entity_types,
             actions,
@@ -246,20 +239,18 @@ impl ValidatorNamespaceDef {
     }
 
     fn build_type_defs(
-        schema_file_type_def: HashMap<SmolStr, SchemaType>,
+        schema_file_type_def: HashMap<Id, SchemaType>,
         schema_namespace: Option<&Name>,
     ) -> Result<TypeDefs> {
         let type_defs = schema_file_type_def
             .into_iter()
-            .map(|(name_str, schema_ty)| -> Result<_> {
+            .map(|(name, schema_ty)| -> Result<_> {
+                let name_str = name.clone().into_smolstr();
                 if Self::is_builtin_type_name(&name_str) {
                     return Err(SchemaError::DuplicateCommonType(name_str.to_string()));
                 }
-                let name = Self::parse_unqualified_name_with_namespace(
-                    &name_str,
-                    schema_namespace.cloned(),
-                )
-                .map_err(SchemaError::ParseCommonType)?;
+                let name =
+                    Self::prefix_namespace(schema_namespace.cloned(), Name::unqualified_name(name));
                 let ty = Self::try_schema_type_into_validator_type(schema_namespace, schema_ty)?
                     .resolve_type_defs(&HashMap::new())?;
                 Ok((name, ty))
@@ -272,7 +263,7 @@ impl ValidatorNamespaceDef {
     // used internally by the validator. This is mostly accomplished by directly
     // copying data between fields.
     fn build_entity_types(
-        schema_files_types: HashMap<SmolStr, schema_file_format::EntityType>,
+        schema_files_types: HashMap<Id, schema_file_format::EntityType>,
         schema_namespace: Option<&Name>,
     ) -> Result<EntityTypesDef> {
         Ok(EntityTypesDef {
@@ -287,15 +278,9 @@ impl ValidatorNamespaceDef {
 
                     let parents = entity_type
                         .member_of_types
-                        .iter()
-                        .map(|parent| -> Result<_> {
-                            Self::parse_possibly_qualified_name_with_default_namespace(
-                                parent,
-                                schema_namespace,
-                            )
-                            .map_err(SchemaError::ParseEntityType)
-                        })
-                        .collect::<Result<HashSet<_>>>()?;
+                        .into_iter()
+                        .map(|ty| Self::prefix_namespace(schema_namespace.cloned(), ty))
+                        .collect();
 
                     let attributes = Self::try_schema_type_into_validator_type(
                         schema_namespace,
@@ -434,7 +419,7 @@ impl ValidatorNamespaceDef {
                     let action_id = Self::parse_action_id_with_namespace(
                         &ActionEntityUID::default_type(action_id_str),
                         schema_namespace,
-                    )?;
+                    );
 
                     let (principal_types, resource_types, context) = action_type
                         .applies_to
@@ -451,8 +436,8 @@ impl ValidatorNamespaceDef {
                     // `EntityTypes`. If one of the lists is `None` (absent from the
                     // schema), then the specification is undefined.
                     let applies_to = ValidatorApplySpec::new(
-                        Self::parse_apply_spec_type_list(principal_types, schema_namespace)?,
-                        Self::parse_apply_spec_type_list(resource_types, schema_namespace)?,
+                        Self::parse_apply_spec_type_list(principal_types, schema_namespace),
+                        Self::parse_apply_spec_type_list(resource_types, schema_namespace),
                     );
 
                     let context = Self::try_schema_type_into_validator_type(
@@ -464,10 +449,10 @@ impl ValidatorNamespaceDef {
                         .member_of
                         .unwrap_or_default()
                         .iter()
-                        .map(|parent| -> Result<_> {
+                        .map(|parent| {
                             Self::parse_action_id_with_namespace(parent, schema_namespace)
                         })
-                        .collect::<Result<HashSet<_>>>()?;
+                        .collect::<HashSet<_>>();
 
                     let (attribute_types, attributes) =
                         Self::convert_attr_jsonval_map_to_attributes(
@@ -506,7 +491,7 @@ impl ValidatorNamespaceDef {
             // The `name` in an entity type declaration cannot be qualified
             // with a namespace (it always implicitly takes the schema
             // namespace), so we do this comparison directly.
-            .any(|(name, _)| name == ACTION_ENTITY_TYPE)
+            .any(|(name, _)| name.to_smolstr() == ACTION_ENTITY_TYPE)
         {
             return Err(SchemaError::ActionEntityTypeDeclared);
         }
@@ -565,9 +550,9 @@ impl ValidatorNamespaceDef {
     /// of the entity type names cannot be parsed, then the `Err` case is
     /// returned, and it will indicate which name did not parse.
     fn parse_apply_spec_type_list(
-        types: Option<Vec<SmolStr>>,
+        types: Option<Vec<Name>>,
         namespace: Option<&Name>,
-    ) -> Result<HashSet<EntityType>> {
+    ) -> HashSet<EntityType> {
         types
             .map(|types| {
                 types
@@ -575,45 +560,16 @@ impl ValidatorNamespaceDef {
                     // Parse each type name string into a `Name`, generating an
                     // `EntityTypeParseError` when the string is not a valid
                     // name.
-                    .map(|ty_str| {
-                        Ok(EntityType::Specified(
-                            Self::parse_possibly_qualified_name_with_default_namespace(
-                                ty_str, namespace,
-                            )
-                            .map_err(SchemaError::ParseEntityType)?,
+                    .map(|ty| {
+                        EntityType::Specified(Self::prefix_namespace(
+                            namespace.cloned(),
+                            ty.clone(),
                         ))
                     })
                     // Fail if any of the types failed.
-                    .collect::<Result<HashSet<_>>>()
+                    .collect::<HashSet<_>>()
             })
-            .unwrap_or_else(|| Ok(HashSet::from([EntityType::Unspecified])))
-    }
-
-    // Parse a `Name` from a string (possibly including namespaces). If it is
-    // not qualified with any namespace, then apply the  default namespace to
-    // create a qualified name.  Do not modify any existing namespace on the
-    // type.
-    pub(crate) fn parse_possibly_qualified_name_with_default_namespace(
-        name_str: &SmolStr,
-        default_namespace: Option<&Name>,
-    ) -> std::result::Result<Name, ParseErrors> {
-        let name = Name::from_normalized_str(name_str)?;
-
-        let qualified_name = if name.namespace_components().next().is_some() {
-            // The name is already qualified. Don't touch it.
-            name
-        } else {
-            // The name does not have a namespace, so qualify the type to
-            // use the default.
-            match default_namespace {
-                Some(namespace) => {
-                    Name::type_in_namespace(name.basename().clone(), namespace.clone())
-                }
-                None => name,
-            }
-        };
-
-        Ok(qualified_name)
+            .unwrap_or_else(|| HashSet::from([EntityType::Unspecified]))
     }
 
     /// Parse a name from a string into the `Id` (basename only).  Then
@@ -638,10 +594,9 @@ impl ValidatorNamespaceDef {
     fn parse_action_id_with_namespace(
         action_id: &ActionEntityUID,
         namespace: Option<&Name>,
-    ) -> Result<EntityUID> {
+    ) -> EntityUID {
         let namespaced_action_type = if let Some(action_ty) = &action_id.ty {
-            Self::parse_possibly_qualified_name_with_default_namespace(action_ty, namespace)
-                .map_err(SchemaError::ParseEntityType)?
+            Self::prefix_namespace(namespace.cloned(), action_ty.clone())
         } else {
             // PANIC SAFETY: The constant ACTION_ENTITY_TYPE is valid entity type.
             #[allow(clippy::expect_used)]
@@ -653,10 +608,7 @@ impl ValidatorNamespaceDef {
                 None => Name::unqualified_name(id),
             }
         };
-        Ok(EntityUID::from_components(
-            namespaced_action_type,
-            Eid::new(action_id.id.clone()),
-        ))
+        EntityUID::from_components(namespaced_action_type, Eid::new(action_id.id.clone()))
     }
 
     /// Implemented to convert a type as written in the schema json format into the
@@ -702,24 +654,19 @@ impl ValidatorNamespaceDef {
                 }
             }
             SchemaType::Type(SchemaTypeVariant::Entity { name }) => {
-                let entity_type_name = Self::parse_possibly_qualified_name_with_default_namespace(
-                    &name,
-                    default_namespace,
-                )
-                .map_err(SchemaError::ParseEntityType)?;
-                Ok(Type::named_entity_reference(entity_type_name).into())
+                Ok(Type::named_entity_reference(Self::prefix_namespace(
+                    default_namespace.cloned(),
+                    name,
+                ))
+                .into())
             }
             SchemaType::Type(SchemaTypeVariant::Extension { name }) => {
-                let extension_type_name =
-                    Name::from_normalized_str(&name).map_err(SchemaError::ParseExtensionType)?;
+                let extension_type_name = Name::unqualified_name(name);
                 Ok(Type::extension(extension_type_name).into())
             }
             SchemaType::TypeDef { type_name } => {
-                let defined_type_name = Self::parse_possibly_qualified_name_with_default_namespace(
-                    &type_name,
-                    default_namespace,
-                )
-                .map_err(SchemaError::ParseCommonType)?;
+                let defined_type_name =
+                    Self::prefix_namespace(default_namespace.cloned(), type_name);
                 Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
                     typ_defs.get(&defined_type_name).cloned().ok_or(
                         SchemaError::UndeclaredCommonTypes(HashSet::from([
@@ -734,5 +681,13 @@ impl ValidatorNamespaceDef {
     /// Access the `Name` for the namespace of this definition.
     pub fn namespace(&self) -> &Option<Name> {
         &self.namespace
+    }
+
+    fn prefix_namespace(ns: Option<Name>, name: Name) -> Name {
+        if name.is_singleton() {
+            name.prefix_namespace(ns)
+        } else {
+            name
+        }
     }
 }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -686,7 +686,6 @@ impl SchemaType {
 #[allow(clippy::panic)]
 impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType> {
-        use cedar_policy_core::ast::Name;
         use std::collections::BTreeSet;
 
         Ok(SchemaType::Type(match u.int_in_range::<u8>(1..=8)? {
@@ -711,15 +710,13 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
             }
             6 => {
                 let name: Name = u.arbitrary()?;
-                SchemaTypeVariant::Entity {
-                    name: name.to_string().into(),
-                }
+                SchemaTypeVariant::Entity { name }
             }
             7 => SchemaTypeVariant::Extension {
-                name: "ipaddr".into(),
+                name: "ipaddr".parse().unwrap(),
             },
             8 => SchemaTypeVariant::Extension {
-                name: "decimal".into(),
+                name: "decimal".parse().unwrap(),
             },
             n => panic!("bad index: {n}"),
         }))

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -713,9 +713,13 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
                 SchemaTypeVariant::Entity { name }
             }
             7 => SchemaTypeVariant::Extension {
+                // PANIC SAFETY: `ipaddr` is a valid `Id`
+                #[allow(clippy::unwrap_used)]
                 name: "ipaddr".parse().unwrap(),
             },
             8 => SchemaTypeVariant::Extension {
+                // PANIC SAFETY: `decimal` is a valid `Id`
+                #[allow(clippy::unwrap_used)]
                 name: "decimal".parse().unwrap(),
             },
             n => panic!("bad index: {n}"),

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -60,7 +60,7 @@ fn slot_in_typechecks() {
         member_of_types: vec![],
         shape: AttributesOrContext::default(),
     };
-    let schema = NamespaceDefinition::new([("typename".into(), etype)], []);
+    let schema = NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
         schema.clone(),
         Expr::binary_app(
@@ -93,7 +93,7 @@ fn slot_equals_typechecks() {
     // typechecker doesn't have access to a schema, so it can't instantiate
     // the template slots with appropriate types. Similar policies that pass
     // strict typechecking are in the test_policy file.
-    let schema = NamespaceDefinition::new([("typename".into(), etype)], []);
+    let schema = NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
         schema.clone(),
         Expr::binary_app(

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1462,23 +1462,6 @@ pub enum SchemaError {
     /// Cycle in the schema's action hierarchy.
     #[error("cycle in action hierarchy containing `{0}`")]
     CycleInActionHierarchy(EntityUid),
-    /// Parse errors occurring while parsing an entity type.
-    #[error("parse error in entity type: {0}")]
-    #[diagnostic(transparent)]
-    ParseEntityType(ParseErrors),
-    /// Parse errors occurring while parsing a namespace identifier.
-    #[error("parse error in namespace identifier: {0}")]
-    #[diagnostic(transparent)]
-    ParseNamespace(ParseErrors),
-    /// Parse errors occurring while parsing an extension type.
-    #[error("parse error in extension type: {0}")]
-    #[diagnostic(transparent)]
-    ParseExtensionType(ParseErrors),
-    /// Parse errors occurring while parsing the name of a reusable
-    /// declared type.
-    #[error("parse error in common type identifier: {0}")]
-    #[diagnostic(transparent)]
-    ParseCommonType(ParseErrors),
     /// The schema file included an entity type `Action` in the entity type
     /// list. The `Action` entity type is always implicitly declared, and it
     /// cannot currently have attributes or be in any groups, so there is no
@@ -1647,12 +1630,6 @@ impl From<cedar_policy_validator::SchemaError> for SchemaError {
             }
             cedar_policy_validator::SchemaError::CycleInActionHierarchy(e) => {
                 Self::CycleInActionHierarchy(EntityUid(e))
-            }
-            cedar_policy_validator::SchemaError::ParseEntityType(e) => Self::ParseEntityType(e),
-            cedar_policy_validator::SchemaError::ParseNamespace(e) => Self::ParseNamespace(e),
-            cedar_policy_validator::SchemaError::ParseCommonType(e) => Self::ParseCommonType(e),
-            cedar_policy_validator::SchemaError::ParseExtensionType(e) => {
-                Self::ParseExtensionType(e)
             }
             cedar_policy_validator::SchemaError::ActionEntityTypeDeclared => {
                 Self::ActionEntityTypeDeclared


### PR DESCRIPTION
## Description of changes

Fields like `NamespaceDefinition::common_types` should have types like `HashMap<Id, SchemaType>` instead of `HashMap<SmolStr, SchemaType>`. So, this PR checks validity of these fields during JSON deserialization instead of post-processing `SchemaFragment`. Moving these checks ahead makes it easier to process `SchemaFrament` without incurring breaking changes. Furthermore, translating human-readable schema to JSON schema avoids redundant validity checks because the parser of the former already ensures such validity.

It's a breaking change because error variants `Parse*` were removed from `SchemaError`. They become custom errors thrown by serde. An example is as follows,

```
 × failed to parse schema from file schema.cedarschema.json
  ├─▶ failed to parse schema: invalid memberOfTypes: unexpected token `!` at line 8 column 13
  ╰─▶ invalid memberOfTypes: unexpected token `!` at line 8 column 13
```
v.s
```
 × failed to parse schema from file schema.cedarschema.json
  ╰─▶ parse error in entity type: unexpected token `!`
```

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

