### PR TITLE
[CLI] default to human schema format

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Changed
+
+- The default `--schema-format` is now `human` for all subcommands that take
+  `--schema-format`.
+
 ## 3.1.1
 
 ## 3.1.0

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -130,7 +130,7 @@ pub enum SchemaFormat {
 
 impl Default for SchemaFormat {
     fn default() -> Self {
-        Self::Json
+        Self::Human
     }
 }
 
@@ -151,7 +151,7 @@ pub struct ValidateArgs {
     #[arg(long = "partial-validate")]
     pub partial_validate: bool,
     /// Schema format (Human-readable or json)
-    #[arg(long, value_enum, default_value_t = SchemaFormat::Json)]
+    #[arg(long, value_enum, default_value_t = SchemaFormat::Human)]
     pub schema_format: SchemaFormat,
 }
 
@@ -347,7 +347,7 @@ pub struct AuthorizeArgs {
     #[arg(short, long = "schema", value_name = "FILE")]
     pub schema_file: Option<String>,
     /// Schema format (Human-readable or JSON)
-    #[arg(long, value_enum, default_value_t = SchemaFormat::Json)]
+    #[arg(long, value_enum, default_value_t = SchemaFormat::Human)]
     pub schema_format: SchemaFormat,
     /// File containing JSON representation of the Cedar entity hierarchy
     #[arg(long = "entities", value_name = "FILE")]
@@ -462,7 +462,7 @@ pub struct EvaluateArgs {
     #[arg(short, long = "schema", value_name = "FILE")]
     pub schema_file: Option<String>,
     /// Schema format (Human-readable or JSON)
-    #[arg(long, value_enum, default_value_t = SchemaFormat::Json)]
+    #[arg(long, value_enum, default_value_t = SchemaFormat::Human)]
     pub schema_format: SchemaFormat,
     /// File containing JSON representation of the Cedar entity hierarchy.
     /// This is optional; if not present, we'll just use an empty hierarchy.


### PR DESCRIPTION
## Description of changes

Change the CLI's default schema format to `human`.  This is a breaking change.

## Issue #, if available

Fixes #683 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

