### PR TITLE
improve error when `null` occurs in entity json data

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1332,6 +1332,245 @@ mod json_parsing_tests {
         });
     }
 
+    /// Test that `null` is properly rejected, with a sane error message, in
+    /// various positions
+    #[test]
+    fn null_failures() {
+        let eparser: EntityJsonParser<'_, '_> =
+            EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": null,
+                "attrs": {},
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+                "in uid field of <unknown entity>, expected a literal entity reference, but got `null`",
+                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": null, "id": "bar" },
+                "attrs": {},
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+                r#"in uid field of <unknown entity>, expected a literal entity reference, but got `{"id":"bar","type":null}`"#,
+                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": null },
+                "attrs": {},
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+                r#"in uid field of <unknown entity>, expected a literal entity reference, but got `{"id":null,"type":"foo"}`"#,
+                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": null,
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                "invalid type: null, expected a map"
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": null },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `attr` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": { "subattr": null } },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `attr` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": [ 3, null ] },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `attr` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": [ 3, { "subattr" : null } ] },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `attr` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "__extn": { "fn": null, "args": [] } },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `__extn` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "__extn": { "fn": "ip", "args": null } },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `__extn` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "__extn": { "fn": "ip", "args": [ null ] } },
+                "parents": [],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                r#"in attribute `__extn` on `foo::"bar"`, found a `null`; JSON `null`s are not allowed in Cedar"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": 2 },
+                "parents": null,
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error(
+                "invalid type: null, expected a sequence"
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": 2 },
+                "parents": [ null ],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+                r#"in parents field of `foo::"bar"`, expected a literal entity reference, but got `null`"#,
+                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": 2 },
+                "parents": [ { "type": "foo", "id": null } ],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+                r#"in parents field of `foo::"bar"`, expected a literal entity reference, but got `{"id":null,"type":"foo"}`"#,
+                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
+            ));
+        });
+
+        let json = serde_json::json!(
+            [
+            {
+                "uid": { "type": "foo", "id": "bar" },
+                "attrs": { "attr": 2 },
+                "parents": [ { "type": "foo", "id": "parent" }, null ],
+            }
+            ]
+        );
+        assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
+            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+                r#"in parents field of `foo::"bar"`, expected a literal entity reference, but got `null`"#,
+                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
+            ));
+        });
+    }
+
     /// helper function to round-trip an Entities (with no schema-based parsing)
     fn roundtrip(entities: &Entities) -> Result<Entities> {
         let mut buf = Vec::new();

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -233,6 +233,9 @@ pub enum JsonDeserializationError {
     #[error("{0}, the `__expr` escape is no longer supported")]
     #[diagnostic(help("to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"))]
     ExprTag(Box<JsonDeserializationErrorContext>),
+    /// Raised when the input JSON contains a `null`
+    #[error("{0}, found a `null`; JSON `null`s are not allowed in Cedar")]
+    Null(Box<JsonDeserializationErrorContext>),
 }
 
 /// Errors thrown during serialization to JSON

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -94,6 +94,9 @@ pub enum CedarValueJson {
     Record(
         #[cfg_attr(feature = "wasm", tsify(type = "{ [key: string]: CedarValueJson }"))] JsonRecord,
     ),
+    /// JSON null, which is never valid, but we put this here in order to
+    /// provide a better error message.
+    Null,
 }
 
 /// Structure representing a Cedar record in JSON
@@ -258,6 +261,7 @@ impl CedarValueJson {
             )),
             Self::ExtnEscape { __extn: extn } => extn.into_expr(ctx),
             Self::ExprEscape { .. } => Err(JsonDeserializationError::ExprTag(Box::new(ctx()))),
+            Self::Null => Err(JsonDeserializationError::Null(Box::new(ctx()))),
         }
     }
 

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -2239,7 +2239,7 @@ mod test {
         let policy = r#"
         permit(principal, action, resource)
         when {
-            
+
             "" like "ḛ̶͑͝x̶͔͛a̵̰̯͛m̴͉̋́p̷̠͂l̵͇̍̔ȩ̶̣͝"
         };
     "#;

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1483,6 +1483,10 @@ fn display_cedarvaluejson(f: &mut std::fmt::Formatter<'_>, v: &CedarValueJson) -
             write!(f, "}}")?;
             Ok(())
         }
+        CedarValueJson::Null => {
+            write!(f, "null")?;
+            Ok(())
+        }
     }
 }
 

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -371,6 +371,10 @@ impl ValidatorNamespaceDef {
                     "extension function escape (`__extn`)".to_owned(),
                 ))
             }
+            CedarValueJson::Null => Err(SchemaError::UnsupportedActionAttribute(
+                action_id.clone(),
+                "null".to_owned(),
+            )),
         }
     }
 


### PR DESCRIPTION
## Description of changes

As it says in the title.

## Issue #, if available

Fixes #530

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

Not breaking because the error type being changed is not re-exported in `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

