### PR TITLE
Nits in CI and `cedar-testing`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,6 +33,8 @@ jobs:
 
   run-integration-tests:
     uses: ./.github/workflows/run_integration_tests_reusable.yml
+    with:
+      cedar_policy_ref: ${{ github.ref }}
 
   # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
   # don't effect it. As a side effect, this will run in parallel, saving some

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -2,6 +2,15 @@ name: Run Integration Tests
 
 on:
   workflow_call:
+    inputs:
+      cedar_integration_tests_ref:
+        required: false
+        default: "main"
+        type: string
+      cedar_policy_ref:
+        required: false
+        default: "main"
+        type: string
 
 jobs:
   run_integration_tests:
@@ -22,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar
-          ref: main
+          ref: ${{ inputs.cedar_policy_ref }}
           path: ./cedar
       - name: Delete old integration tests
         working-directory: ./cedar
@@ -31,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: cedar-policy/cedar-integration-tests
-          ref: main
+          ref: ${{ inputs.cedar_integration_tests_ref }}
           path: ./cedar/cedar-integration-tests
       - name: Decompress corpus tests
         working-directory: ./cedar/cedar-integration-tests

--- a/cedar-testing/src/integration_testing.rs
+++ b/cedar-testing/src/integration_testing.rs
@@ -61,7 +61,7 @@ pub struct JsonTest {
 
 /// JSON representation of a single request, along with its expected result,
 /// in our integration test file format
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct JsonRequest {
     /// Description for the request


### PR DESCRIPTION
## Description of changes

Followup to #746 to add some new `input`s to control which branch is used for CI. 

Also snuck in some refactoring in `cedar-testing` that I want for an upcoming PR to `cedar-spec`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
