### PR TITLE
Cherry-pick multiplication change (RFC 57) to 2.4.x 

### DIFF
--- a/cedar-integration-tests/corpus_tests/7b316784cf9e60631768b35cb7a7e15ba6d01c05.json
+++ b/cedar-integration-tests/corpus_tests/7b316784cf9e60631768b35cb7a7e15ba6d01c05.json
@@ -13,7 +13,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -25,7 +25,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -37,7 +37,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -49,7 +49,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -61,7 +61,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -73,7 +73,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -85,7 +85,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     },
     {
@@ -97,7 +97,7 @@
       "decision": "Deny",
       "reasons": [],
       "errors": [
-        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply -1537158028109086738 by 60138"
+        "error occurred while evaluating policy `policy0`: integer overflow while attempting to multiply the values -1537158028109086738 and 60138"
       ]
     }
   ]

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -71,9 +71,6 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
                 self.expression_stack.push(arg1);
                 self.expression_stack.push(arg2);
             }
-            ExprKind::MulByConst { arg, .. } => {
-                self.expression_stack.push(arg);
-            }
             ExprKind::ExtensionFunctionApp { args, .. } => {
                 for arg in args.as_ref() {
                     self.expression_stack.push(arg);

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -61,6 +61,11 @@ pub enum BinaryOp {
     /// Arguments must have Long type
     Sub,
 
+    /// Integer multiplication
+    ///
+    /// Arguments must have Long type
+    Mul,
+
     /// Hierarchy membership. Specifically, is the first arg a member of the
     /// second.
     ///
@@ -103,6 +108,7 @@ impl std::fmt::Display for BinaryOp {
             BinaryOp::LessEq => write!(f, "_<=_"),
             BinaryOp::Add => write!(f, "_+_"),
             BinaryOp::Sub => write!(f, "_-_"),
+            BinaryOp::Mul => write!(f, "_*_"),
             BinaryOp::In => write!(f, "_in_"),
             BinaryOp::Contains => write!(f, "contains"),
             BinaryOp::ContainsAll => write!(f, "containsAll"),

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -24,6 +24,8 @@ use thiserror::Error;
 
 /// Top level structure for a policy template.
 /// Contains both the AST for template, and the list of open slots in the template.
+///
+/// Note that this "template" may have no slots, in which case this `Template` represents a static policy
 #[derive(Clone, Hash, Eq, PartialEq, Debug, Serialize, Deserialize)]
 #[serde(from = "TemplateBody")]
 #[serde(into = "TemplateBody")]
@@ -31,6 +33,8 @@ pub struct Template {
     body: TemplateBody,
     /// INVARIANT (slot cache correctness): This Vec must contain _all_ of the open slots in `body`
     /// This is maintained by the only two public constructors, `new` and `instantiate_inline_policy`
+    ///
+    /// Note that `slots` may be empty, in which case this `Template` represents a static policy
     slots: Vec<SlotId>,
 }
 

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -205,13 +205,8 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExpressionError> {
                 feature: op.to_string(),
             })
         }
-        ExprKind::MulByConst { .. } => {
-            Err(RestrictedExpressionError::InvalidRestrictedExpression {
-                feature: "multiplication".into(),
-            })
-        }
         ExprKind::GetAttr { .. } => Err(RestrictedExpressionError::InvalidRestrictedExpression {
-            feature: "get-attribute".into(),
+            feature: "attribute accesses".into(),
         }),
         ExprKind::HasAttr { .. } => Err(RestrictedExpressionError::InvalidRestrictedExpression {
             feature: "'has'".into(),

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -62,7 +62,6 @@ impl TryFrom<Expr> for Value {
             ExprKind::Or { .. } => Err(NotValue::NotValue),
             ExprKind::UnaryApp { .. } => Err(NotValue::NotValue),
             ExprKind::BinaryApp { .. } => Err(NotValue::NotValue),
-            ExprKind::MulByConst { .. } => Err(NotValue::NotValue),
             ExprKind::ExtensionFunctionApp { .. } => Err(NotValue::NotValue),
             ExprKind::GetAttr { .. } => Err(NotValue::NotValue),
             ExprKind::HasAttr { .. } => Err(NotValue::NotValue),

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::ast::{self, SlotId};
+use crate::ast;
 use crate::entities::JsonDeserializationError;
 use crate::parser::unescape;
 use smol_str::SmolStr;
@@ -40,7 +40,7 @@ pub enum EstToAstError {
     #[error("found template slot {slot} in a `{clausetype}` clause")]
     SlotsInConditionClause {
         /// Slot that was found in a when/unless clause
-        slot: SlotId,
+        slot: ast::SlotId,
         /// Clause type, e.g. "when" or "unless"
         clausetype: &'static str,
     },

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -522,26 +522,10 @@ impl TryFrom<Expr> for ast::Expr {
                 (*left).clone().try_into()?,
                 (*right).clone().try_into()?,
             )),
-            Expr::ExprNoExt(ExprNoExt::Mul { left, right }) => {
-                let left: ast::Expr = (*left).clone().try_into()?;
-                let right: ast::Expr = (*right).clone().try_into()?;
-                let left_c = match left.expr_kind() {
-                    ast::ExprKind::Lit(ast::Literal::Long(c)) => Some(c),
-                    _ => None,
-                };
-                let right_c = match right.expr_kind() {
-                    ast::ExprKind::Lit(ast::Literal::Long(c)) => Some(c),
-                    _ => None,
-                };
-                match (left_c, right_c) {
-                    (_, Some(c)) => Ok(ast::Expr::mul(left, *c)),
-                    (Some(c), _) => Ok(ast::Expr::mul(right, *c)),
-                    (None, None) => Err(EstToAstError::MultiplicationByNonConstant {
-                        arg1: left,
-                        arg2: right,
-                    })?,
-                }
-            }
+            Expr::ExprNoExt(ExprNoExt::Mul { left, right }) => Ok(ast::Expr::mul(
+                (*left).clone().try_into()?,
+                (*right).clone().try_into()?,
+            )),
             Expr::ExprNoExt(ExprNoExt::Contains { left, right }) => Ok(ast::Expr::contains(
                 (*left).clone().try_into()?,
                 (*right).clone().try_into()?,
@@ -658,15 +642,12 @@ impl From<ast::Expr> for Expr {
                     ast::BinaryOp::LessEq => Expr::lesseq(arg1, arg2),
                     ast::BinaryOp::Add => Expr::add(arg1, arg2),
                     ast::BinaryOp::Sub => Expr::sub(arg1, arg2),
+                    ast::BinaryOp::Mul => Expr::mul(arg1, arg2),
                     ast::BinaryOp::Contains => Expr::contains(Arc::new(arg1), arg2),
                     ast::BinaryOp::ContainsAll => Expr::contains_all(Arc::new(arg1), arg2),
                     ast::BinaryOp::ContainsAny => Expr::contains_any(Arc::new(arg1), arg2),
                 }
             }
-            ast::ExprKind::MulByConst { arg, constant } => Expr::mul(
-                unwrap_or_clone(arg).into(),
-                Expr::lit(JSONValue::Long(constant)),
-            ),
             ast::ExprKind::ExtensionFunctionApp { fn_name, args } => {
                 let args = unwrap_or_clone(args).into_iter().map(Into::into).collect();
                 Expr::ext_call(fn_name.to_string().into(), args)

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -128,7 +128,7 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
 #[derive(Debug, PartialEq, Clone, Error)]
 pub enum IntegerOverflowError {
     /// Overflow during a binary operation
-    #[error("integer overflow while attempting to {} {arg1} by {arg2}", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", BinaryOp::Mul => "multiply", _ => "perform an operation on" })]
+    #[error("integer overflow while attempting to {} the values {arg1} and {arg2}", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", BinaryOp::Mul => "multiply", _ => "perform an operation on" })]
     BinaryOp {
         /// overflow while evaluating this operator
         op: BinaryOp,
@@ -138,8 +138,8 @@ pub enum IntegerOverflowError {
         arg2: Value,
     },
 
-    /// Overflow during a unary operation
-    #[error("integer overflow while attempting to {} the value `{arg}`", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
+    /// Overflow during an integer negation operation
+    #[error("integer overflow while attempting to {} the value {arg}", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
     UnaryOp {
         /// overflow while evaluating this operator
         op: UnaryOp,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -128,7 +128,7 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
 #[derive(Debug, PartialEq, Clone, Error)]
 pub enum IntegerOverflowError {
     /// Overflow during a binary operation
-    #[error("integer overflow while attempting to {} the values `{arg1}` and `{arg2}`", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", BinaryOp::Mul => "multiply", _ => "perform an operation on" })]
+    #[error("integer overflow while attempting to {} {arg1} by {arg2}", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", BinaryOp::Mul => "multiply", _ => "perform an operation on" })]
     BinaryOp {
         /// overflow while evaluating this operator
         op: BinaryOp,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -127,7 +127,8 @@ fn pretty_type_error(expected: &[Type], actual: &Type) -> String {
 
 #[derive(Debug, PartialEq, Clone, Error)]
 pub enum IntegerOverflowError {
-    #[error("integer overflow while attempting to {} the values {arg1} and {arg2}", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", _ => "perform an operation on" })]
+    /// Overflow during a binary operation
+    #[error("integer overflow while attempting to {} the values `{arg1}` and `{arg2}`", match .op { BinaryOp::Add => "add", BinaryOp::Sub => "subtract", BinaryOp::Mul => "multiply", _ => "perform an operation on" })]
     BinaryOp {
         /// overflow while evaluating this operator
         op: BinaryOp,
@@ -137,16 +138,8 @@ pub enum IntegerOverflowError {
         arg2: Value,
     },
 
-    #[error("integer overflow while attempting to multiply {arg} by {constant}")]
-    Multiplication {
-        /// first argument, which wasn't necessarily a constant in the policy
-        arg: Value,
-        /// second argument, which was a constant in the policy
-        constant: i64,
-    },
-
-    /// Overflow during an integer negation operation
-    #[error("integer overflow while attempting to {} the value {arg}", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
+    /// Overflow during a unary operation
+    #[error("integer overflow while attempting to {} the value `{arg}`", match .op { UnaryOp::Neg => "negate", _ => "perform an operation on" })]
     UnaryOp {
         /// overflow while evaluating this operator
         op: UnaryOp,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1205,7 +1205,7 @@ impl ASTNode<Option<cst::Mult>> {
                 )),
             })
             .partition_result();
-        errs.0.extend(new_errs);
+        errs.extend(new_errs);
         if !more.is_empty() {
             // in this case, `first` must be an expr, we should collect any errors there as well
             let first = maybe_first?.into_expr(errs)?;
@@ -2110,8 +2110,6 @@ fn construct_expr_record(kvs: Vec<(SmolStr, ast::Expr)>, l: SourceInfo) -> ast::
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod tests {
-    use cool_asserts::assert_matches;
-
     use super::*;
     use crate::{
         ast::Expr,

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -1010,13 +1010,13 @@ fn neg_typecheck_fails() {
 
 #[test]
 fn mul_typechecks() {
-    let neg_expr = Expr::mul(Expr::val(1), 2);
+    let neg_expr = Expr::mul(Expr::val(1), Expr::val(2));
     assert_typechecks_empty_schema(neg_expr, Type::primitive_long());
 }
 
 #[test]
 fn mul_typecheck_fails() {
-    let neg_expr = Expr::mul(Expr::val("foo"), 2);
+    let neg_expr = Expr::mul(Expr::val("foo"), Expr::val(2));
     assert_typecheck_fails_empty_schema(
         neg_expr,
         Type::primitive_long(),

--- a/cedar-policy-validator/src/typecheck/test_type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test_type_annotation.rs
@@ -103,10 +103,10 @@ fn expr_typechecks_with_correct_annotation() {
             .not(ExprBuilder::with_data(Some(Type::singleton_boolean(false))).val(false)),
     );
     assert_expr_has_annotated_ast(
-        &Expr::mul(Expr::val(3), 4),
+        &Expr::mul(Expr::val(3), Expr::val(4)),
         &ExprBuilder::with_data(Some(Type::primitive_long())).mul(
             ExprBuilder::with_data(Some(Type::primitive_long())).val(3),
-            4,
+            ExprBuilder::with_data(Some(Type::primitive_long())).val(4),
         ),
     );
     assert_expr_has_annotated_ast(

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.4.5 - Coming soon
+
+### Changed
+
+- Implement [RFC 57](https://github.com/cedar-policy/rfcs/pull/57): policies can
+  now include multiplication of arbitrary expressions, not just multiplication of
+  an expression and a constant.
+
 ## 2.4.4
 
 Cedar Language Version: 2.1.3


### PR DESCRIPTION
## Description of changes

Copy this change to 2.4.x for a 2.4.5 release.

This did not cherry-pick cleanly, so review is required to make sure it's all good. Some of the conflicts were in test code, so these should not be relevant to the functionality. I ended up dropping some test refactoring included with the original PR to make the cherry-pick easier.
Plenty other conflicts were in the actual implementation, particularly around where we changed error types to include source information and where we changed the AST to add `is`.

Spec update is in https://github.com/cedar-policy/cedar-spec/pull/266

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

