### PR TITLE
Better testing for error message source locations

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -953,10 +953,11 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in uid field of <unknown entity>, expected a literal entity reference, but got `"test_entity_type::\"Alice\""`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
     }
 
@@ -986,10 +987,11 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "error during entity deserialization: in uid field of <unknown entity>, the `__expr` escape is no longer supported",
+            ).help(
                 "to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly",
-            ));
+            ).build());
         });
     }
 
@@ -1019,10 +1021,11 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in attribute `pancakes` on `test_entity_type::"Alice"`, the `__expr` escape is no longer supported"#,
+            ).help(
                 "to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly",
-            ));
+            ).build());
         });
     }
 
@@ -1050,10 +1053,11 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in parents field of `test_entity_type::"Alice"`, the `__expr` escape is no longer supported"#,
+            ).help(
                 "to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly",
-            ));
+            ).build());
         });
     }
 
@@ -1081,10 +1085,11 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in parents field of `test_entity_type::"Alice"`, expected a literal entity reference, but got `"test_entity_type::\"bob\""`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
     }
 
@@ -1259,10 +1264,11 @@ mod json_parsing_tests {
             ]
         );
         assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"in uid field of <unknown entity>, expected a literal entity reference, but got `"hello"`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
 
         let json = serde_json::json!(
@@ -1275,10 +1281,11 @@ mod json_parsing_tests {
             ]
         );
         assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"in uid field of <unknown entity>, expected a literal entity reference, but got `"\"hello\""`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
 
         let json = serde_json::json!(
@@ -1291,10 +1298,11 @@ mod json_parsing_tests {
             ]
         );
         assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"in uid field of <unknown entity>, expected a literal entity reference, but got `{"spam":"eggs","type":"foo"}`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
 
         let json = serde_json::json!(
@@ -1307,9 +1315,9 @@ mod json_parsing_tests {
             ]
         );
         assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"invalid type: string "foo::\"help\"", expected a sequence"#
-            ));
+            ).build());
         });
 
         let json = serde_json::json!(
@@ -1325,10 +1333,11 @@ mod json_parsing_tests {
             ]
         );
         assert_matches!(eparser.from_json_value(json.clone()), Err(EntitiesError::Deserialization(e)) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"in parents field of `foo::"bar"`, expected a literal entity reference, but got `"foo::\"help\""`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
     }
 
@@ -1490,10 +1499,11 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: action `XYZ::Action::"view"` has a non-action parent `User::"alice"`"#,
+            ).help(
                 "parents of actions need to have type `Action` themselves, perhaps namespaced",
-            ));
+            ).build());
         });
     }
 
@@ -1542,9 +1552,9 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_str(json), Err(e) => {
-            expect_err(json, &e, &ExpectedErrorMessage::error(
+            expect_err(json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: the key `bar` occurs two or more times in the same JSON object at line 11 column 25"# // TODO: put the line-column information in `Diagnostic::labels()` instead of printing it in the error message
-            ));
+            ).build());
         });
     }
 }
@@ -2020,9 +2030,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: value was expected to have type long, but actually has type string: `"3"`"#
-            ));
+            ).build());
         });
     }
 
@@ -2063,10 +2073,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#,
+            ).help(
                 r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ));
+            ).build());
         });
     }
 
@@ -2104,9 +2115,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: value was expected to have type (set of `HR`), but actually has type record with attributes: {"id" => (optional) string, "type" => (optional) string}: `{"id": "aaaaa", "type": "HR"}`"#
-            ));
+            ).build());
         });
     }
 
@@ -2147,9 +2158,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: in attribute `manager` on `Employee::"12UA45"`, type mismatch: value was expected to have type `Employee`, but actually has type `HR`: `HR::"34FB87"`"#
-            ));
+            ).build());
         });
     }
 
@@ -2191,9 +2202,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#
-            ));
+            ).build());
         });
     }
 
@@ -2233,9 +2244,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#
-            ));
+            ).build());
         });
     }
 
@@ -2276,9 +2287,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_starts_with(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error_starts_with(
                 r#"entity does not conform to the schema: in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: value was expected to have type record with attributes: "#
-            ));
+            ).build());
         });
 
         let entitiesjson = json!(
@@ -2351,9 +2362,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: in attribute `json_blob` on `Employee::"12UA45"`, record attribute `inner4` should not exist according to the schema"#
-            ));
+            ).build());
         });
     }
 
@@ -2393,9 +2404,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: expected entity `Employee::"12UA45"` to have attribute `numDirectReports`, but it does not"#
-            ));
+            ).build());
         });
     }
 
@@ -2437,9 +2448,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: attribute `wat` on `Employee::"12UA45"` should not exist according to the schema"#
-            ));
+            ).build());
         });
     }
 
@@ -2482,9 +2493,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: `Employee::"12UA45"` is not allowed to have an ancestor of type `Employee` according to the schema"#
-            ));
+            ).build());
         });
     }
 
@@ -2506,9 +2517,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: entity `CEO::"abcdef"` has type `CEO` which is not declared in the schema"#
-            ));
+            ).build());
         });
     }
 
@@ -2530,9 +2541,9 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: found action entity `Action::"update"`, but it was not declared as an action in the schema"#
-            ));
+            ).build());
         });
     }
 
@@ -2591,10 +2602,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
+            ).help(
                 r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ));
+            ).build());
         });
     }
 
@@ -2620,10 +2632,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
+            ).help(
                 r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ));
+            ).build());
         });
     }
 
@@ -2647,10 +2660,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
+            ).help(
                 r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ));
+            ).build());
         });
     }
 
@@ -2677,10 +2691,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: definition of action `Action::"view"` does not match its schema declaration"#,
+            ).help(
                 r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ));
+            ).build());
         });
     }
 
@@ -2704,10 +2719,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
+            ).help(
                 r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ));
+            ).build());
         });
     }
 
@@ -2734,10 +2750,11 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
+            ).help(
                 r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ));
+            ).build());
         });
     }
 
@@ -2868,9 +2885,9 @@ mod schema_based_parsing_tests {
         );
 
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"entity does not conform to the schema: in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: value was expected to have type `XYZCorp::Employee`, but actually has type `Employee`: `Employee::"34FB87"`"#
-            ));
+            ).build());
         });
 
         let entitiesjson = json!(
@@ -2888,10 +2905,11 @@ mod schema_based_parsing_tests {
         );
 
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"error during entity deserialization: entity `Employee::"12UA45"` has type `Employee` which is not declared in the schema"#,
+            ).help(
                 "did you mean `XYZCorp::Employee`?",
-            ));
+            ).build());
         });
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -356,9 +356,8 @@ impl std::fmt::Display for Clause {
 mod test {
     use super::*;
     use crate::parser::{self, parse_policy_or_template_to_est};
-    use crate::test_utils::ExpectedErrorMessage;
+    use crate::test_utils::ExpectedErrorMessageBuilder;
     use cool_asserts::assert_matches;
-    use miette::Diagnostic;
     use serde_json::json;
 
     /// helper function to just do EST data structure --> JSON --> EST data structure.
@@ -686,10 +685,7 @@ mod test {
             .node
             .unwrap();
         assert_matches!(Policy::try_from(cst), Err(e) => {
-            parser::test_utils::expect_exactly_one_error(policy, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
-            let expected_span = 35..44;
-            assert_eq!(&policy[expected_span.clone()], r#"@foo("2")"#);
-            itertools::assert_equal(e.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+            parser::test_utils::expect_exactly_one_error(policy, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("2")"#).build());
         });
 
         let policy = r#"
@@ -702,10 +698,7 @@ mod test {
             .node
             .unwrap();
         assert_matches!(Policy::try_from(cst), Err(e) => {
-            parser::test_utils::expect_exactly_one_error(policy, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
-            let expected_span = 35..44;
-            assert_eq!(&policy[expected_span.clone()], r#"@foo("1")"#);
-            itertools::assert_equal(e.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+            parser::test_utils::expect_exactly_one_error(policy, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("1")"#).build());
         });
 
         let policy = r#"
@@ -723,12 +716,9 @@ mod test {
             .unwrap();
         assert_matches!(Policy::try_from(cst), Err(e) => {
             assert_eq!(e.len(), 3); // two errors for @foo and one for @bar
-            parser::test_utils::expect_some_error_matches(policy, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
-            parser::test_utils::expect_some_error_matches(policy, &e, &ExpectedErrorMessage::error("duplicate annotation: @bar"));
-            for ((err, expected_span), expected_snippet) in e.iter().zip([62..73, 116..127, 140..151]).zip([r#"@foo("abc")"#, r#"@bar("123")"#, r#"@foo("def")"#]) {
-                assert_eq!(&policy[expected_span.clone()], expected_snippet);
-                itertools::assert_equal(err.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
-            }
+            parser::test_utils::expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("abc")"#).build());
+            parser::test_utils::expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("def")"#).build());
+            parser::test_utils::expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @bar").exactly_one_underline(r#"@bar("123")"#).build());
         });
 
         // the above tests ensure that we give the correct errors for CSTs
@@ -2239,7 +2229,7 @@ mod test {
         let policy = r#"
         permit(principal, action, resource)
         when {
-            
+
             "" like "ḛ̶͑͝x̶͔͛a̵̰̯͛m̴͉̋́p̷̠͂l̵͇̍̔ȩ̶̣͝"
         };
     "#;

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -762,11 +762,13 @@ mod parse_tests {
                 resource == ?resource
             };
             "#;
-        let slot_in_when_clause = ExpectedErrorMessageBuilder::error(
-            "found template slot ?resource in a `when` clause")
-        .help("slots are currently unsupported in `when` clauses")
-        .exactly_one_underline("when {\n                resource == ?resource\n            }")
-        .build();
+        let slot_in_when_clause =
+            ExpectedErrorMessageBuilder::error("found template slot ?resource in a `when` clause")
+                .help("slots are currently unsupported in `when` clauses")
+                .exactly_one_underline(
+                    "when {\n                resource == ?resource\n            }",
+                )
+                .build();
         let unexpected_template = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?resource",
         )
@@ -799,11 +801,13 @@ mod parse_tests {
                 resource == ?principal
             };
             "#;
-        let slot_in_when_clause = ExpectedErrorMessageBuilder::error(
-            "found template slot ?principal in a `when` clause")
-        .help("slots are currently unsupported in `when` clauses")
-        .exactly_one_underline("when {\n                resource == ?principal\n            }")
-        .build();
+        let slot_in_when_clause =
+            ExpectedErrorMessageBuilder::error("found template slot ?principal in a `when` clause")
+                .help("slots are currently unsupported in `when` clauses")
+                .exactly_one_underline(
+                    "when {\n                resource == ?principal\n            }",
+                )
+                .build();
         let unexpected_template = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?principal",
         )
@@ -836,12 +840,10 @@ mod parse_tests {
                 resource == ?blah
             };
             "#;
-        let error = ExpectedErrorMessageBuilder::error(
-            "`?blah` is not a valid template slot"
-        )
-        .help("a template slot may only be `?principal` or `?resource`")
-        .exactly_one_underline("?blah")
-        .build();
+        let error = ExpectedErrorMessageBuilder::error("`?blah` is not a valid template slot")
+            .help("a template slot may only be `?principal` or `?resource`")
+            .exactly_one_underline("?blah")
+            .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &error);
         });
@@ -942,12 +944,10 @@ mod parse_tests {
                 resource == ?blah
             };
             "#;
-        let error = ExpectedErrorMessageBuilder::error(
-            "`?blah` is not a valid template slot"
-        )
-        .help("a template slot may only be `?principal` or `?resource`")
-        .exactly_one_underline("?blah")
-        .build();
+        let error = ExpectedErrorMessageBuilder::error("`?blah` is not a valid template slot")
+            .help("a template slot may only be `?principal` or `?resource`")
+            .exactly_one_underline("?blah")
+            .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &error);
         });
@@ -974,12 +974,13 @@ mod parse_tests {
                 resource == ?resource
             };
             "#;
-        let slot_in_when_clause = ExpectedErrorMessageBuilder::error(
-            "found template slot ?resource in a `when` clause"
-        )
-        .help("slots are currently unsupported in `when` clauses")
-        .exactly_one_underline("when {\n                resource == ?resource\n            }")
-        .build();
+        let slot_in_when_clause =
+            ExpectedErrorMessageBuilder::error("found template slot ?resource in a `when` clause")
+                .help("slots are currently unsupported in `when` clauses")
+                .exactly_one_underline(
+                    "when {\n                resource == ?resource\n            }",
+                )
+                .build();
         let slot_in_unless_clause = ExpectedErrorMessageBuilder::error(
             "found template slot ?resource in a `unless` clause",
         )

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -374,7 +374,7 @@ pub(crate) mod test_utils {
 
     /// Expect that the given `ParseErrors` contains at least one error with the given `ExpectedErrorMessage`.
     ///
-    /// `src` is the original input text, just for better assertion-failure messages
+    /// `src` is the original input text (which the miette labels index into).
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     pub fn expect_some_error_matches(
         src: &str,
@@ -386,7 +386,7 @@ pub(crate) mod test_utils {
             "for the following input:\n{src}\nexpected an error, but the `ParseErrors` was empty"
         );
         assert!(
-            errs.iter().any(|e| msg.matches(e)),
+            errs.iter().any(|e| msg.matches(Some(src), e)),
             "for the following input:\n{src}\nexpected some error to match the following:\n{msg}\nbut actual errors were:\n{:?}", // the Debug representation of `miette::Report` is the pretty one, for some reason
             miette::Report::new(errs.clone()),
         );
@@ -401,11 +401,7 @@ pub(crate) mod test_utils {
             0 => panic!("for the following input:\n{src}\nexpected an error, but the `ParseErrors` was empty"),
             1 => {
                 let err = errs.iter().next().expect("already checked that len was 1");
-                assert!(
-                    msg.matches(err),
-                    "for the following input:\n{src}\nexpected the error to match the following:\n{msg}\nbut actual error was:\n{:?}", // the Debug representation of `miette::Report` is the pretty one, for some reason
-                    miette::Report::new(err.clone()),
-                )
+                expect_err(src, &miette::Report::new(err.clone()), msg);
             }
             n => panic!(
                 "for the following input:\n{src}\nexpected only one error, but got {n}. Expected to match the following:\n{msg}\nbut actual errors were:\n{:?}", // the Debug representation of `miette::Report` is the pretty one, for some reason
@@ -756,7 +752,7 @@ mod parse_tests {
             permit(principal, action, resource) when { principal.name.like == "3" };
             "#;
         let p = parse_policyset_to_ests_and_pset(src);
-        assert_matches!(p, Err(e) => expect_err(src, &e, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `like`")));
+        assert_matches!(p, Err(e) => expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `like`").exactly_one_underline("like").build()));
     }
 
     #[test]
@@ -766,14 +762,17 @@ mod parse_tests {
                 resource == ?resource
             };
             "#;
-        let slot_in_when_clause = ExpectedErrorMessage::error_and_help(
-            "found template slot ?resource in a `when` clause",
-            "slots are currently unsupported in `when` clauses",
-        );
-        let unexpected_template = ExpectedErrorMessage::error_and_help(
+        let slot_in_when_clause = ExpectedErrorMessageBuilder::error(
+            "found template slot ?resource in a `when` clause")
+        .help("slots are currently unsupported in `when` clauses")
+        .exactly_one_underline("when {\n                resource == ?resource\n            }")
+        .build();
+        let unexpected_template = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?resource",
-            "try removing the template slot(s) from this policy",
-        );
+        )
+        .help("try removing the template slot(s) from this policy")
+        .exactly_one_underline("when {\n                resource == ?resource\n            }")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
@@ -800,14 +799,17 @@ mod parse_tests {
                 resource == ?principal
             };
             "#;
-        let slot_in_when_clause = ExpectedErrorMessage::error_and_help(
-            "found template slot ?principal in a `when` clause",
-            "slots are currently unsupported in `when` clauses",
-        );
-        let unexpected_template = ExpectedErrorMessage::error_and_help(
+        let slot_in_when_clause = ExpectedErrorMessageBuilder::error(
+            "found template slot ?principal in a `when` clause")
+        .help("slots are currently unsupported in `when` clauses")
+        .exactly_one_underline("when {\n                resource == ?principal\n            }")
+        .build();
+        let unexpected_template = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?principal",
-            "try removing the template slot(s) from this policy",
-        );
+        )
+        .help("try removing the template slot(s) from this policy")
+        .exactly_one_underline("when {\n                resource == ?principal\n            }")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
@@ -834,10 +836,12 @@ mod parse_tests {
                 resource == ?blah
             };
             "#;
-        let error = ExpectedErrorMessage::error_and_help(
-            "`?blah` is not a valid template slot",
-            "a template slot may only be `?principal` or `?resource`",
-        );
+        let error = ExpectedErrorMessageBuilder::error(
+            "`?blah` is not a valid template slot"
+        )
+        .help("a template slot may only be `?principal` or `?resource`")
+        .exactly_one_underline("?blah")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &error);
         });
@@ -862,14 +866,18 @@ mod parse_tests {
                 resource == ?resource
             };
             "#;
-        let slot_in_unless_clause = ExpectedErrorMessage::error_and_help(
+        let slot_in_unless_clause = ExpectedErrorMessageBuilder::error(
             "found template slot ?resource in a `unless` clause",
-            "slots are currently unsupported in `unless` clauses",
-        );
-        let unexpected_template = ExpectedErrorMessage::error_and_help(
+        )
+        .help("slots are currently unsupported in `unless` clauses")
+        .exactly_one_underline("unless {\n                resource == ?resource\n            }")
+        .build();
+        let unexpected_template = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?resource",
-            "try removing the template slot(s) from this policy",
-        );
+        )
+        .help("try removing the template slot(s) from this policy")
+        .exactly_one_underline("unless {\n                resource == ?resource\n            }")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
@@ -896,14 +904,18 @@ mod parse_tests {
                 resource == ?principal
             };
             "#;
-        let slot_in_unless_clause = ExpectedErrorMessage::error_and_help(
+        let slot_in_unless_clause = ExpectedErrorMessageBuilder::error(
             "found template slot ?principal in a `unless` clause",
-            "slots are currently unsupported in `unless` clauses",
-        );
-        let unexpected_template = ExpectedErrorMessage::error_and_help(
+        )
+        .help("slots are currently unsupported in `unless` clauses")
+        .exactly_one_underline("unless {\n                resource == ?principal\n            }")
+        .build();
+        let unexpected_template = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?principal",
-            "try removing the template slot(s) from this policy",
-        );
+        )
+        .help("try removing the template slot(s) from this policy")
+        .exactly_one_underline("unless {\n                resource == ?principal\n            }")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
@@ -930,10 +942,12 @@ mod parse_tests {
                 resource == ?blah
             };
             "#;
-        let error = ExpectedErrorMessage::error_and_help(
-            "`?blah` is not a valid template slot",
-            "a template slot may only be `?principal` or `?resource`",
-        );
+        let error = ExpectedErrorMessageBuilder::error(
+            "`?blah` is not a valid template slot"
+        )
+        .help("a template slot may only be `?principal` or `?resource`")
+        .exactly_one_underline("?blah")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &error);
         });
@@ -960,22 +974,35 @@ mod parse_tests {
                 resource == ?resource
             };
             "#;
-        let slot_in_when_clause = ExpectedErrorMessage::error_and_help(
-            "found template slot ?resource in a `when` clause",
-            "slots are currently unsupported in `when` clauses",
-        );
-        let slot_in_unless_clause = ExpectedErrorMessage::error_and_help(
+        let slot_in_when_clause = ExpectedErrorMessageBuilder::error(
+            "found template slot ?resource in a `when` clause"
+        )
+        .help("slots are currently unsupported in `when` clauses")
+        .exactly_one_underline("when {\n                resource == ?resource\n            }")
+        .build();
+        let slot_in_unless_clause = ExpectedErrorMessageBuilder::error(
             "found template slot ?resource in a `unless` clause",
-            "slots are currently unsupported in `unless` clauses",
-        );
-        let unexpected_template = ExpectedErrorMessage::error_and_help(
+        )
+        .help("slots are currently unsupported in `unless` clauses")
+        .exactly_one_underline("unless {\n                resource == ?resource\n            }")
+        .build();
+        let unexpected_template_in_when_clause = ExpectedErrorMessageBuilder::error(
             "expected a static policy, got a template containing the slot ?resource",
-            "try removing the template slot(s) from this policy",
-        );
+        )
+        .help("try removing the template slot(s) from this policy")
+        .exactly_one_underline("when {\n                resource == ?resource\n            }")
+        .build();
+        let unexpected_template_in_unless_clause = ExpectedErrorMessageBuilder::error(
+            "expected a static policy, got a template containing the slot ?resource",
+        )
+        .help("try removing the template slot(s) from this policy")
+        .exactly_one_underline("unless {\n                resource == ?resource\n            }")
+        .build();
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
-            expect_some_error_matches(src, &e, &unexpected_template);
+            expect_some_error_matches(src, &e, &unexpected_template_in_when_clause);
+            expect_some_error_matches(src, &e, &unexpected_template_in_unless_clause);
         });
         assert_matches!(parse_policy_template(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
@@ -984,7 +1011,8 @@ mod parse_tests {
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
-            expect_some_error_matches(src, &e, &unexpected_template);
+            expect_some_error_matches(src, &e, &unexpected_template_in_when_clause);
+            expect_some_error_matches(src, &e, &unexpected_template_in_unless_clause);
         });
         assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
@@ -1011,7 +1039,7 @@ mod parse_tests {
         // duplicate key
         let src = r#"permit(principal, action, resource) when { context.foo == { "spam": -341, foo: 2, "🦀": true, foo: "baz" } };"#;
         assert_matches!(parse_policy(None, src), Err(e) => {
-            expect_exactly_one_error(src, &e, &ExpectedErrorMessage::error("duplicate key `foo` in record literal"));
+            expect_exactly_one_error(src, &e, &ExpectedErrorMessageBuilder::error("duplicate key `foo` in record literal").exactly_one_underline(r#"{ "spam": -341, foo: 2, "🦀": true, foo: "baz" }"#).build());
         });
     }
 
@@ -1023,10 +1051,7 @@ mod parse_tests {
             permit(principal, action, resource);
         "#;
         assert_matches!(parse_policy(None, src), Err(e) => {
-            expect_exactly_one_error(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
-            let expected_span = 35..44;
-            assert_eq!(&src[expected_span.clone()], r#"@foo("2")"#);
-            itertools::assert_equal(e.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+            expect_exactly_one_error(src, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("2")"#).build());
         });
 
         let src = r#"
@@ -1035,10 +1060,7 @@ mod parse_tests {
             permit(principal, action, resource);
         "#;
         assert_matches!(parse_policy(None, src), Err(e) => {
-            expect_exactly_one_error(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
-            let expected_span = 35..44;
-            assert_eq!(&src[expected_span.clone()], r#"@foo("1")"#);
-            itertools::assert_equal(e.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
+            expect_exactly_one_error(src, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("1")"#).build());
         });
 
         let src = r#"
@@ -1052,12 +1074,9 @@ mod parse_tests {
         "#;
         assert_matches!(parse_policy(None, src), Err(e) => {
             assert_eq!(e.len(), 3); // two errors for @foo and one for @bar
-            expect_some_error_matches(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @foo"));
-            expect_some_error_matches(src, &e, &ExpectedErrorMessage::error("duplicate annotation: @bar"));
-            for ((err, expected_span), expected_snippet) in e.iter().zip([62..73, 116..127, 140..151]).zip([r#"@foo("abc")"#, r#"@bar("123")"#, r#"@foo("def")"#]) {
-                assert_eq!(&src[expected_span.clone()], expected_snippet);
-                itertools::assert_equal(err.labels().expect("should have labels"), [miette::LabeledSpan::underline(expected_span)]);
-            }
+            expect_some_error_matches(src, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("abc")"#).build());
+            expect_some_error_matches(src, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @foo").exactly_one_underline(r#"@foo("def")"#).build());
+            expect_some_error_matches(src, &e, &ExpectedErrorMessageBuilder::error("duplicate annotation: @bar").exactly_one_underline(r#"@bar("123")"#).build());
         })
     }
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2787,9 +2787,9 @@ mod tests {
         let parse = text_to_cst::parse_expr(src).expect("failed parse");
 
         assert_matches!(parse.to_expr(&mut errs), None => {
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `if`"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("record literal has invalid attributes"));
-            assert_eq!(errs.len(), 3, "{:?}", miette::Report::new(errs)); // the `if` error occurs twice in that expression, so the total number of errors is 3
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `if`").exactly_one_underline("if: true").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `if`").exactly_one_underline("if").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("record literal has invalid attributes").exactly_one_underline("{if: true}").build());
         });
     }
 
@@ -2802,13 +2802,13 @@ mod tests {
         let parse = text_to_cst::parse_expr(src).expect("failed parse");
 
         assert_matches!(parse.to_expr(&mut errs), None => {
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `has`"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `like`"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `in`"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `then`"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("this identifier is reserved and cannot be used: `else`"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error("record literal has invalid attributes"));
-            assert_eq!(errs.len(), 7, "{:?}", miette::Report::new(errs)); // the "record literal has invalid attributes" error occurs twice in that expression
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `has`").exactly_one_underline("has").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `like`").exactly_one_underline("like").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `in`").exactly_one_underline("in").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `then`").exactly_one_underline("then").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("this identifier is reserved and cannot be used: `else`").exactly_one_underline("else").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("record literal has invalid attributes").exactly_one_underline("{has:false}").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("record literal has invalid attributes").exactly_one_underline("{then:true}").build());
         });
     }
 
@@ -2821,13 +2821,12 @@ mod tests {
         let parse = text_to_cst::parse_policy(src).expect("failed parse");
         println!("{:#}", parse.as_inner().expect("internal parse error"));
         assert_matches!(parse.to_policy(ast::PolicyID::from_string("id"), &mut errs), None => {
-            // TODO: check the source snippet pointed to in each of these three errors is `p`, `a`, and `r` respectively
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error_and_help("type constraints using `:` are not supported", "try using `is` instead"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error_and_help("type constraints using `:` are not supported", "try using `is` instead"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error_and_help("type constraints using `:` are not supported", "try using `is` instead"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error_and_help("arbitrary variables are not supported; the valid Cedar variables are `principal`, `action`, `resource`, and `context`", "did you mean to enclose `w` in quotes to make a string?"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error_and_help("arbitrary variables are not supported; the valid Cedar variables are `principal`, `action`, `resource`, and `context`", "did you mean to enclose `u` in quotes to make a string?"));
-            expect_some_error_matches(src, &errs, &ExpectedErrorMessage::error_and_help("not a valid policy condition: `advice`", "condition must be either `when` or `unless`"));
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("type constraints using `:` are not supported").help("try using `is` instead").exactly_one_underline("p").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("type constraints using `:` are not supported").help("try using `is` instead").exactly_one_underline("a").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("type constraints using `:` are not supported").help("try using `is` instead").exactly_one_underline("r").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("arbitrary variables are not supported; the valid Cedar variables are `principal`, `action`, `resource`, and `context`").help("did you mean to enclose `w` in quotes to make a string?").exactly_one_underline("w").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("arbitrary variables are not supported; the valid Cedar variables are `principal`, `action`, `resource`, and `context`").help("did you mean to enclose `u` in quotes to make a string?").exactly_one_underline("u").build());
+            expect_some_error_matches(src, &errs, &ExpectedErrorMessageBuilder::error("not a valid policy condition: `advice`").help("condition must be either `when` or `unless`").exactly_one_underline("advice").build());
         });
     }
 
@@ -3968,24 +3967,51 @@ mod tests {
 
     #[test]
     fn unescape_err_positions() {
-        let assert_invalid_escape = |p_src| {
+        let assert_invalid_escape = |p_src, underline| {
             assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-                expect_err(p_src, &e, &ExpectedErrorMessage::error("the input `\\q` is not a valid escape: InvalidEscape"));
+                expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("the input `\\q` is not a valid escape: InvalidEscape").exactly_one_underline(underline).build());
             });
         };
-        assert_invalid_escape(r#"@foo("\q")permit(principal, action, resource);"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { "\q" };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { "\q".contains(0) };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { "\q".bar };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { "\q"["a"] };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { "" like "\q" };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { {}["\q"] };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { {"\q": 0} };"#);
-        assert_invalid_escape(r#"permit(principal, action, resource) when { User::"\q" };"#);
+        assert_invalid_escape(
+            r#"@foo("\q")permit(principal, action, resource);"#,
+            r#"@foo("\q")"#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { "\q" };"#,
+            r#""\q""#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { "\q".contains(0) };"#,
+            r#""\q".contains(0)"#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { "\q".bar };"#,
+            r#""\q".bar"#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { "\q"["a"] };"#,
+            r#""\q"["a"]"#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { "" like "\q" };"#,
+            r#""\q""#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { {}["\q"] };"#,
+            r#""\q""#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { {"\q": 0} };"#,
+            r#""\q""#,
+        );
+        assert_invalid_escape(
+            r#"permit(principal, action, resource) when { User::"\q" };"#,
+            r#"User::"\q""#,
+        );
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn expect_action_error(test: &str, euid_strs: Vec<&str>) {
+    fn expect_action_error(test: &str, euid_strs: Vec<&str>, underlines: Vec<&str>) {
         let euids = euid_strs
             .iter()
             .map(|euid_str| {
@@ -3999,14 +4025,13 @@ mod tests {
                 es.len(),
                 miette::Report::new(es)
             );
-            for euid in euids {
+            for (euid, underline) in euids.into_iter().zip(underlines.into_iter()) {
                 expect_some_error_matches(
                     test,
                     &es,
-                    &ExpectedErrorMessage::error_and_help(
-                        &format!("expected an entity uid with the type `Action` but got `{euid}`"),
+                    &ExpectedErrorMessageBuilder::error(&format!("expected an entity uid with the type `Action` but got `{euid}`")).help(
                         "action entities must have type `Action`, optionally in a namespace",
-                    ),
+                    ).exactly_one_underline(underline).build(),
                 );
             }
         });
@@ -4043,30 +4068,37 @@ mod tests {
         expect_action_error(
             r#"permit(principal, action == Foo::"view", resource);"#,
             vec!["Foo::\"view\""],
+            vec!["action == Foo::\"view\""], // TODO: don't underline the `action ==` part
         );
         expect_action_error(
             r#"permit(principal, action == Action::Foo::"view", resource);"#,
             vec!["Action::Foo::\"view\""],
+            vec!["action == Action::Foo::\"view\""], // TODO: don't underline the `action ==` part
         );
         expect_action_error(
             r#"permit(principal, action == Bar::Action::Foo::"view", resource);"#,
             vec!["Bar::Action::Foo::\"view\""],
+            vec!["action == Bar::Action::Foo::\"view\""], // TODO: don't underline the `action ==` part
         );
         expect_action_error(
             r#"permit(principal, action in Bar::Action::Foo::"view", resource);"#,
             vec!["Bar::Action::Foo::\"view\""],
+            vec!["action in Bar::Action::Foo::\"view\""], // TODO: don't underline the `action in` part
         );
         expect_action_error(
             r#"permit(principal, action in [Bar::Action::Foo::"view"], resource);"#,
             vec!["Bar::Action::Foo::\"view\""],
+            vec!["action in [Bar::Action::Foo::\"view\"]"], // TODO: don't underline the `action in` part
         );
         expect_action_error(
             r#"permit(principal, action in [Bar::Action::Foo::"view", Action::"check"], resource);"#,
             vec!["Bar::Action::Foo::\"view\""],
+            vec!["action in [Bar::Action::Foo::\"view\", Action::\"check\"]"], // TODO: don't underline the `action in` part
         );
         expect_action_error(
             r#"permit(principal, action in [Bar::Action::Foo::"view", Foo::"delete", Action::"check"], resource);"#,
             vec!["Bar::Action::Foo::\"view\"", "Foo::\"delete\""],
+            vec!["action in [Bar::Action::Foo::\"view\", Foo::\"delete\", Action::\"check\"]"], // TODO: don't underline the `action in` part
         );
     }
 
@@ -4075,10 +4107,11 @@ mod tests {
         let src = r#"permit(principal, action, resource)
             when { contains(true) < 1 };"#;
         assert_matches!(parse_policyset(src), Err(e) => {
-            expect_some_error_matches(src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_some_error_matches(src, &e, &ExpectedErrorMessageBuilder::error(
                 "`contains` is a method, not a function",
+            ).help(
                 "use a method-style call: `e.contains(..)`",
-            ));
+            ).exactly_one_underline("contains(true)").build());
         });
     }
 
@@ -4288,10 +4321,12 @@ mod tests {
         for (es, em) in [
             (
                 "-9223372036854775809",
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "integer literal `9223372036854775809` is too large",
-                    "maximum allowed integer literal is `9223372036854775807`",
-                ),
+                )
+                .help("maximum allowed integer literal is `9223372036854775807`")
+                .exactly_one_underline("-9223372036854775809")
+                .build(),
             ),
             // This test doesn't fail with an internal representation of i128:
             // Contrary to Rust, this expression is not valid because the
@@ -4299,10 +4334,12 @@ mod tests {
             // (9223372036854775808) is too large.
             (
                 "-(9223372036854775808)",
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "integer literal `9223372036854775808` is too large",
-                    "maximum allowed integer literal is `9223372036854775807`",
-                ),
+                )
+                .help("maximum allowed integer literal is `9223372036854775807`")
+                .exactly_one_underline("9223372036854775808")
+                .build(),
             ),
         ] {
             let mut errs = ParseErrors::new();
@@ -4310,7 +4347,7 @@ mod tests {
                 .expect("should construct a CST")
                 .to_expr(&mut errs);
             assert_matches!(e, None => {
-                expect_err(es, &errs, &em);
+                expect_err(es, &miette::Report::new(errs), &em);
             });
         }
     }
@@ -4588,207 +4625,228 @@ mod tests {
         let invalid_is_policies = [
             (
                 r#"permit(principal in Group::"friends" is User, action, resource);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found an `is` expression"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found an `is` expression").exactly_one_underline(r#"Group::"friends" is User"#).build(),
             ),
             (
                 r#"permit(principal, action, resource in Folder::"folder" is File);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found an `is` expression"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found an `is` expression").exactly_one_underline(r#"Folder::"folder" is File"#).build(),
             ),
             (
                 r#"permit(principal is User == User::"Alice", action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the scope at the same time as `==`",
+                ).help(
                     "try moving `is` into a `when` condition"
-                ),
+                ).exactly_one_underline("principal is User == User::\"Alice\"").build(),
             ),
             (
                 r#"permit(principal, action, resource is Doc == Doc::"a");"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the scope at the same time as `==`",
+                ).help(
                     "try moving `is` into a `when` condition"
-                ),
+                ).exactly_one_underline("resource is Doc == Doc::\"a\"").build(),
             ),
             (
                 r#"permit(principal is User::"alice", action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"alice"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("User::\"alice\"").build(),
             ),
             (
                 r#"permit(principal, action, resource is File::"f");"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `File::"f"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("File::\"f\"").build(),
             ),
             (
                 r#"permit(principal is User in 1, action, resource);"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found literal `1`",
-                ),
+                ).exactly_one_underline("1").build(),
             ),
             (
                 r#"permit(principal, action, resource is File in 1);"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found literal `1`",
-                ),
+                ).exactly_one_underline("1").build(),
             ),
             (
                 r#"permit(principal is User in User, action, resource);"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found name `User`",
-                ),
+                ).exactly_one_underline("User").build(),
             ),
             (
                 r#"permit(principal is User::"Alice" in Group::"f", action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"Alice"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("User::\"Alice\"").build(),
             ),
             (
                 r#"permit(principal, action, resource is File in File);"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found name `File`",
-                ),
+                ).exactly_one_underline("File").build(),
             ),
             (
                 r#"permit(principal, action, resource is File::"file" in Folder::"folder");"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `File::"file"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("File::\"file\"").build(),
             ),
             (
                 r#"permit(principal is 1, action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `1`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("1").build(),
             ),
             (
                 r#"permit(principal, action, resource is 1);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `1`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("1").build(),
             ),
             (
                 r#"permit(principal, action is Action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is Action").build(),
             ),
             (
                 r#"permit(principal, action is Action::"a", resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is Action::\"a\"").build(),
             ),
             (
                 r#"permit(principal, action is Action in Action::"A", resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is Action in Action::\"A\"").build(),
             ),
             (
                 r#"permit(principal, action is Action in Action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is Action in Action").build(),
             ),
             (
                 r#"permit(principal, action is Action::"a" in Action::"b", resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is Action::\"a\" in Action::\"b\"").build(),
             ),
             (
                 r#"permit(principal, action is Action in ?action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is Action in ?action").build(),
             ),
             (
                 r#"permit(principal, action is ?action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`is` cannot appear in the action scope",
+                ).help(
                     "try moving `action is ..` into a `when` condition"
-                ),
+                ).exactly_one_underline("action is ?action").build(),
             ),
             (
                 r#"permit(principal is User in ?resource, action, resource);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?resource instead of ?principal"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?resource instead of ?principal").exactly_one_underline("?resource").build(),
             ),
             (
                 r#"permit(principal, action, resource is Folder in ?principal);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?principal instead of ?resource"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?principal instead of ?resource").exactly_one_underline("?principal").build(),
             ),
             (
                 r#"permit(principal is ?principal, action, resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "right hand side of an `is` expression must be an entity type name, but got `?principal`",
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("?principal").build(),
             ),
             (
                 r#"permit(principal, action, resource is ?resource);"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "right hand side of an `is` expression must be an entity type name, but got `?resource`",
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("?resource").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is 1 };"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `1`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("1").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is User::"alice" in Group::"friends" };"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"alice"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("User::\"alice\"").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is ! User::"alice" in Group::"friends" };"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `!User::"alice"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("! User::\"alice\"").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is User::"alice" + User::"alice" in Group::"friends" };"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     r#"right hand side of an `is` expression must be an entity type name, but got `User::"alice" + User::"alice"`"#,
+                ).help(
                     "try using `==` to test for equality"
-                ),
+                ).exactly_one_underline("User::\"alice\" + User::\"alice\"").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is User in User::"alice" in Group::"friends" };"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "unexpected token `in`"
-                ),
+                ).exactly_one_underline("in").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal is User == User::"alice" in Group::"friends" };"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "unexpected token `==`"
-                ),
+                ).exactly_one_underline("==").build(),
             ),
         ];
         for (p_src, expected) in invalid_is_policies {
             assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-                expect_err(p_src, &e, &expected);
+                expect_err(p_src, &miette::Report::new(e), &expected);
             });
         }
     }
@@ -4805,10 +4863,11 @@ mod tests {
         assert_matches!(
             parse_policy(None, policy),
             Err(e) => {
-                expect_some_error_matches(policy, &e, &ExpectedErrorMessage::error_and_help(
+                expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found a `+/-` expression",
+                ).help(
                     "entity types and namespaces cannot use `+` or `-` characters -- perhaps try `_` or `::` instead?",
-                ));
+                ).exactly_one_underline("name-with-dashes::\"Alice\"").build());
             }
         );
     }
@@ -4818,92 +4877,112 @@ mod tests {
         let invalid_exprs = [
             (
                 r#"contains([], 1)"#,
-                ExpectedErrorMessage::error_and_help(
-                    "`contains` is a method, not a function",
-                    "use a method-style call: `e.contains(..)`",
-                ),
+                ExpectedErrorMessageBuilder::error("`contains` is a method, not a function")
+                    .help("use a method-style call: `e.contains(..)`")
+                    .exactly_one_underline("contains([], 1)")
+                    .build(),
             ),
             (
                 r#"[].contains()"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "call to `contains` requires exactly 1 argument, but got 0 arguments",
-                ),
+                )
+                .exactly_one_underline("[].contains()")
+                .build(),
             ),
             (
                 r#"[].contains(1, 2)"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "call to `contains` requires exactly 1 argument, but got 2 arguments",
-                ),
+                )
+                .exactly_one_underline("[].contains(1, 2)")
+                .build(),
             ),
             (
                 r#"[].containsAll()"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "call to `containsAll` requires exactly 1 argument, but got 0 arguments",
-                ),
+                )
+                .exactly_one_underline("[].containsAll()")
+                .build(),
             ),
             (
                 r#"[].containsAll(1, 2)"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "call to `containsAll` requires exactly 1 argument, but got 2 arguments",
-                ),
+                )
+                .exactly_one_underline("[].containsAll(1, 2)")
+                .build(),
             ),
             (
                 r#"[].containsAny()"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "call to `containsAny` requires exactly 1 argument, but got 0 arguments",
-                ),
+                )
+                .exactly_one_underline("[].containsAny()")
+                .build(),
             ),
             (
                 r#"[].containsAny(1, 2)"#,
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "call to `containsAny` requires exactly 1 argument, but got 2 arguments",
-                ),
+                )
+                .exactly_one_underline("[].containsAny(1, 2)")
+                .build(),
             ),
             (
                 r#""1.1.1.1".ip()"#,
-                ExpectedErrorMessage::error_and_help(
-                    "`ip` is a function, not a method",
-                    "use a function-style call: `ip(..)`",
-                ),
+                ExpectedErrorMessageBuilder::error("`ip` is a function, not a method")
+                    .help("use a function-style call: `ip(..)`")
+                    .exactly_one_underline(r#""1.1.1.1".ip()"#)
+                    .build(),
             ),
             (
                 r#"greaterThan(1, 2)"#,
-                ExpectedErrorMessage::error_and_help(
-                    "`greaterThan` is a method, not a function",
-                    "use a method-style call: `e.greaterThan(..)`",
-                ),
+                ExpectedErrorMessageBuilder::error("`greaterThan` is a method, not a function")
+                    .help("use a method-style call: `e.greaterThan(..)`")
+                    .exactly_one_underline("greaterThan(1, 2)")
+                    .build(),
             ),
             (
                 "[].bar()",
-                ExpectedErrorMessage::error("not a valid method name: `bar`"),
+                ExpectedErrorMessageBuilder::error("not a valid method name: `bar`")
+                    .exactly_one_underline("[].bar()")
+                    .build(),
             ),
             (
                 "bar([])",
-                ExpectedErrorMessage::error("`bar` is not a function"),
+                ExpectedErrorMessageBuilder::error("`bar` is not a function")
+                    .exactly_one_underline("bar([])")
+                    .build(),
             ),
             (
                 "principal()",
-                ExpectedErrorMessage::error_and_help(
-                    "`principal(...)` is not a valid function call",
-                    "variables cannot be called as functions",
-                ),
+                ExpectedErrorMessageBuilder::error("`principal(...)` is not a valid function call")
+                    .help("variables cannot be called as functions")
+                    .exactly_one_underline("principal()")
+                    .build(),
             ),
             (
                 "(1+1)()",
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "function calls must be of the form: `<name>(arg1, arg2, ...)`",
-                ),
+                )
+                .exactly_one_underline("(1+1)()")
+                .build(),
             ),
             (
                 "foo.bar()",
-                ExpectedErrorMessage::error(
+                ExpectedErrorMessageBuilder::error(
                     "attempted to call `foo.bar`, but `foo` does not have any methods",
-                ),
+                )
+                .exactly_one_underline("foo.bar()")
+                .build(),
             ),
         ];
         for (src, expected) in invalid_exprs {
             assert_matches!(parse_expr(src), Err(e) => {
-                expect_err(src, &e, &expected);
+                expect_err(src, &miette::Report::new(e), &expected);
             });
         }
     }
@@ -4913,82 +4992,83 @@ mod tests {
         let invalid_policies = [
             (
                 r#"permit(principal == ?resource, action, resource);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?resource instead of ?principal"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?resource instead of ?principal").exactly_one_underline("?resource").build(),
             ),
             (
                 r#"permit(principal in ?resource, action, resource);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?resource instead of ?principal"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?resource instead of ?principal").exactly_one_underline("?resource").build(),
             ),
             (
                 r#"permit(principal == ?foo, action, resource);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?foo instead of ?principal"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?foo instead of ?principal").exactly_one_underline("?foo").build(),
             ),
             (
                 r#"permit(principal in ?foo, action, resource);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?foo instead of ?principal"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?foo instead of ?principal").exactly_one_underline("?foo").build(),
             ),
 
             (
                 r#"permit(principal, action, resource == ?principal);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?principal instead of ?resource"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?principal instead of ?resource").exactly_one_underline("?principal").build(),
             ),
             (
                 r#"permit(principal, action, resource in ?principal);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?principal instead of ?resource"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?principal instead of ?resource").exactly_one_underline("?principal").build(),
             ),
             (
                 r#"permit(principal, action, resource == ?baz);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?baz instead of ?resource"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?baz instead of ?resource").exactly_one_underline("?baz").build(),
             ),
             (
                 r#"permit(principal, action, resource in ?baz);"#,
-                ExpectedErrorMessage::error("expected an entity uid or matching template slot, found ?baz instead of ?resource"),
+                ExpectedErrorMessageBuilder::error("expected an entity uid or matching template slot, found ?baz instead of ?resource").exactly_one_underline("?baz").build(),
             ),
             (
                 r#"permit(principal, action, resource) when { principal == ?foo};"#,
-                ExpectedErrorMessage::error_and_help(
+                ExpectedErrorMessageBuilder::error(
                     "`?foo` is not a valid template slot",
+                ).help(
                     "a template slot may only be `?principal` or `?resource`",
-                )
+                ).exactly_one_underline("?foo").build(),
             ),
 
             (
                 r#"permit(principal, action == ?action, resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid or set of entity uids, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid or set of entity uids, got: template slot").exactly_one_underline("?action").build(),
             ),
             (
                 r#"permit(principal, action in ?action, resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid or set of entity uids, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid or set of entity uids, got: template slot").exactly_one_underline("?action").build(),
             ),
             (
                 r#"permit(principal, action == ?principal, resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid or set of entity uids, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid or set of entity uids, got: template slot").exactly_one_underline("?principal").build(),
             ),
             (
                 r#"permit(principal, action in ?principal, resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid or set of entity uids, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid or set of entity uids, got: template slot").exactly_one_underline("?principal").build(),
             ),
             (
                 r#"permit(principal, action == ?resource, resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid or set of entity uids, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid or set of entity uids, got: template slot").exactly_one_underline("?resource").build(),
             ),
             (
                 r#"permit(principal, action in ?resource, resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid or set of entity uids, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid or set of entity uids, got: template slot").exactly_one_underline("?resource").build(),
             ),
             (
                 r#"permit(principal, action in [?bar], resource);"#,
-                ExpectedErrorMessage::error("expected single entity uid, got: template slot"),
+                ExpectedErrorMessageBuilder::error("expected single entity uid, got: template slot").exactly_one_underline("?bar").build(),
             ),
         ];
 
         for (p_src, expected) in invalid_policies {
             assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-                expect_err(p_src, &e, &expected);
+                expect_err(p_src, &miette::Report::new(e), &expected);
             });
             let forbid_src = format!("forbid{}", &p_src[6..]);
             assert_matches!(parse_policy_template(None, &forbid_src), Err(e) => {
-                expect_err(forbid_src.as_str(), &e, &expected);
+                expect_err(forbid_src.as_str(), &miette::Report::new(e), &expected);
             });
         }
     }
@@ -4997,15 +5077,15 @@ mod tests {
     fn missing_scope_constraint() {
         let p_src = "permit();";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("this policy is missing the `principal` variable in the scope"));
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("this policy is missing the `principal` variable in the scope").exactly_one_underline("").build());
         });
         let p_src = "permit(principal);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("this policy is missing the `action` variable in the scope"));
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("this policy is missing the `action` variable in the scope").exactly_one_underline("").build());
         });
         let p_src = "permit(principal, action);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("this policy is missing the `resource` variable in the scope"));
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("this policy is missing the `resource` variable in the scope").exactly_one_underline("").build());
         });
     }
 
@@ -5013,68 +5093,67 @@ mod tests {
     fn invalid_scope_constraint() {
         let p_src = "permit(foo, action, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected a variable that is valid in the policy scope; found: `foo`",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "foo");
+            ).exactly_one_underline("foo").build());
         });
         let p_src = "permit(foo::principal, action, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "unexpected token `::`",
-            ));
-            expect_source_snippet(p_src, &e, "::");
+            ).exactly_one_underline("::").build());
         });
         let p_src = "permit(resource, action, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "found the variable `resource` where the variable `principal` must be used",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "resource");
+            ).exactly_one_underline("resource").build());
         });
 
         let p_src = "permit(principal, principal, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "found the variable `principal` where the variable `action` must be used",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "principal");
+            ).exactly_one_underline("principal").build());
         });
         let p_src = "permit(principal, if, resource);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected a variable that is valid in the policy scope; found: `if`",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "if");
+            ).exactly_one_underline("if").build());
         });
 
         let p_src = "permit(principal, action, like);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected a variable that is valid in the policy scope; found: `like`",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "like");
+            ).exactly_one_underline("like").build());
         });
         let p_src = "permit(principal, action, principal);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "found the variable `principal` where the variable `resource` must be used",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "principal");
+            ).exactly_one_underline("principal").build());
         });
         let p_src = "permit(principal, action, action);";
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "found the variable `action` where the variable `resource` must be used",
+                ).help(
                 "policy scopes must contain a `principal`, `action`, and `resource` element in that order",
-            ));
-            expect_source_snippet(p_src, &e, "action");
+            ).exactly_one_underline("action").build());
         });
     }
 
@@ -5082,31 +5161,35 @@ mod tests {
     fn invalid_scope_operator() {
         let p_src = r#"permit(principal > User::"alice", action, resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "not a valid policy scope constraint: >",
+                ).help(
                 "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
-            ));
+            ).exactly_one_underline("principal > User::\"alice\"").build());
         });
         let p_src = r#"permit(principal, action != Action::"view", resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "not a valid policy scope constraint: !=",
+                ).help(
                 "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
-            ));
+            ).exactly_one_underline("action != Action::\"view\"").build());
         });
         let p_src = r#"permit(principal, action, resource <= Folder::"things");"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "not a valid policy scope constraint: <=",
+                ).help(
                 "policy scope constraints must be either `==`, `in`, `is`, or `_ is _ in _`"
-            ));
+            ).exactly_one_underline("resource <= Folder::\"things\"").build());
         });
         let p_src = r#"permit(principal = User::"alice", action, resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "'=' is not a valid operator in Cedar",
+                ).help(
                 "try using '==' instead",
-            ));
+            ).exactly_one_underline("principal = User::\"alice\"").build());
         });
     }
 
@@ -5114,7 +5197,7 @@ mod tests {
     fn scope_action_eq_set() {
         let p_src = r#"permit(principal, action == [Action::"view", Action::"edit"], resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("the right hand side of equality in the policy scope must be a single entity uid or a template slot"));
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("the right hand side of equality in the policy scope must be a single entity uid or a template slot").exactly_one_underline(r#"[Action::"view", Action::"edit"]"#).build());
         });
     }
 
@@ -5122,7 +5205,7 @@ mod tests {
     fn scope_action_in_set_set() {
         let p_src = r#"permit(principal, action in [[Action::"view"]], resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
-            expect_err(p_src, &e, &ExpectedErrorMessage::error("expected single entity uid, got: set of entity uids"));
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("expected single entity uid, got: set of entity uids").exactly_one_underline(r#"[Action::"view"]"#).build());
         });
     }
 
@@ -5130,11 +5213,11 @@ mod tests {
     fn unsupported_ops() {
         let src = "1/2";
         assert_matches!(parse_expr(src), Err(e) => {
-            expect_err(src, &e, &ExpectedErrorMessage::error("division is not supported"));
+            expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("division is not supported").exactly_one_underline("1/2").build());
         });
         let src = "7 % 3";
         assert_matches!(parse_expr(src), Err(e) => {
-            expect_err(src, &e, &ExpectedErrorMessage::error("remainder/modulo is not supported"));
+            expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("remainder/modulo is not supported").exactly_one_underline("7 % 3").build());
         });
     }
 
@@ -5142,17 +5225,19 @@ mod tests {
     fn over_unary() {
         let src = "!!!!!!false";
         assert_matches!(parse_expr(src), Err(e) => {
-            expect_err(src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "too many occurrences of `!_`",
+                ).help(
                 "cannot chain more the 4 applications of a unary operator"
-            ));
+            ).exactly_one_underline("!!!!!!false").build());
         });
         let src = "-------0";
         assert_matches!(parse_expr(src), Err(e) => {
-            expect_err(src, &e, &ExpectedErrorMessage::error_and_help(
+            expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "too many occurrences of `-_`",
+                ).help(
                 "cannot chain more the 4 applications of a unary operator"
-            ));
+            ).exactly_one_underline("-------0").build());
         });
     }
 
@@ -5161,10 +5246,11 @@ mod tests {
         #[track_caller]
         fn expect_arbitrary_var(name: &str) {
             assert_matches!(parse_expr(name), Err(e) => {
-                expect_err(name, &e, &ExpectedErrorMessage::error_and_help(
+                expect_err(name, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                     "arbitrary variables are not supported; the valid Cedar variables are `principal`, `action`, `resource`, and `context`",
+                ).help(
                     &format!("did you mean to enclose `{name}` in quotes to make a string?"),
-                ));
+                ).exactly_one_underline(name).build());
             })
         }
         expect_arbitrary_var("foo::principal");
@@ -5186,9 +5272,9 @@ mod tests {
         #[track_caller]
         fn expect_empty_clause(policy: &str, clause: &str) {
             assert_matches!(parse_policy_template(None, policy), Err(e) => {
-                expect_err(policy, &e, &ExpectedErrorMessage::error(
+                expect_err(policy, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                     &format!("`{clause}` condition clause cannot be empty")
-                ));
+                ).exactly_one_underline(&format!("{clause} {{}}")).build());
             })
         }
 
@@ -5217,9 +5303,9 @@ mod tests {
         #[track_caller]
         fn expect_namespaced_attr(expr: &str, name: &str) {
             assert_matches!(parse_expr(expr), Err(e) => {
-                expect_err(expr, &e, &ExpectedErrorMessage::error(
+                expect_err(expr, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                     &format!("`{name}` cannot be used as an attribute as it contains a namespace")
-                ));
+                ).exactly_one_underline(name).build());
             })
         }
 
@@ -5230,9 +5316,9 @@ mod tests {
 
         let expr = "principal has if::foo";
         assert_matches!(parse_expr(expr), Err(e) => {
-            expect_err(expr, &e, &ExpectedErrorMessage::error(
+            expect_err(expr, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "this identifier is reserved and cannot be used: `if`"
-            ));
+            ).exactly_one_underline("if").build());
         })
     }
 
@@ -5241,9 +5327,9 @@ mod tests {
         #[track_caller]
         fn expect_reserved_ident(name: &str, reserved: &str) {
             assert_matches!(parse_expr(name), Err(e) => {
-                expect_err(name, &e, &ExpectedErrorMessage::error(
+                expect_err(name, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                     &format!("this identifier is reserved and cannot be used: `{reserved}`"),
-                ));
+                ).exactly_one_underline(reserved).build());
             })
         }
         expect_reserved_ident("if::principal", "if");

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -11,61 +11,234 @@ pub struct ExpectedErrorMessage<'a> {
     /// actual error message and help text to have additional characters after
     /// the ones that are expected.
     prefix: bool,
+    /// Expected text that is underlined by miette (text found at the error's
+    /// source location(s)).
+    /// If this is an empty vec, we expect the error to have no associated
+    /// source location.
+    /// If this is a vec with one or more elements, we expect the same number of
+    /// miette `labels` in the same order, and the vec elements represent the
+    /// expected contents of the labels.
+    underlines: Vec<&'a str>,
 }
 
-impl<'a> ExpectedErrorMessage<'a> {
-    /// Expect the given exact error message and no help text.
+/// Builder struct for [`ExpectedErrorMessage`]
+pub struct ExpectedErrorMessageBuilder<'a> {
+    /// ExpectedErrorMessage::error
+    error: &'a str,
+    /// ExpectedErrorMessage::help
+    help: Option<&'a str>,
+    /// ExpectedErrorMessage::prefix
+    prefix: bool,
+    /// ExpectedErrorMessage::underlines
+    underlines: Vec<&'a str>,
+}
+
+impl<'a> ExpectedErrorMessageBuilder<'a> {
+    /// Create a builder expecting the given main error message (contents of
+    /// `Display`)
     pub fn error(msg: &'a str) -> Self {
         Self {
             error: msg,
             help: None,
             prefix: false,
+            underlines: vec![],
         }
     }
 
-    /// Expect the given exact error message and help text.
-    pub fn error_and_help(error: &'a str, help: &'a str) -> Self {
-        Self {
-            error,
-            help: Some(help),
-            prefix: false,
-        }
-    }
-
-    /// Expect the error message to start with the given text, and expect no help text.
+    /// Create a builder expecting the main error message (contents of
+    /// `Display`) to _start with_ the given text.
+    ///
+    /// (If you later add expected help text to this builder, that will
+    /// also be an expected prefix, not the entire expected help text.)
     pub fn error_starts_with(msg: &'a str) -> Self {
         Self {
             error: msg,
             help: None,
             prefix: true,
+            underlines: vec![],
         }
     }
 
-    /// Expected the error message and help text to start with the given text respectively.
-    #[allow(dead_code)] // not currently used as of this writing, but included for completeness
-    pub fn error_and_help_start_with(error: &'a str, help: &'a str) -> Self {
+    /// Add expected contents of `help()`, or expected prefix of `help()` if
+    /// this builder was originally constructed with `error_starts_with()`
+    pub fn help(self, msg: &'a str) -> Self {
         Self {
-            error,
-            help: Some(help),
-            prefix: true,
+            help: Some(msg),
+            ..self
         }
     }
 
+    /// Add expected underlined text. The error message will be expected to have
+    /// exactly one miette label, and the underlined portion should be this text.
+    pub fn exactly_one_underline(self, snippet: &'a str) -> Self {
+        Self {
+            underlines: vec![snippet],
+            ..self
+        }
+    }
+
+    /// Build the [`ExpectedErrorMessage`]
+    pub fn build(self) -> ExpectedErrorMessage<'a> {
+        ExpectedErrorMessage {
+            error: self.error,
+            help: self.help,
+            prefix: self.prefix,
+            underlines: self.underlines,
+        }
+    }
+}
+
+impl<'a> ExpectedErrorMessage<'a> {
     /// Return a boolean indicating whether a given error matches this expected message.
     /// (If you want to assert that it matches, use [`expect_err()`] instead,
     /// for much better assertion-failure messages.)
-    pub fn matches(&self, error: &impl miette::Diagnostic) -> bool {
+    ///
+    /// `src` is the full source text (which the miette labels index into).
+    /// It can be omitted only in the case where we expect no underlines.
+    /// Panics if this invariant is violated.
+    pub fn matches(&self, src: Option<&'a str>, error: &impl miette::Diagnostic) -> bool {
+        self.matches_error(error) && self.matches_help(error) && self.matches_underlines(src, error)
+    }
+
+    /// Internal helper: whether the main error message matches
+    fn matches_error(&self, error: &impl miette::Diagnostic) -> bool {
         let e_string = error.to_string();
-        let h_string = error.help().map(|h| h.to_string());
         if self.prefix {
             e_string.starts_with(self.error)
-                && match (h_string.as_deref(), self.help) {
-                    (Some(actual), Some(expected)) => actual.starts_with(expected),
-                    (None, None) => true,
-                    _ => false,
-                }
         } else {
-            e_string == self.error && h_string.as_deref() == self.help
+            e_string == self.error
+        }
+    }
+
+    /// Internal helper: assert the main error message matches
+    #[track_caller]
+    fn expect_error_matches(&self, src: impl Into<OriginalInput<'a>>, error: &miette::Report) {
+        let e_string = error.to_string();
+        if self.prefix {
+            assert!(
+                e_string.starts_with(self.error),
+                "for the following input:\n{}\nfor the following error:\n{error:?}\n\nactual error did not start with the expected prefix\n  actual error: {error}\n  expected prefix: {}", // the Debug representation of miette::Report is the pretty one
+                src.into(),
+                self.error,
+            );
+        } else {
+            assert_eq!(
+                &e_string,
+                self.error,
+                "for the following input:\n{}\nfor the following error:\n{error:?}\n\nactual error did not match expected", // assert_eq! will print the actual and expected messages
+                src.into(),
+            );
+        }
+    }
+
+    /// Internal helper: whether the help message matches
+    fn matches_help(&self, error: &impl miette::Diagnostic) -> bool {
+        let h_string = error.help().map(|h| h.to_string());
+        if self.prefix {
+            match (h_string.as_deref(), self.help) {
+                (Some(actual), Some(expected)) => actual.starts_with(expected),
+                (None, None) => true,
+                _ => false,
+            }
+        } else {
+            h_string.as_deref() == self.help
+        }
+    }
+
+    /// Internal helper: assert the help message matches
+    #[track_caller]
+    fn expect_help_matches(&self, src: impl Into<OriginalInput<'a>>, error: &miette::Report) {
+        let h_string = error.help().map(|h| h.to_string());
+        if self.prefix {
+            match (h_string.as_deref(), &self.help) {
+                (Some(actual), Some(expected)) => {
+                    assert!(
+                        actual.starts_with(expected),
+                        "for the following input:\n{}\nfor the following error:\n{error:?}\n\nactual help did not start with the expected prefix\n  actual help: {actual}\n  expected help: {expected}", // the Debug representation of miette::Report is the pretty one
+                        src.into(),
+                    )
+                }
+                (None, None) => (),
+                (Some(actual), None) => panic!(
+                    "for the following input:\n{}\nfor the following error:\n{error:?}\n\ndid not expect a help message, but found one: {actual}", // the Debug representation of miette::Report is the pretty one
+                    src.into(),
+                ),
+                (None, Some(expected)) => panic!(
+                    "for the following input:\n{}\nfor the following error:\n{error:?}\n\ndid not find a help message, but expected one: {expected}", // the Debug representation of miette::Report is the pretty one
+                    src.into(),
+                ),
+            }
+        } else {
+            assert_eq!(
+                h_string.as_deref(),
+                self.help,
+                "for the following input:\n{}\nfor the following error:\n{error:?}\n\nactual help did not match expected", // assert_eq! will print the actual and expected messages
+                src.into(),
+            );
+        }
+    }
+
+    /// Internal helper: whether the underlines match
+    ///
+    /// `src` is the full source text (which the miette labels index into).
+    /// It can be omitted only in the case where we expect no underlines.
+    /// Panics if this invariant is violated.
+    fn matches_underlines(&self, src: Option<&'a str>, err: &impl miette::Diagnostic) -> bool {
+        let expected_num_labels = self.underlines.len();
+        let actual_num_labels = err.labels().map(|iter| iter.count()).unwrap_or(0);
+        if expected_num_labels != actual_num_labels {
+            return false;
+        }
+        if expected_num_labels == 0 {
+            true
+        } else {
+            let src =
+                src.expect("src can be `None` only in the case where we expect no underlines");
+            for (expected, actual) in self
+                .underlines
+                .iter()
+                .zip(err.labels().unwrap_or_else(|| Box::new(std::iter::empty())))
+            {
+                let actual_snippet = {
+                    let span = actual.inner();
+                    &src[span.offset()..span.offset() + span.len()]
+                };
+                if expected != &actual_snippet {
+                    return false;
+                }
+            }
+            true
+        }
+    }
+
+    /// Internal helper: assert the underlines match
+    ///
+    /// `src` is the full source text (which the miette labels index into).
+    /// It can be omitted only in the case where we expect no underlines.
+    /// Panics if this invariant is violated.
+    #[track_caller]
+    fn expect_underlines_match(&self, src: Option<&'a str>, err: &miette::Report) {
+        let expected_num_labels = self.underlines.len();
+        let actual_num_labels = err.labels().map(|iter| iter.count()).unwrap_or(0);
+        assert_eq!(expected_num_labels, actual_num_labels, "in the following error:\n{err:?}\n\nexpected {expected_num_labels} underlines but found {actual_num_labels}"); // the Debug representation of miette::Report is the pretty one
+        if expected_num_labels != 0 {
+            let src =
+                src.expect("src can be `None` only in the case where we expect no underlines");
+            for (expected, actual) in self
+                .underlines
+                .iter()
+                .zip(err.labels().unwrap_or_else(|| Box::new(std::iter::empty())))
+            {
+                let actual_snippet = {
+                    let span = actual.inner();
+                    &src[span.offset()..span.offset() + span.len()]
+                };
+                assert_eq!(
+                    expected,
+                    &actual_snippet,
+                    "in the following error:\n{err:?}\n\nexpected underlined portion to be:\n  {expected}\nbut it was:\n  {actual_snippet}", // the Debug representation of miette::Report is the pretty one
+                );
+            }
         }
     }
 }
@@ -83,6 +256,14 @@ impl<'a> std::fmt::Display for ExpectedErrorMessage<'a> {
             match self.help {
                 Some(help) => writeln!(f, "expected help: {help}")?,
                 None => writeln!(f, "  with no help message")?,
+            }
+        }
+        if self.underlines.is_empty() {
+            writeln!(f, "and expected no source locations / underlined segments.")?;
+        } else {
+            writeln!(f, "and expected the following underlined segments:")?;
+            for underline in &self.underlines {
+                writeln!(f, "  {underline}")?;
             }
         }
         Ok(())
@@ -127,82 +308,24 @@ impl<'a> std::fmt::Display for OriginalInput<'a> {
 /// including `&str` and `&serde_json::Value`.
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub fn expect_err<'a>(
-    src: impl Into<OriginalInput<'a>>,
-    err: &impl miette::Diagnostic,
-    msg: &ExpectedErrorMessage<'_>,
+    src: impl Into<OriginalInput<'a>> + Copy,
+    err: &miette::Report,
+    msg: &ExpectedErrorMessage<'a>,
 ) {
-    let error = err.to_string();
-    let help = err.help().map(|h| h.to_string());
-    if msg.prefix {
-        assert!(
-            error.starts_with(msg.error),
-            "for the following input:\n{}\nactual error did not start with the expected prefix\n  actual error: {error}\n  expected prefix: {}", src.into(), msg.error,
-        );
-        match (help.as_deref(), &msg.help) {
-            (Some(actual), Some(expected)) => {
-                assert!(
-                    actual.starts_with(expected),
-                    "for the following input:\n{}\nactual help did not start with the expected prefix\n  actual help: {actual}\n  expected help: {expected}", src.into(),
-                )
-            }
-            (None, None) => (),
-            (Some(actual), None) => panic!(
-                "for the following input:\n{}\ndid not expect a help message, but found one: {actual}",
-                src.into()
-            ),
-            (None, Some(expected)) => panic!(
-                "for the following input:\n{}\ndid not find a help message, but expected one: {expected}",
-                src.into()
-            ),
-        }
+    msg.expect_error_matches(src, err);
+    msg.expect_help_matches(src, err);
+    if msg.underlines.is_empty() {
+        msg.expect_underlines_match(None, err);
     } else {
-        assert_eq!(
-            &error,
-            msg.error,
-            "for the following input:\n{}\nactual error did not match expected", // assert_eq! will print the actual and expected messages
-            src.into()
-        );
-        assert_eq!(
-            help.as_deref(),
-            msg.help,
-            "for the following input:\n{}\nactual help did not match expected", // assert_eq! will print the actual and expected messages
-            src.into()
-        );
+        match src.into() {
+            OriginalInput::String(s) => {
+                msg.expect_underlines_match(Some(s), err);
+            }
+            OriginalInput::Json(val) => {
+                // need to convert to string so we can compute the underlines
+                let src = serde_json::to_string_pretty(val).unwrap();
+                msg.expect_underlines_match(Some(&src), err);
+            }
+        }
     }
-}
-
-/// Expect that the given `err` has a (single) source location, where the
-/// contents of that source location are `snippet`.
-///
-/// `src` is the original input text, used both for assertion-failure messages
-/// but also as the source we assume the error's source location indexes into.
-#[track_caller]
-// PANIC SAFETY: testing
-#[allow(clippy::indexing_slicing)]
-pub fn expect_source_snippet(
-    src: impl AsRef<str>,
-    err: &impl miette::Diagnostic,
-    snippet: impl AsRef<str>,
-) {
-    use itertools::Itertools;
-    let src = src.as_ref();
-    let snippet = snippet.as_ref();
-    let labels = err.labels().unwrap_or_else(|| {
-        panic!("for the following input:\n{src}\ndid not find a source location, but expected one")
-    });
-    let label = labels.exactly_one().unwrap_or_else(|labels| {
-        panic!(
-            "for the following input:\n{src}\nexpected exactly one source location, but found {}",
-            labels.count(),
-        )
-    });
-    let actual_snippet = {
-        let span = label.inner();
-        &src[span.offset()..span.offset() + span.len()]
-    };
-    assert_eq!(
-        actual_snippet,
-        snippet,
-        "for the following input:\n{src}\nexpected source snippet to be:\n  {snippet}\nbut it was:\n  {actual_snippet}\n",
-    );
 }


### PR DESCRIPTION
## Description of changes

Tests the source location for all errors currently being tested via our `ExpectedErrorMessage` helpers.  This will make it easier to test, e.g., a fix for #736.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

