### PR TITLE
Update strict least-upper-bound and subtype to match Lean

### DIFF
--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -27,14 +27,18 @@ use cool_asserts::assert_matches;
 use serde_json::json;
 use std::str::FromStr;
 
-use cedar_policy_core::ast::{EntityType, EntityUID, Expr};
-
-use crate::{
-    types::{EffectSet, OpenTag, RequestEnv, Type},
-    IncompatibleTypes, SchemaFragment, TypeErrorKind, ValidationMode,
+use cedar_policy_core::{
+    ast::{EntityType, EntityUID, Expr, Policy, Template},
+    parser::parse_policy_template,
 };
 
-use super::test_utils::with_typechecker_from_schema;
+use crate::{
+    typecheck::test_utils::assert_policy_typecheck_fails,
+    types::{AttributeType, EffectSet, OpenTag, RequestEnv, Type},
+    IncompatibleTypes, SchemaFragment, TypeError, TypeErrorKind, ValidationMode,
+};
+
+use super::test_utils::{assert_typecheck_fails, with_typechecker_from_schema};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
@@ -678,4 +682,40 @@ fn true_false_set() {
             Type::set(Type::set(Type::set(Type::primitive_boolean()))),
         )
     })
+}
+
+#[test]
+fn qualified_record_attr() {
+    let (schema, _) = SchemaFragment::from_str_natural(
+        r#"action A appliesTo { context: {num_of_things?: Long } };"#,
+    )
+    .unwrap();
+    let p = parse_policy_template(
+        None,
+        "permit(principal, action, resource) when { context == {num_of_things: 1}};",
+    )
+    .unwrap();
+    assert_policy_typecheck_fails(
+        schema,
+        p.clone(),
+        vec![TypeError::incompatible_types(
+            "context == {num_of_things: 1}".parse().unwrap(),
+            [
+                Type::record_with_attributes(
+                    [(
+                        "num_of_things".into(),
+                        AttributeType::new(Type::primitive_long(), false),
+                    )],
+                    OpenTag::ClosedAttributes,
+                ),
+                Type::record_with_attributes(
+                    [(
+                        "num_of_things".into(),
+                        AttributeType::new(Type::primitive_long(), true),
+                    )],
+                    OpenTag::ClosedAttributes,
+                ),
+            ],
+        )],
+    );
 }

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -28,7 +28,7 @@ use serde_json::json;
 use std::str::FromStr;
 
 use cedar_policy_core::{
-    ast::{EntityType, EntityUID, Expr, Policy, Template},
+    ast::{EntityType, EntityUID, Expr},
     parser::parse_policy_template,
 };
 
@@ -38,7 +38,7 @@ use crate::{
     IncompatibleTypes, SchemaFragment, TypeError, TypeErrorKind, ValidationMode,
 };
 
-use super::test_utils::{assert_typecheck_fails, with_typechecker_from_schema};
+use super::test_utils::with_typechecker_from_schema;
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737)
 - Improved `Display` implementation for Cedar schemas, both JSON and human syntax. (#780)
 - Changed policy validation to reject comparisons and conditionals between
-  record type that differ in whether an attribute is required or optional.
+  record types that differ in whether an attribute is required or optional.
 
 ## [3.1.2] - 2024-03-29
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ValidationWarningKind::ImpossiblePolicy` so future improvements to Cedar
   typing precision will not result in breaking changes. (resolving #539)
 - Changed policy validation to reject comparisons and conditionals between
-  record type that differ in if an attribute is required or optional.
+  record type that differ in whether an attribute is required or optional.
 
 ## [3.1.2] - 2024-03-29
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated error `TypeErrorKind::ImpossiblePolicy` in favor of warning
   `ValidationWarningKind::ImpossiblePolicy` so future improvements to Cedar
   typing precision will not result in breaking changes. (resolving #539)
+- Changed policy validation to reject comparisons and conditionals between
+  record type that differ in if an attribute is required or optional.
 
 ## [3.1.2] - 2024-03-29
 


### PR DESCRIPTION
## Description of changes

Update strict least-upper-bound and subtype to match Lean

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

