### PR TITLE
Fix schema serialization

### DIFF
--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -17,42 +17,13 @@ jobs:
     outputs:
       branch_name: ${{ steps.get_branch_name.outputs.branch_name }}
 
-  cedar-drt:
-    name: CedarDRT
-    runs-on: ubuntu-latest
+  build-cedar-drt:
     needs: get-branch-name
-    strategy:
-      matrix:
-        toolchain:
-          - stable
-    steps:
-      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Install Lean
-        shell: bash
-        run: |
-            wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
-            bash elan-init.sh -y
-      - name: Checkout cedar-spec
-        uses: actions/checkout@v4
-        with:
-          repository: cedar-policy/cedar-spec
-          ref: ${{ needs.get-branch-name.outputs.branch_name }}
-          path: ./cedar-spec
-      - name: checkout cedar
-        uses: actions/checkout@v4
-        with:
-          path: cedar-spec/cedar
-      - name: build cedar-lean
-        working-directory: cedar-spec/cedar-lean
-        shell: bash
-        run: source ~/.profile && lake build Cedar:static DiffTest:static Std:static
-      - name: build cedar-drt
-        working-directory: cedar-spec/cedar-drt
-        run: source ~/.profile && source ./set_env_vars.sh && RUSTFLAGS="-D warnings" cargo build
-      - name: build cedar-drt/fuzz
-        working-directory: cedar-spec/cedar-drt/fuzz
-        run: source ~/.profile && source ../set_env_vars.sh && RUSTFLAGS="--cfg=fuzzing -D warnings" cargo build
-
+    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_drt_reusable.yml@main
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_spec_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+          
   cedar-java:
     name: CedarJava
     runs-on: ubuntu-latest

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-cedar-drt:
     needs: get-branch-name
-    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_drt_reusable.yml@khieta/ci-fix
+    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_drt_reusable.yml@main
     with:
       cedar_policy_ref: ${{ github.ref }}
       cedar_spec_ref: ${{ needs.get-branch-name.outputs.branch_name }}

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -19,7 +19,7 @@ jobs:
 
   build-cedar-drt:
     needs: get-branch-name
-    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_drt_reusable.yml@main
+    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_drt_reusable.yml@khieta/ci-fix
     with:
       cedar_policy_ref: ${{ github.ref }}
       cedar_spec_ref: ${{ needs.get-branch-name.outputs.branch_name }}

--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use smol_str::SmolStr;
 
 use crate::{parser::err::ParseErrors, FromNormalizedStr};
@@ -9,7 +9,7 @@ use crate::{parser::err::ParseErrors, FromNormalizedStr};
 /// `true | false | if | then | else | in | is | like | has`).
 //
 // For now, internally, `Id`s are just owned `SmolString`s.
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[derive(Serialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 pub struct Id(SmolStr);
 
 impl Id {
@@ -60,6 +60,34 @@ impl std::str::FromStr for Id {
 impl FromNormalizedStr for Id {
     fn describe_self() -> &'static str {
         "Id"
+    }
+}
+
+struct IdVisitor;
+
+impl<'de> serde::de::Visitor<'de> for IdVisitor {
+    type Value = Id;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a valid id")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Id::from_normalized_str(value)
+            .map_err(|err| serde::de::Error::custom(format!("invalid id `{value}`: {err}")))
+    }
+}
+
+/// Deserialize an `Id` using `from_normalized_str`
+impl<'de> Deserialize<'de> for Id {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(IdVisitor)
     }
 }
 

--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -81,7 +81,8 @@ impl<'de> serde::de::Visitor<'de> for IdVisitor {
     }
 }
 
-/// Deserialize an `Id` using `from_normalized_str`
+/// Deserialize an `Id` using `from_normalized_str`.
+/// This deserialization implementation is used in the JSON schema format.
 impl<'de> Deserialize<'de> for Id {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -184,7 +184,7 @@ impl<'de> serde::de::Visitor<'de> for NameVisitor {
     type Value = Name;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("a name consisting of a path and id, separated by `::`")
+        formatter.write_str("a name consisting of an optional namespace and id")
     }
 
     fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -192,7 +192,7 @@ impl<'de> serde::de::Visitor<'de> for NameVisitor {
         E: serde::de::Error,
     {
         Name::from_normalized_str(value)
-            .map_err(|err| serde::de::Error::custom(format!("invalid name: {err}")))
+            .map_err(|err| serde::de::Error::custom(format!("invalid name `{value}`: {err}")))
     }
 }
 

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -154,6 +154,7 @@ impl std::fmt::Display for Name {
 }
 
 /// Serialize a `Name` using its `Display` implementation
+/// This serialization implementation is used in the JSON schema format.
 impl Serialize for Name {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -197,6 +198,7 @@ impl<'de> serde::de::Visitor<'de> for NameVisitor {
 }
 
 /// Deserialize a `Name` using `from_normalized_str`
+/// This deserialization implementation is used in the JSON schema format.
 impl<'de> Deserialize<'de> for Name {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -16,7 +16,8 @@
 
 use super::id::Id;
 use itertools::Itertools;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use smol_str::ToSmolStr;
 use std::sync::Arc;
 
 use crate::parser::err::ParseErrors;
@@ -28,7 +29,7 @@ use super::PrincipalOrResource;
 /// This is the `Name` type used to name types, functions, etc.
 /// The name can include namespaces.
 /// Clone is O(1).
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Name {
     /// Basename
@@ -152,6 +153,16 @@ impl std::fmt::Display for Name {
     }
 }
 
+/// Serialize a `Name` using its `Display` implementation
+impl Serialize for Name {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_smolstr().serialize(serializer)
+    }
+}
+
 // allow `.parse()` on a string to make a `Name`
 impl std::str::FromStr for Name {
     type Err = ParseErrors;
@@ -164,6 +175,34 @@ impl std::str::FromStr for Name {
 impl FromNormalizedStr for Name {
     fn describe_self() -> &'static str {
         "Name"
+    }
+}
+
+struct NameVisitor;
+
+impl<'de> serde::de::Visitor<'de> for NameVisitor {
+    type Value = Name;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("a name consisting of a path and id, separated by `::`")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Name::from_normalized_str(value)
+            .map_err(|err| serde::de::Error::custom(format!("invalid name: {err}")))
+    }
+}
+
+/// Deserialize a `Name` using `from_normalized_str`
+impl<'de> Deserialize<'de> for Name {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(NameVisitor)
     }
 }
 
@@ -275,8 +314,6 @@ mod vars_test {
 
 #[cfg(test)]
 mod test {
-    use smol_str::ToSmolStr;
-
     use super::*;
 
     #[test]

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -1187,7 +1187,6 @@ mod strengthened_types {
            "memberOfTypes": [""]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        println!("{:?}", schema);
         assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -1048,6 +1048,7 @@ mod strengthened_types {
     };
 
     /// Assert that `result` is an `Err`, and the error message matches `msg`
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_error_matches<T: std::fmt::Debug>(result: Result<T, serde_json::Error>, msg: &str) {
         assert_matches!(result, Err(err) => assert_eq!(&err.to_string(), msg));
     }
@@ -1401,6 +1402,7 @@ mod strengthened_types {
 mod test_json_roundtrip {
     use super::*;
 
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn roundtrip(schema: SchemaFragment) {
         let json = serde_json::to_value(schema.clone()).unwrap();
         let new_schema: SchemaFragment = serde_json::from_value(json).unwrap();

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -1046,6 +1046,11 @@ mod strengthened_types {
         ActionEntityUID, ApplySpec, EntityType, NamespaceDefinition, SchemaFragment, SchemaType,
     };
 
+    /// Assert that `result` is an `Err`, and the error message matches `msg`
+    fn assert_error_matches<T: std::fmt::Debug>(result: Result<T, serde_json::Error>, msg: &str) {
+        assert_matches!(result, Err(err) => assert_eq!(&err.to_string(), msg));
+    }
+
     #[test]
     fn invalid_namespace() {
         let src = serde_json::json!(
@@ -1056,7 +1061,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `\n`: unexpected end of input");
+        assert_error_matches(schema, "invalid namespace `\n`: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1066,7 +1071,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `1`: unexpected token `1`");
+        assert_error_matches(schema, "invalid namespace `1`: unexpected token `1`");
 
         let src = serde_json::json!(
         {
@@ -1076,7 +1081,8 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `*1`: unexpected token `*`");
+        assert_error_matches(schema, "invalid namespace `*1`: unexpected token `*`");
+
         let src = serde_json::json!(
         {
            "::" : {
@@ -1085,7 +1091,8 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `::`: unexpected token `::`");
+        assert_error_matches(schema, "invalid namespace `::`: unexpected token `::`");
+
         let src = serde_json::json!(
         {
            "A::" : {
@@ -1094,7 +1101,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `A::`: unexpected end of input");
+        assert_error_matches(schema, "invalid namespace `A::`: unexpected end of input");
     }
 
     #[test]
@@ -1110,7 +1117,7 @@ mod strengthened_types {
             }
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id ``: unexpected end of input");
+        assert_error_matches(schema, "invalid id ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1123,7 +1130,7 @@ mod strengthened_types {
             }
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `~`: invalid token");
+        assert_error_matches(schema, "invalid id `~`: invalid token");
 
         let src = serde_json::json!(
         {
@@ -1136,7 +1143,7 @@ mod strengthened_types {
             }
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `A::B`: unexpected token `::`");
+        assert_error_matches(schema, "invalid id `A::B`: unexpected token `::`");
     }
 
     #[test]
@@ -1149,7 +1156,7 @@ mod strengthened_types {
             "actions": {}
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id ``: unexpected end of input");
+        assert_error_matches(schema, "invalid id ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1159,7 +1166,7 @@ mod strengthened_types {
             "actions": {}
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid id `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1169,7 +1176,7 @@ mod strengthened_types {
             "actions": {}
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `A::B`: unexpected token `::`");
+        assert_error_matches(schema, "invalid id `A::B`: unexpected token `::`");
     }
 
     #[test]
@@ -1180,28 +1187,28 @@ mod strengthened_types {
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
         println!("{:?}", schema);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name ``: unexpected end of input");
+        assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["*"]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["A::"]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `A::`: unexpected end of input");
+        assert_error_matches(schema, "invalid name `A::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["::A"]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `::A`: unexpected token `::`");
+        assert_error_matches(schema, "invalid name `::A`: unexpected token `::`");
     }
 
     #[test]
@@ -1211,28 +1218,28 @@ mod strengthened_types {
            "resourceTypes": [""]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name ``: unexpected end of input");
+        assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["*"]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["A::"]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `A::`: unexpected end of input");
+        assert_error_matches(schema, "invalid name `A::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["::A"]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `::A`: unexpected token `::`");
+        assert_error_matches(schema, "invalid name `::A`: unexpected token `::`");
     }
 
     #[test]
@@ -1243,7 +1250,7 @@ mod strengthened_types {
             "name": ""
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type ``: unexpected end of input");
+        assert_error_matches(schema, "invalid entity type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1251,7 +1258,7 @@ mod strengthened_types {
             "name": "*"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid entity type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1259,14 +1266,15 @@ mod strengthened_types {
             "name": "::A"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type `::A`: unexpected token `::`");
+        assert_error_matches(schema, "invalid entity type `::A`: unexpected token `::`");
+
         let src = serde_json::json!(
         {
            "type": "Entity",
             "name": "A::"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type `A::`: unexpected end of input");
+        assert_error_matches(schema, "invalid entity type `A::`: unexpected end of input");
     }
 
     #[test]
@@ -1277,7 +1285,7 @@ mod strengthened_types {
             "type": ""
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name ``: unexpected end of input");
+        assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1285,7 +1293,7 @@ mod strengthened_types {
             "type": "*"
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1293,7 +1301,7 @@ mod strengthened_types {
             "type": "Action::"
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `Action::`: unexpected end of input");
+        assert_error_matches(schema, "invalid name `Action::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1301,7 +1309,7 @@ mod strengthened_types {
             "type": "::Action"
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `::Action`: unexpected token `::`");
+        assert_error_matches(schema, "invalid name `::Action`: unexpected token `::`");
     }
 
     #[test]
@@ -1311,27 +1319,28 @@ mod strengthened_types {
            "type": ""
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type ``: unexpected end of input");
+        assert_error_matches(schema, "invalid common type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "type": "*"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid common type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "type": "::A"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type `::A`: unexpected token `::`");
+        assert_error_matches(schema, "invalid common type `::A`: unexpected token `::`");
+
         let src = serde_json::json!(
         {
            "type": "A::"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type `A::`: unexpected end of input");
+        assert_error_matches(schema, "invalid common type `A::`: unexpected end of input");
     }
 
     #[test]
@@ -1342,7 +1351,7 @@ mod strengthened_types {
            "name": ""
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type ``: unexpected end of input");
+        assert_error_matches(schema, "invalid extension type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1350,7 +1359,7 @@ mod strengthened_types {
            "name": "*"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `*`: unexpected token `*`");
+        assert_error_matches(schema, "invalid extension type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1358,14 +1367,21 @@ mod strengthened_types {
            "name": "__cedar::decimal"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `__cedar::decimal`: unexpected token `::`");
+        assert_error_matches(
+            schema,
+            "invalid extension type `__cedar::decimal`: unexpected token `::`",
+        );
+
         let src = serde_json::json!(
         {
             "type": "Extension",
            "name": "__cedar::"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `__cedar::`: unexpected token `::`");
+        assert_error_matches(
+            schema,
+            "invalid extension type `__cedar::`: unexpected token `::`",
+        );
 
         let src = serde_json::json!(
         {
@@ -1373,7 +1389,10 @@ mod strengthened_types {
            "name": "::__cedar"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `::__cedar`: unexpected token `::`");
+        assert_error_matches(
+            schema,
+            "invalid extension type `::__cedar`: unexpected token `::`",
+        );
     }
 }
 

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -1470,6 +1470,19 @@ mod test_json_roundtrip {
     }
 
     #[test]
+    fn empty_namespace() {
+        let fragment = SchemaFragment(HashMap::from([(
+            None,
+            NamespaceDefinition {
+                common_types: HashMap::new(),
+                entity_types: HashMap::new(),
+                actions: HashMap::new(),
+            },
+        )]));
+        roundtrip(fragment);
+    }
+
+    #[test]
     fn nonempty_namespace() {
         let fragment = SchemaFragment(HashMap::from([(
             Some("a".parse().unwrap()),
@@ -1483,15 +1496,90 @@ mod test_json_roundtrip {
     }
 
     #[test]
-    fn empty_namespace() {
+    fn nonempty_entity_types() {
         let fragment = SchemaFragment(HashMap::from([(
             None,
             NamespaceDefinition {
                 common_types: HashMap::new(),
-                entity_types: HashMap::new(),
-                actions: HashMap::new(),
+                entity_types: HashMap::from([(
+                    "a".parse().unwrap(),
+                    EntityType {
+                        member_of_types: vec!["a".parse().unwrap()],
+                        shape: AttributesOrContext(SchemaType::Type(SchemaTypeVariant::Record {
+                            attributes: BTreeMap::new(),
+                            additional_attributes: false,
+                        })),
+                    },
+                )]),
+                actions: HashMap::from([(
+                    "action".into(),
+                    ActionType {
+                        attributes: None,
+                        applies_to: Some(ApplySpec {
+                            resource_types: Some(vec!["a".parse().unwrap()]),
+                            principal_types: Some(vec!["a".parse().unwrap()]),
+                            context: AttributesOrContext(SchemaType::Type(
+                                SchemaTypeVariant::Record {
+                                    attributes: BTreeMap::new(),
+                                    additional_attributes: false,
+                                },
+                            )),
+                        }),
+                        member_of: None,
+                    },
+                )]),
             },
         )]));
+        roundtrip(fragment);
+    }
+
+    #[test]
+    fn multiple_namespaces() {
+        let fragment = SchemaFragment(HashMap::from([
+            (
+                Some("foo".parse().unwrap()),
+                NamespaceDefinition {
+                    common_types: HashMap::new(),
+                    entity_types: HashMap::from([(
+                        "a".parse().unwrap(),
+                        EntityType {
+                            member_of_types: vec!["a".parse().unwrap()],
+                            shape: AttributesOrContext(SchemaType::Type(
+                                SchemaTypeVariant::Record {
+                                    attributes: BTreeMap::new(),
+                                    additional_attributes: false,
+                                },
+                            )),
+                        },
+                    )]),
+                    actions: HashMap::new(),
+                },
+            ),
+            (
+                None,
+                NamespaceDefinition {
+                    common_types: HashMap::new(),
+                    entity_types: HashMap::new(),
+                    actions: HashMap::from([(
+                        "action".into(),
+                        ActionType {
+                            attributes: None,
+                            applies_to: Some(ApplySpec {
+                                resource_types: Some(vec!["foo::a".parse().unwrap()]),
+                                principal_types: Some(vec!["foo::a".parse().unwrap()]),
+                                context: AttributesOrContext(SchemaType::Type(
+                                    SchemaTypeVariant::Record {
+                                        attributes: BTreeMap::new(),
+                                        additional_attributes: false,
+                                    },
+                                )),
+                            }),
+                            member_of: None,
+                        },
+                    )]),
+                },
+            ),
+        ]));
         roundtrip(fragment);
     }
 }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -17,7 +17,6 @@
 use cedar_policy_core::{
     ast::{Id, Name},
     entities::CedarValueJson,
-    parser::err::ParseErrors,
     FromNormalizedStr,
 };
 use serde::{
@@ -53,52 +52,33 @@ pub struct SchemaFragment(
     pub  HashMap<Option<Name>, NamespaceDefinition>,
 );
 
-fn deserialize_hash_map<'de, D, K, V>(
-    key_parser: impl Fn(SmolStr) -> std::result::Result<K, ParseErrors>,
-    deserializer: D,
-    kind: &'static str,
-) -> std::result::Result<HashMap<K, V>, D::Error>
-where
-    D: Deserializer<'de>,
-    V: Deserialize<'de>,
-    K: std::cmp::Eq + std::hash::Hash,
-{
-    let raw: HashMap<SmolStr, V> =
-        serde_with::rust::maps_duplicate_key_is_error::deserialize(deserializer)?;
-    Ok(HashMap::from_iter(
-        raw.into_iter()
-            .map(|(key, value)| {
-                Ok((
-                    key_parser(key).map_err(|err| {
-                        serde::de::Error::custom(format!("invalid {kind}: {err}"))
-                    })?,
-                    value,
-                ))
-            })
-            .collect::<std::result::Result<Vec<(K, V)>, D::Error>>()?,
-    ))
-}
-
+/// Custom deserializer to ensure that the empty namespace is mapped to `None`
 fn deserialize_schema_fragment<'de, D>(
     deserializer: D,
 ) -> std::result::Result<HashMap<Option<Name>, NamespaceDefinition>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    deserialize_hash_map(
-        |key| {
-            if key.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(Name::from_normalized_str(&key)?))
-            }
-        },
-        deserializer,
-        "namespace",
-    )
+    let raw: HashMap<SmolStr, NamespaceDefinition> =
+        serde_with::rust::maps_duplicate_key_is_error::deserialize(deserializer)?;
+    Ok(HashMap::from_iter(
+        raw.into_iter()
+            .map(|(key, value)| {
+                let key = if key.is_empty() {
+                    None
+                } else {
+                    Some(Name::from_normalized_str(&key).map_err(|err| {
+                        serde::de::Error::custom(format!("invalid namespace `{key}`: {err}"))
+                    })?)
+                };
+                Ok((key, value))
+            })
+            .collect::<std::result::Result<Vec<(Option<Name>, NamespaceDefinition)>, D::Error>>()?,
+    ))
 }
 
 impl Serialize for SchemaFragment {
+    /// Custom serializer to ensure that `None` is mapped to the empty namespace
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -160,40 +140,14 @@ impl SchemaFragment {
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct NamespaceDefinition {
     #[serde(default)]
-    #[serde(deserialize_with = "deserialize_common_types")]
+    #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     #[serde(rename = "commonTypes")]
     pub common_types: HashMap<Id, SchemaType>,
     #[serde(rename = "entityTypes")]
-    #[serde(deserialize_with = "deserialize_entity_types")]
+    #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     pub entity_types: HashMap<Id, EntityType>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     pub actions: HashMap<SmolStr, ActionType>,
-}
-
-fn deserialize_common_types<'de, D>(
-    deserializer: D,
-) -> std::result::Result<HashMap<Id, SchemaType>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_hash_map(
-        |key| Id::from_normalized_str(&key),
-        deserializer,
-        "common type",
-    )
-}
-
-fn deserialize_entity_types<'de, D>(
-    deserializer: D,
-) -> std::result::Result<HashMap<Id, EntityType>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    deserialize_hash_map(
-        |key| Id::from_normalized_str(&key),
-        deserializer,
-        "entity type",
-    )
 }
 
 impl NamespaceDefinition {
@@ -219,21 +173,9 @@ impl NamespaceDefinition {
 pub struct EntityType {
     #[serde(default)]
     #[serde(rename = "memberOfTypes")]
-    #[serde(deserialize_with = "deserialize_member_of_types")]
     pub member_of_types: Vec<Name>,
     #[serde(default)]
     pub shape: AttributesOrContext,
-}
-
-fn deserialize_member_of_types<'de, D>(deserializer: D) -> std::result::Result<Vec<Name>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let raw = Vec::<SmolStr>::deserialize(deserializer)?;
-    raw.into_iter()
-        .map(|s| Name::from_normalized_str(&s))
-        .collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(|err| serde::de::Error::custom(format!("invalid member of type: {err}")))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -296,32 +238,12 @@ pub struct ActionType {
 pub struct ApplySpec {
     #[serde(default)]
     #[serde(rename = "resourceTypes")]
-    #[serde(deserialize_with = "deserialize_pr_types")]
     pub resource_types: Option<Vec<Name>>,
     #[serde(default)]
     #[serde(rename = "principalTypes")]
-    #[serde(deserialize_with = "deserialize_pr_types")]
     pub principal_types: Option<Vec<Name>>,
     #[serde(default)]
     pub context: AttributesOrContext,
-}
-
-fn deserialize_pr_types<'de, D>(deserializer: D) -> std::result::Result<Option<Vec<Name>>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let raw = Option::<Vec<SmolStr>>::deserialize(deserializer)?;
-    match raw {
-        Some(vs) => Ok(Some(
-            vs.into_iter()
-                .map(|v| Name::from_normalized_str(&v))
-                .collect::<std::result::Result<Vec<Name>, _>>()
-                .map_err(|err| {
-                    serde::de::Error::custom(format!("invalid principal or resource types: {err}"))
-                })?,
-        )),
-        None => Ok(None),
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -333,21 +255,7 @@ pub struct ActionEntityUID {
 
     #[serde(rename = "type")]
     #[serde(default)]
-    #[serde(deserialize_with = "deserialize_action_type")]
     pub ty: Option<Name>,
-}
-
-fn deserialize_action_type<'de, D>(deserializer: D) -> std::result::Result<Option<Name>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    let raw = Option::<SmolStr>::deserialize(deserializer)?;
-    match raw {
-        Some(s) => Ok(Some(Name::from_normalized_str(&s).map_err(|err| {
-            serde::de::Error::custom(format!("invalid action type: {err}"))
-        })?)),
-        None => Ok(None),
-    }
 }
 
 impl ActionEntityUID {
@@ -615,9 +523,14 @@ impl SchemaTypeVisitor {
                 )?;
 
                 if let Some(name) = name {
+                    let name = name?;
                     Ok(SchemaType::Type(SchemaTypeVariant::Entity {
-                        name: cedar_policy_core::ast::Name::from_normalized_str(&name?).map_err(
-                            |err| serde::de::Error::custom(format!("invalid entity type: {err}")),
+                        name: cedar_policy_core::ast::Name::from_normalized_str(&name).map_err(
+                            |err| {
+                                serde::de::Error::custom(format!(
+                                    "invalid entity type `{name}`: {err}"
+                                ))
+                            },
                         )?,
                     }))
                 } else {
@@ -631,9 +544,12 @@ impl SchemaTypeVisitor {
                 )?;
 
                 if let Some(name) = name {
+                    let name = name?;
                     Ok(SchemaType::Type(SchemaTypeVariant::Extension {
-                        name: Id::from_normalized_str(&name?).map_err(|err| {
-                            serde::de::Error::custom(format!("invalid extension type: {err}"))
+                        name: Id::from_normalized_str(&name).map_err(|err| {
+                            serde::de::Error::custom(format!(
+                                "invalid extension type `{name}`: {err}"
+                            ))
                         })?,
                     }))
                 } else {
@@ -645,7 +561,9 @@ impl SchemaTypeVisitor {
                 Ok(SchemaType::TypeDef {
                     type_name: cedar_policy_core::ast::Name::from_normalized_str(type_name)
                         .map_err(|err| {
-                            serde::de::Error::custom(format!("invalid common type: {err}"))
+                            serde::de::Error::custom(format!(
+                                "invalid common type `{type_name}`: {err}"
+                            ))
                         })?,
                 })
             }
@@ -1138,7 +1056,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `\n`: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1148,7 +1066,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace: unexpected token `1`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `1`: unexpected token `1`");
 
         let src = serde_json::json!(
         {
@@ -1158,7 +1076,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `*1`: unexpected token `*`");
         let src = serde_json::json!(
         {
            "::" : {
@@ -1167,7 +1085,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `::`: unexpected token `::`");
         let src = serde_json::json!(
         {
            "A::" : {
@@ -1176,7 +1094,7 @@ mod strengthened_types {
            }
         });
         let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid namespace `A::`: unexpected end of input");
     }
 
     #[test]
@@ -1192,7 +1110,7 @@ mod strengthened_types {
             }
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1205,7 +1123,7 @@ mod strengthened_types {
             }
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: invalid token");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `~`: invalid token");
 
         let src = serde_json::json!(
         {
@@ -1218,7 +1136,7 @@ mod strengthened_types {
             }
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `A::B`: unexpected token `::`");
     }
 
     #[test]
@@ -1231,7 +1149,7 @@ mod strengthened_types {
             "actions": {}
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1241,7 +1159,7 @@ mod strengthened_types {
             "actions": {}
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1251,7 +1169,7 @@ mod strengthened_types {
             "actions": {}
         });
         let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid id `A::B`: unexpected token `::`");
     }
 
     #[test]
@@ -1261,28 +1179,29 @@ mod strengthened_types {
            "memberOfTypes": [""]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid member of type: unexpected end of input");
+        println!("{:?}", schema);
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["*"]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid member of type: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["A::"]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid member of type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `A::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["::A"]
         });
         let schema: Result<EntityType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid member of type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `::A`: unexpected token `::`");
     }
 
     #[test]
@@ -1292,28 +1211,28 @@ mod strengthened_types {
            "resourceTypes": [""]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid principal or resource types: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["*"]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid principal or resource types: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["A::"]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid principal or resource types: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `A::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["::A"]
         });
         let schema: Result<ApplySpec, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid principal or resource types: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `::A`: unexpected token `::`");
     }
 
     #[test]
@@ -1324,7 +1243,7 @@ mod strengthened_types {
             "name": ""
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1332,7 +1251,7 @@ mod strengthened_types {
             "name": "*"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1340,14 +1259,14 @@ mod strengthened_types {
             "name": "::A"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type `::A`: unexpected token `::`");
         let src = serde_json::json!(
         {
            "type": "Entity",
             "name": "A::"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid entity type `A::`: unexpected end of input");
     }
 
     #[test]
@@ -1358,7 +1277,7 @@ mod strengthened_types {
             "type": ""
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid action type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1366,7 +1285,7 @@ mod strengthened_types {
             "type": "*"
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid action type: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1374,7 +1293,7 @@ mod strengthened_types {
             "type": "Action::"
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid action type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `Action::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1382,7 +1301,7 @@ mod strengthened_types {
             "type": "::Action"
         });
         let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid action type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid name `::Action`: unexpected token `::`");
     }
 
     #[test]
@@ -1392,27 +1311,27 @@ mod strengthened_types {
            "type": ""
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "type": "*"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "type": "::A"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type `::A`: unexpected token `::`");
         let src = serde_json::json!(
         {
            "type": "A::"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid common type `A::`: unexpected end of input");
     }
 
     #[test]
@@ -1423,7 +1342,7 @@ mod strengthened_types {
            "name": ""
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type: unexpected end of input");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
@@ -1431,7 +1350,7 @@ mod strengthened_types {
            "name": "*"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type: unexpected token `*`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
@@ -1439,14 +1358,14 @@ mod strengthened_types {
            "name": "__cedar::decimal"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `__cedar::decimal`: unexpected token `::`");
         let src = serde_json::json!(
         {
             "type": "Extension",
            "name": "__cedar::"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `__cedar::`: unexpected token `::`");
 
         let src = serde_json::json!(
         {
@@ -1454,7 +1373,7 @@ mod strengthened_types {
            "name": "::__cedar"
         });
         let schema: Result<SchemaType, _> = serde_json::from_value(src);
-        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type: unexpected token `::`");
+        assert_matches!(schema, Err(err) if &err.to_string() == "invalid extension type `::__cedar`: unexpected token `::`");
     }
 }
 


### PR DESCRIPTION
## Description of changes

Followup to #749 to fix json schema serialization.

* Added custom (de)serialization for `Id` and `Name`. This will affect our internal formats (e.g., used by DRT), but should not affect external formats, aside from error messages.
* This allowed me to remove some of the boilerplate in `schema_file_format.rs`

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in cedar-spec, and how you have tested that your updates are correct.)

