### PR TITLE
Andrewmwells/reuse downstream java ci

### DIFF
--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -55,7 +55,7 @@ jobs:
 
   build-cedar-java:
     needs: get-branch-name
-    uses: cedar-policy/cedar-java/.github/workflows/build_cedar_java_reusable.yml@main
+    uses: cedar-policy/cedar-java/.github/workflows/run_cedar_java_reusable.yml@main
     with:
       cedar_policy_ref: ${{ github.ref }}
       cedar_examples_ref: ${{ needs.get-branch-name.outputs.branch_name }}


### PR DESCRIPTION
## Description of changes
Fix CedarJava CI from this PR (https://github.com/cedar-policy/cedar/pull/768), where the downstream Java build silently didn't run because the filename was wrong.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


