### PR TITLE
Forbid warnings in wasm target build

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,6 +82,10 @@ jobs:
       matrix:
         toolchain:
           - stable
+
+    env:
+      RUSTFLAGS: '-D warnings -F unsafe-code'
+
     steps:
       - uses: actions/checkout@v4
       - run: cd ./cedar-wasm && cargo install wasm-pack && ./build-wasm.sh

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -31,6 +31,7 @@ use itertools::Either;
 use nonempty::nonempty;
 use smol_str::SmolStr;
 
+#[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
 // PANIC SAFETY `Name`s in here are valid `Name`s

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -230,6 +230,7 @@ impl EvaluationError {
     }
 
     /// Construct a [`RecursionLimit`] error
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn recursion_limit(source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: EvaluationErrorKind::RecursionLimit,

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -53,6 +53,7 @@ use cedar_policy_core::ast::{
     PrincipalOrResourceConstraint, SlotId, Template, UnaryOp, Var,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
 /// TypecheckAnswer holds the result of typechecking an expression.


### PR DESCRIPTION
Fix dead code warnings in this target by conditionally not compiling some code used to bound recursion.

Fix #721 

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
