### PR TITLE
Update schema displays

### DIFF
--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -401,7 +401,7 @@ namespace Baz {action "Foo" appliesTo {
         };
         let fragment = SchemaFragment(HashMap::from([(None, namespace)]));
         let src = fragment.as_natural_schema().unwrap();
-        assert!(src.contains(r#"action "j" ;"#), "schema was: `{src}`")
+        assert!(src.contains(r#"action "j";"#), "schema was: `{src}`")
     }
 
     #[test]

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -312,7 +312,8 @@ mod demo_tests {
         let namespace = NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
         let fragment = SchemaFragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
         let as_src = fragment.as_natural_schema().unwrap();
-        let expected = r#"action "foo" appliesTo {  context: {}
+        let expected = r#"action "foo" appliesTo {
+  context: {}
 };"#;
         assert!(as_src.contains(expected), "src was:\n`{as_src}`");
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated error `TypeErrorKind::ImpossiblePolicy` in favor of warning
   `ValidationWarningKind::ImpossiblePolicy` so future improvements to Cedar
   typing precision will not result in breaking changes. (resolving #539)
-- Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737) 
+- Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737)
+- Improved `Display` implementation for Cedar schemas, both JSON and human syntax. (#780)
 
 ## [3.1.2] - 2024-03-29
 


### PR DESCRIPTION
## Description of changes

Small fixes to schema `Display`s, which are visible via the CLI's `translate-schema` command.
* Added some additional newlines to the display impl for the Cedar schema format to change
```
action "edit" appliesTo {  principal: [User], 
  resource: [Photo], 
  ...
```
to
```
action "edit" appliesTo {
  principal: [User], 
  resource: [Photo], 
  ...
```
* Updated the display impl for the Cedar schema format to omit empty attribute fields, changing `entity UserGroup  = {  };` to `entity UserGroup;`
* Added `skip_serializing_if` annotations to default JSON fields (resolving #776)

## Issue #, if available

#776, #682 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
