### PR TITLE
changelog nits

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.1.3
+
+- The `translate-schema` command now produces prettier output.
+
 ## 3.1.2
 
 ## 3.1.1
@@ -12,8 +16,9 @@ Now uses Cedar language version 3.1.0.
 
 - Added support for the human-readable schema format (`--schema-format human`
   when a schema is needed). The default schema format is still JSON for backward
-  compatibility.  - Added command `translate-schema` that translates a schema in
-  the JSON format to its human-readable format and vice versa (except comments).
+  compatibility.
+- Added command `translate-schema` that translates a schema in the JSON format
+  to its human-readable format and vice versa (except comments).
 - The `-p`/`--policies` flag can now be omitted across all subcommands where it
   is present. If the flag is omitted, policies will be read from `stdin`.
 - `--policy-format` flag to many subcommands, allowing you to pass policies in

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -5,20 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.1.3] -
+## [3.1.3] - 2024-04-15
 
 ### Changed
 
 - Improve parser errors on unexpected tokens. (#698, partially resolving #176)
 - Validation error messages render types in the new, more readable, schema
   syntax. (#708, resolving #242)
-- Improved error messages when `null` occurs in entity json data. (#751, resolving #530)
-- Improved source location reporting for error `found template slot in a when clause`. (#758, resolving #736)
-- Improved `Display` implementation for Cedar schemas, both JSON and human syntax. (#780)
+- Improved error messages when `null` occurs in entity json data. (#751,
+  resolving #530)
+- Improved source location reporting for error `found template slot in a when clause`.
+  (#758, resolving #736)
+- Improved `Display` implementation for Cedar schemas, both JSON and human
+  syntax. (#780)
 
 ### Fixed
 
-- Support identifiers in context declarations in the human-readable schema format. (#734, resolving #681)
+- Support identifiers in context declarations in the human-readable schema
+  format. (#734, resolving #681)
 
 ## [3.1.2] - 2024-03-29
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -423,7 +423,8 @@ Cedar Language Version: 2.0.0
 Cedar Language Version: 2.0.0
 - Initial release of `cedar-policy`.
 
-[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.1.2...main
+[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.1.3...main
+[3.1.3]: https://github.com/cedar-policy/cedar/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/cedar-policy/cedar/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/cedar-policy/cedar/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/cedar-policy/cedar/compare/v3.0.1...v3.1.0


### PR DESCRIPTION
Final changelog nits prior to 3.1.3 release.  Includes a 3.1.3 section for the CLI changelog, as we hadn't added one yet.
