### PR TITLE
Add missing -p/--policies argument to documentation for formatter

### DIFF
--- a/cedar-policy-formatter/README.md
+++ b/cedar-policy-formatter/README.md
@@ -10,11 +10,11 @@ The easiest way to format your Cedar policies is via [Cedar CLI](../cedar-policy
 ```shell
 # Default indentation is two spaces.
 # Default line width is 80.
-cedar format my-policies.cedar
+cedar format -p my-policies.cedar
 # I want more indentation.
-cedar format -i 4 my-policies.cedar
+cedar format -i 4 -p my-policies.cedar
 # I like shorter lines.
-cedar format -l 40 my-policies.cedar
+cedar format -l 40 -p my-policies.cedar
 ```
 
 ## Usage


### PR DESCRIPTION
## Description of changes

Hey, thanks for the awesome library and tooling!

When setting up Cedar, I noticed that the documentation for the formatter is missing the policies argument.

Running cedar without -p/--policies yields an error, because Clap doesn't expect any positional arguments for FormatArgs.

```sh
cedar format foo.cedar
error: unexpected argument 'foo.cedar' found

Usage: cedar format [OPTIONS]

For more information, try '--help'.
```

This small small patch simply adds the -p/--policies document to that README document. I assumed I wouldn't have to open an issue according to the contributing guidelines for this :sweat_smile: 

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is:

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like 

I confirm that this PR:

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

