### PR TITLE
760's changes but for validation APIs

### DIFF
--- a/cedar-wasm/src/validator.rs
+++ b/cedar-wasm/src/validator.rs
@@ -25,10 +25,14 @@ pub fn wasm_validate(call: ValidationCall) -> ValidateResult {
         ValidationAnswer::Success {
             validation_errors,
             validation_warnings,
+            other_warnings: _,
         } => ValidateResult::Success {
             validation_errors,
             validation_warnings,
         },
-        ValidationAnswer::Failure { errors } => ValidateResult::Error { errors },
+        ValidationAnswer::Failure {
+            errors,
+            warnings: _,
+        } => ValidateResult::Error { errors },
     }
 }


### PR DESCRIPTION
## Description of changes

The same changes that #760 made for authorization APIs, but here for validation APIs.  In particular:
* New top-level signatures
* Enables the human schema format (!)
* More propagation of warnings

## Issue #, if available

#757 (but this is only a small portion of the work for #757)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

(or rather, the changelog entry for #760 is general enough to cover it)

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

