### PR TITLE
Implement -w/--write flag for cedar format

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - The default `--schema-format` is now `human` for all subcommands that take
   `--schema-format`.
+- A new `--write` flag has been added to the `format` subcommand. This flag
+  writes the formatted policy to the file specified by the `--policies` flag.
 
 ## 3.1.3
 

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/format/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/format/README.md
@@ -1,0 +1,4 @@
+# format
+
+This sample is used to verify that the cedar-policy-cli's format command works as expected when writing back to the
+file system.

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/format/unformatted.cedar
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/format/unformatted.cedar
@@ -1,0 +1,12 @@
+permit
+
+(
+      principal
+                            == User::"alice",
+  action    == Action::"update"
+
+  ,
+  resource  == Photo::"VacationPhoto94.jpg"
+)
+
+;

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -635,6 +635,7 @@ fn format_policies_inner(args: &FormatArgs) -> Result<()> {
         Some(policies_file) if args.write => {
             let mut file = OpenOptions::new()
                 .write(true)
+                .truncate(true)
                 .open(policies_file)
                 .into_diagnostic()
                 .wrap_err(format!("failed to open {policies_file} for writing"))?;


### PR DESCRIPTION
## Description of changes

Adds a -w/--write flag to `cedar format` for automatically writing the formatted policy back into file, as described in #789 

## Issue #, if available

Fixes #789 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

