### PR TITLE
Add -c/--check to cedar format for validating policy

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -8,6 +8,9 @@
   `--schema-format`.
 - A new `--write` flag has been added to the `format` subcommand. This flag
   writes the formatted policy to the file specified by the `--policies` flag.
+- A new `--check` flag has been added to the `format` subcommand. This flag
+  checks if the policy is already formatted and exits with a non-zero status if
+  it is not.
 
 ## 3.1.3
 

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -28,6 +28,7 @@ partial-validate = ["cedar-policy/partial-validate"]
 assert_cmd = "2.0"
 tempfile = "3"
 glob = "0.3.1"
+predicates = "3.1.0"
 
 # We override the name of the binary for src/main.rs, which otherwise would be
 # cedar-cli (matching the crate name).

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/format/formatted.cedar
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/format/formatted.cedar
@@ -1,0 +1,5 @@
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -404,7 +404,7 @@ pub struct FormatArgs {
     #[arg(short, long, group = "action")]
     pub write: bool,
 
-    /// Check that the code formats without any changes. Mutually exclusive with `write`.
+    /// Check that the policies formats without any changes. Mutually exclusive with `write`.
     #[arg(short, long, group = "action")]
     pub check: bool,
 }

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -402,7 +402,13 @@ pub struct FormatArgs {
 
     /// Automatically write back the formatted policies to the input file.
     #[arg(short, long)]
+    #[clap(group = "action")]
     pub write: bool,
+
+    /// Check that the code formats without any changes. Mutually exclusive with `write`.
+    #[arg(short, long)]
+    #[clap(group = "action")]
+    pub check: bool,
 }
 
 #[derive(Args, Debug)]
@@ -624,13 +630,19 @@ pub fn link(args: &LinkArgs) -> CedarExitCode {
     }
 }
 
-fn format_policies_inner(args: &FormatArgs) -> Result<()> {
+/// Format the policies in the given file or stdin.
+///
+/// Returns a boolean indicating whether the formatted policies are the same as the original
+/// policies.
+fn format_policies_inner(args: &FormatArgs) -> Result<bool> {
     let policies_str = read_from_file_or_stdin(args.policies_file.as_ref(), "policy set")?;
     let config = Config {
         line_width: args.line_width,
         indent_width: args.indent_width,
     };
     let formatted_policy = policies_str_to_pretty(&policies_str, &config)?;
+    let are_policies_equivalent = policies_str == formatted_policy;
+
     match &args.policies_file {
         Some(policies_file) if args.write => {
             let mut file = OpenOptions::new()
@@ -647,15 +659,17 @@ fn format_policies_inner(args: &FormatArgs) -> Result<()> {
         }
         _ => println!("{}", formatted_policy),
     }
-    Ok(())
+    Ok(are_policies_equivalent)
 }
 
 pub fn format_policies(args: &FormatArgs) -> CedarExitCode {
-    if let Err(err) = format_policies_inner(args) {
-        println!("{err:?}");
-        CedarExitCode::Failure
-    } else {
-        CedarExitCode::Success
+    match format_policies_inner(args) {
+        Ok(false) if args.check => CedarExitCode::Failure,
+        Err(err) => {
+            println!("{err:?}");
+            CedarExitCode::Failure
+        }
+        _ => CedarExitCode::Success,
     }
 }
 

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -401,13 +401,11 @@ pub struct FormatArgs {
     pub indent_width: isize,
 
     /// Automatically write back the formatted policies to the input file.
-    #[arg(short, long)]
-    #[clap(group = "action")]
+    #[arg(short, long, group = "action")]
     pub write: bool,
 
     /// Check that the code formats without any changes. Mutually exclusive with `write`.
-    #[arg(short, long)]
-    #[clap(group = "action")]
+    #[arg(short, long, group = "action")]
     pub check: bool,
 }
 

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -943,3 +943,45 @@ fn test_format_write() {
         "original and formatted should differ under -w\noriginal:{original}\n\nformatted:{formatted}"
     );
 }
+
+#[test]
+fn test_format_check() {
+    const POLICY_REQUIRING_FORMAT: &str = "sample-data/tiny_sandboxes/format/unformatted.cedar";
+    const POLICY_ALREADY_FORMATTED: &str = "sample-data/tiny_sandboxes/format/formatted.cedar";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("format")
+        .arg("-p")
+        .arg(POLICY_REQUIRING_FORMAT)
+        .arg("-c")
+        .assert()
+        .code(1);
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("format")
+        .arg("-p")
+        .arg(POLICY_ALREADY_FORMATTED)
+        .arg("-c")
+        .assert()
+        .code(0);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_write_check_are_mutually_exclusive() {
+    const POLICY_SOURCE: &str = "sample-data/tiny_sandboxes/format/unformatted.cedar";
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("format")
+        .arg("-p")
+        .arg(&POLICY_SOURCE)
+        .arg("-w")
+        .arg("-c")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "the argument '--write' cannot be used with '--check'",
+        ));
+}


### PR DESCRIPTION
## Description of changes

Implements a new -c/--check flag to `cedar format` that will exit with exit code 1 if the formatted version of the policy did not match the original.

I've made the --write and --check options mutually exclusive, since you're probably not interested in writing the file at the same time as checking it. Let me know if you disagree and would like that changed.

## Issue #, if available

Fixes #796 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

