### PR TITLE
Require --policies to be present when using --write

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -401,7 +401,7 @@ pub struct FormatArgs {
     pub indent_width: isize,
 
     /// Automatically write back the formatted policies to the input file.
-    #[arg(short, long, group = "action")]
+    #[arg(short, long, group = "action", requires = "policies_file")]
     pub write: bool,
 
     /// Check that the policies formats without any changes. Mutually exclusive with `write`.

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -985,6 +985,7 @@ fn test_write_check_are_mutually_exclusive() {
         ));
 }
 
+#[test]
 fn test_require_policies_for_write() {
     assert_cmd::Command::cargo_bin("cedar")
         .expect("bin exists")

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -969,7 +969,6 @@ fn test_format_check() {
 }
 
 #[test]
-#[cfg(target_os = "linux")]
 fn test_write_check_are_mutually_exclusive() {
     const POLICY_SOURCE: &str = "sample-data/tiny_sandboxes/format/unformatted.cedar";
     assert_cmd::Command::cargo_bin("cedar")
@@ -985,3 +984,17 @@ fn test_write_check_are_mutually_exclusive() {
             "the argument '--write' cannot be used with '--check'",
         ));
 }
+
+fn test_require_policies_for_write() {
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("format")
+        .arg("-w")
+        .write_stdin("permit (principal, action, resource);")
+        .assert()
+        .failure()
+        .stderr(predicates::str::contains(
+            "the following required arguments were not provided:\n  --policies <FILE>",
+        ));
+}
+#[cfg(target_os = "linux")]

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -997,4 +997,3 @@ fn test_require_policies_for_write() {
             "the following required arguments were not provided:\n  --policies <FILE>",
         ));
 }
-#[cfg(target_os = "linux")]


### PR DESCRIPTION
## Description of changes

Adds a clap requirement for `--policies` to be present when using `--write`. Previously this would print the formatted policy to stdout (practically ignoring `--write`)

## Issue #, if available

N/A, I spotted this really quickly and figured it's a really small fix.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

This only affects the `cedar format -w` which was introduced yesterday in #795, which is yet to be released.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

