### PR TITLE
Expose test-utils from core under feature flag

### DIFF
--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -44,6 +44,9 @@ decimal = ["dep:regex"]
 # Enables `Arbitrary` implementations for several types in this crate
 arbitrary = ["dep:arbitrary"]
 
+# Expose test utilities
+test-util = []
+
 # Experimental features.
 partial-eval = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -33,5 +33,5 @@ pub mod jsonvalue;
 pub mod parser;
 pub mod transitive_closure;
 
-#[cfg(test)]
-mod test_utils;
+#[cfg(any(test, feature = "test-util"))]
+pub mod test_utils;

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -15,8 +15,18 @@
  */
 
 // PANIC SAFETY: testing code
-#![allow(clippy::panic)]
+#![allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::expect_used
+)]
 
+//! Shared test utilities.
+
+/// Describes the contents of an error message. Fields are based on the contents
+/// of `miette::Diagnostic`.
+#[derive(Debug)]
 pub struct ExpectedErrorMessage<'a> {
     /// Expected contents of `Display`, or expected prefix of `Display` if `prefix` is `true`
     error: &'a str,
@@ -38,6 +48,7 @@ pub struct ExpectedErrorMessage<'a> {
 }
 
 /// Builder struct for [`ExpectedErrorMessage`]
+#[derive(Debug)]
 pub struct ExpectedErrorMessageBuilder<'a> {
     /// ExpectedErrorMessage::error
     error: &'a str,
@@ -288,6 +299,7 @@ impl<'a> std::fmt::Display for ExpectedErrorMessage<'a> {
 
 /// Forms in which [`expect_err()`] accepts the original input text.
 /// See notes on [`expect_err()`].
+#[derive(Debug)]
 pub enum OriginalInput<'a> {
     /// A plain string
     String(&'a str),


### PR DESCRIPTION
## Description of changes

Convenient for writing some tests in the validator crate 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
