### PR TITLE
Implement `Diagnostic` for internal `cedar-policy-validator` types

### DIFF
--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -25,7 +25,7 @@ use unicode_security::MixedScript;
 /// Perform identifier and string safety checks.
 pub fn confusable_string_checks<'a>(
     p: impl Iterator<Item = &'a Template>,
-) -> impl Iterator<Item = ValidationWarning<'a>> {
+) -> impl Iterator<Item = ValidationWarning> {
     let mut warnings = vec![];
 
     for policy in p {
@@ -43,7 +43,7 @@ pub fn confusable_string_checks<'a>(
 
             if let Some(kind) = warning {
                 warnings.push(ValidationWarning {
-                    location: SourceLocation::new(policy.id(), loc.cloned()),
+                    location: SourceLocation::new(policy.id().clone(), loc.cloned()),
                     kind,
                 })
             }
@@ -150,7 +150,7 @@ mod test {
         );
         assert_eq!(
             location,
-            &SourceLocation::new(&PolicyID::from_string("test"), None)
+            &SourceLocation::new(PolicyID::from_string("test"), None)
         );
     }
 
@@ -196,7 +196,7 @@ mod test {
         assert_eq!(
             location,
             &SourceLocation::new(
-                &PolicyID::from_string("test"),
+                PolicyID::from_string("test"),
                 Some(Loc::new(64..94, Arc::from(src)))
             ),
         );
@@ -227,7 +227,7 @@ mod test {
         assert_eq!(
             location,
             &SourceLocation::new(
-                &PolicyID::from_string("test"),
+                PolicyID::from_string("test"),
                 Some(Loc::new(90..131, Arc::from(src)))
             )
         );

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -76,9 +76,8 @@ impl ValidationResult {
 /// policy. The error contains a enumeration that specifies the kind of problem,
 /// and provides details specific to that kind of problem. The error also records
 /// where the problem was encountered.
-#[derive(Clone, Debug, Error)]
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
 #[error("{error_kind}")]
-#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct ValidationError {
     location: SourceLocation,
     error_kind: ValidationErrorKind,
@@ -176,8 +175,7 @@ impl SourceLocation {
 
 /// Enumeration of the possible diagnostic error that could be found by the
 /// verification steps.
-#[derive(Debug, Clone, Diagnostic, Error)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Debug, Clone, Diagnostic, Error, Eq, PartialEq)]
 #[non_exhaustive]
 pub enum ValidationErrorKind {
     /// A policy contains an entity type that is not declared in the schema.
@@ -249,8 +247,7 @@ impl ValidationErrorKind {
 }
 
 /// Structure containing details about an unrecognized entity type error.
-#[derive(Debug, Clone, Error)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Debug, Clone, Error, Eq, PartialEq)]
 #[error("unrecognized entity type `{actual_entity_type}`")]
 pub struct UnrecognizedEntityType {
     /// The entity type seen in the policy.
@@ -270,8 +267,7 @@ impl Diagnostic for UnrecognizedEntityType {
 }
 
 /// Structure containing details about an unrecognized action id error.
-#[derive(Debug, Clone, Error)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Debug, Clone, Error, Eq, PartialEq)]
 #[error("unrecognized action `{actual_action_id}`")]
 pub struct UnrecognizedActionId {
     /// Action Id seen in the policy.
@@ -291,8 +287,7 @@ impl Diagnostic for UnrecognizedActionId {
 }
 
 /// Structure containing details about an invalid action application error.
-#[derive(Debug, Clone, Error)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Debug, Clone, Error, Eq, PartialEq)]
 #[error("unable to find an applicable action given the policy head constraints")]
 pub struct InvalidActionApplication {
     pub(crate) would_in_fix_principal: bool,
@@ -317,8 +312,7 @@ impl Diagnostic for InvalidActionApplication {
 }
 
 /// Structure containing details about an unspecified entity error.
-#[derive(Debug, Clone, Diagnostic, Error)]
-#[cfg_attr(test, derive(Eq, PartialEq))]
+#[derive(Debug, Clone, Diagnostic, Error, Eq, PartialEq)]
 #[error("unspecified entity with id `{entity_id}`")]
 #[diagnostic(help("unspecified entities cannot be used in policies"))]
 pub struct UnspecifiedEntityError {

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -150,7 +150,7 @@ impl ValidationError {
 }
 
 /// Represents a location in Cedar policy source.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct SourceLocation {
     policy_id: PolicyID,
     source_loc: Option<Loc>,

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -26,15 +26,15 @@ use crate::TypeErrorKind;
 /// Validation succeeds if there are no fatal errors. There may still be
 /// non-fatal warnings present when validation passes.
 #[derive(Debug)]
-pub struct ValidationResult<'a> {
-    validation_errors: Vec<ValidationError<'a>>,
-    validation_warnings: Vec<ValidationWarning<'a>>,
+pub struct ValidationResult {
+    validation_errors: Vec<ValidationError>,
+    validation_warnings: Vec<ValidationWarning>,
 }
 
-impl<'a> ValidationResult<'a> {
+impl ValidationResult {
     pub fn new(
-        errors: impl IntoIterator<Item = ValidationError<'a>>,
-        warnings: impl IntoIterator<Item = ValidationWarning<'a>>,
+        errors: impl IntoIterator<Item = ValidationError>,
+        warnings: impl IntoIterator<Item = ValidationWarning>,
     ) -> Self {
         Self {
             validation_errors: errors.into_iter().collect(),
@@ -62,8 +62,8 @@ impl<'a> ValidationResult<'a> {
     pub fn into_errors_and_warnings(
         self,
     ) -> (
-        impl Iterator<Item = ValidationError<'a>>,
-        impl Iterator<Item = ValidationWarning<'a>>,
+        impl Iterator<Item = ValidationError>,
+        impl Iterator<Item = ValidationWarning>,
     ) {
         (
             self.validation_errors.into_iter(),
@@ -78,14 +78,14 @@ impl<'a> ValidationResult<'a> {
 /// where the problem was encountered.
 #[derive(Debug)]
 #[cfg_attr(test, derive(Eq, PartialEq))]
-pub struct ValidationError<'a> {
-    location: SourceLocation<'a>,
+pub struct ValidationError {
+    location: SourceLocation,
     error_kind: ValidationErrorKind,
 }
 
-impl<'a> ValidationError<'a> {
+impl ValidationError {
     pub(crate) fn with_policy_id(
-        id: &'a PolicyID,
+        id: PolicyID,
         source_loc: Option<Loc>,
         error_kind: ValidationErrorKind,
     ) -> Self {
@@ -96,7 +96,7 @@ impl<'a> ValidationError<'a> {
     }
 
     /// Deconstruct this into its component source location and error kind.
-    pub fn into_location_and_error_kind(self) -> (SourceLocation<'a>, ValidationErrorKind) {
+    pub fn into_location_and_error_kind(self) -> (SourceLocation, ValidationErrorKind) {
         (self.location, self.error_kind)
     }
 
@@ -113,13 +113,13 @@ impl<'a> ValidationError<'a> {
 
 /// Represents a location in Cedar policy source.
 #[derive(Debug, Clone, Eq, PartialEq)]
-pub struct SourceLocation<'a> {
-    policy_id: &'a PolicyID,
+pub struct SourceLocation {
+    policy_id: PolicyID,
     source_loc: Option<Loc>,
 }
 
-impl<'a> SourceLocation<'a> {
-    pub(crate) fn new(policy_id: &'a PolicyID, source_loc: Option<Loc>) -> Self {
+impl SourceLocation {
+    pub(crate) fn new(policy_id: PolicyID, source_loc: Option<Loc>) -> Self {
         Self {
             policy_id,
             source_loc,
@@ -127,8 +127,8 @@ impl<'a> SourceLocation<'a> {
     }
 
     /// Get the `PolicyId` for the policy at this source location.
-    pub fn policy_id(&self) -> &'a PolicyID {
-        self.policy_id
+    pub fn policy_id(&self) -> &PolicyID {
+        &self.policy_id
     }
 
     pub fn source_loc(&self) -> Option<&Loc> {
@@ -290,14 +290,14 @@ pub struct UnspecifiedEntityError {
 
 /// The structure for validation warnings.
 #[derive(Debug, Clone)]
-pub struct ValidationWarning<'a> {
-    pub(crate) location: SourceLocation<'a>,
+pub struct ValidationWarning {
+    pub(crate) location: SourceLocation,
     pub(crate) kind: ValidationWarningKind,
 }
 
-impl<'a> ValidationWarning<'a> {
+impl ValidationWarning {
     pub(crate) fn with_policy_id(
-        id: &'a PolicyID,
+        id: PolicyID,
         source_loc: Option<Loc>,
         warning_kind: ValidationWarningKind,
     ) -> Self {
@@ -307,7 +307,7 @@ impl<'a> ValidationWarning<'a> {
         }
     }
 
-    pub fn location(&self) -> &SourceLocation<'a> {
+    pub fn location(&self) -> &SourceLocation {
         &self.location
     }
 
@@ -315,12 +315,12 @@ impl<'a> ValidationWarning<'a> {
         &self.kind
     }
 
-    pub fn to_kind_and_location(self) -> (SourceLocation<'a>, ValidationWarningKind) {
+    pub fn to_kind_and_location(self) -> (SourceLocation, ValidationWarningKind) {
         (self.location, self.kind)
     }
 }
 
-impl std::fmt::Display for ValidationWarning<'_> {
+impl std::fmt::Display for ValidationWarning {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1667,8 +1667,8 @@ impl ValidationResult {
     }
 }
 
-impl<'a> From<cedar_policy_validator::ValidationResult<'a>> for ValidationResult {
-    fn from(r: cedar_policy_validator::ValidationResult<'a>) -> Self {
+impl From<cedar_policy_validator::ValidationResult> for ValidationResult {
+    fn from(r: cedar_policy_validator::ValidationResult) -> Self {
         let (errors, warnings) = r.into_errors_and_warnings();
         Self {
             validation_errors: errors.map(ValidationError::from).collect(),
@@ -1781,8 +1781,8 @@ impl ValidationError {
 }
 
 #[doc(hidden)]
-impl<'a> From<cedar_policy_validator::ValidationError<'a>> for ValidationError {
-    fn from(err: cedar_policy_validator::ValidationError<'a>) -> Self {
+impl From<cedar_policy_validator::ValidationError> for ValidationError {
+    fn from(err: cedar_policy_validator::ValidationError) -> Self {
         let (location, error_kind) = err.into_location_and_error_kind();
         Self {
             location: SourceLocation::from(location),
@@ -1864,8 +1864,8 @@ impl std::fmt::Display for SourceLocation {
     }
 }
 
-impl<'a> From<cedar_policy_validator::SourceLocation<'a>> for SourceLocation {
-    fn from(loc: cedar_policy_validator::SourceLocation<'a>) -> Self {
+impl From<cedar_policy_validator::SourceLocation> for SourceLocation {
+    fn from(loc: cedar_policy_validator::SourceLocation) -> Self {
         let policy_id = PolicyId(loc.policy_id().clone());
         let source_loc = loc.source_loc().cloned();
         Self {
@@ -1907,8 +1907,8 @@ impl ValidationWarning {
 }
 
 #[doc(hidden)]
-impl<'a> From<cedar_policy_validator::ValidationWarning<'a>> for ValidationWarning {
-    fn from(w: cedar_policy_validator::ValidationWarning<'a>) -> Self {
+impl From<cedar_policy_validator::ValidationWarning> for ValidationWarning {
+    fn from(w: cedar_policy_validator::ValidationWarning) -> Self {
         let (loc, kind) = w.to_kind_and_location();
         Self {
             location: loc.into(),


### PR DESCRIPTION
## Description of changes

## Issue #, if available

This makes it possible to write tests for these errors in the same style as our parser errors.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

