### PR TITLE
Add source location to `TemplateBody`

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -69,6 +69,7 @@ impl Template {
     /// Construct a `Template` from its components
     pub fn new(
         id: PolicyID,
+        loc: Option<Loc>,
         annotations: Annotations,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
@@ -78,6 +79,7 @@ impl Template {
     ) -> Self {
         let body = TemplateBody::new(
             id,
+            loc,
             annotations,
             effect,
             principal_constraint,
@@ -93,6 +95,7 @@ impl Template {
     /// Construct a template from an expression/annotations that are already [`std::sync::Arc`] allocated
     pub fn new_shared(
         id: PolicyID,
+        loc: Option<Loc>,
         annotations: Arc<Annotations>,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
@@ -102,6 +105,7 @@ impl Template {
     ) -> Self {
         let body = TemplateBody::new_shared(
             id,
+            loc,
             annotations,
             effect,
             principal_constraint,
@@ -150,6 +154,11 @@ impl Template {
             body: self.body.new_id(id),
             slots: self.slots.clone(),
         }
+    }
+
+    /// Get the location of this policy
+    pub fn loc(&self) -> &Option<Loc> {
+        self.body.loc()
     }
 
     /// Get the `Effect` (`Permit` or `Deny`) of this template
@@ -381,8 +390,14 @@ impl Policy {
     }
 
     /// Build a policy with a given effect, given when clause, and unconstrained head variables
-    pub fn from_when_clause(effect: Effect, when: Expr, id: PolicyID) -> Self {
-        Self::from_when_clause_annos(effect, Arc::new(when), id, Arc::new(Annotations::default()))
+    pub fn from_when_clause(effect: Effect, when: Expr, id: PolicyID, loc: Option<Loc>) -> Self {
+        Self::from_when_clause_annos(
+            effect,
+            Arc::new(when),
+            id,
+            loc,
+            Arc::new(Annotations::default()),
+        )
     }
 
     /// Build a policy with a given effect, given when clause, and unconstrained head variables
@@ -390,10 +405,12 @@ impl Policy {
         effect: Effect,
         when: Arc<Expr>,
         id: PolicyID,
+        loc: Option<Loc>,
         annotations: Arc<Annotations>,
     ) -> Self {
         let t = Template::new_shared(
             id,
+            loc,
             annotations,
             effect,
             PrincipalConstraint::any(),
@@ -505,6 +522,11 @@ impl Policy {
                 values: self.values.clone(),
             },
         }
+    }
+
+    /// Get the location of this policy
+    pub fn loc(&self) -> &Option<Loc> {
+        self.template.loc()
     }
 
     /// Returns true if this policy is an inline policy
@@ -801,6 +823,7 @@ impl StaticPolicy {
     /// Construct a `StaticPolicy` from its components
     pub fn new(
         id: PolicyID,
+        loc: Option<Loc>,
         annotations: Annotations,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
@@ -810,6 +833,7 @@ impl StaticPolicy {
     ) -> Result<Self, UnexpectedSlotError> {
         let body = TemplateBody::new(
             id,
+            loc,
             annotations,
             effect,
             principal_constraint,
@@ -859,6 +883,8 @@ impl From<StaticPolicy> for Arc<Template> {
 pub struct TemplateBody {
     /// ID of this policy
     id: PolicyID,
+    /// Source location spanning the entire policy
+    loc: Option<Loc>,
     /// Annotations available for external applications, as key-value store.
     /// Note that the keys are `AnyId`, so Cedar reserved words like `if` and `has`
     /// are explicitly allowed as annotations.
@@ -888,6 +914,11 @@ impl TemplateBody {
     /// Get the `Id` of this policy.
     pub fn id(&self) -> &PolicyID {
         &self.id
+    }
+
+    /// Get the location of this policy
+    pub fn loc(&self) -> &Option<Loc> {
+        &self.loc
     }
 
     /// Clone this policy with a new `Id`.
@@ -977,16 +1008,20 @@ impl TemplateBody {
                 Expr::and(
                     self.principal_constraint_expr(),
                     self.action_constraint_expr(),
-                ),
+                )
+                .with_maybe_source_loc(self.loc.clone()),
                 self.resource_constraint_expr(),
-            ),
+            )
+            .with_maybe_source_loc(self.loc.clone()),
             self.non_head_constraints.as_ref().clone(),
         )
+        .with_maybe_source_loc(self.loc.clone())
     }
 
     /// Construct a `Policy` from components that are already [`std::sync::Arc`] allocated
     pub fn new_shared(
         id: PolicyID,
+        loc: Option<Loc>,
         annotations: Arc<Annotations>,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
@@ -996,6 +1031,7 @@ impl TemplateBody {
     ) -> Self {
         Self {
             id,
+            loc,
             annotations,
             effect,
             principal_constraint,
@@ -1008,6 +1044,7 @@ impl TemplateBody {
     /// Construct a `Policy` from its components
     pub fn new(
         id: PolicyID,
+        loc: Option<Loc>,
         annotations: Annotations,
         effect: Effect,
         principal_constraint: PrincipalConstraint,
@@ -1017,6 +1054,7 @@ impl TemplateBody {
     ) -> Self {
         Self {
             id,
+            loc,
             annotations: Arc::new(annotations),
             effect,
             principal_constraint,
@@ -1794,6 +1832,7 @@ pub mod test_generators {
                 for resource in all_resource_constraints() {
                     let permit = Template::new(
                         permit.clone(),
+                        None,
                         Annotations::new(),
                         Effect::Permit,
                         principal.clone(),
@@ -1803,6 +1842,7 @@ pub mod test_generators {
                     );
                     let forbid = Template::new(
                         forbid.clone(),
+                        None,
                         Annotations::new(),
                         Effect::Forbid,
                         principal.clone(),
@@ -1878,7 +1918,7 @@ mod test {
             let a = template.action_constraint().clone();
             let r = template.resource_constraint().clone();
             let nhc = template.non_head_constraints().clone();
-            let t2 = Template::new(id, Annotations::new(), effect, p, a, r, nhc);
+            let t2 = Template::new(id, None, Annotations::new(), effect, p, a, r, nhc);
             assert_eq!(template, t2);
         }
     }
@@ -1897,8 +1937,8 @@ mod test {
                 let a = ip.action_constraint().clone();
                 let r = ip.resource_constraint().clone();
                 let nhc = ip.non_head_constraints().clone();
-                let ip2 =
-                    StaticPolicy::new(id, anno, e, p, a, r, nhc).expect("Policy Creation Failed");
+                let ip2 = StaticPolicy::new(id, None, anno, e, p, a, r, nhc)
+                    .expect("Policy Creation Failed");
                 assert_eq!(ip, ip2);
                 let (t2, inst) = Template::link_static_policy(ip2);
                 assert!(inst.is_static());
@@ -1913,6 +1953,7 @@ mod test {
         let iid = PolicyID::from_string("iid");
         let t = Arc::new(Template::new(
             tid,
+            None,
             Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq_slot(),
@@ -1934,6 +1975,7 @@ mod test {
         let iid = PolicyID::from_string("iid");
         let t = Arc::new(Template::new(
             tid,
+            None,
             Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq_slot(),
@@ -1959,6 +2001,7 @@ mod test {
         let iid = PolicyID::from_string("linked");
         let t = Arc::new(Template::new(
             tid,
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_in_slot(),

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -682,6 +682,7 @@ mod test {
         let lid = PolicyID::from_string("link");
         let t = Template::new(
             tid.clone(),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -710,6 +711,7 @@ mod test {
         let lid = PolicyID::from_string("link");
         let t = Template::new(
             tid.clone(),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq_slot(),
@@ -745,6 +747,7 @@ mod test {
         let id = PolicyID::from_string("id");
         let p = StaticPolicy::new(
             id.clone(),
+            None,
             Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::any(),
@@ -773,6 +776,7 @@ mod test {
         let link_id = PolicyID::from_string("link");
         let t = Template::new(
             template_id.clone(),
+            None,
             Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq_slot(),
@@ -807,6 +811,7 @@ mod test {
         let tid1 = PolicyID::from_string("template");
         let policy1 = StaticPolicy::new(
             id1.clone(),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -817,6 +822,7 @@ mod test {
         .expect("Policy Creation Failed");
         let template1 = Template::new(
             tid1.clone(),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -836,6 +842,7 @@ mod test {
         let id2 = PolicyID::from_string("id2");
         let policy2 = StaticPolicy::new(
             id2.clone(),
+            None,
             Annotations::new(),
             Effect::Forbid,
             PrincipalConstraint::is_eq(EntityUID::with_eid("jane")),
@@ -850,6 +857,7 @@ mod test {
         let tid2 = PolicyID::from_string("template2");
         let template2 = Template::new(
             tid2.clone(),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq_slot(),

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -261,6 +261,7 @@ mod test {
         let pid = PolicyID::from_string(id);
         StaticPolicy::new(
             pid,
+            None,
             Annotations::new(),
             e,
             PrincipalConstraint::any(),
@@ -275,6 +276,7 @@ mod test {
         let pid = PolicyID::from_string(id);
         StaticPolicy::new(
             pid,
+            None,
             Annotations::new(),
             effect,
             PrincipalConstraint::any(),

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -337,7 +337,13 @@ impl From<PartialResponse> for Response {
 
 /// Build a policy from a policy prototype
 fn construct_policy((effect, id, expr, annotations): PolicyPrototype<'_>) -> Policy {
-    Policy::from_when_clause_annos(effect, expr.clone(), id.clone(), (*annotations).clone())
+    Policy::from_when_clause_annos(
+        effect,
+        expr.clone(),
+        id.clone(),
+        expr.source_loc().cloned(),
+        (*annotations).clone(),
+    )
 }
 
 /// Given a mapping from unknown names to values and a policy prototype
@@ -351,6 +357,7 @@ fn map_unknowns<'a>(
             effect,
             Arc::new(expr.substitute(mapping)),
             id.clone(),
+            expr.source_loc().cloned(),
             annotations.clone(),
         )
     }
@@ -499,43 +506,51 @@ mod test {
                 Policy::from_when_clause(
                     Effect::Permit,
                     Expr::val(true),
-                    PolicyID::from_string("a")
+                    PolicyID::from_string("a"),
+                    None,
                 ),
                 Policy::from_when_clause(
                     Effect::Permit,
                     Expr::val(false),
-                    PolicyID::from_string("b")
+                    PolicyID::from_string("b"),
+                    None,
                 ),
                 Policy::from_when_clause(
                     Effect::Permit,
                     Expr::val(false),
-                    PolicyID::from_string("c")
+                    PolicyID::from_string("c"),
+                    None,
                 ),
                 Policy::from_when_clause_annos(
                     Effect::Permit,
                     one_plus_two.clone(),
                     PolicyID::from_string("d"),
+                    None,
                     Arc::default()
                 ),
                 Policy::from_when_clause(
                     Effect::Forbid,
                     Expr::val(true),
-                    PolicyID::from_string("e")
+                    PolicyID::from_string("e"),
+                    None,
                 ),
                 Policy::from_when_clause(
                     Effect::Forbid,
                     Expr::val(false),
-                    PolicyID::from_string("f")
+                    PolicyID::from_string("f"),
+                    None,
                 ),
                 Policy::from_when_clause(
                     Effect::Forbid,
                     Expr::val(false),
-                    PolicyID::from_string("g")
+                    PolicyID::from_string("g"),
+                    None,
                 ),
                 Policy::from_when_clause_annos(
                     Effect::Forbid,
                     three_plus_four.clone(),
                     PolicyID::from_string("h"),
+                    None,
                     Arc::default()
                 ),
             ])
@@ -552,12 +567,14 @@ mod test {
                     Effect::Permit,
                     one_plus_two.clone(),
                     PolicyID::from_string("d"),
+                    None,
                     Arc::default()
                 ),
                 Policy::from_when_clause_annos(
                     Effect::Forbid,
                     three_plus_four.clone(),
                     PolicyID::from_string("h"),
+                    None,
                     Arc::default()
                 ),
             ])

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -248,6 +248,7 @@ impl Policy {
         };
         Ok(ast::Template::new(
             id,
+            None,
             self.annotations
                 .into_iter()
                 .map(|(key, val)| (key, ast::Annotation { val, loc: None }))

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2317,6 +2317,7 @@ fn construct_template_policy(
     let construct_template = |non_head_constraint| {
         ast::Template::new(
             id,
+            Some(loc.clone()),
             annotations,
             effect,
             principal,

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -47,6 +47,7 @@ wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [dev-dependencies]
 cool_asserts = "2.0"
+cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core", features = ["test-util"] }
 
 [build-dependencies]
 lalrpop = "0.20.0"

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -17,13 +17,16 @@
 //! Contains the validation logic specific to RBAC policy validation.
 
 use cedar_policy_core::ast::{
-    self, ActionConstraint, EntityReference, EntityUID, Name, PrincipalConstraint,
+    self, ActionConstraint, EntityReference, EntityUID, Name, Policy, PrincipalConstraint,
     PrincipalOrResourceConstraint, ResourceConstraint, SlotEnv, Template,
 };
 
 use std::{collections::HashSet, sync::Arc};
 
-use crate::expr_iterator::{policy_entity_type_names, policy_entity_uids};
+use crate::{
+    expr_iterator::{policy_entity_type_names, policy_entity_uids},
+    ValidationError,
+};
 
 use super::{
     fuzzy_match::fuzzy_search, schema::*, validation_result::ValidationErrorKind, Validator,
@@ -252,11 +255,35 @@ impl Validator {
         }
     }
 
+    pub(crate) fn validate_linked_action_application<'a>(
+        &self,
+        p: &'a Policy,
+    ) -> impl Iterator<Item = ValidationError> + 'a {
+        self.validate_action_application(
+            &p.principal_constraint(),
+            p.action_constraint(),
+            &p.resource_constraint(),
+        )
+        .map(move |e| ValidationError::with_policy_id(p.id().clone(), p.loc().clone(), e))
+    }
+
+    pub(crate) fn validate_template_action_application<'a>(
+        &self,
+        t: &'a Template,
+    ) -> impl Iterator<Item = ValidationError> + 'a {
+        self.validate_action_application(
+            t.principal_constraint(),
+            t.action_constraint(),
+            t.resource_constraint(),
+        )
+        .map(|e| ValidationError::with_policy_id(t.id().clone(), t.loc().clone(), e))
+    }
+
     // Check that there exists a (action id, principal type, resource type)
     // entity type pair where the action can be applied to both the principal
     // and resource. This function takes the three scope constraints as input
     // (rather than a template) to facilitate code reuse.
-    pub(crate) fn validate_action_application(
+    fn validate_action_application(
         &self,
         principal_constraint: &PrincipalConstraint,
         action_constraint: &ActionConstraint,
@@ -425,7 +452,9 @@ mod test {
             ResourceConstraint,
         },
         parser::{parse_policy, parse_policy_template},
+        test_utils::{expect_err, ExpectedErrorMessageBuilder},
     };
+    use miette::Report;
 
     use super::*;
     use crate::{
@@ -441,6 +470,7 @@ mod test {
     fn validate_entity_type_empty_schema() -> Result<()> {
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -473,84 +503,50 @@ mod test {
     }
 
     #[test]
-    fn validate_equals_instead_of_in() -> Result<()> {
-        let user_type = "user";
-        let group_type = "admins";
-        let widget_type = "widget";
-        let bin_type = "bin";
-        let action_name = "act";
-        let schema_file = NamespaceDefinition::new(
-            [
-                (
-                    user_type.parse().unwrap(),
-                    EntityType {
-                        member_of_types: vec![group_type.parse().unwrap()],
-                        shape: AttributesOrContext::default(),
+    fn validate_equals_instead_of_in() {
+        let schema_file: NamespaceDefinition = serde_json::from_value(serde_json::json!(
+            {
+                "entityTypes": {
+                    "user": {
+                        "memberOfTypes": ["admins"]
                     },
-                ),
-                (
-                    group_type.parse().unwrap(),
-                    EntityType {
-                        member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                    "admins": {},
+                    "widget": {
+                        "memberOfTypes": ["bin"]
                     },
-                ),
-                (
-                    widget_type.parse().unwrap(),
-                    EntityType {
-                        member_of_types: vec![bin_type.parse().unwrap()],
-                        shape: AttributesOrContext::default(),
-                    },
-                ),
-                (
-                    bin_type.parse().unwrap(),
-                    EntityType {
-                        member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
-                    },
-                ),
-            ],
-            [(
-                action_name.into(),
-                ActionType {
-                    applies_to: Some(ApplySpec {
-                        resource_types: Some(vec![widget_type.parse().unwrap()]),
-                        principal_types: Some(vec![user_type.parse().unwrap()]),
-                        context: AttributesOrContext::default(),
-                    }),
-                    member_of: None,
-                    attributes: None,
+                    "bin": {}
                 },
-            )],
-        );
+                "actions": {
+                    "act": {
+                        "appliesTo": {
+                            "principalTypes": ["user"],
+                            "resourceTypes": ["widget"]
+                        }
+                    }
+                }
+            }
+        ))
+        .unwrap();
         let schema = schema_file.try_into().unwrap();
 
-        let group_eid = EntityUID::with_eid_and_type(group_type, "admin1").expect("");
+        let src = r#"permit(principal == admins::"admin1", action == Action::"act", resource == bin::"bin");"#;
+        let p = parse_policy_template(None, src).unwrap();
 
-        let action_eid = EntityUID::with_eid_and_type("Action", action_name).expect("");
+        let validate = Validator::new(schema);
+        let notes: Vec<ValidationError> =
+            validate.validate_template_action_application(&p).collect();
 
-        let bin_eid = EntityUID::with_eid_and_type(bin_type, "bin").expect("");
-
-        let principal_constraint = PrincipalConstraint::is_eq(group_eid);
-        let action_constraint = ActionConstraint::is_eq(action_eid);
-        let resource_constraint = ResourceConstraint::is_eq(bin_eid);
-
-        let v = Validator::new(schema);
-
-        let notes = v
-            .validate_action_application(
-                &principal_constraint,
-                &action_constraint,
-                &resource_constraint,
+        expect_err(
+            src,
+            &Report::new(notes.first().unwrap().clone()),
+            &ExpectedErrorMessageBuilder::error(
+                r#"unable to find an applicable action given the policy head constraints"#,
             )
-            .collect::<Vec<_>>();
-
-        assert_eq!(
-            vec![ValidationErrorKind::invalid_action_application(true, true)],
-            notes,
-            "Validation result did not contain InvalidActionApplication with both suggested fixes."
+            .help("try replacing `==` with `in` in the principal clause and the resource clause")
+            .exactly_one_underline(src)
+            .build(),
         );
-        Ok(())
+        assert_eq!(notes.len(), 1, "{:?}", notes);
     }
 
     #[test]
@@ -605,6 +601,7 @@ mod test {
         let singleton_schema = schema_file.try_into().unwrap();
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(
@@ -645,6 +642,7 @@ mod test {
             .expect("should be a valid identifier");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -821,6 +819,7 @@ mod test {
             .expect("Should be a valid identifier");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -903,6 +902,7 @@ mod test {
             .expect("Expected entity parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -970,6 +970,7 @@ mod test {
         let entity_type: Name = "Bogus::Foo".parse().expect("Expected entity type parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(EntityUID::from_components(entity_type, Eid::new("bar"))),
@@ -1225,123 +1226,75 @@ mod test {
     }
 
     #[test]
-    fn validate_action_apply_incorrect_principal() -> Result<()> {
-        let (_, action, resource, schema) = schema_with_single_principal_action_resource();
+    fn validate_action_apply_incorrect_principal() {
+        let (_, _, _, schema) = schema_with_single_principal_action_resource();
 
-        let principal_constraint = PrincipalConstraint::is_eq(resource.clone());
-        let action_constraint = ActionConstraint::is_eq(action);
-        let resource_constraint = ResourceConstraint::is_eq(resource);
-
-        let validate = Validator::new(schema);
-        let notes: Vec<ValidationErrorKind> = validate
-            .validate_action_application(
-                &principal_constraint,
-                &action_constraint,
-                &resource_constraint,
-            )
-            .collect();
-        assert_eq!(1, notes.len());
-        match notes.first() {
-            Some(ValidationErrorKind::InvalidActionApplication(_)) => (),
-            _ => panic!("Unexpected variant of ValidationErrorKind."),
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn validate_action_apply_incorrect_resource() -> Result<()> {
-        let (principal, action, _, schema) = schema_with_single_principal_action_resource();
-
-        let principal_constraint = PrincipalConstraint::is_eq(principal.clone());
-        let action_constraint = ActionConstraint::is_eq(action);
-        let resource_constraint = ResourceConstraint::is_eq(principal);
+        let src =
+            r#"permit(principal == baz::"p", action == Action::"foo", resource == baz::"r");"#;
+        let p = parse_policy_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
-        let notes: Vec<ValidationErrorKind> = validate
-            .validate_action_application(
-                &principal_constraint,
-                &action_constraint,
-                &resource_constraint,
+        let notes: Vec<ValidationError> =
+            validate.validate_template_action_application(&p).collect();
+
+        expect_err(
+            src,
+            &Report::new(notes.first().unwrap().clone()),
+            &ExpectedErrorMessageBuilder::error(
+                r#"unable to find an applicable action given the policy head constraints"#,
             )
-            .collect();
-        assert_eq!(1, notes.len());
-        match notes.first() {
-            Some(ValidationErrorKind::InvalidActionApplication(_)) => (),
-            _ => panic!("Unexpected variant of ValidationErrorKind."),
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn validate_action_apply_incorrect_principal_and_resource() -> Result<()> {
-        let (principal, action, resource, schema) = schema_with_single_principal_action_resource();
-
-        let principal_constraint = PrincipalConstraint::is_eq(resource);
-        let action_constraint = ActionConstraint::is_eq(action);
-        let resource_constraint = ResourceConstraint::is_eq(principal);
-
-        let validate = Validator::new(schema);
-        let notes: Vec<ValidationErrorKind> = validate
-            .validate_action_application(
-                &principal_constraint,
-                &action_constraint,
-                &resource_constraint,
-            )
-            .collect();
-        assert_eq!(1, notes.len());
-        match notes.first() {
-            Some(ValidationErrorKind::InvalidActionApplication(_)) => (),
-            _ => panic!("Unexpected variant of ValidationErrorKind."),
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn validate_used_as_correct() -> Result<()> {
-        let (principal, action, resource, schema) = schema_with_single_principal_action_resource();
-        let policy = Template::new(
-            PolicyID::from_string("policy0"),
-            None,
-            Annotations::new(),
-            Effect::Permit,
-            PrincipalConstraint::is_eq(principal),
-            ActionConstraint::is_eq(action),
-            ResourceConstraint::is_eq(resource),
-            Expr::val(true),
+            .exactly_one_underline(src)
+            .build(),
         );
-
-        let validator = Validator::new(schema);
-        assert_validate_policy_succeeds(&validator, &policy);
-        Ok(())
+        assert_eq!(notes.len(), 1, "{:?}", notes);
     }
 
     #[test]
-    fn validate_used_as_incorrect() -> Result<()> {
-        let (principal, _, resource, schema) = schema_with_single_principal_action_resource();
+    fn validate_action_apply_incorrect_resource() {
+        let (_, _, _, schema) = schema_with_single_principal_action_resource();
 
-        let principal_constraint = PrincipalConstraint::is_eq(resource);
-        let action_constraint = ActionConstraint::any();
-        let resource_constraint = ResourceConstraint::is_eq(principal);
+        let src =
+            r#"permit(principal == bar::"p", action == Action::"foo", resource == bar::"r");"#;
+        let p = parse_policy_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
-        let notes: Vec<_> = validate
-            .validate_action_application(
-                &principal_constraint,
-                &action_constraint,
-                &resource_constraint,
-            )
-            .collect();
-        assert_eq!(
-            notes,
-            vec![ValidationErrorKind::invalid_action_application(
-                false, false
-            )],
-        );
+        let notes: Vec<ValidationError> =
+            validate.validate_template_action_application(&p).collect();
 
-        Ok(())
+        expect_err(
+            src,
+            &Report::new(notes.first().unwrap().clone()),
+            &ExpectedErrorMessageBuilder::error(
+                r#"unable to find an applicable action given the policy head constraints"#,
+            )
+            .exactly_one_underline(src)
+            .build(),
+        );
+        assert_eq!(notes.len(), 1, "{:?}", notes);
+    }
+
+    #[test]
+    fn validate_action_apply_incorrect_principal_and_resource() {
+        let (_, _, _, schema) = schema_with_single_principal_action_resource();
+
+        let src =
+            r#"permit(principal == baz::"p", action == Action::"foo", resource == bar::"r");"#;
+        let p = parse_policy_template(None, src).unwrap();
+
+        let validate = Validator::new(schema);
+        let notes: Vec<ValidationError> =
+            validate.validate_template_action_application(&p).collect();
+
+        expect_err(
+            src,
+            &Report::new(notes.first().unwrap().clone()),
+            &ExpectedErrorMessageBuilder::error(
+                r#"unable to find an applicable action given the policy head constraints"#,
+            )
+            .exactly_one_underline(src)
+            .build(),
+        );
+        assert_eq!(notes.len(), 1, "{:?}", notes);
     }
 
     #[test]

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -569,6 +569,7 @@ mod test {
         let singleton_schema = schema_file.try_into().unwrap();
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -692,6 +693,7 @@ mod test {
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -868,6 +870,7 @@ mod test {
             .expect("Expected entity parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -936,6 +939,7 @@ mod test {
         let entity_type: Name = "NS::Foo".parse().expect("Expected entity type parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(EntityUID::from_components(entity_type, Eid::new("bar"))),
@@ -1206,6 +1210,7 @@ mod test {
 
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(principal),
@@ -1299,6 +1304,7 @@ mod test {
         let (principal, action, resource, schema) = schema_with_single_principal_action_resource();
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_eq(principal),
@@ -1587,6 +1593,7 @@ mod test {
 
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -1609,6 +1616,7 @@ mod test {
         // resource == Unspecified::"foo"
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),
@@ -1627,6 +1635,7 @@ mod test {
         // principal in Unspecified::"foo"
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::is_in(EntityUID::unspecified_from_eid(Eid::new("foo"))),
@@ -1652,6 +1661,7 @@ mod test {
         // resource == Unspecified::"foo"
         let policy = Template::new(
             PolicyID::from_string("policy0"),
+            None,
             Annotations::new(),
             Effect::Permit,
             PrincipalConstraint::any(),

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -43,7 +43,7 @@ use crate::{
     types::{
         AttributeType, Effect, EffectSet, EntityRecordKind, OpenTag, Primitive, RequestEnv, Type,
     },
-    AttributeAccess, UnexpectedTypeHelp, ValidationMode, ValidationWarningKind,
+    AttributeAccess, UnexpectedTypeHelp, ValidationMode, ValidationWarning, ValidationWarningKind,
 };
 
 use super::type_error::TypeError;
@@ -270,11 +270,11 @@ impl<'a> Typechecker<'a> {
     /// relevant error is expected to be added by a different pass. Finally,
     /// warnings may be added to the `warnings` list, although these will not
     /// impact the boolean return value.
-    pub fn typecheck_policy(
+    pub fn typecheck_policy<'b>(
         &self,
-        t: &Template,
+        t: &'b Template,
         type_errors: &mut HashSet<TypeError>,
-        warnings: &mut HashSet<ValidationWarningKind>,
+        warnings: &mut HashSet<ValidationWarning>,
     ) -> bool {
         let typecheck_answers = self.typecheck_by_request_env(t);
 
@@ -298,7 +298,11 @@ impl<'a> Typechecker<'a> {
         // If every policy typechecked with type false, then the policy cannot
         // possibly apply to any request.
         if all_false {
-            warnings.insert(ValidationWarningKind::ImpossiblePolicy);
+            warnings.insert(ValidationWarning::with_policy_id(
+                t.id().clone(),
+                t.loc().clone(),
+                ValidationWarningKind::ImpossiblePolicy,
+            ));
         }
 
         all_succ

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -270,9 +270,9 @@ impl<'a> Typechecker<'a> {
     /// relevant error is expected to be added by a different pass. Finally,
     /// warnings may be added to the `warnings` list, although these will not
     /// impact the boolean return value.
-    pub fn typecheck_policy<'b>(
+    pub fn typecheck_policy(
         &self,
-        t: &'b Template,
+        t: &Template,
         type_errors: &mut HashSet<TypeError>,
         warnings: &mut HashSet<ValidationWarning>,
     ) -> bool {

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -29,8 +29,8 @@ use crate::typecheck::Typechecker;
 use crate::types::{EntityLUB, Type};
 use crate::UnexpectedTypeHelp;
 use crate::{
-    AttributeAccess, NamespaceDefinition, TypeError, ValidationMode, ValidationWarningKind,
-    ValidatorSchema,
+    AttributeAccess, NamespaceDefinition, TypeError, ValidationMode, ValidationWarning,
+    ValidationWarningKind, ValidatorSchema,
 };
 
 use super::test_utils::empty_schema_file;
@@ -43,7 +43,7 @@ pub(crate) fn assert_partial_typecheck(
     let schema = schema.try_into().expect("Failed to construct schema.");
     let typechecker = Typechecker::new(&schema, ValidationMode::Partial);
     let mut type_errors: HashSet<TypeError> = HashSet::new();
-    let mut warnings: HashSet<ValidationWarningKind> = HashSet::new();
+    let mut warnings: HashSet<ValidationWarning> = HashSet::new();
     let typechecked = typechecker.typecheck_policy(
         &Template::link_static_policy(policy.clone()).0,
         &mut type_errors,
@@ -62,7 +62,7 @@ pub(crate) fn assert_partial_typecheck_fails(
     let schema = schema.try_into().expect("Failed to construct schema.");
     let typechecker = Typechecker::new(&schema, ValidationMode::Partial);
     let mut type_errors: HashSet<TypeError> = HashSet::new();
-    let mut warnings: HashSet<ValidationWarningKind> = HashSet::new();
+    let mut warnings: HashSet<ValidationWarning> = HashSet::new();
     let typechecked = typechecker.typecheck_policy(
         &Template::link_static_policy(policy.clone()).0,
         &mut type_errors,
@@ -81,7 +81,7 @@ pub(crate) fn assert_partial_typecheck_warns(
     let schema = schema.try_into().expect("Failed to construct schema.");
     let typechecker = Typechecker::new(&schema, ValidationMode::Partial);
     let mut type_errors: HashSet<TypeError> = HashSet::new();
-    let mut warnings: HashSet<ValidationWarningKind> = HashSet::new();
+    let mut warnings: HashSet<ValidationWarning> = HashSet::new();
     let typechecked = typechecker.typecheck_policy(
         &Template::link_static_policy(policy.clone()).0,
         &mut type_errors,

--- a/cedar-policy-validator/src/typecheck/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test_utils.rs
@@ -34,8 +34,8 @@ use crate::{
     schema::ACTION_ENTITY_TYPE,
     type_error::TypeError,
     types::{EffectSet, OpenTag, RequestEnv, Type},
-    NamespaceDefinition, UnexpectedTypeHelp, ValidationMode, ValidationWarningKind,
-    ValidatorSchema,
+    NamespaceDefinition, UnexpectedTypeHelp, ValidationMode, ValidationWarning,
+    ValidationWarningKind, ValidatorSchema,
 };
 
 impl TypeError {
@@ -155,11 +155,11 @@ pub(crate) fn assert_expected_type_errors(expected: &Vec<TypeError>, actual: &Ha
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_expected_warnings(
     expected: &Vec<ValidationWarningKind>,
-    actual: &HashSet<ValidationWarningKind>,
+    actual: &HashSet<ValidationWarning>,
 ) {
     expected.iter().for_each(|expected| {
             assert!(
-                actual.contains(expected),
+                actual.iter().any(|w| w.kind() == expected),
                 "Expected generated warnings to contain {:#?}, but warning was not found. The following warnings were generated: {:#?}",
                 expected,
                 actual
@@ -192,7 +192,7 @@ pub(crate) fn assert_policy_typechecks_for_mode(
         let policy: Arc<Template> = policy.into();
         typechecker.mode = mode;
         let mut type_errors: HashSet<TypeError> = HashSet::new();
-        let mut warnings: HashSet<ValidationWarningKind> = HashSet::new();
+        let mut warnings: HashSet<ValidationWarning> = HashSet::new();
         let typechecked = typechecker.typecheck_policy(&policy, &mut type_errors, &mut warnings);
         assert_eq!(type_errors, HashSet::new(), "Did not expect any errors.");
         assert!(typechecked, "Expected that policy would typecheck.");
@@ -252,7 +252,7 @@ pub(crate) fn assert_policy_typecheck_fails_for_mode(
     with_typechecker_from_schema(schema, |mut typechecker| {
         typechecker.mode = mode;
         let mut type_errors: HashSet<TypeError> = HashSet::new();
-        let mut warnings: HashSet<ValidationWarningKind> = HashSet::new();
+        let mut warnings: HashSet<ValidationWarning> = HashSet::new();
         let typechecked =
             typechecker.typecheck_policy(&policy.into(), &mut type_errors, &mut warnings);
         assert_expected_type_errors(&expected_type_errors, &type_errors);
@@ -270,9 +270,9 @@ pub(crate) fn assert_policy_typecheck_warns_for_mode(
     with_typechecker_from_schema(schema, |mut typechecker| {
         typechecker.mode = mode;
         let mut type_errors: HashSet<TypeError> = HashSet::new();
-        let mut warnings: HashSet<ValidationWarningKind> = HashSet::new();
-        let typechecked =
-            typechecker.typecheck_policy(&policy.into(), &mut type_errors, &mut warnings);
+        let mut warnings: HashSet<ValidationWarning> = HashSet::new();
+        let policy = policy.into();
+        let typechecked = typechecker.typecheck_policy(&policy, &mut type_errors, &mut warnings);
         assert_expected_warnings(&expected_warnings, &warnings);
         assert!(
             typechecked,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737)
 - Changed policy validation to reject comparisons and conditionals between
   record types that differ in whether an attribute is required or optional.
+* Validation error for invalid use of an action now includes a source location
+  containing the offending policy.
 
 ## [3.1.3] - 2024-04-15
 

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -913,6 +913,7 @@ mod policy_set_tests {
                 },
             )),
             ast::PolicyID::from_smolstr("static".into()),
+            None,
         );
         let static_policy = Policy::from_ast(ast);
         let mut pset = PolicySet::new();


### PR DESCRIPTION
## Description of changes

Partially resolves #521 by adding source info onto `TemplateBody`. This source info is then added onto `InvalidActionApplication` validation errors that did not previously have a source range. 

More work we could do later would be adding source information onto each scope constraint for more precise error reporting, but this is a substantial amount of extra work. 

## Issue #, if available


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

