### PR TITLE
Improve error message and add help text for LUB errors

### DIFF
--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -24,6 +24,7 @@ mod cst_to_ast;
 pub mod err;
 /// implementations for formatting, like `Display`
 mod fmt;
+pub use fmt::join_with_conjunction;
 /// Source location struct
 mod loc;
 pub use loc::Loc;

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -453,7 +453,7 @@ impl std::fmt::Display for Slot {
 
 /// Format an iterator as a natural-language string, separating items with
 /// commas and a conjunction (e.g., "and", "or") between the last two items.
-pub(crate) fn join_with_conjunction<T, W: Write>(
+pub fn join_with_conjunction<T, W: Write>(
     f: &mut W,
     conjunction: &str,
     items: impl IntoIterator<Item = T>,

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -131,6 +131,7 @@ impl TypeError {
         on_expr: Expr,
         types: impl IntoIterator<Item = Type>,
         hint: LubHelp,
+        context: LubContext,
     ) -> Self {
         Self {
             on_expr: Some(on_expr),
@@ -138,6 +139,7 @@ impl TypeError {
             kind: TypeErrorKind::IncompatibleTypes(IncompatibleTypes {
                 types: types.into_iter().collect::<BTreeSet<_>>(),
                 hint,
+                context,
             }),
         }
     }
@@ -338,10 +340,11 @@ pub(crate) enum UnexpectedTypeHelp {
 
 /// Structure containing details about an incompatible type error.
 #[derive(Diagnostic, Error, Debug, Clone, Hash, Eq, PartialEq)]
+#[diagnostic(help("{context} must have compatible types; {hint}"))]
 pub struct IncompatibleTypes {
     pub(crate) types: BTreeSet<Type>,
-    #[help]
     pub(crate) hint: LubHelp,
+    pub(crate) context: LubContext,
 }
 
 impl Display for IncompatibleTypes {
@@ -364,6 +367,20 @@ pub(crate) enum LubHelp {
     EntityRecord,
     #[error("types must be exactly equal to be compatible")]
     None,
+}
+
+#[derive(Error, Debug, Clone, Hash, Eq, PartialEq)]
+pub(crate) enum LubContext {
+    #[error("elements of a set")]
+    Set,
+    #[error("both branches of a conditional")]
+    Conditional,
+    #[error("both operands to a `==` expression")]
+    Equality,
+    #[error("elements of the first operand and the second operand to a `contains` expression")]
+    Contains,
+    #[error("elements of both set operands to a `containsAll` or `containsAny` expression")]
+    ContainsAnyAll,
 }
 
 /// Structure containing details about a missing attribute error.

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -354,13 +354,13 @@ impl Display for IncompatibleTypes {
 
 #[derive(Error, Debug, Clone, Hash, Eq, PartialEq)]
 pub(crate) enum LubHelp {
-    #[error("corresponding attributes of compatible record types must either both be required or both be optional")]
+    #[error("corresponding attributes of compatible record types must have the same optionality, either both being required or both being optional")]
     AttributeQualifier,
     #[error("compatible record types must have exactly the same attributes")]
     RecordWidth,
-    #[error("entity types with different names are never compatible even when their attributes would be compatible")]
+    #[error("different entity types are never compatible even when their attributes would be compatible")]
     EntityType,
-    #[error("entity and record types are never compatible even when their attribute would be compatible")]
+    #[error("entity and record types are never compatible even when their attributes would be compatible")]
     EntityRecord,
     #[error("types must be exactly equal to be compatible")]
     None,

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -340,7 +340,7 @@ pub(crate) enum UnexpectedTypeHelp {
 
 /// Structure containing details about an incompatible type error.
 #[derive(Diagnostic, Error, Debug, Clone, Hash, Eq, PartialEq)]
-#[diagnostic(help("{context} must have compatible types; {hint}"))]
+#[diagnostic(help("{context} must have compatible types. {hint}"))]
 pub struct IncompatibleTypes {
     pub(crate) types: BTreeSet<Type>,
     pub(crate) hint: LubHelp,
@@ -349,7 +349,7 @@ pub struct IncompatibleTypes {
 
 impl Display for IncompatibleTypes {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "The types ")?;
+        write!(f, "the types ")?;
         join_with_conjunction(f, "and", self.types.iter(), |f, t| write!(f, "{t}"))?;
         write!(f, " are not compatible")
     }

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -357,15 +357,15 @@ impl Display for IncompatibleTypes {
 
 #[derive(Error, Debug, Clone, Hash, Eq, PartialEq)]
 pub(crate) enum LubHelp {
-    #[error("corresponding attributes of compatible record types must have the same optionality, either both being required or both being optional")]
+    #[error("Corresponding attributes of compatible record types must have the same optionality, either both being required or both being optional")]
     AttributeQualifier,
-    #[error("compatible record types must have exactly the same attributes")]
+    #[error("Compatible record types must have exactly the same attributes")]
     RecordWidth,
-    #[error("different entity types are never compatible even when their attributes would be compatible")]
+    #[error("Different entity types are never compatible even when their attributes would be compatible")]
     EntityType,
-    #[error("entity and record types are never compatible even when their attributes would be compatible")]
+    #[error("Entity and record types are never compatible even when their attributes would be compatible")]
     EntityRecord,
-    #[error("types must be exactly equal to be compatible")]
+    #[error("Types must be exactly equal to be compatible")]
     None,
 }
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1607,7 +1607,7 @@ impl<'a> Typechecker<'a> {
                         TypecheckAnswer::success(annotated_expr)
                     }
                 }
-                // We failed to a compute a type for either lhs or rhs, meaning
+                // We failed to compute a type for either lhs or rhs, meaning
                 // we already failed typechecking for that expression.
                 _ => TypecheckAnswer::success(annotated_expr),
             },

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -26,8 +26,8 @@ use serde_json::json;
 use smol_str::SmolStr;
 
 use crate::{
-    type_error::TypeError, types::Type, AttributeAccess, AttributesOrContext, EntityType, LubHelp,
-    NamespaceDefinition, SchemaFragment, UnexpectedTypeHelp, ValidationMode,
+    type_error::TypeError, types::Type, AttributeAccess, AttributesOrContext, EntityType,
+    LubContext, LubHelp, NamespaceDefinition, SchemaFragment, UnexpectedTypeHelp, ValidationMode,
 };
 
 use super::test_utils::{
@@ -145,6 +145,7 @@ fn heterogeneous_set() {
             set,
             vec![Type::singleton_boolean(true), Type::primitive_long()],
             LubHelp::None,
+            LubContext::Set,
         )],
     );
 }
@@ -673,6 +674,7 @@ fn record_get_attr_lub_typecheck_fails() {
                 Type::primitive_long(),
             ],
             LubHelp::None,
+            LubContext::Conditional,
         )],
     );
 }
@@ -1028,6 +1030,7 @@ fn if_no_lub_error() {
             if_expr,
             vec![Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
+            LubContext::Conditional,
         )],
     );
 }
@@ -1042,6 +1045,7 @@ fn if_typecheck_fails() {
                 if_expr,
                 vec![Type::primitive_long(), Type::primitive_string()],
                 LubHelp::None,
+                LubContext::Conditional,
             ),
             TypeError::expected_type(
                 Expr::val("fail"),

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -26,7 +26,7 @@ use serde_json::json;
 use smol_str::SmolStr;
 
 use crate::{
-    type_error::TypeError, types::Type, AttributeAccess, AttributesOrContext, EntityType,
+    type_error::TypeError, types::Type, AttributeAccess, AttributesOrContext, EntityType, LubHelp,
     NamespaceDefinition, SchemaFragment, UnexpectedTypeHelp, ValidationMode,
 };
 
@@ -144,6 +144,7 @@ fn heterogeneous_set() {
         vec![TypeError::incompatible_types(
             set,
             vec![Type::singleton_boolean(true), Type::primitive_long()],
+            LubHelp::None,
         )],
     );
 }
@@ -671,6 +672,7 @@ fn record_get_attr_lub_typecheck_fails() {
                 )]),
                 Type::primitive_long(),
             ],
+            LubHelp::None,
         )],
     );
 }
@@ -1025,6 +1027,7 @@ fn if_no_lub_error() {
         vec![TypeError::incompatible_types(
             if_expr,
             vec![Type::primitive_long(), Type::primitive_string()],
+            LubHelp::None,
         )],
     );
 }
@@ -1038,6 +1041,7 @@ fn if_typecheck_fails() {
             TypeError::incompatible_types(
                 if_expr,
                 vec![Type::primitive_long(), Type::primitive_string()],
+                LubHelp::None,
             ),
             TypeError::expected_type(
                 Expr::val("fail"),

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -653,7 +653,7 @@ mod fail_partial_schema {
     use std::str::FromStr;
 
     use super::*;
-    use crate::LubHelp;
+    use crate::{LubContext, LubHelp};
 
     #[test]
     fn error_on_declared_attr() {
@@ -696,6 +696,7 @@ mod fail_partial_schema {
                 Expr::from_str("if resource.foo then principal.age else (if resource.bar then principal.name else principal.unknown)").unwrap(),
                 vec![Type::primitive_long(), Type::primitive_string()],
                 LubHelp::None,
+                LubContext::Conditional,
             )],
         );
     }

--- a/cedar-policy-validator/src/typecheck/test_partial.rs
+++ b/cedar-policy-validator/src/typecheck/test_partial.rs
@@ -653,6 +653,7 @@ mod fail_partial_schema {
     use std::str::FromStr;
 
     use super::*;
+    use crate::LubHelp;
 
     #[test]
     fn error_on_declared_attr() {
@@ -694,6 +695,7 @@ mod fail_partial_schema {
             vec![TypeError::incompatible_types(
                 Expr::from_str("if resource.foo then principal.age else (if resource.bar then principal.name else principal.unknown)").unwrap(),
                 vec![Type::primitive_long(), Type::primitive_string()],
+                LubHelp::None,
             )],
         );
     }

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -38,7 +38,8 @@ use crate::{
     type_error::TypeError,
     typecheck::{test_utils::static_to_template, PolicyCheck},
     types::{EntityLUB, Type},
-    AttributeAccess, LubHelp, NamespaceDefinition, ValidationMode, ValidationWarningKind,
+    AttributeAccess, LubContext, LubHelp, NamespaceDefinition, ValidationMode,
+    ValidationWarningKind,
 };
 
 fn simple_schema_file() -> NamespaceDefinition {
@@ -718,6 +719,7 @@ fn entity_record_lub_is_none() {
                     Type::named_entity_reference_from_str("User"),
                 ],
                 LubHelp::EntityRecord,
+                LubContext::Conditional,
             )
         ],
     );
@@ -939,6 +941,7 @@ fn record_entity_lub_non_term() {
                 Type::named_entity_reference_from_str("U"),
             ],
             LubHelp::EntityRecord,
+            LubContext::Conditional,
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -38,7 +38,7 @@ use crate::{
     type_error::TypeError,
     typecheck::{test_utils::static_to_template, PolicyCheck},
     types::{EntityLUB, Type},
-    AttributeAccess, NamespaceDefinition, ValidationMode, ValidationWarningKind,
+    AttributeAccess, LubHelp, NamespaceDefinition, ValidationMode, ValidationWarningKind,
 };
 
 fn simple_schema_file() -> NamespaceDefinition {
@@ -716,7 +716,8 @@ fn entity_record_lub_is_none() {
                 [
                     Type::closed_record_with_required_attributes([("name".into(), Type::primitive_string())]),
                     Type::named_entity_reference_from_str("User"),
-                ]
+                ],
+                LubHelp::EntityRecord,
             )
         ],
     );
@@ -937,6 +938,7 @@ fn record_entity_lub_non_term() {
                 )]),
                 Type::named_entity_reference_from_str("U"),
             ],
+            LubHelp::EntityRecord,
         )],
     );
 }

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -35,7 +35,8 @@ use cedar_policy_core::{
 use crate::{
     typecheck::test_utils::assert_policy_typecheck_fails,
     types::{AttributeType, EffectSet, OpenTag, RequestEnv, Type},
-    IncompatibleTypes, LubHelp, SchemaFragment, TypeError, TypeErrorKind, ValidationMode,
+    IncompatibleTypes, LubContext, LubHelp, SchemaFragment, TypeError, TypeErrorKind,
+    ValidationMode,
 };
 
 use super::test_utils::with_typechecker_from_schema;
@@ -100,6 +101,7 @@ fn assert_types_must_match(
     expected_type: Type,
     unequal_types: impl IntoIterator<Item = Type>,
     hint: LubHelp,
+    context: LubContext,
 ) {
     assert_strict_type_error(
         schema,
@@ -110,6 +112,7 @@ fn assert_types_must_match(
         TypeErrorKind::IncompatibleTypes(IncompatibleTypes {
             types: unequal_types.into_iter().collect(),
             hint,
+            context,
         }),
     )
 }
@@ -231,6 +234,7 @@ fn eq_strict_types_mismatch() {
             Type::primitive_boolean(),
             [Type::primitive_string(), Type::primitive_long()],
             LubHelp::None,
+            LubContext::Equality,
         )
     })
 }
@@ -246,6 +250,7 @@ fn contains_strict_types_mismatch() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
+            LubContext::Contains,
         )
     })
 }
@@ -264,6 +269,7 @@ fn contains_any_strict_types_mismatch() {
                 Type::set(Type::primitive_long()),
             ],
             LubHelp::None,
+            LubContext::ContainsAnyAll,
         )
     })
 }
@@ -282,6 +288,7 @@ fn contains_all_strict_types_mismatch() {
                 Type::set(Type::primitive_long()),
             ],
             LubHelp::None,
+            LubContext::ContainsAnyAll,
         )
     })
 }
@@ -345,6 +352,7 @@ fn if_bool_strict_type_mismatch() {
                 Type::named_entity_reference_from_str("Photo"),
             ],
             LubHelp::EntityType,
+            LubContext::Conditional,
         )
     })
 }
@@ -363,6 +371,7 @@ fn set_strict_types_mismatch() {
                 Type::named_entity_reference_from_str("Photo"),
             ],
             LubHelp::EntityType,
+            LubContext::Set,
         )
     })
 }
@@ -431,6 +440,7 @@ fn entity_in_lub() {
                 Type::named_entity_reference_from_str("Photo"),
             ],
             LubHelp::EntityType,
+            LubContext::Conditional,
         )
     });
 }
@@ -457,6 +467,7 @@ fn test_and() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
             LubHelp::None,
+            LubContext::Equality,
         );
         assert_types_must_match(
             s,
@@ -466,6 +477,7 @@ fn test_and() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -488,6 +500,7 @@ fn test_or() {
             Type::primitive_boolean(),
             [Type::primitive_boolean(), Type::primitive_long()],
             LubHelp::None,
+            LubContext::Equality,
         );
         assert_types_must_match(
             s,
@@ -497,6 +510,7 @@ fn test_or() {
             Type::primitive_boolean(),
             [Type::primitive_boolean(), Type::primitive_long()],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -519,6 +533,7 @@ fn test_unary() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -541,6 +556,7 @@ fn test_mul() {
             Type::primitive_long(),
             [Type::primitive_long(), Type::singleton_boolean(false)],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -563,6 +579,7 @@ fn test_like() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::singleton_boolean(false)],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -585,6 +602,7 @@ fn test_get_attr() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -623,6 +641,7 @@ fn test_has_attr() {
                 )]),
             ],
             LubHelp::RecordWidth,
+            LubContext::Conditional,
         );
     })
 }
@@ -646,6 +665,7 @@ fn test_extension() {
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::singleton_boolean(false)],
             LubHelp::None,
+            LubContext::Equality,
         );
     })
 }
@@ -736,6 +756,7 @@ fn qualified_record_attr() {
                 ),
             ],
             LubHelp::AttributeQualifier,
+            LubContext::Equality,
         )],
     );
 }

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -34,7 +34,7 @@ use cedar_policy_core::{
     extensions::Extensions,
 };
 
-use crate::ValidationMode;
+use crate::{LubHelp, ValidationMode};
 
 use super::schema::{
     is_action_entity_type, ValidatorActionId, ValidatorEntityType, ValidatorSchema,
@@ -346,12 +346,12 @@ impl Type {
         ty0: &Type,
         ty1: &Type,
         mode: ValidationMode,
-    ) -> Option<Type> {
+    ) -> Result<Type, LubHelp> {
         match (ty0, ty1) {
-            _ if Type::is_subtype(schema, ty0, ty1, mode) => Some(ty1.clone()),
-            _ if Type::is_subtype(schema, ty1, ty0, mode) => Some(ty0.clone()),
+            _ if Type::is_subtype(schema, ty0, ty1, mode) => Ok(ty1.clone()),
+            _ if Type::is_subtype(schema, ty1, ty0, mode) => Ok(ty0.clone()),
 
-            (Type::True | Type::False, Type::True | Type::False) => Some(Type::primitive_boolean()),
+            (Type::True | Type::False, Type::True | Type::False) => Ok(Type::primitive_boolean()),
 
             // `None` as an element type represents the top type for the set
             // element, so every other set is a subtype of set<None>, making a
@@ -360,7 +360,7 @@ impl Type {
             // subtype checks in the first two match cases, but we handle it
             // explicitly as an alternative to panicking if it occurs.
             (ty_lub @ Type::Set { element_type: None }, Type::Set { .. })
-            | (Type::Set { .. }, ty_lub @ Type::Set { element_type: None }) => Some(ty_lub.clone()),
+            | (Type::Set { .. }, ty_lub @ Type::Set { element_type: None }) => Ok(ty_lub.clone()),
 
             // The least upper bound of two set types is a set with
             // an element type that is the element type least upper bound.
@@ -371,13 +371,13 @@ impl Type {
                 Type::Set {
                     element_type: Some(te1),
                 },
-            ) => Some(Type::set(Type::least_upper_bound(schema, te0, te1, mode)?)),
+            ) => Ok(Type::set(Type::least_upper_bound(schema, te0, te1, mode)?)),
 
-            (Type::EntityOrRecord(rk0), Type::EntityOrRecord(rk1)) => Some(Type::EntityOrRecord(
+            (Type::EntityOrRecord(rk0), Type::EntityOrRecord(rk1)) => Ok(Type::EntityOrRecord(
                 EntityRecordKind::least_upper_bound(schema, rk0, rk1, mode)?,
             )),
 
-            _ => None,
+            _ => Err(LubHelp::None),
         }
     }
 
@@ -412,7 +412,7 @@ impl Type {
         schema: &ValidatorSchema,
         tys: &[Type],
         mode: ValidationMode,
-    ) -> Option<Type> {
+    ) -> Result<Type, LubHelp> {
         tys.iter().try_fold(Type::Never, |lub, next| {
             Type::least_upper_bound(schema, &lub, next, mode)
         })
@@ -1127,11 +1127,11 @@ impl Attributes {
         attrs0: &Attributes,
         attrs1: &Attributes,
         mode: ValidationMode,
-    ) -> Option<Attributes> {
+    ) -> Result<Attributes, LubHelp> {
         if mode.is_strict() {
             Self::strict_least_upper_bound(schema, attrs0, attrs1)
         } else {
-            Some(Self::permissive_least_upper_bound(schema, attrs0, attrs1))
+            Ok(Self::permissive_least_upper_bound(schema, attrs0, attrs1))
         }
     }
 
@@ -1140,15 +1140,15 @@ impl Attributes {
         attrs0: &'a Attributes,
         attrs1: &'a Attributes,
         mode: ValidationMode,
-    ) -> impl Iterator<Item = Option<(SmolStr, AttributeType)>> + 'a {
+    ) -> impl Iterator<Item = Result<(SmolStr, AttributeType), LubHelp>> + 'a {
         attrs0.attrs.iter().map(move |(attr, ty0)| {
-            let ty1 = attrs1.attrs.get(attr)?;
+            let ty1 = attrs1.attrs.get(attr).ok_or(LubHelp::RecordWidth)?;
             Type::least_upper_bound(schema, &ty0.attr_type, &ty1.attr_type, mode).and_then(|lub| {
                 let is_lub_required = ty0.is_required && ty1.is_required;
                 if mode.is_strict() && ty0.is_required != ty1.is_required {
-                    None
+                    Err(LubHelp::AttributeQualifier)
                 } else {
-                    Some((attr.clone(), AttributeType::new(lub, is_lub_required)))
+                    Ok((attr.clone(), AttributeType::new(lub, is_lub_required)))
                 }
             })
         })
@@ -1158,27 +1158,13 @@ impl Attributes {
         schema: &ValidatorSchema,
         attrs0: &Attributes,
         attrs1: &Attributes,
-    ) -> Option<Attributes> {
+    ) -> Result<Attributes, LubHelp> {
         if attrs0.keys().collect::<HashSet<_>>() != attrs1.keys().collect::<HashSet<_>>() {
-            return None;
+            return Err(LubHelp::RecordWidth);
         }
-
-        let mut any_err = false;
-        let attrs: Vec<_> =
-            Self::attributes_lub_iter(schema, attrs0, attrs1, ValidationMode::Strict)
-                .filter_map(|e| {
-                    if e.is_none() {
-                        any_err = true;
-                    }
-                    e
-                })
-                .collect();
-
-        if any_err {
-            None
-        } else {
-            Some(Attributes::with_attributes(attrs))
-        }
+        Self::attributes_lub_iter(schema, attrs0, attrs1, ValidationMode::Strict)
+            .collect::<Result<Vec<_>, _>>()
+            .map(Attributes::with_attributes)
     }
 
     pub(crate) fn permissive_least_upper_bound(
@@ -1326,7 +1312,7 @@ impl EntityRecordKind {
         rk0: &EntityRecordKind,
         rk1: &EntityRecordKind,
         mode: ValidationMode,
-    ) -> Option<EntityRecordKind> {
+    ) -> Result<EntityRecordKind, LubHelp> {
         use EntityRecordKind::*;
         match (rk0, rk1) {
             (
@@ -1360,7 +1346,7 @@ impl EntityRecordKind {
                 } else {
                     OpenTag::ClosedAttributes
                 };
-                Some(Record {
+                Ok(Record {
                     attrs,
                     open_attributes,
                 })
@@ -1394,45 +1380,47 @@ impl EntityRecordKind {
                             attrs,
                         })
                 } else if mode.is_strict() {
-                    None
+                    Err(LubHelp::EntityType)
                 } else {
-                    Some(AnyEntity)
+                    Ok(AnyEntity)
                 }
             }
             (Entity(lub0), Entity(lub1)) => {
                 if mode.is_strict() && lub0 != lub1 {
-                    None
+                    Err(LubHelp::EntityType)
                 } else {
-                    Some(Entity(lub0.least_upper_bound(lub1)))
+                    Ok(Entity(lub0.least_upper_bound(lub1)))
                 }
             }
 
-            (AnyEntity, AnyEntity) => Some(AnyEntity),
+            (AnyEntity, AnyEntity) => Ok(AnyEntity),
 
             (AnyEntity, Entity(_))
             | (Entity(_), AnyEntity)
             | (AnyEntity, ActionEntity { .. })
             | (ActionEntity { .. }, AnyEntity) => {
                 if mode.is_strict() {
-                    None
+                    Err(LubHelp::EntityType)
                 } else {
-                    Some(AnyEntity)
+                    Ok(AnyEntity)
                 }
             }
 
             // Entity and record types do not have a least upper bound to avoid
             // a non-terminating case.
-            (AnyEntity, Record { .. }) | (Record { .. }, AnyEntity) => None,
-            (Record { .. }, Entity(_)) | (Entity(_), Record { .. }) => None,
+            (AnyEntity, Record { .. }) | (Record { .. }, AnyEntity) => Err(LubHelp::EntityRecord),
+            (Record { .. }, Entity(_)) | (Entity(_), Record { .. }) => Err(LubHelp::EntityRecord),
 
             //Likewise, we can't mix action entities and records
-            (ActionEntity { .. }, Record { .. }) | (Record { .. }, ActionEntity { .. }) => None,
+            (ActionEntity { .. }, Record { .. }) | (Record { .. }, ActionEntity { .. }) => {
+                Err(LubHelp::EntityRecord)
+            }
             //Action entities can be mixed with Entities. In this case, the LUB is AnyEntity
             (ActionEntity { .. }, Entity(_)) | (Entity(_), ActionEntity { .. }) => {
                 if mode.is_strict() {
-                    None
+                    Err(LubHelp::EntityType)
                 } else {
-                    Some(AnyEntity)
+                    Ok(AnyEntity)
                 }
             }
         }
@@ -1633,7 +1621,12 @@ mod test {
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn assert_least_upper_bound(schema: ValidatorSchema, lhs: Type, rhs: Type, lub: Option<Type>) {
+    fn assert_least_upper_bound(
+        schema: ValidatorSchema,
+        lhs: Type,
+        rhs: Type,
+        lub: Result<Type, LubHelp>,
+    ) {
         assert_eq!(
             Type::least_upper_bound(&schema, &lhs, &rhs, ValidationMode::Permissive),
             lub,
@@ -1653,7 +1646,7 @@ mod test {
         lub_attrs: &[(&str, Type)],
     ) {
         let lub = Type::least_upper_bound(&schema, &lhs, &rhs, ValidationMode::Permissive);
-        assert_matches!(lub, Some(Type::EntityOrRecord(EntityRecordKind::Entity(entity_lub))) => {
+        assert_matches!(lub, Ok(Type::EntityOrRecord(EntityRecordKind::Entity(entity_lub))) => {
             assert_eq!(
                 lub_names
                     .iter()
@@ -1683,7 +1676,7 @@ mod test {
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn assert_least_upper_bound_empty_schema(lhs: Type, rhs: Type, lub: Option<Type>) {
+    fn assert_least_upper_bound_empty_schema(lhs: Type, rhs: Type, lub: Result<Type, LubHelp>) {
         assert_least_upper_bound(empty_schema(), lhs, rhs, lub);
     }
 
@@ -1692,72 +1685,88 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::False,
             Type::True,
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
-        assert_least_upper_bound_empty_schema(Type::False, Type::False, Some(Type::False));
+        assert_least_upper_bound_empty_schema(Type::False, Type::False, Ok(Type::False));
         assert_least_upper_bound_empty_schema(
             Type::False,
             Type::primitive_boolean(),
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
 
-        assert_least_upper_bound_empty_schema(Type::True, Type::True, Some(Type::True));
+        assert_least_upper_bound_empty_schema(Type::True, Type::True, Ok(Type::True));
         assert_least_upper_bound_empty_schema(
             Type::True,
             Type::False,
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
         assert_least_upper_bound_empty_schema(
             Type::True,
             Type::primitive_boolean(),
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
 
         assert_least_upper_bound_empty_schema(
             Type::primitive_boolean(),
             Type::False,
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
         assert_least_upper_bound_empty_schema(
             Type::primitive_boolean(),
             Type::True,
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
         assert_least_upper_bound_empty_schema(
             Type::primitive_boolean(),
             Type::primitive_boolean(),
-            Some(Type::primitive_boolean()),
+            Ok(Type::primitive_boolean()),
         );
         assert_least_upper_bound_empty_schema(
             Type::primitive_string(),
             Type::primitive_string(),
-            Some(Type::primitive_string()),
+            Ok(Type::primitive_string()),
         );
 
         assert_least_upper_bound_empty_schema(
             Type::primitive_long(),
             Type::primitive_long(),
-            Some(Type::primitive_long()),
+            Ok(Type::primitive_long()),
         );
 
-        assert_least_upper_bound_empty_schema(Type::False, Type::primitive_string(), None);
-        assert_least_upper_bound_empty_schema(Type::False, Type::primitive_long(), None);
-        assert_least_upper_bound_empty_schema(Type::True, Type::primitive_string(), None);
-        assert_least_upper_bound_empty_schema(Type::True, Type::primitive_long(), None);
+        assert_least_upper_bound_empty_schema(
+            Type::False,
+            Type::primitive_string(),
+            Err(LubHelp::None),
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::False,
+            Type::primitive_long(),
+            Err(LubHelp::None),
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::True,
+            Type::primitive_string(),
+            Err(LubHelp::None),
+        );
+        assert_least_upper_bound_empty_schema(
+            Type::True,
+            Type::primitive_long(),
+            Err(LubHelp::None),
+        );
         assert_least_upper_bound_empty_schema(
             Type::primitive_boolean(),
             Type::primitive_string(),
-            None,
+            Err(LubHelp::None),
         );
         assert_least_upper_bound_empty_schema(
             Type::primitive_boolean(),
             Type::primitive_long(),
-            None,
+            Err(LubHelp::None),
         );
         assert_least_upper_bound_empty_schema(
             Type::primitive_string(),
             Type::primitive_long(),
-            None,
+            Err(LubHelp::None),
         );
     }
 
@@ -1767,23 +1776,27 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::extension(ipaddr.clone()),
             Type::extension(ipaddr.clone()),
-            Some(Type::extension(ipaddr.clone())),
+            Ok(Type::extension(ipaddr.clone())),
         );
         assert_least_upper_bound_empty_schema(
             Type::extension(ipaddr.clone()),
             Type::extension("test".parse().expect("should be a valid identifier")),
-            None,
+            Err(LubHelp::None),
         );
-        assert_least_upper_bound_empty_schema(Type::extension(ipaddr.clone()), Type::False, None);
+        assert_least_upper_bound_empty_schema(
+            Type::extension(ipaddr.clone()),
+            Type::False,
+            Err(LubHelp::None),
+        );
         assert_least_upper_bound_empty_schema(
             Type::extension(ipaddr.clone()),
             Type::primitive_string(),
-            None,
+            Err(LubHelp::None),
         );
         assert_least_upper_bound_empty_schema(
             Type::extension(ipaddr),
             Type::any_entity_reference(),
-            None,
+            Err(LubHelp::None),
         );
     }
 
@@ -1792,23 +1805,23 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::set(Type::True),
             Type::set(Type::True),
-            Some(Type::set(Type::True)),
+            Ok(Type::set(Type::True)),
         );
         assert_least_upper_bound_empty_schema(
             Type::set(Type::False),
             Type::set(Type::True),
-            Some(Type::set(Type::primitive_boolean())),
+            Ok(Type::set(Type::primitive_boolean())),
         );
 
         assert_least_upper_bound_empty_schema(
             Type::set(Type::primitive_boolean()),
             Type::set(Type::primitive_long()),
-            None,
+            Err(LubHelp::None),
         );
         assert_least_upper_bound_empty_schema(
             Type::set(Type::primitive_boolean()),
             Type::primitive_boolean(),
-            None,
+            Err(LubHelp::None),
         );
     }
 
@@ -1817,19 +1830,19 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::open_record_with_attributes(None),
             Type::primitive_string(),
-            None,
+            Err(LubHelp::None),
         );
 
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_attributes(None),
             Type::primitive_string(),
-            None,
+            Err(LubHelp::None),
         );
 
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_attributes(None),
             Type::set(Type::primitive_boolean()),
-            None,
+            Err(LubHelp::None),
         );
     }
 
@@ -1838,22 +1851,22 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_attributes(None),
             Type::closed_record_with_attributes(None),
-            Some(Type::closed_record_with_attributes(None)),
+            Ok(Type::closed_record_with_attributes(None)),
         );
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_attributes(None),
             Type::open_record_with_attributes(None),
-            Some(Type::open_record_with_attributes(None)),
+            Ok(Type::open_record_with_attributes(None)),
         );
         assert_least_upper_bound_empty_schema(
             Type::open_record_with_attributes(None),
             Type::closed_record_with_attributes(None),
-            Some(Type::open_record_with_attributes(None)),
+            Ok(Type::open_record_with_attributes(None)),
         );
         assert_least_upper_bound_empty_schema(
             Type::open_record_with_attributes(None),
             Type::open_record_with_attributes(None),
-            Some(Type::open_record_with_attributes(None)),
+            Ok(Type::open_record_with_attributes(None)),
         );
 
         assert_least_upper_bound_empty_schema(
@@ -1865,7 +1878,7 @@ mod test {
                 ("foo".into(), Type::primitive_string()),
                 ("bar".into(), Type::primitive_long()),
             ]),
-            Some(Type::open_record_with_required_attributes([(
+            Ok(Type::open_record_with_required_attributes([(
                 "bar".into(),
                 Type::primitive_long(),
             )])),
@@ -1877,7 +1890,7 @@ mod test {
                 ("foo".into(), Type::primitive_string()),
                 ("bar".into(), Type::primitive_long()),
             ]),
-            Some(Type::open_record_with_required_attributes([(
+            Ok(Type::open_record_with_required_attributes([(
                 "bar".into(),
                 Type::primitive_long(),
             )])),
@@ -1892,7 +1905,7 @@ mod test {
                 ("foo".into(), Type::True),
                 ("baz".into(), Type::primitive_long()),
             ]),
-            Some(Type::open_record_with_required_attributes([(
+            Ok(Type::open_record_with_required_attributes([(
                 "foo".into(),
                 Type::primitive_boolean(),
             )])),
@@ -1901,7 +1914,7 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_required_attributes([("foo".into(), Type::False)]),
             Type::closed_record_with_required_attributes([("foo".into(), Type::True)]),
-            Some(Type::closed_record_with_required_attributes([(
+            Ok(Type::closed_record_with_required_attributes([(
                 "foo".into(),
                 Type::primitive_boolean(),
             )])),
@@ -1928,7 +1941,7 @@ mod test {
                     AttributeType::new(Type::primitive_long(), false),
                 ),
             ]),
-            Some(Type::closed_record_with_attributes([
+            Ok(Type::closed_record_with_attributes([
                 (
                     "foo".into(),
                     AttributeType::new(Type::primitive_long(), false),
@@ -1943,7 +1956,7 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_required_attributes([("a".into(), Type::primitive_long())]),
             Type::closed_record_with_attributes([]),
-            Some(Type::open_record_with_attributes([])),
+            Ok(Type::open_record_with_attributes([])),
         );
     }
 
@@ -1965,7 +1978,7 @@ mod test {
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn assert_least_upper_bound_simple_schema(lhs: Type, rhs: Type, lub: Option<Type>) {
+    fn assert_least_upper_bound_simple_schema(lhs: Type, rhs: Type, lub: Result<Type, LubHelp>) {
         assert_least_upper_bound(simple_schema(), lhs, rhs, lub);
     }
 
@@ -1984,7 +1997,7 @@ mod test {
         assert_least_upper_bound_simple_schema(
             Type::any_entity_reference(),
             Type::any_entity_reference(),
-            Some(Type::any_entity_reference()),
+            Ok(Type::any_entity_reference()),
         );
         assert_entity_lub_attrs_simple_schema(
             Type::named_entity_reference_from_str("foo"),
@@ -2001,17 +2014,17 @@ mod test {
         assert_least_upper_bound_simple_schema(
             Type::any_entity_reference(),
             Type::named_entity_reference_from_str("foo"),
-            Some(Type::any_entity_reference()),
+            Ok(Type::any_entity_reference()),
         );
         assert_least_upper_bound_simple_schema(
             Type::named_entity_reference_from_str("foo"),
             Type::primitive_boolean(),
-            None,
+            Err(LubHelp::None),
         );
         assert_least_upper_bound_simple_schema(
             Type::named_entity_reference_from_str("foo"),
             Type::set(Type::any_entity_reference()),
-            None,
+            Err(LubHelp::None),
         );
     }
 
@@ -2034,7 +2047,7 @@ mod test {
         assert_least_upper_bound_simple_schema(
             Type::named_entity_reference_from_str("Action"),
             Type::any_entity_reference(),
-            Some(Type::any_entity_reference()),
+            Ok(Type::any_entity_reference()),
         );
     }
 
@@ -2076,7 +2089,7 @@ mod test {
     }
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn assert_least_upper_bound_attr_schema(lhs: Type, rhs: Type, lub: Option<Type>) {
+    fn assert_least_upper_bound_attr_schema(lhs: Type, rhs: Type, lub: Result<Type, LubHelp>) {
         assert_least_upper_bound(attr_schema(), lhs, rhs, lub);
     }
 
@@ -2132,12 +2145,12 @@ mod test {
         assert_least_upper_bound_empty_schema(
             Type::any_entity_reference(),
             Type::any_record(),
-            None,
+            Err(LubHelp::EntityRecord),
         );
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_attributes(None),
             Type::any_entity_reference(),
-            None,
+            Err(LubHelp::EntityRecord),
         );
         assert_least_upper_bound_empty_schema(
             Type::closed_record_with_required_attributes([
@@ -2145,17 +2158,17 @@ mod test {
                 ("bar".into(), Type::primitive_long()),
             ]),
             Type::any_entity_reference(),
-            None,
+            Err(LubHelp::EntityRecord),
         );
         assert_least_upper_bound_attr_schema(
             Type::named_entity_reference_from_str("foo"),
             Type::any_record(),
-            None,
+            Err(LubHelp::EntityRecord),
         );
         assert_least_upper_bound_attr_schema(
             Type::named_entity_reference_from_str("baz"),
             Type::any_record(),
-            None,
+            Err(LubHelp::EntityRecord),
         );
         assert_least_upper_bound_attr_schema(
             Type::named_entity_reference_from_str("buz"),
@@ -2164,7 +2177,7 @@ mod test {
                 ("b".into(), Type::primitive_long()),
                 ("c".into(), Type::named_entity_reference_from_str("bar")),
             ]),
-            None,
+            Err(LubHelp::EntityRecord),
         );
     }
 
@@ -2207,7 +2220,7 @@ mod test {
                 "foo".into(),
                 Type::named_entity_reference_from_str("U"),
             )]),
-            None,
+            Err(LubHelp::EntityRecord),
         );
     }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737)
 - Changed policy validation to reject comparisons and conditionals between
   record types that differ in whether an attribute is required or optional.
+- Improved validation error messages when incompatible types appears in
+  `if`, `==`, `contains`, `containsAll`, and `containsAny` expressions.
 
 ## [3.1.3] - 2024-04-15
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737)
 - Changed policy validation to reject comparisons and conditionals between
   record types that differ in whether an attribute is required or optional.
-- Improved validation error messages when incompatible types appears in
+- Improved validation error messages when incompatible types appear in
   `if`, `==`, `contains`, `containsAll`, and `containsAny` expressions.
 
 ## [3.1.3] - 2024-04-15


### PR DESCRIPTION
## Description of changes

Example:

```
  × policy set validation failed
  ╰─▶ The types {} and User are not compatible
    ╭─[19:4]
 18 │   context == {a: 1} &&
 19 │   (if Photo::"a" in resource then principal else {}).attr
    ·    ────────────────────────────────────────────────
 20 │ };
    ╰────
  help: both branches of a conditional must have compatible types; entity and record types are never compatible even when their attributes would be compatible

Error:   × The types Photo and User are not compatible
    ╭─[17:3]
 16 │   [true, 2] &&
 17 │   [User::"alice"].contains(Photo::"1") &&
    ·   ────────────────────────────────────
 18 │   context == {a: 1} &&
    ╰────
  help: elements of the first operand and the second operand to a `contains` expression must have compatible types; different entity types are never compatible even when their attributes would be compatible

Error:   × The types {} and {a: Long,} are not compatible
    ╭─[18:3]
 17 │   [User::"alice"].contains(Photo::"1") &&
 18 │   context == {a: 1} &&
    ·   ─────────────────
 19 │   (if Photo::"a" in resource then principal else {}).attr
    ╰────
  help: both operands to a `==` expression must have compatible types; compatible record types must have exactly the same attributes

Error:   × The types __cedar::internal::True and Long are not compatible
    ╭─[16:3]
 15 │ ) when {
 16 │   [true, 2] &&
    ·   ─────────
 17 │   [User::"alice"].contains(Photo::"1") &&
    ╰────
  help: elements of a set must have compatible types; types must be exactly equal to be compatible

```

## Issue #, if available

Fixes #346

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
