### PR TITLE
Fix validation error msg for invalid attribute on nested entity attribute

### DIFF
--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -440,11 +440,14 @@ pub(crate) enum AttributeAccess {
 }
 
 impl AttributeAccess {
+    /// Construct an `Attribute` access from `GetAttr` expressions which is
+    /// constructed as `expr.attr`.
     pub(crate) fn from_expr(
         req_env: &RequestEnv,
         mut expr: &Expr<Option<Type>>,
+        attr: SmolStr,
     ) -> AttributeAccess {
-        let mut attrs: Vec<SmolStr> = Vec::new();
+        let mut attrs: Vec<SmolStr> = vec![attr];
         loop {
             if let Some(Type::EntityOrRecord(EntityRecordKind::Entity(lub))) = expr.data() {
                 return AttributeAccess::EntityLUB(lub.clone(), attrs);
@@ -525,7 +528,7 @@ impl Display for AttributeAccess {
 // optional attribute without a guard, then the help message is also printed.
 #[cfg(test)]
 mod test_attr_access {
-    use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprBuilder, Var};
+    use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprBuilder, ExprKind, Var};
 
     use crate::{
         types::{OpenTag, RequestEnv, Type},
@@ -548,7 +551,11 @@ mod test_attr_access {
             resource_slot: None,
         };
 
-        let access = AttributeAccess::from_expr(&env, attr_access);
+        let ExprKind::GetAttr { expr, attr } = attr_access.expr_kind() else {
+            panic!("Can only test `AttributeAccess::from_expr` only `GetAttr` expressions");
+        };
+
+        let access = AttributeAccess::from_expr(&env, expr, attr.clone());
         assert_eq!(
             access.to_string().as_str(),
             msg.as_ref(),
@@ -601,6 +608,21 @@ mod test_attr_access {
             "`foo.bar.baz` for entity type User",
             "e.foo.bar has baz",
         );
+    }
+
+    #[test]
+    fn entity_type_attr_access() {
+        let e = ExprBuilder::with_data(Some(Type::named_entity_reference_from_str("Thing")))
+            .get_attr(
+                ExprBuilder::with_data(Some(Type::named_entity_reference_from_str("User")))
+                    .var(Var::Principal),
+                "thing".into(),
+            );
+        assert_message_and_help(&e, "`thing` for entity type User", "e has thing");
+        let e = ExprBuilder::new().get_attr(e, "bar".into());
+        assert_message_and_help(&e, "`bar` for entity type Thing", "e has bar");
+        let e = ExprBuilder::new().get_attr(e, "baz".into());
+        assert_message_and_help(&e, "`bar.baz` for entity type Thing", "e.bar has baz");
     }
 
     #[test]

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -440,8 +440,7 @@ pub(crate) enum AttributeAccess {
 }
 
 impl AttributeAccess {
-    /// Construct an `Attribute` access from `GetAttr` expressions which is
-    /// constructed as `expr.attr`.
+    /// Construct an `AttributeAccess` access from a `GetAttr` expression `expr.attr`.
     pub(crate) fn from_expr(
         req_env: &RequestEnv,
         mut expr: &Expr<Option<Type>>,
@@ -552,7 +551,7 @@ mod test_attr_access {
         };
 
         let ExprKind::GetAttr { expr, attr } = attr_access.expr_kind() else {
-            panic!("Can only test `AttributeAccess::from_expr` only `GetAttr` expressions");
+            panic!("Can only test `AttributeAccess::from_expr` for `GetAttr` expressions");
         };
 
         let access = AttributeAccess::from_expr(&env, expr, attr.clone());

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1000,7 +1000,11 @@ impl<'a> Typechecker<'a> {
                                 } else {
                                     type_errors.push(TypeError::unsafe_optional_attribute_access(
                                         e.clone(),
-                                        AttributeAccess::from_expr(request_env, &annot_expr),
+                                        AttributeAccess::from_expr(
+                                            request_env,
+                                            &typ_expr_actual,
+                                            attr.clone(),
+                                        ),
                                     ));
                                     TypecheckAnswer::fail(annot_expr)
                                 }
@@ -1024,7 +1028,11 @@ impl<'a> Typechecker<'a> {
                                 let suggestion = fuzzy_search(attr, &borrowed);
                                 type_errors.push(TypeError::unsafe_attribute_access(
                                     e.clone(),
-                                    AttributeAccess::from_expr(request_env, &annot_expr),
+                                    AttributeAccess::from_expr(
+                                        request_env,
+                                        &typ_expr_actual,
+                                        attr.clone(),
+                                    ),
                                     suggestion,
                                     Type::may_have_attr(self.schema, typ_actual, attr),
                                 ));

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Validation error for invalid use of an action now includes a source location
   containing the offending policy.
 
+### Fixed
+
+- Validation error message for an invalid attribute access now reports the
+  correct attribute and entity type when accessing an optional attribute that is
+  itself an entity.
+
 ## [3.1.3] - 2024-04-15
 
 ### Changed


### PR DESCRIPTION
## Description of changes

In `sandbox_b/policies_5_bad.cedar` the validation error message was

```
× policy set validation failed
  ╰─▶ unable to guarantee safety of access to optional attribute `` for entity type User
    ╭─[14:10]
 13 │ when { resource.private }
 14 │ unless { resource.account.owner == principal };
    ·          ──────────────────────
    ╰────
  help: try testing for the attribute with `e has f && ..`
```

The attribute name was empty, it it thought the access happened on a `User` entity. 
With this fix it correctly sees that the policy access `owner` on an `Account` entity.

```
  × policy set validation failed
  ╰─▶ unable to guarantee safety of access to optional attribute `owner` for entity type Account
    ╭─[14:10]
 13 │ when { resource.private }
 14 │ unless { resource.account.owner == principal };
    ·          ──────────────────────
    ╰────
  help: try testing for the attribute with `e has owner && ..`
```

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

