### PR TITLE
Revert "update integration tests for #814 (#819)"

### DIFF
--- a/cedar-integration-tests/tests/multi/5.json
+++ b/cedar-integration-tests/tests/multi/5.json
@@ -41,7 +41,7 @@
       "context": {
         "authenticated": true
       },
-      "enableRequestValidation": false,
+      "enable_request_validation": false,
       "decision": "Deny",
       "reasons": [],
       "errors": [
@@ -84,7 +84,7 @@
       "context": {
         "authenticated": false
       },
-      "enableRequestValidation": false,
+      "enable_request_validation": false,
       "decision": "Deny",
       "reasons": [
         "policy1"
@@ -130,7 +130,7 @@
       "context": {
         "authenticated": true
       },
-      "enableRequestValidation": false,
+      "enable_request_validation": false,
       "decision": "Allow",
       "reasons": [
         "policy2"


### PR DESCRIPTION
This reverts commit 575e1926aaa0d6ef96a42e29e66f908e139ef1aa.

## Description of changes

Reverts #819, which breaks consumers that depend on the integration-test format.  Although the FFI format has been updated to camelCase all keys, the integration-test format has not been.