### PR TITLE
Surface locations from validation errors, improve TS interfaces

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1814,6 +1814,15 @@ impl SourceLocation {
     pub fn range_end(&self) -> Option<usize> {
         self.0.source_loc().map(parser::Loc::end)
     }
+
+    /// Returns a tuple of (start, end) of the location.
+    /// Returns `None` if this location does not have a range.
+    pub fn range_start_and_end(&self) -> Option<(usize, usize)> {
+        self.0
+            .source_loc()
+            .as_ref()
+            .map(|loc| (loc.start(), loc.end()))
+    }
 }
 
 impl std::fmt::Display for SourceLocation {

--- a/cedar-wasm/src/authorizer.rs
+++ b/cedar-wasm/src/authorizer.rs
@@ -21,7 +21,8 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum AuthorizationResult {
     Success { response: Response },

--- a/cedar-wasm/src/formatter.rs
+++ b/cedar-wasm/src/formatter.rs
@@ -21,16 +21,12 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum FormattingResult {
-    #[serde(rename_all = "camelCase")]
-    Success {
-        formatted_policy: String,
-    },
-    Error {
-        errors: Vec<String>,
-    },
+    Success { formatted_policy: String },
+    Error { errors: Vec<String> },
 }
 
 #[wasm_bindgen(js_name = "formatPolicies")]

--- a/cedar-wasm/src/policies_and_templates.rs
+++ b/cedar-wasm/src/policies_and_templates.rs
@@ -24,7 +24,7 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
 #[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum JsonToPolicyResult {
@@ -59,7 +59,8 @@ pub fn policy_text_from_json(json_str: &str) -> JsonToPolicyResult {
 }
 
 #[derive(Tsify, Debug, Serialize, Deserialize, Clone)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum PolicyToJsonResult {
     Success {
@@ -81,20 +82,21 @@ pub fn policy_text_to_json(cedar_str: &str) -> PolicyToJsonResult {
 }
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 /// struct that defines the result for the syntax validation function
 pub enum CheckParsePolicySetResult {
     /// represents successful syntax validation
     Success { policies: i32, templates: i32 },
     /// represents a syntax error and encloses a vector of the errors
-    SyntaxError { errors: Vec<String> },
+    Error { errors: Vec<String> },
 }
 
 #[wasm_bindgen(js_name = "checkParsePolicySet")]
 pub fn check_parse_policy_set(input_policies_str: &str) -> CheckParsePolicySetResult {
     match PolicySet::from_str(input_policies_str) {
-        Err(parse_errors) => CheckParsePolicySetResult::SyntaxError {
+        Err(parse_errors) => CheckParsePolicySetResult::Error {
             errors: parse_errors.errors_as_strings(),
         },
         Ok(policy_set) => {
@@ -107,7 +109,7 @@ pub fn check_parse_policy_set(input_policies_str: &str) -> CheckParsePolicySetRe
                     policies: p,
                     templates: t,
                 },
-                _ => CheckParsePolicySetResult::SyntaxError {
+                _ => CheckParsePolicySetResult::Error {
                     errors: vec!["Error counting policies or templates".to_string()],
                 },
             }
@@ -116,7 +118,8 @@ pub fn check_parse_policy_set(input_policies_str: &str) -> CheckParsePolicySetRe
 }
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum CheckParseTemplateResult {
     /// represents successful template validation
@@ -218,7 +221,7 @@ mod test {
     }
 
     fn assert_result_had_syntax_errors(result: &CheckParsePolicySetResult) {
-        assert_matches!(result, CheckParsePolicySetResult::SyntaxError { .. });
+        assert_matches!(result, CheckParsePolicySetResult::Error { .. });
     }
 
     #[test]

--- a/cedar-wasm/src/schema_and_entities_and_context.rs
+++ b/cedar-wasm/src/schema_and_entities_and_context.rs
@@ -22,21 +22,22 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 /// struct that defines the result for the syntax validation function
 pub enum CheckParseResult {
     /// represents successful syntax validation
     Success,
     /// represents a syntax error and encloses a vector of the errors
-    SyntaxError { errors: Vec<String> },
+    Error { errors: Vec<String> },
 }
 
 #[wasm_bindgen(js_name = "checkParseSchema")]
 pub fn check_parse_schema(input_schema: &str) -> CheckParseResult {
     match Schema::from_str(input_schema) {
         Ok(_schema) => CheckParseResult::Success,
-        Err(err) => CheckParseResult::SyntaxError {
+        Err(err) => CheckParseResult::Error {
             errors: vec![err.to_string()],
         },
     }
@@ -47,14 +48,14 @@ pub fn check_parse_entities(entities_str: &str, schema_str: &str) -> CheckParseR
     let parsed_schema = match Schema::from_str(schema_str) {
         Ok(schema) => schema,
         Err(err) => {
-            return CheckParseResult::SyntaxError {
+            return CheckParseResult::Error {
                 errors: vec![err.to_string()],
             }
         }
     };
     match Entities::from_json_str(entities_str, Some(&parsed_schema)) {
         Ok(_) => CheckParseResult::Success,
-        Err(err) => CheckParseResult::SyntaxError {
+        Err(err) => CheckParseResult::Error {
             errors: vec![err.to_string()],
         },
     }
@@ -69,7 +70,7 @@ pub fn check_parse_context(
     let parsed_schema = match Schema::from_str(schema_str) {
         Ok(schema) => schema,
         Err(err) => {
-            return CheckParseResult::SyntaxError {
+            return CheckParseResult::Error {
                 errors: vec![err.to_string()],
             }
         }
@@ -77,14 +78,14 @@ pub fn check_parse_context(
     let parsed_action = match EntityUid::from_str(action_str) {
         Ok(action) => action,
         Err(err) => {
-            return CheckParseResult::SyntaxError {
+            return CheckParseResult::Error {
                 errors: vec![err.to_string()],
             }
         }
     };
     match Context::from_json_str(context_str, Some((&parsed_schema, &parsed_action))) {
         Ok(_entities) => CheckParseResult::Success,
-        Err(err) => CheckParseResult::SyntaxError {
+        Err(err) => CheckParseResult::Error {
             errors: vec![err.to_string()],
         },
     }
@@ -259,7 +260,7 @@ mod test {
     fn assert_syntax_result_has_errors(parse_result: &CheckParseResult) {
         assert!(matches!(
             parse_result,
-            CheckParseResult::SyntaxError { errors: _ }
+            CheckParseResult::Error { errors: _ }
         ))
     }
 }

--- a/cedar-wasm/src/validator.rs
+++ b/cedar-wasm/src/validator.rs
@@ -22,7 +22,8 @@ use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 #[derive(Tsify, Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
 #[tsify(into_wasm_abi, from_wasm_abi)]
 pub enum ValidateResult {
     #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Description of changes

* Improves wasm interfaces in accordance with https://github.com/cedar-policy/cedar/issues/806
* Also subsumes changes in https://github.com/cedar-policy/cedar/pull/805, which needed to be rebased

## Issue #, if available

806

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).


I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


