### PR TITLE
Change `head` to `scope` in doc comments and errors

### DIFF
--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -180,7 +180,7 @@ pub enum ToASTErrorKind {
     #[error("this policy is missing the `{0}` variable in the scope")]
     MissingScopeConstraint(Var),
     /// Returned when a policy has an extra scope clause. This is not valid syntax
-    #[error("this policy has an extra head constraint in the scope: `{0}`")]
+    #[error("this policy has an extra constraint in the scope: `{0}`")]
     #[diagnostic(help(
         "a policy must have exactly `principal`, `action`, and `resource` constraints"
     ))]

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -540,7 +540,7 @@ mod test {
             src,
             &Report::new(notes.first().unwrap().clone()),
             &ExpectedErrorMessageBuilder::error(
-                r#"unable to find an applicable action given the policy head constraints"#,
+                r#"unable to find an applicable action given the policy scope constraints"#,
             )
             .help("try replacing `==` with `in` in the principal clause and the resource clause")
             .exactly_one_underline(src)
@@ -1241,7 +1241,7 @@ mod test {
             src,
             &Report::new(notes.first().unwrap().clone()),
             &ExpectedErrorMessageBuilder::error(
-                r#"unable to find an applicable action given the policy head constraints"#,
+                r#"unable to find an applicable action given the policy scope constraints"#,
             )
             .exactly_one_underline(src)
             .build(),
@@ -1265,7 +1265,7 @@ mod test {
             src,
             &Report::new(notes.first().unwrap().clone()),
             &ExpectedErrorMessageBuilder::error(
-                r#"unable to find an applicable action given the policy head constraints"#,
+                r#"unable to find an applicable action given the policy scope constraints"#,
             )
             .exactly_one_underline(src)
             .build(),
@@ -1289,7 +1289,7 @@ mod test {
             src,
             &Report::new(notes.first().unwrap().clone()),
             &ExpectedErrorMessageBuilder::error(
-                r#"unable to find an applicable action given the policy head constraints"#,
+                r#"unable to find an applicable action given the policy scope constraints"#,
             )
             .exactly_one_underline(src)
             .build(),

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -186,9 +186,9 @@ pub enum ValidationErrorKind {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnrecognizedActionId(#[from] UnrecognizedActionId),
-    /// There is no action satisfying the action head constraint that can be
+    /// There is no action satisfying the action scope constraint that can be
     /// applied to a principal and resources that both satisfy their respective
-    /// head conditions.
+    /// scope conditions.
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionApplication(#[from] InvalidActionApplication),
@@ -288,7 +288,7 @@ impl Diagnostic for UnrecognizedActionId {
 
 /// Structure containing details about an invalid action application error.
 #[derive(Debug, Clone, Error, Eq, PartialEq)]
-#[error("unable to find an applicable action given the policy head constraints")]
+#[error("unable to find an applicable action given the policy scope constraints")]
 pub struct InvalidActionApplication {
     pub(crate) would_in_fix_principal: bool,
     pub(crate) would_in_fix_resource: bool,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2762,7 +2762,7 @@ impl Template {
         self.ast.slots().map(|slot| SlotId::ref_cast(&slot.id))
     }
 
-    /// Get the head constraint on this policy's principal
+    /// Get the scope constraint on this policy's principal
     pub fn principal_constraint(&self) -> TemplatePrincipalConstraint {
         match self.ast.principal_constraint().as_inner() {
             ast::PrincipalOrResourceConstraint::Any => TemplatePrincipalConstraint::Any,
@@ -2793,7 +2793,7 @@ impl Template {
         }
     }
 
-    /// Get the head constraint on this policy's action
+    /// Get the scope constraint on this policy's action
     pub fn action_constraint(&self) -> ActionConstraint {
         // Clone the data from Core to be consistent with the other constraints
         match self.ast.action_constraint() {
@@ -2807,7 +2807,7 @@ impl Template {
         }
     }
 
-    /// Get the head constraint on this policy's resource
+    /// Get the scope constraint on this policy's resource
     pub fn resource_constraint(&self) -> TemplateResourceConstraint {
         match self.ast.resource_constraint().as_inner() {
             ast::PrincipalOrResourceConstraint::Any => TemplateResourceConstraint::Any,
@@ -2883,7 +2883,7 @@ impl FromStr for Template {
     }
 }
 
-/// Head constraint on policy principals.
+/// Scope constraint on policy principals.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PrincipalConstraint {
     /// Un-constrained
@@ -2898,7 +2898,7 @@ pub enum PrincipalConstraint {
     IsIn(EntityTypeName, EntityUid),
 }
 
-/// Head constraint on policy principals for templates.
+/// Scope constraint on policy principals for templates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TemplatePrincipalConstraint {
     /// Un-constrained
@@ -2926,7 +2926,7 @@ impl TemplatePrincipalConstraint {
     }
 }
 
-/// Head constraint on policy actions.
+/// Scope constraint on policy actions.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ActionConstraint {
     /// Un-constrained
@@ -2937,7 +2937,7 @@ pub enum ActionConstraint {
     Eq(EntityUid),
 }
 
-/// Head constraint on policy resources.
+/// Scope constraint on policy resources.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ResourceConstraint {
     /// Un-constrained
@@ -2952,7 +2952,7 @@ pub enum ResourceConstraint {
     IsIn(EntityTypeName, EntityUid),
 }
 
-/// Head constraint on policy resources for templates.
+/// Scope constraint on policy resources for templates.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TemplateResourceConstraint {
     /// Un-constrained
@@ -3113,7 +3113,7 @@ impl Policy {
         self.ast.is_static()
     }
 
-    /// Get the head constraint on this policy's principal
+    /// Get the scope constraint on this policy's principal
     pub fn principal_constraint(&self) -> PrincipalConstraint {
         let slot_id = ast::SlotId::principal();
         match self.ast.template().principal_constraint().as_inner() {
@@ -3136,7 +3136,7 @@ impl Policy {
         }
     }
 
-    /// Get the head constraint on this policy's action
+    /// Get the scope constraint on this policy's action
     pub fn action_constraint(&self) -> ActionConstraint {
         // Clone the data from Core to be consistant with the other constraints
         // INVARIANT: all of the EntityUids come from a policy, which must have Concrete EntityUids
@@ -3152,7 +3152,7 @@ impl Policy {
         }
     }
 
-    /// Get the head constraint on this policy's resource
+    /// Get the scope constraint on this policy's resource
     pub fn resource_constraint(&self) -> ResourceConstraint {
         let slot_id = ast::SlotId::resource();
         match self.ast.template().resource_constraint().as_inner() {


### PR DESCRIPTION
## Description of changes

Some of our doc strings and error messages still referred to "head" constraints instead of "scope" constraints 

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
