### PR TITLE
Fix remaining mentions of template "instantiation" to refer to "linking"

### DIFF
--- a/cedar-policy-cli/sample-data/sandbox_c/README.md
+++ b/cedar-policy-cli/sample-data/sandbox_c/README.md
@@ -27,7 +27,8 @@ cargo run authorize \
 
 We should get `DENY`, as there is no policy that allows this.
 
-## Instantiating a template
+## Linking a template
+
 Our policy store contains a Policy Template that we can use to grant `alice` access:
 ```
 @id("AccessVacation")

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -375,7 +375,7 @@ pub struct LinkArgs {
     /// Policies args (incorporated by reference)
     #[command(flatten)]
     pub policies: PoliciesArgs,
-    /// Id of the template to instantiate
+    /// Id of the template to link
     #[arg(long)]
     pub template_id: String,
     /// Id for the new template linked policy

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -82,19 +82,16 @@ impl Policy {
     /// error if `vals` doesn't contain a necessary mapping, but does not throw
     /// an error if `vals` contains unused mappings -- and in particular if
     /// `self` is an inline policy (in which case it is returned unchanged).
-    pub fn link(
-        self,
-        vals: &HashMap<ast::SlotId, EntityUidJson>,
-    ) -> Result<Self, InstantiationError> {
+    pub fn link(self, vals: &HashMap<ast::SlotId, EntityUidJson>) -> Result<Self, LinkingError> {
         Ok(Policy {
             effect: self.effect,
-            principal: self.principal.instantiate(vals)?,
-            action: self.action.instantiate(vals)?,
-            resource: self.resource.instantiate(vals)?,
+            principal: self.principal.link(vals)?,
+            action: self.action.link(vals)?,
+            resource: self.resource.link(vals)?,
             conditions: self
                 .conditions
                 .into_iter()
-                .map(|clause| clause.instantiate(vals))
+                .map(|clause| clause.link(vals))
                 .collect::<Result<Vec<_>, _>>()?,
             annotations: self.annotations,
         })
@@ -105,10 +102,7 @@ impl Clause {
     /// Fill in any slots in the clause using the values in `vals`. Throws an
     /// error if `vals` doesn't contain a necessary mapping, but does not throw
     /// an error if `vals` contains unused mappings.
-    pub fn instantiate(
-        self,
-        _vals: &HashMap<ast::SlotId, EntityUidJson>,
-    ) -> Result<Self, InstantiationError> {
+    pub fn link(self, _vals: &HashMap<ast::SlotId, EntityUidJson>) -> Result<Self, LinkingError> {
         // currently, slots are not allowed in clauses
         Ok(self)
     }
@@ -2925,7 +2919,7 @@ mod test {
     }
 
     #[test]
-    fn instantiate() {
+    fn link() {
         let template = r#"
             permit(
                 principal == ?principal,
@@ -2946,7 +2940,7 @@ mod test {
             .expect_err("didn't fill all the slots");
         assert_eq!(
             err,
-            InstantiationError::MissedSlot {
+            LinkingError::MissedSlot {
                 slot: ast::SlotId::principal()
             }
         );
@@ -2959,7 +2953,7 @@ mod test {
             .expect_err("didn't fill all the slots");
         assert_eq!(
             err,
-            InstantiationError::MissedSlot {
+            LinkingError::MissedSlot {
                 slot: ast::SlotId::resource()
             }
         );
@@ -3896,7 +3890,7 @@ mod test {
         }
 
         #[test]
-        fn instantiate() {
+        fn link() {
             let template = r#"
             permit(
                 principal is User in ?principal,
@@ -3912,7 +3906,7 @@ mod test {
             let err = est.clone().link(&HashMap::from_iter([]));
             assert_eq!(
                 err,
-                Err(InstantiationError::MissedSlot {
+                Err(LinkingError::MissedSlot {
                     slot: ast::SlotId::principal()
                 })
             );
@@ -3922,7 +3916,7 @@ mod test {
             )]));
             assert_eq!(
                 err,
-                Err(InstantiationError::MissedSlot {
+                Err(LinkingError::MissedSlot {
                     slot: ast::SlotId::resource()
                 })
             );
@@ -3965,7 +3959,7 @@ mod test {
         }
 
         #[test]
-        fn instantiate_no_slot() {
+        fn link_no_slot() {
             let template = r#"permit(principal is User, action, resource is Doc);"#;
             let cst = parser::text_to_cst::parse_policy(template)
                 .unwrap()

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -15,7 +15,6 @@
  */
 
 use crate::ast;
-use crate::ast::{LinkingError, PolicySetError};
 use crate::entities::JsonDeserializationError;
 use crate::parser::err::ParseErrors;
 use crate::parser::unescape;
@@ -84,18 +83,18 @@ pub enum FromJsonError {
     /// Error reported when a policy set has duplicate ids
     #[error("Error creating policy set: {0}")]
     #[diagnostic(transparent)]
-    PolicySet(#[from] PolicySetError),
+    PolicySet(#[from] ast::PolicySetError),
     /// Error reported when attempting to create a template-link
     #[error("Error linking policy set: {0}")]
     #[diagnostic(transparent)]
-    Linking(#[from] LinkingError),
+    Linking(#[from] ast::LinkingError),
 }
 
-/// Errors while instantiating a policy
+/// Errors while linking a policy
 #[derive(Debug, PartialEq, Diagnostic, Error)]
-pub enum InstantiationError {
+pub enum LinkingError {
     /// Template contains this slot, but a value wasn't provided for it
-    #[error("failed to instantiate template: no value provided for `{slot}`")]
+    #[error("failed to link template: no value provided for `{slot}`")]
     MissedSlot {
         /// Slot which didn't have a value provided for it
         slot: ast::SlotId,

--- a/cedar-policy-core/src/est/head_constraints.rs
+++ b/cedar-policy-core/src/est/head_constraints.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use super::{FromJsonError, InstantiationError};
+use super::{FromJsonError, LinkingError};
 use crate::entities::{EntityUidJson, JsonDeserializationErrorContext};
 use crate::{ast, FromNormalizedStr};
 use serde::{Deserialize, Serialize};
@@ -161,10 +161,7 @@ impl PrincipalConstraint {
     /// Fill in any slots in the principal constraint using the values in
     /// `vals`. Throws an error if `vals` doesn't contain a necessary mapping,
     /// but does not throw an error if `vals` contains unused mappings.
-    pub fn instantiate(
-        self,
-        vals: &HashMap<ast::SlotId, EntityUidJson>,
-    ) -> Result<Self, InstantiationError> {
+    pub fn link(self, vals: &HashMap<ast::SlotId, EntityUidJson>) -> Result<Self, LinkingError> {
         match self {
             PrincipalConstraint::All => Ok(PrincipalConstraint::All),
             PrincipalConstraint::Eq(EqConstraint::Entity { entity }) => {
@@ -177,7 +174,7 @@ impl PrincipalConstraint {
                 Some(val) => Ok(PrincipalConstraint::Eq(EqConstraint::Entity {
                     entity: val.clone(),
                 })),
-                None => Err(InstantiationError::MissedSlot { slot }),
+                None => Err(LinkingError::MissedSlot { slot }),
             },
             PrincipalConstraint::In(PrincipalOrResourceInConstraint::Slot { slot }) => {
                 match vals.get(&slot) {
@@ -186,7 +183,7 @@ impl PrincipalConstraint {
                             entity: val.clone(),
                         },
                     )),
-                    None => Err(InstantiationError::MissedSlot { slot }),
+                    None => Err(LinkingError::MissedSlot { slot }),
                 }
             }
             e @ PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
@@ -201,7 +198,7 @@ impl PrincipalConstraint {
                 in_entity: Some(PrincipalOrResourceInConstraint::Entity {
                     entity: vals
                         .get(&slot)
-                        .ok_or(InstantiationError::MissedSlot { slot })?
+                        .ok_or(LinkingError::MissedSlot { slot })?
                         .clone(),
                 }),
             })),
@@ -213,10 +210,7 @@ impl ResourceConstraint {
     /// Fill in any slots in the resource constraint using the values in
     /// `vals`. Throws an error if `vals` doesn't contain a necessary mapping,
     /// but does not throw an error if `vals` contains unused mappings.
-    pub fn instantiate(
-        self,
-        vals: &HashMap<ast::SlotId, EntityUidJson>,
-    ) -> Result<Self, InstantiationError> {
+    pub fn link(self, vals: &HashMap<ast::SlotId, EntityUidJson>) -> Result<Self, LinkingError> {
         match self {
             ResourceConstraint::All => Ok(ResourceConstraint::All),
             ResourceConstraint::Eq(EqConstraint::Entity { entity }) => {
@@ -229,7 +223,7 @@ impl ResourceConstraint {
                 Some(val) => Ok(ResourceConstraint::Eq(EqConstraint::Entity {
                     entity: val.clone(),
                 })),
-                None => Err(InstantiationError::MissedSlot { slot }),
+                None => Err(LinkingError::MissedSlot { slot }),
             },
             ResourceConstraint::In(PrincipalOrResourceInConstraint::Slot { slot }) => {
                 match vals.get(&slot) {
@@ -238,7 +232,7 @@ impl ResourceConstraint {
                             entity: val.clone(),
                         },
                     )),
-                    None => Err(InstantiationError::MissedSlot { slot }),
+                    None => Err(LinkingError::MissedSlot { slot }),
                 }
             }
             e @ ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
@@ -253,7 +247,7 @@ impl ResourceConstraint {
                 in_entity: Some(PrincipalOrResourceInConstraint::Entity {
                     entity: vals
                         .get(&slot)
-                        .ok_or(InstantiationError::MissedSlot { slot })?
+                        .ok_or(LinkingError::MissedSlot { slot })?
                         .clone(),
                 }),
             })),
@@ -265,10 +259,7 @@ impl ActionConstraint {
     /// Fill in any slots in the action constraint using the values in `vals`.
     /// Throws an error if `vals` doesn't contain a necessary mapping, but does
     /// not throw an error if `vals` contains unused mappings.
-    pub fn instantiate(
-        self,
-        _vals: &HashMap<ast::SlotId, EntityUidJson>,
-    ) -> Result<Self, InstantiationError> {
+    pub fn link(self, _vals: &HashMap<ast::SlotId, EntityUidJson>) -> Result<Self, LinkingError> {
         // currently, slots are not allowed in action constraints
         Ok(self)
     }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -4389,7 +4389,7 @@ pub mod test {
             PolicyID::from_string("instance"),
             values,
         )
-        .expect("Instantiation failed!");
+        .expect("Linking failed!");
         let q = Request::new(
             (EntityUID::with_eid("p"), None),
             (EntityUID::with_eid("a"), None),

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -305,7 +305,7 @@ mod test {
     }
 
     #[test]
-    fn top_level_validate_with_instantiations() -> Result<()> {
+    fn top_level_validate_with_links() -> Result<()> {
         let mut set = PolicySet::new();
         let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment>(
             r#"
@@ -368,7 +368,7 @@ mod test {
             Vec::<&ValidationError>::new()
         );
 
-        // a valid instantiation is valid
+        // a valid link is valid
         let mut values = HashMap::new();
         values.insert(
             ast::SlotId::resource(),
@@ -386,7 +386,7 @@ mod test {
         let result = validator.validate(&set, ValidationMode::default());
         assert!(result.validation_passed());
 
-        // an invalid instantiation results in an error
+        // an invalid link results in an error
         let mut values = HashMap::new();
         values.insert(
             ast::SlotId::resource(),
@@ -421,7 +421,7 @@ mod test {
         assert!(result.validation_errors().any(|x| x == &undefined_err));
         assert!(result.validation_errors().any(|x| x == &invalid_action_err));
 
-        // this is also an invalid instantiation (not a valid resource type for any action in the schema)
+        // this is also an invalid link (not a valid resource type for any action in the schema)
         let mut values = HashMap::new();
         values.insert(
             ast::SlotId::resource(),

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -446,7 +446,7 @@ impl<'a> Typechecker<'a> {
     }
 
     /// Given a request environment and a template, return new environments
-    /// formed by instantiating template slots with possible entity types.
+    /// formed by linking template slots with possible entity types.
     fn link_request_env<'b>(
         &'b self,
         env: RequestEnv<'b>,
@@ -461,14 +461,14 @@ impl<'a> Typechecker<'a> {
                 context,
                 ..
             } => Box::new(
-                self.possible_slot_instantiations(
+                self.possible_slot_links(
                     t,
                     SlotId::principal(),
                     principal,
                     t.principal_constraint().as_inner(),
                 )
                 .flat_map(move |p_slot| {
-                    self.possible_slot_instantiations(
+                    self.possible_slot_links(
                         t,
                         SlotId::resource(),
                         resource,
@@ -487,11 +487,11 @@ impl<'a> Typechecker<'a> {
         }
     }
 
-    /// Get the entity types which could instantiate the slot given in this
+    /// Get the entity types which could link the slot given in this
     /// template based on the policy scope constraints. We use this function to
     /// avoid typechecking with slot bindings that will always be false based
     /// only on the scope constraints.
-    fn possible_slot_instantiations(
+    fn possible_slot_links(
         &self,
         t: &Template,
         slot_id: SlotId,
@@ -521,7 +521,7 @@ impl<'a> Typechecker<'a> {
                 // This can't happen for the moment because slots may only
                 // appear in scope constraints, but if we ever see this, then the
                 // only correct way to proceed is by returning all entity types
-                // as possible instantiations.
+                // as possible links.
                 PrincipalOrResourceConstraint::Is(_) | PrincipalOrResourceConstraint::Any => {
                     Box::new(
                         all_entity_types.map(|(name, _)| Some(EntityType::Specified(name.clone()))),
@@ -530,7 +530,7 @@ impl<'a> Typechecker<'a> {
             }
         } else {
             // If the template does not contain this slot, then we don't need to
-            // consider its instantiations..
+            // consider its links.
             Box::new(std::iter::once(None))
         }
     }

--- a/cedar-policy-validator/src/typecheck/test_expr.rs
+++ b/cedar-policy-validator/src/typecheck/test_expr.rs
@@ -90,7 +90,7 @@ fn slot_equals_typechecks() {
         shape: AttributesOrContext::default(),
     };
     // These don't typecheck in strict mode because the test_util expression
-    // typechecker doesn't have access to a schema, so it can't instantiate
+    // typechecker doesn't have access to a schema, so it can't link
     // the template slots with appropriate types. Similar policies that pass
     // strict typechecking are in the test_policy file.
     let schema = NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3401,7 +3401,7 @@ impl LosslessPolicy {
     fn link<'a>(
         self,
         vals: impl IntoIterator<Item = (ast::SlotId, &'a ast::EntityUID)>,
-    ) -> Result<Self, est::InstantiationError> {
+    ) -> Result<Self, est::LinkingError> {
         match self {
             Self::Est(est) => {
                 let unwrapped_est_vals: HashMap<
@@ -3461,8 +3461,8 @@ pub enum PolicyToJsonError {
     JsonSerialization(#[from] json_errors::PolicyJsonSerializationError),
 }
 
-impl From<est::InstantiationError> for PolicyToJsonError {
-    fn from(e: est::InstantiationError) -> Self {
+impl From<est::LinkingError> for PolicyToJsonError {
+    fn from(e: est::LinkingError) -> Self {
         json_errors::JsonLinkError::from(e).into()
     }
 }
@@ -3486,7 +3486,7 @@ pub mod json_errors {
     pub struct JsonLinkError {
         /// Underlying error
         #[from]
-        err: est::InstantiationError,
+        err: est::LinkingError,
     }
 
     /// Error serializing a policy as JSON

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -632,11 +632,10 @@ struct TemplateLink {
     /// Template ID to fill in
     template_id: String,
 
-    /// Policy id for resulting concrete policy instance
+    /// Policy ID for resulting linked policy
     result_policy_id: String,
 
-    /// List of strings to fill in all slots in policy template "template_id".
-    /// (slot, String)
+    /// Links for all slots in policy template `template_id`
     instantiations: Links,
 }
 
@@ -648,11 +647,11 @@ struct TemplateLink {
 #[serde(rename_all = "camelCase")]
 struct Links(Vec<Link>);
 
-/// Error returned for duplicate link ids in a template instantiation
+/// Error returned for duplicate slot ids
 #[derive(Debug, Clone, Diagnostic, Error)]
 pub enum DuplicateLinkError {
-    /// Duplicate instantiations for the same slot
-    #[error("duplicate instantiations of the slot(s): {}", .0.iter().map(|s| format!("`{s}`")).join(", "))]
+    /// Duplicate values for the same slot
+    #[error("duplicate values for the slot(s): {}", .0.iter().map(|s| format!("`{s}`")).join(", "))]
     Duplicates(Vec<String>),
 }
 
@@ -699,13 +698,11 @@ struct RecvdSlice {
     #[serde_as(as = "Option<MapPreventDuplicates<_, _>>")]
     templates: Option<HashMap<String, String>>,
 
-    /// Optional template instantiations.
-    /// List of instantiations, one per
-    /// If present, instantiate policies
+    /// Optional template links
     template_instantiations: Option<Vec<TemplateLink>>,
 }
 
-fn parse_instantiation(v: &Link) -> Result<(SlotId, EntityUid), Vec<String>> {
+fn parse_link(v: &Link) -> Result<(SlotId, EntityUid), Vec<String>> {
     let slot = match v.slot.as_str() {
         "?principal" => SlotId::principal(),
         "?resource" => SlotId::resource(),
@@ -729,25 +726,22 @@ fn parse_instantiation(v: &Link) -> Result<(SlotId, EntityUid), Vec<String>> {
     }
 }
 
-fn parse_instantiations(
-    policies: &mut crate::PolicySet,
-    instantiation: TemplateLink,
-) -> Result<(), Vec<String>> {
-    let template_id = PolicyId::from_str(instantiation.template_id.as_str());
-    let instance_id = PolicyId::from_str(instantiation.result_policy_id.as_str());
+fn parse_links(policies: &mut crate::PolicySet, link: TemplateLink) -> Result<(), Vec<String>> {
+    let template_id = PolicyId::from_str(link.template_id.as_str());
+    let instance_id = PolicyId::from_str(link.result_policy_id.as_str());
     match (template_id, instance_id) {
         (Err(never), _) | (_, Err(never)) => match never {},
         (Ok(template_id), Ok(instance_id)) => {
             let mut vals = HashMap::new();
-            for i in instantiation.instantiations.0 {
-                match parse_instantiation(&i) {
+            for i in link.instantiations.0 {
+                match parse_link(&i) {
                     Err(e) => return Err(e),
                     Ok(val) => vals.insert(val.0, val.1),
                 };
             }
             match policies.link(template_id, instance_id, vals) {
                 Ok(()) => Ok(()),
-                Err(e) => Err(vec![format!("Error instantiating template: {e}")]),
+                Err(e) => Err(vec![format!("Error linking template: {e}")]),
             }
         }
     }
@@ -790,9 +784,9 @@ impl RecvdSlice {
             }
         };
 
-        if let Some(t_inst_list) = template_instantiations {
-            for instantiation in t_inst_list {
-                match parse_instantiations(&mut policies, instantiation) {
+        if let Some(links) = template_instantiations {
+            for link in links {
+                match parse_links(&mut policies, link) {
                     Ok(()) => (),
                     Err(err) => errs.extend(err),
                 }
@@ -1318,7 +1312,7 @@ mod test {
     }
 
     #[test]
-    fn test_authorized_with_template_instantiation() {
+    fn test_authorized_with_template_link() {
         let call = json!({
             "principal": {
              "type": "User",
@@ -1389,7 +1383,7 @@ mod test {
     }
 
     #[test]
-    fn test_authorized_fails_on_duplicate_instantiations_ids() {
+    fn test_authorized_fails_on_duplicate_link_ids() {
         let call = json!({
             "principal" : {
                 "type" : "User",
@@ -1434,12 +1428,12 @@ mod test {
         });
         assert_is_authorized_json_is_failure(
             call,
-            "Error instantiating template: unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
+            "Error linking template: unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
         );
     }
 
     #[test]
-    fn test_authorized_fails_on_template_instantiation_collision_with_template() {
+    fn test_authorized_fails_on_template_link_collision_with_template() {
         let call = json!({
             "principal" : {
                 "type" : "User",
@@ -1474,12 +1468,12 @@ mod test {
         });
         assert_is_authorized_json_is_failure(
             call,
-            "Error instantiating template: unable to link template: template-linked policy id `ID0` conflicts with an existing policy id",
+            "Error linking template: unable to link template: template-linked policy id `ID0` conflicts with an existing policy id",
         );
     }
 
     #[test]
-    fn test_authorized_fails_on_template_instantiation_collision_with_policy() {
+    fn test_authorized_fails_on_template_link_collision_with_policy() {
         let call = json!({
             "principal" : {
                 "type" : "User",
@@ -1514,7 +1508,7 @@ mod test {
         });
         assert_is_authorized_json_is_failure(
             call,
-            "Error instantiating template: unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
+            "Error linking template: unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
         );
     }
 
@@ -1563,7 +1557,7 @@ mod test {
     }
 
     #[test]
-    fn test_authorized_fails_on_duplicate_slot_instantiation1() {
+    fn test_authorized_fails_on_duplicate_slot_link1() {
         let call = json!({
             "principal" : "User::\"alice\"",
             "action" : "Photo::\"view\"",
@@ -1592,12 +1586,12 @@ mod test {
             }
         });
         assert_matches!(is_authorized_json(call), Err(e) => {
-            assert!(e.to_string().contains("duplicate instantiations of the slot(s): `?principal`"));
+            assert!(e.to_string().contains("duplicate values for the slot(s): `?principal`"));
         });
     }
 
     #[test]
-    fn test_authorized_fails_on_duplicate_slot_instantiation2() {
+    fn test_authorized_fails_on_duplicate_slot_link2() {
         let call = json!({
             "principal" : "User::\"alice\"",
             "action" : "Photo::\"view\"",
@@ -1630,12 +1624,12 @@ mod test {
             }
         });
         assert_matches!(is_authorized_json(call), Err(e) => {
-            assert!(e.to_string().contains("duplicate instantiations of the slot(s): `?principal`"));
+            assert!(e.to_string().contains("duplicate values for the slot(s): `?principal`"));
         });
     }
 
     #[test]
-    fn test_authorized_fails_on_duplicate_slot_instantiation3() {
+    fn test_authorized_fails_on_duplicate_slot_link3() {
         let call = json!({
             "principal" : "User::\"alice\"",
             "action" : "Photo::\"view\"",
@@ -1672,7 +1666,7 @@ mod test {
             }
         });
         assert_matches!(is_authorized_json(call), Err(e) => {
-            assert!(e.to_string().contains("duplicate instantiations of the slot(s): `?principal`, `?resource`"));
+            assert!(e.to_string().contains("duplicate values for the slot(s): `?principal`, `?resource`"));
         });
     }
 


### PR DESCRIPTION
## Description of changes

Fix all* remaining mentions of template "instantiation" to refer to "linking".

*this PR designed to be non-breaking, so it did not fix JSON fields `instantiations` or `template_instantiations` in the public FFI interface, although it does update their doc comments.  Those fields are due to be renamed/refactored as part of the work for #757 anyway, which will be done separately.

## Issue #, if available

Split out from #800

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

