### PR TITLE
Update from 'head' to 'scope' everywhere

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -230,7 +230,7 @@ impl<T> Expr<T> {
 
     /// Check whether this expression is an entity reference
     ///
-    /// This is used for policy headers, where some syntax is
+    /// This is used for policy scopes, where some syntax is
     /// required to be an entity reference.
     pub fn is_ref(&self) -> bool {
         match &self.expr_kind {
@@ -246,7 +246,7 @@ impl<T> Expr<T> {
 
     /// Check whether this expression is a set of entity references
     ///
-    /// This is used for policy headers, where some syntax is
+    /// This is used for policy scopes, where some syntax is
     /// required to be an entity reference set.
     pub fn is_ref_set(&self) -> bool {
         match &self.expr_kind {

--- a/cedar-policy-core/src/ast/literal.rs
+++ b/cedar-policy-core/src/ast/literal.rs
@@ -128,7 +128,7 @@ impl From<Arc<EntityUID>> for Literal {
 impl Literal {
     /// Check if this literal is an entity reference
     ///
-    /// This is used for policy headers, where some syntax is
+    /// This is used for policy scopes, where some syntax is
     /// required to be an entity reference.
     pub fn is_ref(&self) -> bool {
         matches!(self, Self::EntityUID(..))

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -75,7 +75,7 @@ impl Template {
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
         resource_constraint: ResourceConstraint,
-        non_head_constraint: Expr,
+        non_scope_constraint: Expr,
     ) -> Self {
         let body = TemplateBody::new(
             id,
@@ -85,7 +85,7 @@ impl Template {
             principal_constraint,
             action_constraint,
             resource_constraint,
-            non_head_constraint,
+            non_scope_constraint,
         );
         // INVARIANT (slot cache correctness)
         // This invariant is maintained in the body of the From impl
@@ -101,7 +101,7 @@ impl Template {
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
         resource_constraint: ResourceConstraint,
-        non_head_constraint: Arc<Expr>,
+        non_scope_constraint: Arc<Expr>,
     ) -> Self {
         let body = TemplateBody::new_shared(
             id,
@@ -111,7 +111,7 @@ impl Template {
             principal_constraint,
             action_constraint,
             resource_constraint,
-            non_head_constraint,
+            non_scope_constraint,
         );
         // INVARIANT (slot cache correctness)
         // This invariant is maintained in the body of the From impl
@@ -133,14 +133,14 @@ impl Template {
         self.body.resource_constraint()
     }
 
-    /// Get the non-head constraint on the body
-    pub fn non_head_constraints(&self) -> &Expr {
-        self.body.non_head_constraints()
+    /// Get the non-scope constraint on the body
+    pub fn non_scope_constraints(&self) -> &Expr {
+        self.body.non_scope_constraints()
     }
 
-    /// Get Arc to non-head constraint on the body
-    pub fn non_head_constraints_arc(&self) -> &Arc<Expr> {
-        self.body.non_head_constraints_arc()
+    /// Get Arc to non-scope constraint on the body
+    pub fn non_scope_constraints_arc(&self) -> &Arc<Expr> {
+        self.body.non_scope_constraints_arc()
     }
 
     /// Get the PolicyID of this template
@@ -183,7 +183,7 @@ impl Template {
 
     /// Get the condition expression of this template.
     ///
-    /// This will be a conjunction of the template's head constraints (on
+    /// This will be a conjunction of the template's scope constraints (on
     /// principal, resource, and action); the template's "when" conditions; and
     /// the negation of each of the template's "unless" conditions.
     pub fn condition(&self) -> Expr {
@@ -389,7 +389,7 @@ impl Policy {
         }
     }
 
-    /// Build a policy with a given effect, given when clause, and unconstrained head variables
+    /// Build a policy with a given effect, given when clause, and unconstrained scope variables
     pub fn from_when_clause(effect: Effect, when: Expr, id: PolicyID, loc: Option<Loc>) -> Self {
         Self::from_when_clause_annos(
             effect,
@@ -400,7 +400,7 @@ impl Policy {
         )
     }
 
-    /// Build a policy with a given effect, given when clause, and unconstrained head variables
+    /// Build a policy with a given effect, given when clause, and unconstrained scope variables
     pub fn from_when_clause_annos(
         effect: Effect,
         when: Arc<Expr>,
@@ -482,14 +482,14 @@ impl Policy {
         }
     }
 
-    /// Get the non-head constraints for the policy
-    pub fn non_head_constraints(&self) -> &Expr {
-        self.template.non_head_constraints()
+    /// Get the non-scope constraints for the policy
+    pub fn non_scope_constraints(&self) -> &Expr {
+        self.template.non_scope_constraints()
     }
 
-    /// Get the [`Arc`] owning non-head constraints for the policy
-    pub fn non_head_constraints_arc(&self) -> &Arc<Expr> {
-        self.template.non_head_constraints_arc()
+    /// Get the [`Arc`] owning non-scope constraints for the policy
+    pub fn non_scope_constraints_arc(&self) -> &Arc<Expr> {
+        self.template.non_scope_constraints_arc()
     }
 
     /// Get the expression that represents this policy.
@@ -767,53 +767,53 @@ impl StaticPolicy {
         self.0.annotations()
     }
 
-    /// Get the `principal` head constraint of this policy.
+    /// Get the `principal` scope constraint of this policy.
     pub fn principal_constraint(&self) -> &PrincipalConstraint {
         self.0.principal_constraint()
     }
 
-    /// Get the `principal` head constraint as an expression.
+    /// Get the `principal` scope constraint as an expression.
     /// This will be a boolean-valued expression: either `true` (if the policy
     /// just has `principal,`), or an equality or hierarchy constraint
     pub fn principal_constraint_expr(&self) -> Expr {
         self.0.principal_constraint_expr()
     }
 
-    /// Get the `action` head constraint of this policy.
+    /// Get the `action` scope constraint of this policy.
     pub fn action_constraint(&self) -> &ActionConstraint {
         self.0.action_constraint()
     }
 
-    /// Get the `action` head constraint of this policy as an expression.
+    /// Get the `action` scope constraint of this policy as an expression.
     /// This will be a boolean-valued expression: either `true` (if the policy
     /// just has `action,`), or an equality or hierarchy constraint
     pub fn action_constraint_expr(&self) -> Expr {
         self.0.action_constraint_expr()
     }
 
-    /// Get the `resource` head constraint of this policy.
+    /// Get the `resource` scope constraint of this policy.
     pub fn resource_constraint(&self) -> &ResourceConstraint {
         self.0.resource_constraint()
     }
 
-    /// Get the `resource` head constraint of this policy as an expression.
+    /// Get the `resource` scope constraint of this policy as an expression.
     /// This will be a boolean-valued expression: either `true` (if the policy
     /// just has `resource,`), or an equality or hierarchy constraint
     pub fn resource_constraint_expr(&self) -> Expr {
         self.0.resource_constraint_expr()
     }
 
-    /// Get the non-head constraints of this policy.
+    /// Get the non-scope constraints of this policy.
     ///
     /// This will be a conjunction of the policy's `when` conditions and the
     /// negation of each of the policy's `unless` conditions.
-    pub fn non_head_constraints(&self) -> &Expr {
-        self.0.non_head_constraints()
+    pub fn non_scope_constraints(&self) -> &Expr {
+        self.0.non_scope_constraints()
     }
 
     /// Get the condition expression of this policy.
     ///
-    /// This will be a conjunction of the policy's head constraints (on
+    /// This will be a conjunction of the policy's scope constraints (on
     /// principal, resource, and action); the policy's "when" conditions; and
     /// the negation of each of the policy's "unless" conditions.
     pub fn condition(&self) -> Expr {
@@ -829,7 +829,7 @@ impl StaticPolicy {
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
         resource_constraint: ResourceConstraint,
-        non_head_constraints: Expr,
+        non_scope_constraints: Expr,
     ) -> Result<Self, UnexpectedSlotError> {
         let body = TemplateBody::new(
             id,
@@ -839,7 +839,7 @@ impl StaticPolicy {
             principal_constraint,
             action_constraint,
             resource_constraint,
-            non_head_constraints,
+            non_scope_constraints,
         );
         let first_slot = body.condition().slots().next();
         // INVARIANT (inline policy correctness), checks that no slots exists
@@ -891,23 +891,23 @@ pub struct TemplateBody {
     annotations: Arc<Annotations>,
     /// `Effect` of this policy
     effect: Effect,
-    /// Head constraint for principal. This will be a boolean-valued expression:
+    /// Scope constraint for principal. This will be a boolean-valued expression:
     /// either `true` (if the policy just has `principal,`), or an equality or
     /// hierarchy constraint
     principal_constraint: PrincipalConstraint,
-    /// Head constraint for action. This will be a boolean-valued expression:
+    /// Scope constraint for action. This will be a boolean-valued expression:
     /// either `true` (if the policy just has `action,`), or an equality or
     /// hierarchy constraint
     action_constraint: ActionConstraint,
-    /// Head constraint for resource. This will be a boolean-valued expression:
+    /// Scope constraint for resource. This will be a boolean-valued expression:
     /// either `true` (if the policy just has `resource,`), or an equality or
     /// hierarchy constraint
     resource_constraint: ResourceConstraint,
-    /// Conjunction of all of the non-head constraints in the policy.
+    /// Conjunction of all of the non-scope constraints in the policy.
     ///
     /// This will be a conjunction of the policy's `when` conditions and the
     /// negation of each of the policy's `unless` conditions.
-    non_head_constraints: Arc<Expr>,
+    non_scope_constraints: Arc<Expr>,
 }
 
 impl TemplateBody {
@@ -948,58 +948,58 @@ impl TemplateBody {
         self.annotations.iter()
     }
 
-    /// Get the `principal` head constraint of this policy.
+    /// Get the `principal` scope constraint of this policy.
     pub fn principal_constraint(&self) -> &PrincipalConstraint {
         &self.principal_constraint
     }
 
-    /// Get the `principal` head constraint as an expression.
+    /// Get the `principal` scope constraint as an expression.
     /// This will be a boolean-valued expression: either `true` (if the policy
     /// just has `principal,`), or an equality or hierarchy constraint
     pub fn principal_constraint_expr(&self) -> Expr {
         self.principal_constraint.as_expr()
     }
 
-    /// Get the `action` head constraint of this policy.
+    /// Get the `action` scope constraint of this policy.
     pub fn action_constraint(&self) -> &ActionConstraint {
         &self.action_constraint
     }
 
-    /// Get the `action` head constraint of this policy as an expression.
+    /// Get the `action` scope constraint of this policy as an expression.
     /// This will be a boolean-valued expression: either `true` (if the policy
     /// just has `action,`), or an equality or hierarchy constraint
     pub fn action_constraint_expr(&self) -> Expr {
         self.action_constraint.as_expr()
     }
 
-    /// Get the `resource` head constraint of this policy.
+    /// Get the `resource` scope constraint of this policy.
     pub fn resource_constraint(&self) -> &ResourceConstraint {
         &self.resource_constraint
     }
 
-    /// Get the `resource` head constraint of this policy as an expression.
+    /// Get the `resource` scope constraint of this policy as an expression.
     /// This will be a boolean-valued expression: either `true` (if the policy
     /// just has `resource,`), or an equality or hierarchy constraint
     pub fn resource_constraint_expr(&self) -> Expr {
         self.resource_constraint.as_expr()
     }
 
-    /// Get the non-head constraints of this policy.
+    /// Get the non-scope constraints of this policy.
     ///
     /// This will be a conjunction of the policy's `when` conditions and the
     /// negation of each of the policy's `unless` conditions.
-    pub fn non_head_constraints(&self) -> &Expr {
-        &self.non_head_constraints
+    pub fn non_scope_constraints(&self) -> &Expr {
+        &self.non_scope_constraints
     }
 
-    /// Get the Arc owning the non head constraints
-    pub fn non_head_constraints_arc(&self) -> &Arc<Expr> {
-        &self.non_head_constraints
+    /// Get the Arc owning the non scope constraints
+    pub fn non_scope_constraints_arc(&self) -> &Arc<Expr> {
+        &self.non_scope_constraints
     }
 
     /// Get the condition expression of this policy.
     ///
-    /// This will be a conjunction of the policy's head constraints (on
+    /// This will be a conjunction of the policy's scope constraints (on
     /// principal, resource, and action); the policy's "when" conditions; and
     /// the negation of each of the policy's "unless" conditions.
     pub fn condition(&self) -> Expr {
@@ -1013,7 +1013,7 @@ impl TemplateBody {
                 self.resource_constraint_expr(),
             )
             .with_maybe_source_loc(self.loc.clone()),
-            self.non_head_constraints.as_ref().clone(),
+            self.non_scope_constraints.as_ref().clone(),
         )
         .with_maybe_source_loc(self.loc.clone())
     }
@@ -1027,7 +1027,7 @@ impl TemplateBody {
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
         resource_constraint: ResourceConstraint,
-        non_head_constraints: Arc<Expr>,
+        non_scope_constraints: Arc<Expr>,
     ) -> Self {
         Self {
             id,
@@ -1037,7 +1037,7 @@ impl TemplateBody {
             principal_constraint,
             action_constraint,
             resource_constraint,
-            non_head_constraints,
+            non_scope_constraints,
         }
     }
 
@@ -1050,7 +1050,7 @@ impl TemplateBody {
         principal_constraint: PrincipalConstraint,
         action_constraint: ActionConstraint,
         resource_constraint: ResourceConstraint,
-        non_head_constraints: Expr,
+        non_scope_constraints: Expr,
     ) -> Self {
         Self {
             id,
@@ -1060,7 +1060,7 @@ impl TemplateBody {
             principal_constraint,
             action_constraint,
             resource_constraint,
-            non_head_constraints: Arc::new(non_head_constraints),
+            non_scope_constraints: Arc::new(non_scope_constraints),
         }
     }
 }
@@ -1083,7 +1083,7 @@ impl std::fmt::Display for TemplateBody {
             self.principal_constraint(),
             self.action_constraint(),
             self.resource_constraint(),
-            self.non_head_constraints()
+            self.non_scope_constraints()
         )
     }
 }
@@ -1165,7 +1165,7 @@ impl AsRef<str> for Annotation {
     }
 }
 
-/// Template constraint on principal head variables
+/// Template constraint on principal scope variables
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct PrincipalConstraint {
     pub(crate) constraint: PrincipalOrResourceConstraint,
@@ -1272,7 +1272,7 @@ impl std::fmt::Display for PrincipalConstraint {
     }
 }
 
-/// Template constraint on resource head variables
+/// Template constraint on resource scope variables
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct ResourceConstraint {
     pub(crate) constraint: PrincipalOrResourceConstraint,
@@ -1599,7 +1599,7 @@ impl PrincipalOrResourceConstraint {
     }
 }
 
-/// Constraint for action head variables.
+/// Constraint for action scope variables.
 /// Action variables can be constrained to be in any variable in a list.
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub enum ActionConstraint {
@@ -1694,7 +1694,7 @@ impl std::fmt::Display for StaticPolicy {
             self.principal_constraint(),
             self.action_constraint(),
             self.resource_constraint(),
-            self.non_head_constraints()
+            self.non_scope_constraints()
         )
     }
 }
@@ -1917,8 +1917,8 @@ mod test {
             let p = template.principal_constraint().clone();
             let a = template.action_constraint().clone();
             let r = template.resource_constraint().clone();
-            let nhc = template.non_head_constraints().clone();
-            let t2 = Template::new(id, None, Annotations::new(), effect, p, a, r, nhc);
+            let non_scope = template.non_scope_constraints().clone();
+            let t2 = Template::new(id, None, Annotations::new(), effect, p, a, r, non_scope);
             assert_eq!(template, t2);
         }
     }
@@ -1936,8 +1936,8 @@ mod test {
                 let p = ip.principal_constraint().clone();
                 let a = ip.action_constraint().clone();
                 let r = ip.resource_constraint().clone();
-                let nhc = ip.non_head_constraints().clone();
-                let ip2 = StaticPolicy::new(id, None, anno, e, p, a, r, nhc)
+                let non_scope = ip.non_scope_constraints().clone();
+                let ip2 = StaticPolicy::new(id, None, anno, e, p, a, r, non_scope)
                     .expect("Policy Creation Failed");
                 assert_eq!(ip, ip2);
                 let (t2, inst) = Template::link_static_policy(ip2);

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -603,7 +603,7 @@ mod test {
         assert_eq!(p.principal_constraint(), PrincipalConstraint::any());
         assert_eq!(p.resource_constraint(), ResourceConstraint::any());
         assert_eq!(p.id(), &id);
-        assert_eq!(p.non_head_constraints(), e.as_ref());
+        assert_eq!(p.non_scope_constraints(), e.as_ref());
     }
 
     #[test]
@@ -617,7 +617,7 @@ mod test {
         assert_eq!(p.principal_constraint(), PrincipalConstraint::any());
         assert_eq!(p.resource_constraint(), ResourceConstraint::any());
         assert_eq!(p.id(), &id);
-        assert_eq!(p.non_head_constraints(), e.as_ref());
+        assert_eq!(p.non_scope_constraints(), e.as_ref());
     }
 
     #[test]

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -20,10 +20,10 @@ mod err;
 pub use err::*;
 mod expr;
 pub use expr::*;
-mod scope_constraints;
-pub use scope_constraints::*;
 mod policy_set;
 pub use policy_set::*;
+mod scope_constraints;
+pub use scope_constraints::*;
 
 use crate::ast;
 use crate::entities::EntityUidJson;

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -20,8 +20,8 @@ mod err;
 pub use err::*;
 mod expr;
 pub use expr::*;
-mod head_constraints;
-pub use head_constraints::*;
+mod scope_constraints;
+pub use scope_constraints::*;
 mod policy_set;
 pub use policy_set::*;
 
@@ -46,11 +46,11 @@ extern crate tsify;
 pub struct Policy {
     /// `Effect` of the policy or template
     effect: ast::Effect,
-    /// Principal head constraint
+    /// Principal scope constraint
     principal: PrincipalConstraint,
-    /// Action head constraint
+    /// Action scope constraint
     action: ActionConstraint,
-    /// Resource head constraint
+    /// Resource scope constraint
     resource: ResourceConstraint,
     /// `when` and/or `unless` clauses
     conditions: Vec<Clause>,
@@ -119,7 +119,7 @@ impl TryFrom<cst::Policy> for Policy {
     fn try_from(policy: cst::Policy) -> Result<Policy, ParseErrors> {
         let mut errs = ParseErrors::new();
         let effect = policy.effect.to_effect(&mut errs);
-        let (principal, action, resource) = policy.extract_head(&mut errs);
+        let (principal, action, resource) = policy.extract_scope(&mut errs);
         let (annot_success, annotations) = policy.get_ast_annotations(&mut errs);
         let conditions = match policy
             .conds
@@ -293,7 +293,7 @@ impl From<ast::Policy> for Policy {
             principal: ast.principal_constraint().into(),
             action: ast.action_constraint().clone().into(),
             resource: ast.resource_constraint().into(),
-            conditions: vec![ast.non_head_constraints().clone().into()],
+            conditions: vec![ast.non_scope_constraints().clone().into()],
             annotations: ast
                 .annotations()
                 .map(|(k, v)| (k.clone(), v.val.clone()))
@@ -310,7 +310,7 @@ impl From<ast::Template> for Policy {
             principal: ast.principal_constraint().clone().into(),
             action: ast.action_constraint().clone().into(),
             resource: ast.resource_constraint().clone().into(),
-            conditions: vec![ast.non_head_constraints().clone().into()],
+            conditions: vec![ast.non_scope_constraints().clone().into()],
             annotations: ast
                 .annotations()
                 .map(|(k, v)| (k.clone(), v.val.clone()))

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
-/// Serde JSON structure for a principal head constraint in the EST format
+/// Serde JSON structure for a principal scope constraint in the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
@@ -46,7 +46,7 @@ pub enum PrincipalConstraint {
     Is(PrincipalOrResourceIsConstraint),
 }
 
-/// Serde JSON structure for an action head constraint in the EST format
+/// Serde JSON structure for an action scope constraint in the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
@@ -64,7 +64,7 @@ pub enum ActionConstraint {
     In(ActionInConstraint),
 }
 
-/// Serde JSON structure for a resource head constraint in the EST format
+/// Serde JSON structure for a resource scope constraint in the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
@@ -85,7 +85,7 @@ pub enum ResourceConstraint {
     Is(PrincipalOrResourceIsConstraint),
 }
 
-/// Serde JSON structure for a `==` head constraint in the EST format
+/// Serde JSON structure for a `==` scope constraint in the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
@@ -104,7 +104,7 @@ pub enum EqConstraint {
     },
 }
 
-/// Serde JSON structure for an `in` head constraint for principal/resource in
+/// Serde JSON structure for an `in` scope constraint for principal/resource in
 /// the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -124,7 +124,7 @@ pub enum PrincipalOrResourceInConstraint {
     },
 }
 
-/// Serde JSON structure for an `is` head constraint for principal/resource in
+/// Serde JSON structure for an `is` scope constraint for principal/resource in
 /// the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -138,7 +138,7 @@ pub struct PrincipalOrResourceIsConstraint {
     in_entity: Option<PrincipalOrResourceInConstraint>,
 }
 
-/// Serde JSON structure for an `in` head constraint for action in the EST
+/// Serde JSON structure for an `in` scope constraint for action in the EST
 /// format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -441,11 +441,11 @@ mod test {
             assert_eq!(parsed.resource_constraint(), template.resource_constraint());
             assert!(
                 parsed
-                    .non_head_constraints()
-                    .eq_shape(template.non_head_constraints()),
+                    .non_scope_constraints()
+                    .eq_shape(template.non_scope_constraints()),
                 "{:?} and {:?} should have the same shape.",
-                parsed.non_head_constraints(),
-                template.non_head_constraints()
+                parsed.non_scope_constraints(),
+                template.non_scope_constraints()
             );
         }
     }

--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -378,7 +378,7 @@ pub enum Slot {
 }
 
 impl Slot {
-    /// Check if a slot matches a head variable.
+    /// Check if a slot matches a scope variable.
     pub fn matches(&self, var: crate::ast::Var) -> bool {
         matches!(
             (self, var),

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -180,7 +180,7 @@ pub enum ToASTErrorKind {
     #[error("this policy is missing the `{0}` variable in the scope")]
     MissingScopeConstraint(Var),
     /// Returned when a policy has an extra scope clause. This is not valid syntax
-    #[error("this policy has an extra scope constraint in the scope: `{0}`")]
+    #[error("this policy has an extra constraint in the scope: `{0}`")]
     #[diagnostic(help(
         "a policy must have exactly `principal`, `action`, and `resource` constraints"
     ))]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -180,11 +180,11 @@ pub enum ToASTErrorKind {
     #[error("this policy is missing the `{0}` variable in the scope")]
     MissingScopeConstraint(Var),
     /// Returned when a policy has an extra scope clause. This is not valid syntax
-    #[error("this policy has an extra constraint in the scope: `{0}`")]
+    #[error("this policy has an extra scope constraint in the scope: `{0}`")]
     #[diagnostic(help(
         "a policy must have exactly `principal`, `action`, and `resource` constraints"
     ))]
-    ExtraHeadConstraints(cst::VariableDef),
+    ExtraScopeConstraints(cst::VariableDef),
     /// Returned when a policy uses a reserved keyword as an identifier.
     #[error("this identifier is reserved and cannot be used: `{0}`")]
     ReservedIdentifier(cst::Ident),

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -495,7 +495,7 @@ mod test {
 
     #[test]
     fn idempotent1() {
-        // Note: the context field in the head is no longer supported and
+        // Note: the context field in the scope is no longer supported and
         // will produce an error during CST -> AST conversion. But it is
         // still correctly parsed & displayed by the CST code.
         let cstnode1 = text_to_cst::parse_policies(

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -65,8 +65,8 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
             && f_p.action_constraint() == p.action_constraint()
             && f_p.resource_constraint() == p.resource_constraint()
             && f_p
-                .non_head_constraints()
-                .eq_shape(p.non_head_constraints()))
+                .non_scope_constraints()
+                .eq_shape(p.non_scope_constraints()))
         {
             return Err(miette!(
                 "policies differ in meaning or annotations:\noriginal: {p}\nformatted: {f_p}"

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -42,7 +42,7 @@ pub(super) fn expr_entity_type_names(expr: &Expr) -> impl Iterator<Item = &Name>
 }
 
 /// Returns an iterator over all literal entity uids in a policy. This iterates
-/// over any entities in the policy head condition in addition to any entities
+/// over any entities in the policy scope condition in addition to any entities
 /// in the body.
 pub(super) fn policy_entity_uids(template: &Template) -> impl Iterator<Item = &EntityUID> {
     template
@@ -51,11 +51,11 @@ pub(super) fn policy_entity_uids(template: &Template) -> impl Iterator<Item = &E
         .iter_euids()
         .chain(template.action_constraint().iter_euids())
         .chain(template.resource_constraint().as_inner().iter_euids())
-        .chain(expr_entity_uids(template.non_head_constraints()))
+        .chain(expr_entity_uids(template.non_scope_constraints()))
 }
 
 /// Returns an iterator over all entity type names in the policy. This iterates
-/// over the policy head condition in addition to the body.
+/// over the policy scope condition in addition to the body.
 /// The Unspecified entity type does not have a `Name`, so it is excluded
 /// from this iter.
 pub(super) fn policy_entity_type_names(template: &Template) -> impl Iterator<Item = &Name> {
@@ -70,7 +70,7 @@ pub(super) fn policy_entity_type_names(template: &Template) -> impl Iterator<Ite
                 .as_inner()
                 .iter_entity_type_names(),
         )
-        .chain(expr_entity_type_names(template.non_head_constraints()))
+        .chain(expr_entity_type_names(template.non_scope_constraints()))
 }
 
 /// The 3 different "classes" of text in an expression.
@@ -295,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn entity_full_head() {
+    fn entity_full_scope() {
         let euid_foo =
             EntityUID::with_eid_and_type("test_entity_type", "foo").expect("valid identifier");
         let euid_bar =
@@ -304,7 +304,7 @@ mod tests {
             EntityUID::with_eid_and_type("test_entity_type", "baz").expect("valid identifier");
         let euid_buz =
             EntityUID::with_eid_and_type("test_entity_type", "buz").expect("valid identifier");
-        let head = Expr::and(
+        let scope = Expr::and(
             Expr::is_eq(Expr::var(Var::Principal), Expr::val(euid_foo.clone())),
             Expr::and(
                 Expr::is_in(
@@ -318,7 +318,7 @@ mod tests {
             ),
         );
 
-        let entities: HashSet<EntityUID> = expr_entity_uids(&head).cloned().collect();
+        let entities: HashSet<EntityUID> = expr_entity_uids(&scope).cloned().collect();
         assert_eq!(
             HashSet::from([euid_foo, euid_bar, euid_baz, euid_buz]),
             entities

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -397,7 +397,7 @@ fn policy_lub_entity_type_attr() {
 }
 
 #[test]
-fn policy_impossible_head() {
+fn policy_impossible_scope() {
     let p = parse_policy(
         Some("0".to_string()),
         r#"permit(principal == Group::"foo", action == Action::"delete_group", resource);"#,

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -250,7 +250,7 @@ permit(principal ==  A :: B
     }
 }
 
-mod head_constraints_tests {
+mod scope_constraints_tests {
     use super::*;
 
     #[test]


### PR DESCRIPTION
## Description of changes

Follow up to #825, making the change everywhere. Changes the names of a couple function that are `pub` in `core`, so might also need a `cedar-spec` update, pending result of CI tests.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
