### PR TITLE
Refactoring in api.rs

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2843,8 +2843,8 @@ impl Expression {
 
     /// Deconstruct an [`Expression`] to get the internal type.
     /// This function is only intended to be used internally.
-    #[allow(dead_code)]
-    pub(crate) fn unwrap(self) -> ast::Expr {
+    #[cfg(test)]
+    pub(crate) fn into_inner(self) -> ast::Expr {
         self.0
     }
 }
@@ -2938,19 +2938,19 @@ impl RestrictedExpression {
 
     /// Deconstruct an [`RestrictedExpression`] to get the internal type.
     /// This function is only intended to be used internally.
-    #[allow(dead_code)]
-    pub(crate) fn unwrap(self) -> ast::RestrictedExpr {
+    #[cfg(test)]
+    pub(crate) fn into_inner(self) -> ast::RestrictedExpr {
         self.0
     }
 }
 
-pub(crate) fn decimal_extension_name() -> ast::Name {
+fn decimal_extension_name() -> ast::Name {
     // PANIC SAFETY: This is a constant and is known to be safe, verified by a test
     #[allow(clippy::unwrap_used)]
     ast::Name::unqualified_name("decimal".parse().unwrap())
 }
 
-pub(crate) fn ip_extension_name() -> ast::Name {
+fn ip_extension_name() -> ast::Name {
     // PANIC SAFETY: This is a constant and is known to be safe, verified by a test
     #[allow(clippy::unwrap_used)]
     ast::Name::unqualified_name("ip".parse().unwrap())

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -47,7 +47,6 @@ use cedar_policy_core::evaluator::RestrictedEvaluator;
 pub use cedar_policy_core::extensions;
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::parser;
-use cedar_policy_core::parser::err::ParseErrors;
 use cedar_policy_core::FromNormalizedStr;
 use cedar_policy_validator::RequestValidationError; // this type is unsuitable for `pub use` because it contains internal types like `EntityUID` and `EntityType`
 use itertools::{Either, Itertools};

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -100,12 +100,14 @@ impl std::fmt::Display for SlotId {
     }
 }
 
+#[doc(hidden)]
 impl From<ast::SlotId> for SlotId {
     fn from(a: ast::SlotId) -> Self {
         Self(a)
     }
 }
 
+#[doc(hidden)]
 impl From<SlotId> for ast::SlotId {
     fn from(s: SlotId) -> Self {
         s.0
@@ -921,6 +923,7 @@ pub struct Diagnostics {
     errors: Vec<AuthorizationError>,
 }
 
+#[doc(hidden)]
 impl From<authorizer::Diagnostics> for Diagnostics {
     fn from(diagnostics: authorizer::Diagnostics) -> Self {
         Self {
@@ -1085,6 +1088,7 @@ impl Response {
     }
 }
 
+#[doc(hidden)]
 impl From<authorizer::Response> for Response {
     fn from(a: authorizer::Response) -> Self {
         Self {
@@ -1112,6 +1116,7 @@ pub enum ValidationMode {
     Partial,
 }
 
+#[doc(hidden)]
 impl From<ValidationMode> for cedar_policy_validator::ValidationMode {
     fn from(mode: ValidationMode) -> Self {
         match mode {
@@ -1402,6 +1407,7 @@ impl ValidationResult {
     }
 }
 
+#[doc(hidden)]
 impl From<cedar_policy_validator::ValidationResult> for ValidationResult {
     fn from(r: cedar_policy_validator::ValidationResult) -> Self {
         let (errors, warnings) = r.into_errors_and_warnings();

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -26,7 +26,7 @@ pub use cedar_policy_core::entities::EntitiesError;
 use cedar_policy_core::est;
 pub use cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind};
 use cedar_policy_core::parser;
-use cedar_policy_core::parser::err::ParseErrors;
+pub use cedar_policy_core::parser::err::ParseErrors;
 pub use cedar_policy_validator::human_schema::SchemaWarning;
 pub use cedar_policy_validator::{
     TypeErrorKind, UnsupportedFeature, ValidationErrorKind, ValidationWarningKind,

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -499,32 +499,6 @@ impl From<ast::UnexpectedSlotError> for PolicySetError {
     }
 }
 
-/// Error types related to JSON processing
-pub mod json_errors {
-    use cedar_policy_core::est;
-    use miette::Diagnostic;
-    use thiserror::Error;
-
-    /// Error linking the JSON representation of a linked policy
-    #[derive(Debug, Diagnostic, Error)]
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    pub struct JsonLinkError {
-        /// Underlying error
-        #[from]
-        err: est::LinkingError,
-    }
-
-    /// Error serializing a policy as JSON
-    #[derive(Debug, Diagnostic, Error)]
-    #[error(transparent)]
-    pub struct PolicyJsonSerializationError {
-        /// Underlying error
-        #[from]
-        err: serde_json::Error,
-    }
-}
-
 /// Errors that can happen when getting the JSON representation of a policy
 #[derive(Debug, Diagnostic, Error)]
 pub enum PolicyToJsonError {
@@ -550,6 +524,32 @@ impl From<est::LinkingError> for PolicyToJsonError {
 impl From<serde_json::Error> for PolicyToJsonError {
     fn from(e: serde_json::Error) -> Self {
         json_errors::PolicyJsonSerializationError::from(e).into()
+    }
+}
+
+/// Error types related to JSON processing
+pub mod json_errors {
+    use cedar_policy_core::est;
+    use miette::Diagnostic;
+    use thiserror::Error;
+
+    /// Error linking the JSON representation of a linked policy
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    pub struct JsonLinkError {
+        /// Underlying error
+        #[from]
+        err: est::LinkingError,
+    }
+
+    /// Error serializing a policy as JSON
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    pub struct PolicyJsonSerializationError {
+        /// Underlying error
+        #[from]
+        err: serde_json::Error,
     }
 }
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -1,0 +1,569 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module defines the publicly exported error types.
+
+use crate::EntityTypeName;
+use crate::EntityUid;
+use crate::PolicyId;
+use cedar_policy_core::ast;
+use cedar_policy_core::authorizer;
+use cedar_policy_core::entities::ContextJsonDeserializationError;
+pub use cedar_policy_core::entities::EntitiesError;
+use cedar_policy_core::est;
+pub use cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind};
+use cedar_policy_core::parser;
+use cedar_policy_core::parser::err::ParseErrors;
+pub use cedar_policy_validator::human_schema::SchemaWarning;
+pub use cedar_policy_validator::{
+    TypeErrorKind, UnsupportedFeature, ValidationErrorKind, ValidationWarningKind,
+};
+use itertools::Itertools;
+use miette::Diagnostic;
+use nonempty::NonEmpty;
+use ref_cast::RefCast;
+use smol_str::SmolStr;
+use std::collections::HashSet;
+use thiserror::Error;
+
+/// Errors that can occur during authorization
+#[derive(Debug, Diagnostic, PartialEq, Eq, Error, Clone)]
+pub enum AuthorizationError {
+    /// An error occurred when evaluating a policy.
+    #[error("while evaluating policy `{id}`: {error}")]
+    PolicyEvaluationError {
+        /// Id of the policy with an error
+        #[doc(hidden)]
+        id: ast::PolicyID,
+        /// Underlying evaluation error
+        #[diagnostic(transparent)]
+        error: EvaluationError,
+    },
+}
+
+impl AuthorizationError {
+    /// Get the id of the erroring policy
+    pub fn id(&self) -> &PolicyId {
+        match self {
+            Self::PolicyEvaluationError { id, error: _ } => PolicyId::ref_cast(id),
+        }
+    }
+}
+
+#[doc(hidden)]
+impl From<authorizer::AuthorizationError> for AuthorizationError {
+    fn from(value: authorizer::AuthorizationError) -> Self {
+        match value {
+            authorizer::AuthorizationError::PolicyEvaluationError { id, error } => {
+                Self::PolicyEvaluationError { id, error }
+            }
+        }
+    }
+}
+
+/// Errors that can be encountered when re-evaluating a partial response
+#[derive(Debug, Error)]
+pub enum ReAuthorizeError {
+    /// An evaluation error was encountered
+    #[error("{err}")]
+    Evaluation {
+        /// The evaluation error
+        #[from]
+        err: EvaluationError,
+    },
+    /// A policy id conflict was found
+    #[error("{err}")]
+    PolicySet {
+        /// The conflicting ids
+        #[from]
+        err: cedar_policy_core::ast::PolicySetError,
+    },
+}
+
+/// Errors encountered during construction of a Validation Schema
+#[derive(Debug, Diagnostic, Error)]
+pub enum SchemaError {
+    /// Error thrown by the `serde_json` crate during deserialization
+    #[error("failed to parse schema: {0}")]
+    Serde(#[from] serde_json::Error),
+    /// Errors occurring while computing or enforcing transitive closure on
+    /// action hierarchy.
+    #[error("transitive closure computation/enforcement error on action hierarchy: {0}")]
+    ActionTransitiveClosure(String),
+    /// Errors occurring while computing or enforcing transitive closure on
+    /// entity type hierarchy.
+    #[error("transitive closure computation/enforcement error on entity type hierarchy: {0}")]
+    EntityTypeTransitiveClosure(String),
+    /// Error generated when processing a schema file that uses unsupported features
+    #[error("unsupported feature used in schema: {0}")]
+    UnsupportedFeature(String),
+    /// Undeclared entity type(s) used in the `memberOf` field of an entity
+    /// type, the `appliesTo` fields of an action, or an attribute type in a
+    /// context or entity attribute record. Entity types in the error message
+    /// are fully qualified, including any implicit or explicit namespaces.
+    #[error("undeclared entity type(s): {0:?}")]
+    UndeclaredEntityTypes(HashSet<String>),
+    /// Undeclared action(s) used in the `memberOf` field of an action.
+    #[error("undeclared action(s): {0:?}")]
+    UndeclaredActions(HashSet<String>),
+    /// Undeclared common type(s) used in entity or context attributes.
+    #[error("undeclared common type(s): {0:?}")]
+    UndeclaredCommonTypes(HashSet<String>),
+    /// Duplicate specifications for an entity type. Argument is the name of
+    /// the duplicate entity type.
+    #[error("duplicate entity type `{0}`")]
+    DuplicateEntityType(String),
+    /// Duplicate specifications for an action. Argument is the name of the
+    /// duplicate action.
+    #[error("duplicate action `{0}`")]
+    DuplicateAction(String),
+    /// Duplicate specification for a reusable type declaration.
+    #[error("duplicate common type `{0}`")]
+    DuplicateCommonType(String),
+    /// Cycle in the schema's action hierarchy.
+    #[error("cycle in action hierarchy containing `{0}`")]
+    CycleInActionHierarchy(EntityUid),
+    /// The schema file included an entity type `Action` in the entity type
+    /// list. The `Action` entity type is always implicitly declared, and it
+    /// cannot currently have attributes or be in any groups, so there is no
+    /// purposes in adding an explicit entry.
+    #[error("entity type `Action` declared in `entityTypes` list")]
+    ActionEntityTypeDeclared,
+    /// `context` or `shape` fields are not records
+    #[error("{0} is declared with a type other than `Record`")]
+    ContextOrShapeNotRecord(ContextOrShape),
+    /// An action entity (transitively) has an attribute that is an empty set.
+    /// The validator cannot assign a type to an empty set.
+    /// This error variant should only be used when `PermitAttributes` is enabled.
+    #[error("action `{0}` has an attribute that is an empty set")]
+    ActionAttributesContainEmptySet(EntityUid),
+    /// An action entity (transitively) has an attribute of unsupported type (`ExprEscape`, `EntityEscape` or `ExtnEscape`).
+    /// This error variant should only be used when `PermitAttributes` is enabled.
+    #[error("action `{0}` has an attribute with unsupported JSON representation: {1}")]
+    UnsupportedActionAttribute(EntityUid, String),
+    /// Error when evaluating an action attribute
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ActionAttrEval(EntityAttrEvaluationError),
+    /// Error thrown when the schema contains the `__expr` escape.
+    /// Support for this escape form has been dropped.
+    #[error("schema contained the non-supported `__expr` escape")]
+    ExprEscapeUsed,
+}
+
+/// Errors serializing Schemas to the natural syntax
+#[derive(Debug, Error, Diagnostic)]
+pub enum ToHumanSyntaxError {
+    /// Duplicate names were found in the schema
+    #[error("There are type name collisions: [{}]", .0.iter().join(", "))]
+    NameCollisions(NonEmpty<SmolStr>),
+}
+
+impl From<cedar_policy_validator::human_schema::ToHumanSchemaStrError> for ToHumanSyntaxError {
+    fn from(value: cedar_policy_validator::human_schema::ToHumanSchemaStrError) -> Self {
+        match value {
+            cedar_policy_validator::human_schema::ToHumanSchemaStrError::NameCollisions(
+                collisions,
+            ) => Self::NameCollisions(collisions),
+        }
+    }
+}
+
+/// Errors when parsing schemas
+#[derive(Debug, Diagnostic, Error)]
+pub enum HumanSchemaError {
+    /// Error parsing a schema in natural syntax
+    #[error("Error parsing schema: {0}")]
+    #[diagnostic(transparent)]
+    ParseError(#[from] cedar_policy_validator::human_schema::parser::HumanSyntaxParseErrors),
+    /// Errors combining fragments into full schemas
+    #[error("{0}")]
+    #[diagnostic(transparent)]
+    Core(#[from] SchemaError),
+    /// IO errors while parsing
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_validator::HumanSchemaError> for HumanSchemaError {
+    fn from(value: cedar_policy_validator::HumanSchemaError) -> Self {
+        match value {
+            cedar_policy_validator::HumanSchemaError::Core(core) => Self::Core(core.into()),
+            cedar_policy_validator::HumanSchemaError::IO(io_err) => Self::Io(io_err),
+            cedar_policy_validator::HumanSchemaError::Parsing(e) => Self::ParseError(e),
+        }
+    }
+}
+
+impl From<cedar_policy_validator::SchemaError> for HumanSchemaError {
+    fn from(value: cedar_policy_validator::SchemaError) -> Self {
+        Self::Core(value.into())
+    }
+}
+
+/// Error when evaluating an entity attribute
+#[derive(Debug, Diagnostic, Error)]
+#[error("in attribute `{attr}` of `{uid}`: {err}")]
+pub struct EntityAttrEvaluationError {
+    /// Action that had the attribute with the error
+    pub uid: EntityUid,
+    /// Attribute that had the error
+    pub attr: SmolStr,
+    /// Underlying evaluation error
+    #[diagnostic(transparent)]
+    pub err: EvaluationError,
+}
+
+impl From<ast::EntityAttrEvaluationError> for EntityAttrEvaluationError {
+    fn from(err: ast::EntityAttrEvaluationError) -> Self {
+        Self {
+            uid: EntityUid::new(err.uid),
+            attr: err.attr,
+            err: err.err,
+        }
+    }
+}
+
+/// Describes in what action context or entity type shape a schema parsing error
+/// occurred.
+#[derive(Debug)]
+pub enum ContextOrShape {
+    /// An error occurred when parsing the context for the action with this
+    /// `EntityUid`.
+    ActionContext(EntityUid),
+    /// An error occurred when parsing the shape for the entity type with this
+    /// `EntityTypeName`.
+    EntityTypeShape(EntityTypeName),
+}
+
+impl std::fmt::Display for ContextOrShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ActionContext(action) => write!(f, "Context for action {action}"),
+            Self::EntityTypeShape(entity_type) => {
+                write!(f, "Shape for entity type {entity_type}")
+            }
+        }
+    }
+}
+
+impl From<cedar_policy_validator::ContextOrShape> for ContextOrShape {
+    fn from(value: cedar_policy_validator::ContextOrShape) -> Self {
+        match value {
+            cedar_policy_validator::ContextOrShape::ActionContext(euid) => {
+                Self::ActionContext(EntityUid::new(euid))
+            }
+            cedar_policy_validator::ContextOrShape::EntityTypeShape(name) => {
+                Self::EntityTypeShape(EntityTypeName::new(name))
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_validator::SchemaError> for SchemaError {
+    fn from(value: cedar_policy_validator::SchemaError) -> Self {
+        match value {
+            cedar_policy_validator::SchemaError::Serde(e) => Self::Serde(e),
+            cedar_policy_validator::SchemaError::ActionTransitiveClosure(e) => {
+                Self::ActionTransitiveClosure(e.to_string())
+            }
+            cedar_policy_validator::SchemaError::EntityTypeTransitiveClosure(e) => {
+                Self::EntityTypeTransitiveClosure(e.to_string())
+            }
+            cedar_policy_validator::SchemaError::UnsupportedFeature(e) => {
+                Self::UnsupportedFeature(e.to_string())
+            }
+            cedar_policy_validator::SchemaError::UndeclaredEntityTypes(e) => {
+                Self::UndeclaredEntityTypes(e)
+            }
+            cedar_policy_validator::SchemaError::UndeclaredActions(e) => Self::UndeclaredActions(e),
+            cedar_policy_validator::SchemaError::UndeclaredCommonTypes(c) => {
+                Self::UndeclaredCommonTypes(c)
+            }
+            cedar_policy_validator::SchemaError::DuplicateEntityType(e) => {
+                Self::DuplicateEntityType(e)
+            }
+            cedar_policy_validator::SchemaError::DuplicateAction(e) => Self::DuplicateAction(e),
+            cedar_policy_validator::SchemaError::DuplicateCommonType(c) => {
+                Self::DuplicateCommonType(c)
+            }
+            cedar_policy_validator::SchemaError::CycleInActionHierarchy(e) => {
+                Self::CycleInActionHierarchy(EntityUid::new(e))
+            }
+            cedar_policy_validator::SchemaError::ActionEntityTypeDeclared => {
+                Self::ActionEntityTypeDeclared
+            }
+            cedar_policy_validator::SchemaError::ContextOrShapeNotRecord(context_or_shape) => {
+                Self::ContextOrShapeNotRecord(context_or_shape.into())
+            }
+            cedar_policy_validator::SchemaError::ActionAttributesContainEmptySet(uid) => {
+                Self::ActionAttributesContainEmptySet(EntityUid::new(uid))
+            }
+            cedar_policy_validator::SchemaError::UnsupportedActionAttribute(uid, escape_type) => {
+                Self::UnsupportedActionAttribute(EntityUid::new(uid), escape_type)
+            }
+            cedar_policy_validator::SchemaError::ActionAttrEval(err) => {
+                Self::ActionAttrEval(err.into())
+            }
+            cedar_policy_validator::SchemaError::ExprEscapeUsed => Self::ExprEscapeUsed,
+        }
+    }
+}
+
+/// An error generated by the validator when it finds a potential problem in a
+/// policy. The error contains a enumeration that specifies the kind of problem,
+/// and provides details specific to that kind of problem. The error also records
+/// where the problem was encountered.
+#[derive(Debug, Clone, Error, Diagnostic)]
+#[error(transparent)]
+#[diagnostic(transparent)]
+pub struct ValidationError {
+    error: cedar_policy_validator::ValidationError,
+}
+
+impl ValidationError {
+    /// Extract details about the exact issue detected by the validator.
+    pub fn error_kind(&self) -> &ValidationErrorKind {
+        self.error.error_kind()
+    }
+
+    /// Extract the location where the validator found the issue.
+    pub fn location(&self) -> &SourceLocation {
+        SourceLocation::ref_cast(self.error.location())
+    }
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_validator::ValidationError> for ValidationError {
+    fn from(error: cedar_policy_validator::ValidationError) -> Self {
+        Self { error }
+    }
+}
+
+/// Represents a location in Cedar policy source.
+#[derive(Debug, Clone, Eq, PartialEq, RefCast)]
+#[repr(transparent)]
+pub struct SourceLocation(cedar_policy_validator::SourceLocation);
+
+impl SourceLocation {
+    /// Get the `PolicyId` for the policy at this source location.
+    pub fn policy_id(&self) -> &PolicyId {
+        PolicyId::ref_cast(self.0.policy_id())
+    }
+
+    /// Get the start of the location. Returns `None` if this location does not
+    /// have a range.
+    pub fn range_start(&self) -> Option<usize> {
+        self.0.source_loc().map(parser::Loc::start)
+    }
+
+    /// Get the end of the location. Returns `None` if this location does not
+    /// have a range.
+    pub fn range_end(&self) -> Option<usize> {
+        self.0.source_loc().map(parser::Loc::end)
+    }
+
+    /// Returns a tuple of (start, end) of the location.
+    /// Returns `None` if this location does not have a range.
+    pub fn range_start_and_end(&self) -> Option<(usize, usize)> {
+        self.0
+            .source_loc()
+            .as_ref()
+            .map(|loc| (loc.start(), loc.end()))
+    }
+}
+
+impl std::fmt::Display for SourceLocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "policy `{}`", self.0.policy_id())?;
+        if let Some(loc) = self.0.source_loc() {
+            write!(f, " at offset {}-{}", loc.start(), loc.end())?;
+        }
+        Ok(())
+    }
+}
+
+impl From<&cedar_policy_validator::SourceLocation> for SourceLocation {
+    fn from(loc: &cedar_policy_validator::SourceLocation) -> Self {
+        Self(loc.clone())
+    }
+}
+
+#[derive(Debug, Clone, Error, Diagnostic)]
+#[error(transparent)]
+#[diagnostic(transparent)]
+/// Warnings found in Cedar policies
+pub struct ValidationWarning {
+    warning: cedar_policy_validator::ValidationWarning,
+}
+
+impl ValidationWarning {
+    /// Extract details about the exact issue detected by the validator.
+    pub fn warning_kind(&self) -> &ValidationWarningKind {
+        self.warning.kind()
+    }
+
+    /// Extract the location where the validator found the issue.
+    pub fn location(&self) -> &SourceLocation {
+        SourceLocation::ref_cast(self.warning.location())
+    }
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_validator::ValidationWarning> for ValidationWarning {
+    fn from(warning: cedar_policy_validator::ValidationWarning) -> Self {
+        Self { warning }
+    }
+}
+
+/// Potential errors when adding to a `PolicySet`.
+#[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
+pub enum PolicySetError {
+    /// There was a duplicate [`PolicyId`] encountered in either the set of
+    /// templates or the set of policies.
+    #[error("duplicate template or policy id `{id}`")]
+    AlreadyDefined {
+        /// [`PolicyId`] that was duplicate
+        id: PolicyId,
+    },
+    /// Error when linking a template
+    #[error("unable to link template: {0}")]
+    #[diagnostic(transparent)]
+    LinkingError(#[from] ast::LinkingError),
+    /// Expected a static policy, but a template-linked policy was provided
+    #[error("expected a static policy, but a template-linked policy was provided")]
+    ExpectedStatic,
+    /// Expected a template, but a static policy was provided.
+    #[error("expected a template, but a static policy was provided")]
+    ExpectedTemplate,
+    /// Error when removing a static policy
+    #[error("unable to remove static policy `{0}` because it does not exist")]
+    PolicyNonexistentError(PolicyId),
+    /// Error when removing a template that doesn't exist
+    #[error("unable to remove policy template `{0}` because it does not exist")]
+    TemplateNonexistentError(PolicyId),
+    /// Error when removing a template with active links
+    #[error("unable to remove policy template `{0}` because it has active links")]
+    RemoveTemplateWithActiveLinksError(PolicyId),
+    /// Error when removing a template that is not a template
+    #[error("unable to remove policy template `{0}` because it is not a template")]
+    RemoveTemplateNotTemplateError(PolicyId),
+    /// Error when unlinking a template
+    #[error("unable to unlink policy template `{0}` because it does not exist")]
+    LinkNonexistentError(PolicyId),
+    /// Error when removing a link that is not a link
+    #[error("unable to unlink `{0}` because it is not a link")]
+    UnlinkLinkNotLinkError(PolicyId),
+    /// Error when converting from EST
+    #[error("Error deserializing a policy/template from JSON: {0}")]
+    #[diagnostic(transparent)]
+    FromJson(#[from] cedar_policy_core::est::FromJsonError),
+    /// Error when converting to EST
+    #[error("Error serializing a policy to JSON: {0}")]
+    #[diagnostic(transparent)]
+    ToJson(#[from] PolicyToJsonError),
+    /// Errors encountered in JSON ser/de
+    #[error("Error serializing or deserializing from JSON: {0})")]
+    Json(#[from] serde_json::Error),
+}
+
+impl From<ast::PolicySetError> for PolicySetError {
+    fn from(e: ast::PolicySetError) -> Self {
+        match e {
+            ast::PolicySetError::Occupied { id } => Self::AlreadyDefined {
+                id: PolicyId::new(id),
+            },
+        }
+    }
+}
+
+impl From<ast::UnexpectedSlotError> for PolicySetError {
+    fn from(_: ast::UnexpectedSlotError) -> Self {
+        Self::ExpectedStatic
+    }
+}
+
+/// Error types related to JSON processing
+pub mod json_errors {
+    use cedar_policy_core::est;
+    use miette::Diagnostic;
+    use thiserror::Error;
+
+    /// Error linking the JSON representation of a linked policy
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    pub struct JsonLinkError {
+        /// Underlying error
+        #[from]
+        err: est::LinkingError,
+    }
+
+    /// Error serializing a policy as JSON
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    pub struct PolicyJsonSerializationError {
+        /// Underlying error
+        #[from]
+        err: serde_json::Error,
+    }
+}
+
+/// Errors that can happen when getting the JSON representation of a policy
+#[derive(Debug, Diagnostic, Error)]
+pub enum PolicyToJsonError {
+    /// Parse error in the policy text
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Parse(#[from] ParseErrors),
+    /// For linked policies, error linking the JSON representation
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Link(#[from] json_errors::JsonLinkError),
+    /// Error in the JSON serialization
+    #[error(transparent)]
+    JsonSerialization(#[from] json_errors::PolicyJsonSerializationError),
+}
+
+impl From<est::LinkingError> for PolicyToJsonError {
+    fn from(e: est::LinkingError) -> Self {
+        json_errors::JsonLinkError::from(e).into()
+    }
+}
+
+impl From<serde_json::Error> for PolicyToJsonError {
+    fn from(e: serde_json::Error) -> Self {
+        json_errors::PolicyJsonSerializationError::from(e).into()
+    }
+}
+
+/// Error type for parsing `Context` from JSON
+#[derive(Debug, Diagnostic, Error)]
+pub enum ContextJsonError {
+    /// Error deserializing the JSON into a Context
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    JsonDeserialization(#[from] ContextJsonDeserializationError),
+    /// The supplied action doesn't exist in the supplied schema
+    #[error("action `{action}` does not exist in the supplied schema")]
+    MissingAction {
+        /// UID of the action which doesn't exist
+        action: EntityUid,
+    },
+}

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -172,6 +172,7 @@ pub enum ToHumanSyntaxError {
     NameCollisions(NonEmpty<SmolStr>),
 }
 
+#[doc(hidden)]
 impl From<cedar_policy_validator::human_schema::ToHumanSchemaStrError> for ToHumanSyntaxError {
     fn from(value: cedar_policy_validator::human_schema::ToHumanSchemaStrError) -> Self {
         match value {
@@ -209,6 +210,7 @@ impl From<cedar_policy_validator::HumanSchemaError> for HumanSchemaError {
     }
 }
 
+#[doc(hidden)]
 impl From<cedar_policy_validator::SchemaError> for HumanSchemaError {
     fn from(value: cedar_policy_validator::SchemaError) -> Self {
         Self::Core(value.into())
@@ -228,6 +230,7 @@ pub struct EntityAttrEvaluationError {
     pub err: EvaluationError,
 }
 
+#[doc(hidden)]
 impl From<ast::EntityAttrEvaluationError> for EntityAttrEvaluationError {
     fn from(err: ast::EntityAttrEvaluationError) -> Self {
         Self {
@@ -261,6 +264,7 @@ impl std::fmt::Display for ContextOrShape {
     }
 }
 
+#[doc(hidden)]
 impl From<cedar_policy_validator::ContextOrShape> for ContextOrShape {
     fn from(value: cedar_policy_validator::ContextOrShape) -> Self {
         match value {
@@ -398,6 +402,7 @@ impl std::fmt::Display for SourceLocation {
     }
 }
 
+#[doc(hidden)]
 impl From<&cedar_policy_validator::SourceLocation> for SourceLocation {
     fn from(loc: &cedar_policy_validator::SourceLocation) -> Self {
         Self(loc.clone())
@@ -483,6 +488,7 @@ pub enum PolicySetError {
     Json(#[from] serde_json::Error),
 }
 
+#[doc(hidden)]
 impl From<ast::PolicySetError> for PolicySetError {
     fn from(e: ast::PolicySetError) -> Self {
         match e {
@@ -493,6 +499,7 @@ impl From<ast::PolicySetError> for PolicySetError {
     }
 }
 
+#[doc(hidden)]
 impl From<ast::UnexpectedSlotError> for PolicySetError {
     fn from(_: ast::UnexpectedSlotError) -> Self {
         Self::ExpectedStatic
@@ -515,6 +522,7 @@ pub enum PolicyToJsonError {
     JsonSerialization(#[from] json_errors::PolicyJsonSerializationError),
 }
 
+#[doc(hidden)]
 impl From<est::LinkingError> for PolicyToJsonError {
     fn from(e: est::LinkingError) -> Self {
         json_errors::JsonLinkError::from(e).into()

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -1,0 +1,288 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module defines the publicly exported identifier types `PolicyId` and `EntityUid`.
+
+use cedar_policy_core::ast;
+use ref_cast::RefCast;
+use serde::{Deserialize, Serialize};
+use std::convert::Infallible;
+use std::str::FromStr;
+
+/// Unique ids assigned to policies and templates.
+///
+/// A [`PolicyId`] can can be constructed using [`PolicyId::from_str`] or by
+/// calling `parse()` on a string.
+/// This implementation is [`Infallible`], so the parsed [`EntityId`] can be extracted safely.
+/// Examples:
+/// ```
+/// # use cedar_policy::PolicyId;
+/// let id = PolicyId::new("my-id");
+/// let id : PolicyId = "my-id".parse().unwrap_or_else(|never| match never {});
+/// # assert_eq!(id.as_ref(), "my-id");
+/// ```
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, RefCast)]
+pub struct PolicyId(ast::PolicyID);
+
+impl PolicyId {
+    /// Construct a [`PolicyId`] from a source string
+    pub fn new(id: impl AsRef<str>) -> Self {
+        Self(ast::PolicyID::from_string(id.as_ref()))
+    }
+
+    /// Deconstruct an [`PolicyId`] to get the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn into_inner(self) -> ast::PolicyID {
+        self.0
+    }
+
+    /// Deconstruct an [`PolicyId`] to get the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn as_inner(&self) -> &ast::PolicyID {
+        &self.0
+    }
+}
+
+impl FromStr for PolicyId {
+    type Err = Infallible;
+
+    /// Create a `PolicyId` from a string. Currently always returns `Ok()`.
+    fn from_str(id: &str) -> Result<Self, Self::Err> {
+        Ok(Self(ast::PolicyID::from_string(id)))
+    }
+}
+
+impl std::fmt::Display for PolicyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for PolicyId {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+/// Identifier portion of the [`EntityUid`] type.
+///
+/// All strings are valid [`EntityId`]s, and can be
+/// constructed either using [`EntityId::new`]
+/// or by using the implementation of [`FromStr`]. This implementation is [`Infallible`], so the
+/// parsed [`EntityId`] can be extracted safely.
+///
+/// ```
+/// # use cedar_policy::EntityId;
+/// let id : EntityId = "my-id".parse().unwrap_or_else(|never| match never {});
+/// # assert_eq!(id.as_ref(), "my-id");
+/// ```
+#[repr(transparent)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
+pub struct EntityId(ast::Eid);
+
+impl EntityId {
+    /// Construct an [`EntityId`] from a source string
+    pub fn new(src: impl AsRef<str>) -> Self {
+        match src.as_ref().parse() {
+            Ok(eid) => eid,
+            Err(infallible) => match infallible {},
+        }
+    }
+}
+
+impl FromStr for EntityId {
+    type Err = Infallible;
+    fn from_str(eid_str: &str) -> Result<Self, Self::Err> {
+        Ok(Self(ast::Eid::new(eid_str)))
+    }
+}
+
+impl AsRef<str> for EntityId {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
+    }
+}
+
+// Note that this Display formatter will format the EntityId as it would be expected
+// in the EntityUid string form. For instance, the `"alice"` in `User::"alice"`.
+// This means it adds quotes and potentially performs some escaping.
+impl std::fmt::Display for EntityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Represents an entity type name. Consists of a namespace and the type name.
+///
+/// An `EntityTypeName` can can be constructed using
+/// [`EntityTypeName::from_str`] or by calling `parse()` on a string. Unlike
+/// [`EntityId::from_str`], _this can fail_, so it is important to properly
+/// handle an `Err` result.
+///
+/// ```
+/// # use cedar_policy::EntityTypeName;
+/// let id : Result<EntityTypeName, _> = "Namespace::Type".parse();
+/// # let id = id.unwrap();
+/// # assert_eq!(id.basename(), "Type");
+/// # assert_eq!(id.namespace(), "Namespace");
+/// ```
+#[repr(transparent)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
+pub struct EntityTypeName(ast::Name);
+
+impl EntityTypeName {
+    /// Get the basename of the `EntityTypeName` (ie, with namespaces stripped).
+    /// ```
+    /// # use cedar_policy::EntityTypeName;
+    /// # use std::str::FromStr;
+    /// let type_name = EntityTypeName::from_str("MySpace::User").unwrap();
+    /// assert_eq!(type_name.basename(), "User");
+    /// ```
+    pub fn basename(&self) -> &str {
+        self.0.basename().as_ref()
+    }
+
+    /// Get the namespace of the `EntityTypeName`, as components
+    /// ```
+    /// # use cedar_policy::EntityTypeName;
+    /// # use std::str::FromStr;
+    /// let type_name = EntityTypeName::from_str("Namespace::MySpace::User").unwrap();
+    /// let mut components = type_name.namespace_components();
+    /// assert_eq!(components.next(), Some("Namespace"));
+    /// assert_eq!(components.next(), Some("MySpace"));
+    /// assert_eq!(components.next(), None);
+    /// ```
+    pub fn namespace_components(&self) -> impl Iterator<Item = &str> {
+        self.0.namespace_components().map(AsRef::as_ref)
+    }
+
+    /// Get the full namespace of the `EntityTypeName`, as a single string.
+    /// ```
+    /// # use cedar_policy::EntityTypeName;
+    /// # use std::str::FromStr;
+    /// let type_name = EntityTypeName::from_str("Namespace::MySpace::User").unwrap();
+    /// let components = type_name.namespace();
+    /// assert_eq!(components,"Namespace::MySpace");
+    /// ```
+    pub fn namespace(&self) -> String {
+        self.0.namespace()
+    }
+
+    /// Construct an [`EntityTypeName`] from the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn new(ty: ast::Name) -> Self {
+        Self(ty)
+    }
+}
+
+impl std::fmt::Display for EntityTypeName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Unique id for an entity, such as `User::"alice"`.
+///
+/// An `EntityUid` contains an [`EntityTypeName`] and [`EntityId`]. It can
+/// be constructed from these components using
+/// [`EntityUid::from_type_name_and_id`], parsed from a string using `.parse()`
+/// (via [`EntityUid::from_str`]), or constructed from a JSON value using
+/// [`EntityUid::from_json`].
+///
+// INVARIANT: this can never be an `ast::EntityType::Unspecified`
+#[repr(transparent)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
+pub struct EntityUid(ast::EntityUID);
+
+impl EntityUid {
+    /// Returns the portion of the Euid that represents namespace and entity type
+    /// ```
+    /// # use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid};
+    /// # use std::str::FromStr;
+    /// let json_data = serde_json::json!({ "__entity": { "type": "User", "id": "alice" } });
+    /// let euid = EntityUid::from_json(json_data).unwrap();
+    /// assert_eq!(euid.type_name(), &EntityTypeName::from_str("User").unwrap());
+    /// ```
+    pub fn type_name(&self) -> &EntityTypeName {
+        // PANIC SAFETY by invariant on struct
+        #[allow(clippy::panic)]
+        match self.0.entity_type() {
+            ast::EntityType::Unspecified => panic!("Impossible to have an unspecified entity"),
+            ast::EntityType::Specified(name) => EntityTypeName::ref_cast(name),
+        }
+    }
+
+    /// Returns the id portion of the Euid
+    /// ```
+    /// # use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid};
+    /// # use std::str::FromStr;
+    /// let json_data = serde_json::json!({ "__entity": { "type": "User", "id": "alice" } });
+    /// let euid = EntityUid::from_json(json_data).unwrap();
+    /// assert_eq!(euid.id(), &EntityId::from_str("alice").unwrap());
+    /// ```
+    pub fn id(&self) -> &EntityId {
+        EntityId::ref_cast(self.0.eid())
+    }
+
+    /// Creates `EntityUid` from `EntityTypeName` and `EntityId`
+    ///```
+    /// # use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid};
+    /// # use std::str::FromStr;
+    /// let eid = EntityId::from_str("alice").unwrap();
+    /// let type_name: EntityTypeName = EntityTypeName::from_str("User").unwrap();
+    /// let euid = EntityUid::from_type_name_and_id(type_name, eid);
+    /// # assert_eq!(euid.type_name(), &EntityTypeName::from_str("User").unwrap());
+    /// # assert_eq!(euid.id(), &EntityId::from_str("alice").unwrap());
+    /// ```
+    pub fn from_type_name_and_id(name: EntityTypeName, id: EntityId) -> Self {
+        // INVARIANT: `from_components` always constructs a Concrete id
+        Self(ast::EntityUID::from_components(name.0, id.0, None))
+    }
+
+    /// Testing utility for creating `EntityUids` a bit easier
+    #[cfg(test)]
+    pub(crate) fn from_strs(typename: &str, id: &str) -> Self {
+        Self::from_type_name_and_id(
+            EntityTypeName::from_str(typename).unwrap(),
+            EntityId::from_str(id).unwrap(),
+        )
+    }
+
+    /// Construct an [`EntityUid`] from the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn new(uid: ast::EntityUID) -> Self {
+        Self(uid)
+    }
+
+    /// Deconstruct an [`EntityUid`] to get the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn into_inner(self) -> ast::EntityUID {
+        self.0
+    }
+
+    /// Deconstruct an [`EntityUid`] to get the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn as_inner(&self) -> &ast::EntityUID {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for EntityUid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-//! This module defines the publicly exported identifier types `EntityUid` and `PolicyId`.
+//! This module defines the publicly exported identifier types including
+//! `EntityUid` and `PolicyId`.
 
 use cedar_policy_core::ast;
 use ref_cast::RefCast;

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -14,69 +14,13 @@
  * limitations under the License.
  */
 
-//! This module defines the publicly exported identifier types `PolicyId` and `EntityUid`.
+//! This module defines the publicly exported identifier types `EntityUid` and `PolicyId`.
 
 use cedar_policy_core::ast;
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use std::convert::Infallible;
 use std::str::FromStr;
-
-/// Unique ids assigned to policies and templates.
-///
-/// A [`PolicyId`] can can be constructed using [`PolicyId::from_str`] or by
-/// calling `parse()` on a string.
-/// This implementation is [`Infallible`], so the parsed [`EntityId`] can be extracted safely.
-/// Examples:
-/// ```
-/// # use cedar_policy::PolicyId;
-/// let id = PolicyId::new("my-id");
-/// let id : PolicyId = "my-id".parse().unwrap_or_else(|never| match never {});
-/// # assert_eq!(id.as_ref(), "my-id");
-/// ```
-#[repr(transparent)]
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, RefCast)]
-pub struct PolicyId(ast::PolicyID);
-
-impl PolicyId {
-    /// Construct a [`PolicyId`] from a source string
-    pub fn new(id: impl AsRef<str>) -> Self {
-        Self(ast::PolicyID::from_string(id.as_ref()))
-    }
-
-    /// Deconstruct an [`PolicyId`] to get the internal type.
-    /// This function is only intended to be used internally.
-    pub(crate) fn into_inner(self) -> ast::PolicyID {
-        self.0
-    }
-
-    /// Deconstruct an [`PolicyId`] to get the internal type.
-    /// This function is only intended to be used internally.
-    pub(crate) fn as_inner(&self) -> &ast::PolicyID {
-        &self.0
-    }
-}
-
-impl FromStr for PolicyId {
-    type Err = Infallible;
-
-    /// Create a `PolicyId` from a string. Currently always returns `Ok()`.
-    fn from_str(id: &str) -> Result<Self, Self::Err> {
-        Ok(Self(ast::PolicyID::from_string(id)))
-    }
-}
-
-impl std::fmt::Display for PolicyId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl AsRef<str> for PolicyId {
-    fn as_ref(&self) -> &str {
-        self.0.as_ref()
-    }
-}
 
 /// Identifier portion of the [`EntityUid`] type.
 ///
@@ -284,5 +228,61 @@ impl EntityUid {
 impl std::fmt::Display for EntityUid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+/// Unique ids assigned to policies and templates.
+///
+/// A [`PolicyId`] can can be constructed using [`PolicyId::from_str`] or by
+/// calling `parse()` on a string.
+/// This implementation is [`Infallible`], so the parsed [`EntityId`] can be extracted safely.
+/// Examples:
+/// ```
+/// # use cedar_policy::PolicyId;
+/// let id = PolicyId::new("my-id");
+/// let id : PolicyId = "my-id".parse().unwrap_or_else(|never| match never {});
+/// # assert_eq!(id.as_ref(), "my-id");
+/// ```
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize, RefCast)]
+pub struct PolicyId(ast::PolicyID);
+
+impl PolicyId {
+    /// Construct a [`PolicyId`] from a source string
+    pub fn new(id: impl AsRef<str>) -> Self {
+        Self(ast::PolicyID::from_string(id.as_ref()))
+    }
+
+    /// Deconstruct an [`PolicyId`] to get the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn into_inner(self) -> ast::PolicyID {
+        self.0
+    }
+
+    /// Deconstruct an [`PolicyId`] to get the internal type.
+    /// This function is only intended to be used internally.
+    pub(crate) fn as_inner(&self) -> &ast::PolicyID {
+        &self.0
+    }
+}
+
+impl FromStr for PolicyId {
+    type Err = Infallible;
+
+    /// Create a `PolicyId` from a string. Currently always returns `Ok()`.
+    fn from_str(id: &str) -> Result<Self, Self::Err> {
+        Ok(Self(ast::PolicyID::from_string(id)))
+    }
+}
+
+impl std::fmt::Display for PolicyId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl AsRef<str> for PolicyId {
+    fn as_ref(&self) -> &str {
+        self.0.as_ref()
     }
 }

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3561,14 +3561,9 @@ mod decimal_ip_constructors {
     use super::*;
 
     #[test]
-    fn ip_name_correct() {
-        assert_eq!(ip_extension_name(), ast::Name::from_str("ip").unwrap());
-    }
-
-    #[test]
     fn expr_ip_constructor() {
         let ip = Expression::new_ip("10.10.10.10");
-        assert_matches!(ip.unwrap().expr_kind(),
+        assert_matches!(ip.into_inner().expr_kind(),
             ast::ExprKind::ExtensionFunctionApp { fn_name, args} => {
                 assert_eq!(fn_name, &("ip".parse().unwrap()));
                 assert_eq!(args.as_ref().len(), 1);
@@ -3640,7 +3635,7 @@ mod decimal_ip_constructors {
     #[test]
     fn rexpr_ip_constructor() {
         let ip = RestrictedExpression::new_ip("10.10.10.10");
-        assert_matches!(ip.unwrap().expr_kind(),
+        assert_matches!(ip.into_inner().expr_kind(),
             ast::ExprKind::ExtensionFunctionApp { fn_name, args} => {
                 assert_eq!(fn_name, &("ip".parse().unwrap()));
                 assert_eq!(args.as_ref().len(), 1);
@@ -3652,17 +3647,9 @@ mod decimal_ip_constructors {
     }
 
     #[test]
-    fn decimal_name_correct() {
-        assert_eq!(
-            decimal_extension_name(),
-            ast::Name::from_str("decimal").unwrap()
-        );
-    }
-
-    #[test]
     fn expr_decimal_constructor() {
         let decimal = Expression::new_decimal("1234.1234");
-        assert_matches!(decimal.unwrap().expr_kind(),
+        assert_matches!(decimal.into_inner().expr_kind(),
             ast::ExprKind::ExtensionFunctionApp { fn_name, args} => {
                 assert_eq!(fn_name, &("decimal".parse().unwrap()));
                 assert_eq!(args.as_ref().len(), 1);
@@ -3676,7 +3663,7 @@ mod decimal_ip_constructors {
     #[test]
     fn rexpr_decimal_constructor() {
         let decimal = RestrictedExpression::new_decimal("1234.1234");
-        assert_matches!(decimal.unwrap().expr_kind(),
+        assert_matches!(decimal.into_inner().expr_kind(),
             ast::ExprKind::ExtensionFunctionApp { fn_name, args} => {
                 assert_eq!(fn_name, &("decimal".parse().unwrap()));
                 assert_eq!(args.as_ref().len(), 1);

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -4045,7 +4045,7 @@ mod policy_set_est_tests {
         "links" : [
             {
                 "id" : "link",
-                "template" : "non_existant",
+                "template" : "non_existent",
                 "slots" : {
                     "?principal" : { "type" : "User", "id" : "John" }
                 }
@@ -4053,7 +4053,7 @@ mod policy_set_est_tests {
         ]});
 
         let err = PolicySet::from_json_value(value).err().unwrap();
-        let template1 = PolicyId::new("non_existant").into_inner();
+        let template1 = PolicyId::new("non_existent").into();
         assert_matches!(
             err,
             PolicySetError::LinkingError(ast::LinkingError::NoSuchTemplate { id }) if id == template1


### PR DESCRIPTION
## Description of changes

This PR performs some refactoring to reduce the size of our api.rs file. For the most part, the changes are just copy-and-paste, but I did need to add some new `pub(crate)` functions to handle the new layer of indirection. I’ll add review comments to any new functions added.
* Moved `EntityUid` and `PolicyId` to a separate api/id.rs file.
* Moved all error definitions to a separate api/err.rs file. (My theory is that this change will make it easier to keep track of the upcoming changes for #745.)
* Moved tests in api.rs to join their friends in the tests.rs file.

The new files are included in api.rs using:
```rust
mod id;
pub use id::*;

mod err;
pub use err::*;
```
I believe this leaves the API unchanged from a user's perspective. Lmk if I'm wrong about that.

The changes in this PR introduce two new clippy warnings:
* [module_name_repetitions](https://rust-lang.github.io/rust-clippy/master/index.html#/module_name_repetitions) for both `PolicyId` and `EntityId` since these types end with "id" (the name of the containing module). I think we can safely ignore these because the types are `pub use`d in api.rs, so users should write `cedar_policy::PolicyId` instead of `cedar_policy::id::PolicyId`.
* [redundant_pub_crate](https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_pub_crate) for the `fold_partition` function. The reason I made it `pub(crate)` instead of private is that it's also used in testing code. I _think_ it is still effectively private with the current setting.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
