### PR TITLE
fix camelCasing in FFI

### DIFF
--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -383,6 +383,7 @@ impl TryFrom<crate::PartialResponse> for ResidualResponse {
 #[serde(rename_all = "camelCase")]
 pub enum AuthorizationAnswer {
     /// Represents a failure to parse or call the authorizer entirely
+    #[serde(rename_all = "camelCase")]
     Failure {
         /// Errors encountered
         errors: Vec<DetailedError>,
@@ -391,6 +392,7 @@ pub enum AuthorizationAnswer {
     },
     /// Represents a successful authorization call (although individual policy
     /// evaluation may still have errors)
+    #[serde(rename_all = "camelCase")]
     Success {
         /// Authorization decision and diagnostics, which may include policy
         /// evaluation errors
@@ -412,6 +414,7 @@ pub enum AuthorizationAnswer {
 #[serde(rename_all = "camelCase")]
 pub enum PartialAuthorizationAnswer {
     /// Represents a failure to parse or call the authorizer entirely
+    #[serde(rename_all = "camelCase")]
     Failure {
         /// Errors encountered
         errors: Vec<DetailedError>,
@@ -420,6 +423,7 @@ pub enum PartialAuthorizationAnswer {
     },
     /// Represents a successful authorization call with either a partial or
     /// concrete answer.  Individual policy evaluation may still have errors.
+    #[serde(rename_all = "camelCase")]
     Residuals {
         /// Information about the authorization decision and residuals
         response: Box<ResidualResponse>,

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -146,11 +146,9 @@ pub struct ValidationSettings {
 #[serde(rename_all = "camelCase")]
 pub enum ValidationEnabled {
     /// Setting for which policies will be validated against the schema
-    #[serde(rename = "on")]
     #[serde(alias = "regular")]
     On,
     /// Setting for which no validation will be done
-    #[serde(rename = "off")]
     Off,
 }
 
@@ -182,6 +180,7 @@ pub struct ValidationError {
 #[serde(rename_all = "camelCase")]
 pub enum ValidationAnswer {
     /// Represents a failure to parse or call the validator
+    #[serde(rename_all = "camelCase")]
     Failure {
         /// Parsing errors
         errors: Vec<DetailedError>,
@@ -189,6 +188,7 @@ pub enum ValidationAnswer {
         warnings: Vec<DetailedError>,
     },
     /// Represents a successful validation call
+    #[serde(rename_all = "camelCase")]
     Success {
         /// Errors from any issues found during validation
         validation_errors: Vec<ValidationError>,
@@ -224,6 +224,8 @@ mod test {
     #[track_caller]
     fn assert_validates_with_errors(json: serde_json::Value, expected_num_errors: usize) {
         let ans_val = validate_json(json).unwrap();
+        assert_matches!(ans_val.get("validationErrors"), Some(_)); // should be present, with this camelCased name
+        assert_matches!(ans_val.get("validationWarnings"), Some(_)); // should be present, with this camelCased name
         let result: Result<ValidationAnswer, _> = serde_json::from_value(ans_val);
         assert_matches!(result, Ok(ValidationAnswer::Success { validation_errors, validation_warnings: _, other_warnings: _ }) => {
             assert_eq!(validation_errors.len(), expected_num_errors, "actual validation errors were: {validation_errors:?}");


### PR DESCRIPTION
## Description of changes

It turns out that if you put `#[serde(rename_all = "camelCase")]` on an enum, `serde` doesn't automatically recursively apply the attribute to fields inside enum variants, only to the enum variant names themselves.

#814 missed this, and as a result, did not camelCase the `validation_errors` and `validation_warnings` fields in `ValidationAnswer`.  This PR finishes the job.

Our tests in this crate did not catch this because, although they use explicit JSON structures for call _inputs_ (like `ValidationCall`), they do not use explicit JSON structures for call _outputs_ (like `ValidationAnswer`), instead relying on `serde` to deserialize into `ValidationAnswer` and then check that.  As a result, the tests are fine with any shape of `ValidationAnswer` as long as `serde` deserializes it correctly.  This PR adds the minimal check that `ValidationAnswer` includes fields with the appropriate camelCase names when validation fails.

I discovered this when observing that cedar-policy/cedar-java#133 still needed to expect the snake_cased names for these fields.  I think we should still merge that PR (which is compatible with #814) and then later as a followup make a new PR compatible with this one.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

