### PR TITLE
Declare, and verify, our minimum Rust version

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -75,6 +75,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: EmbarkStudios/cargo-deny-action@v1
 
+  # See https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: taiki-e/install-action@cargo-hack
+    - run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+
   wasm-build:
     name: run wasm build script
     runs-on: ubuntu-latest

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cedar-policy-cli"
 edition = "2021"
+rust-version = "1.76.0" # minimum supported Rust version is currently 1.76.0 because `cedar-policy-core` requirement. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
 
 version = "4.0.0"
 license = "Apache-2.0"
@@ -31,7 +32,7 @@ glob = "0.3.1"
 predicates = "3.1.0"
 
 # We override the name of the binary for src/main.rs, which otherwise would be
-# cedar-cli (matching the crate name).
+# cedar-policy-cli (matching the crate name).
 [[bin]]
 name = "cedar"
 path = "src/main.rs"

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cedar-policy-core"
 edition = "2021"
+rust-version = "1.76.0" # minimum supported Rust version is currently 1.76.0 because of use of `Arc::unwrap_or_clone()`. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
 build = "build.rs"
 
 version = "4.0.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cedar-policy-formatter"
 version = "4.0.0"
 edition = "2021"
+rust-version = "1.76.0" # minimum supported Rust version is currently 1.76.0 because `cedar-policy-core` requirement. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
 license = "Apache-2.0"
 categories = ["compilers", "config"]
 description = "Policy formatter for the Cedar Policy Language."

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cedar-policy-validator"
 edition = "2021"
+rust-version = "1.76.0" # minimum supported Rust version is currently 1.76.0 because `cedar-policy-core` requirement. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
 
 version = "4.0.0"
 license = "Apache-2.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "cedar-policy"
 edition = "2021"
+rust-version = "1.76.0" # minimum supported Rust version is currently 1.76.0 because `cedar-policy-core` requirement. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
 
 version = "4.0.0"
 license = "Apache-2.0"


### PR DESCRIPTION
## Description of changes

Following the guidelines in https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field and https://doc.rust-lang.org/cargo/guide/continuous-integration.html#verifying-rust-version

Primarily this will give a nicer error message if you try to use Rust < 1.76.0 to compile Cedar.  Instead of a message about the use of unstable features, it will tell you your Rust is too old.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

