### PR TITLE
Add `help` message for `NonLitExtConstructor`

### DIFF
--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -289,6 +289,7 @@ pub enum TypeErrorKind {
     #[error("empty set literals are forbidden in policies")]
     EmptySetForbidden,
     #[error("extension constructors may not be called with non-literal expressions")]
+    #[diagnostic(help("consider applying extension constructors to attributes when constructing entity or context data"))]
     NonLitExtConstructor,
     /// To pass strict validation a policy cannot contain an `in` expression
     /// where the entity type on the left might not be able to be a member of

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -289,7 +289,7 @@ pub enum TypeErrorKind {
     #[error("empty set literals are forbidden in policies")]
     EmptySetForbidden,
     #[error("extension constructors may not be called with non-literal expressions")]
-    #[diagnostic(help("consider applying extension constructors to attributes when constructing entity or context data"))]
+    #[diagnostic(help("consider applying extension constructors to literal values when constructing entity or context data"))]
     NonLitExtConstructor,
     /// To pass strict validation a policy cannot contain an `in` expression
     /// where the entity type on the left might not be able to be a member of


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

