### PR TITLE
Add Policy::unknown_entities method

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adds an JSON representation for Policy Sets (#783, resolving #549),
     along with methods like `::from_json_value/file/str` and `::to_json`
     for `PolicySet`.
+- `Policy::unknown_entities`
 
 ### Changed
 


### PR DESCRIPTION
The new method collect all unknown entities from a partially evalauted policy.

## Description of changes

Previously, when using `Authorizer::evaluate_policies_partial` API, users can then extract all unknown entities from the returned policy sets that have residuals by calling `PolicySet::unknown_entities`. Since `Authorizer::evluate_policies_partial` is removed in favor of the new `Authorizer::is_authorized_partial` API, users now gets an iterator of policies that contain residuals. Adding `Policy::unknown_entities` method can avoid the trouble of collecting the iterator into a `PolicySet` .

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

