### PR TITLE
update readmes

### DIFF
--- a/cedar-policy-cli/sample-data/sandbox_a/README.md
+++ b/cedar-policy-cli/sample-data/sandbox_a/README.md
@@ -92,11 +92,11 @@ You can validate if a policy conforms with the schema. Try the following:
 ```
 cargo run validate \
   --policies policies_1.cedar \
-  --schema schema.cedarschema.json
+  --schema schema.cedarschema
 ```
-Validation should pass. If you look at the `schema.cedarschema.json` file, you will see it has two sections: the `entityTypes` section, first, and the `actions` section. The first section describes the legal entity types, including member relationships. For example, we see that entities of type `Photo` can be members of entities of type `Album` or `Account` -- membership is tantamount to a parent-child relationship in the entity hierarchy.
+Validation should pass. If you look at the `schema.cedarschema` file, you will see it has two kinds of declarations: `entity` declarations and `action` declarations. The `entity` declarations describe the legal entity types, including member relationships. For example, we see that entities of type `Photo` can be members of entities of type `Account` or `Album`.
 
-The second section of the schema defines all of the legal actions (each of which has entity type `Action`, not shown), and the principal and resource types of entities that are allowed in authorization requests for that action. We can see that there are four legal actions, and each one has the same assumptions: only `User` entities can be passed in as principals in requests, and either `Photo`, `Album`, or `Video` entities can be passed in as resources.
+The `action` declarations in the schema define all of the legal actions (each of which has entity type `Action`, not shown), and the principal and resource types of entities that are allowed in authorization requests for that action. We can see that there are four legal actions, and each one has the same assumptions: only `User` entities can be passed in as principals in requests, and either `Photo`, `Album`, or `Video` entities can be passed in as resources.
 
 Now try validation on `policies_1_bad.cedar`. You will see that validation fails, indicating that entity type `UsrGroup` is unrecognized; this is because it is not listed in the `entityTypes` section (it was meant to be `UserGroup` but there was a typo).
 

--- a/cedar-policy-cli/sample-data/sandbox_b/README.md
+++ b/cedar-policy-cli/sample-data/sandbox_b/README.md
@@ -77,9 +77,9 @@ You can validate if a policy conforms with the schema. Try the following:
 ```
 cargo run validate \
   --policies policies_5.cedar \
-  --schema schema.cedarschema.json
+  --schema schema.cedarschema
 ```
-You can see that validation passes. If you look at `schema.cedarschema.json` you can see that it is larger than the schema used for `sandbox_a`. The `entityTypes` section now contains information about some of the entity types' legal attributes. This information is in the `shapes` portion of the entity type description. Notice that some attributes are paired with a `required` field which indicates whether they are optional or not. The `actions` section also has an additional element for some of the actions, which describes the legal shape of the `context` that can be passed in on authorization requests for that action.
+You can see that validation passes. If you look at `schema.cedarschema` you can see that it is larger than the schema used for `sandbox_a`. The `entity` declarations now contain information about some of the entity types' legal attributes. Notice that some attributes have a `?` by their name, which indicates they are optional. The `action` declarations also have a `context` field, which describes the legal shape of the `context` that can be passed in on authorization requests for that action.
 
 If you try validating `policies_5_bad.cedar` instead, you'll see a validation failure. This is because the second policy (the `forbid` one) does not have the expression `resource.account has owner` prior to accessing the `owner` attribute; since that attribute is optional, the lack of a `has` check could result in a failure, so the validator flags it.
 
@@ -88,4 +88,3 @@ If you try validating `policies_5_bad.cedar` instead, you'll see a validation fa
 Try even more authorization requests. Change the data in the policies or entities
 files and see how Cedar responds. Maybe even write your own entities and
 policies.
-

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample1/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample1/README.md
@@ -25,12 +25,12 @@ cargo run  authorize \
 
 ### Validation:
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample2/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample2/README.md
@@ -18,12 +18,12 @@ cargo run  authorize \
 
 ### Validation:
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 ### Evaluate
 

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample3/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample3/README.md
@@ -20,12 +20,12 @@ cargo run  authorize \
 
 ### Validation:
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 ### Evaluate

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample4/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample4/README.md
@@ -19,12 +19,12 @@ cargo run  authorize \
 
 # Validation
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 ### Evaluate

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample5/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample5/README.md
@@ -1,6 +1,6 @@
 ## sample 5
 
-### Authorize 
+### Authorize
 
  Can User::bob  view Photo:VacationPhoto94.jpg
 
@@ -16,12 +16,12 @@ cargo run  authorize \
 
 ### Validation
 
-Is `policy.cedar` valid based on the schema `schema.cedarschema.json`
+Is `policy.cedar` valid based on the schema `schema.cedarschema`
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 ### Evaluate:

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample6/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample6/README.md
@@ -18,12 +18,12 @@ cargo run  authorize \
 
 ### Validation
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 ### Evaluate

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample7/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample7/README.md
@@ -18,12 +18,12 @@ cargo run  authorize \
 
 ### Validation:
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 ### Evaluate

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample8/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample8/README.md
@@ -15,12 +15,12 @@ cargo run  authorize \
 
 ### Validation:
 
-Is policy.cedar valid based on the schema schema.cedarschema.json
+Is policy.cedar valid based on the schema schema.cedarschema
 
 ```
 cargo run  validate \
     --policies policy.cedar \
-    --schema schema.cedarschema.json
+    --schema schema.cedarschema
 ```
 
 Evaluate

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample9/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample9/README.md
@@ -20,7 +20,7 @@ and `ScreenTime` entities, but only `Photo` entities have an owner. Policy
 validation detects this issue.
 
 ```console
-sample9$ cedar validate --policies policy_bad.cedar --schema schema.cedarschema.json
+sample9$ cedar validate --policies policy_bad.cedar --schema schema.cedarschema
 Validation Results:
 validation error on policy `policy0` at offset 83-97: attribute `owner` for entity type ScreenTime not found
 ```
@@ -37,7 +37,7 @@ when { principal == resource.owner };
 ```
 
 ```console
-sample9$ cedar validate --policies policy.cedar --schema schema.cedarschema.json
+sample9$ cedar validate --policies policy.cedar --schema schema.cedarschema
 Validation Passed
 ```
 

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -707,6 +707,7 @@ pub fn translate_schema(args: &TranslateSchemaArgs) -> CedarExitCode {
     }
 }
 
+/// Write a schema (in JSON format) to `path`
 fn generate_schema(path: &Path) -> Result<()> {
     std::fs::write(
         path,


### PR DESCRIPTION
## Description of changes

Updates the READMEs in `cedar-policy-cli/sample-data` to use the Cedar schema format instead of the JSON one.  This change relies on #750; it's not breaking itself, but things will be broken if we don't take this PR into any release that #750 is in.  (This shouldn't be hard, as #750 is breaking, so we just need to make sure both #750 and this PR make it into the 4.0 release.)

## Issue #, if available

Comes from a comment on #750 after it was merged.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

