### PR TITLE
better error help when schema is in the wrong format

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -98,7 +98,7 @@ impl HumanSyntaxParseError {
         let suspect_json_format = match src.trim_start().chars().next() {
             None => false, // schema is empty or only whitespace; the problem is unlikely to be JSON vs human format
             Some('{') => true, // yes, this looks like it was intended to be a JSON schema
-            Some(_) => true, // any character other than '{', not likely it was intended to be a JSON schema
+            Some(_) => false, // any character other than '{', not likely it was intended to be a JSON schema
         };
         Self {
             errs,
@@ -106,7 +106,7 @@ impl HumanSyntaxParseError {
         }
     }
 
-    #[cfg_attr(not(test), allow(dead_code))]
+    #[cfg(test)]
     pub(crate) fn inner(&self) -> &human_schema::parser::HumanSyntaxParseErrors {
         &self.errs
     }
@@ -262,7 +262,7 @@ pub struct JsonDeserializationError {
 impl Diagnostic for JsonDeserializationError {
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         if self.suspect_human_format {
-            Some(Box::new("this API was expecting a schema in the JSON format; did you mean to use `from_natural_str()` or similar, which expects the Cedar schema format?"))
+            Some(Box::new("this API was expecting a schema in the JSON format; did you mean to use a different function, which expects the Cedar schema format?"))
         } else {
             None
         }

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -24,25 +24,100 @@ use itertools::Itertools;
 use miette::Diagnostic;
 use thiserror::Error;
 
-use crate::human_schema::parser::HumanSyntaxParseErrors;
+use crate::human_schema;
 
 #[derive(Debug, Error, Diagnostic)]
 pub enum HumanSchemaError {
-    #[error("{0}")]
+    #[error(transparent)]
     #[diagnostic(transparent)]
     Core(#[from] SchemaError),
-    #[error("{0}")]
+    #[error(transparent)]
     IO(#[from] std::io::Error),
-    #[error("{0}")]
+    #[error(transparent)]
     #[diagnostic(transparent)]
-    Parsing(#[from] HumanSyntaxParseErrors),
+    Parsing(#[from] HumanSyntaxParseError),
+}
+
+/// Error parsing a human-syntax schema
+#[derive(Debug, Error)]
+#[error("error parsing schema: {errs}")]
+pub struct HumanSyntaxParseError {
+    /// Underlying parse error(s)
+    errs: human_schema::parser::HumanSyntaxParseErrors,
+    /// Did the schema look like it was intended to be JSON format instead of
+    /// human?
+    suspect_json_format: bool,
+}
+
+impl Diagnostic for HumanSyntaxParseError {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        let suspect_json_help = if self.suspect_json_format {
+            Some(Box::new("this API was expecting a schema in the Cedar schema format; did you mean to use a different function, which expects a JSON-format Cedar schema"))
+        } else {
+            None
+        };
+        match (suspect_json_help, self.errs.help()) {
+            (Some(json), Some(inner)) => Some(Box::new(format!("{inner}\n{json}"))),
+            (Some(h), None) => Some(h),
+            (None, Some(h)) => Some(h),
+            (None, None) => None,
+        }
+    }
+
+    // Everything else is forwarded to `errs`
+
+    fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        self.errs.code()
+    }
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        self.errs.labels()
+    }
+    fn severity(&self) -> Option<miette::Severity> {
+        self.errs.severity()
+    }
+    fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        self.errs.url()
+    }
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        self.errs.source_code()
+    }
+    fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
+        self.errs.diagnostic_source()
+    }
+    fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {
+        self.errs.related()
+    }
+}
+
+impl HumanSyntaxParseError {
+    /// `errs`: the `human_schema::parser::HumanSyntaxParseErrors` that were thrown
+    ///
+    /// `src`: the human-syntax text that we were trying to parse
+    pub(crate) fn new(errs: human_schema::parser::HumanSyntaxParseErrors, src: &str) -> Self {
+        // let's see what the first non-whitespace character is
+        let suspect_json_format = match src.trim_start().chars().next() {
+            None => false, // schema is empty or only whitespace; the problem is unlikely to be JSON vs human format
+            Some('{') => true, // yes, this looks like it was intended to be a JSON schema
+            Some(_) => true, // any character other than '{', not likely it was intended to be a JSON schema
+        };
+        Self {
+            errs,
+            suspect_json_format,
+        }
+    }
+
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn inner(&self) -> &human_schema::parser::HumanSyntaxParseErrors {
+        &self.errs
+    }
 }
 
 #[derive(Debug, Diagnostic, Error)]
 pub enum SchemaError {
-    /// Error thrown by the `serde_json` crate during deserialization
-    #[error("failed to parse schema: {0}")]
-    Serde(#[from] serde_json::Error),
+    /// This error is thrown when `serde_json` fails to deserialize the JSON
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    JsonDeserialization(#[from] JsonDeserializationError),
     /// Errors occurring while computing or enforcing transitive closure on
     /// action hierarchy.
     #[error("transitive closure computation/enforcement error on action hierarchy: {0}")]
@@ -171,4 +246,51 @@ pub enum UnsupportedFeature {
     // Action attributes are allowed if `ActionBehavior` is `PermitAttributes`
     #[error("action declared with attributes: [{}]", .0.iter().join(", "))]
     ActionAttributes(Vec<String>),
+}
+
+/// This error is thrown when `serde_json` fails to deserialize the JSON
+#[derive(Debug, Error)]
+#[error("failed to parse schema in JSON format: {err}")]
+pub struct JsonDeserializationError {
+    /// Error thrown by the `serde_json` crate
+    err: serde_json::Error,
+    /// Did the schema look like it was intended to be human format instead of
+    /// JSON?
+    suspect_human_format: bool,
+}
+
+impl Diagnostic for JsonDeserializationError {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        if self.suspect_human_format {
+            Some(Box::new("this API was expecting a schema in the JSON format; did you mean to use `from_natural_str()` or similar, which expects the Cedar schema format?"))
+        } else {
+            None
+        }
+    }
+}
+
+impl JsonDeserializationError {
+    /// `err`: the `serde_json::Error` that was thrown
+    ///
+    /// `src`: the JSON that we were trying to deserialize (if available in string form)
+    pub(crate) fn new(err: serde_json::Error, src: Option<&str>) -> Self {
+        match src {
+            None => Self {
+                err,
+                suspect_human_format: false,
+            },
+            Some(src) => {
+                // let's see what the first non-whitespace character is
+                let suspect_human_format = match src.trim_start().chars().next() {
+                    None => false, // schema is empty or only whitespace; the problem is unlikely to be JSON vs human format
+                    Some('{') => false, // yes, this looks like it was intended to be a JSON schema
+                    Some(_) => true, // any character other than '{', we suspect it might be a human-format schema
+                };
+                Self {
+                    err,
+                    suspect_human_format,
+                }
+            }
+        }
+    }
 }

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -267,11 +267,10 @@ mod demo_tests {
             Err(e) => e,
             _ => panic!("Should have failed to parse"),
         };
-        assert_matches!(err,
-        crate::HumanSchemaError::Parsing(err) => assert_matches!(err,
-            human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
+        assert_matches!(err, crate::HumanSchemaError::Parsing(err) => {
+            assert_matches!(err.inner(), human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
                 assert!(json_errs
-                    .into_iter()
+                    .iter()
                     .any(|err| {
                         matches!(
                             err,
@@ -280,8 +279,10 @@ mod demo_tests {
                                 ..
                             }
                         )
-                    }));
-            }));
+                    })
+                );
+            });
+        });
     }
 
     #[test]
@@ -302,10 +303,10 @@ mod demo_tests {
             _ => panic!("Should have failed to parse"),
         };
         assert_matches!(err,
-        crate::HumanSchemaError::Parsing(err) => assert_matches!(err,
+        crate::HumanSchemaError::Parsing(err) => assert_matches!(err.inner(),
             human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
                 assert!(json_errs
-                    .into_iter()
+                    .iter()
                     .any(|err| {
                         matches!(
                             err,
@@ -429,8 +430,8 @@ namespace Baz {action "Foo" appliesTo {
         action "Group1" ;
         }namespace NS2 {entity SystemEntity1 in [NS1::SystemEntity2] = {  };
         action "Group1" in [NS1::Action::"Group1"];
-        action "Action1" in [Action::"Group1"]appliesTo {  principal: [NS1::PrincipalEntity], 
-          resource: [NS2::SystemEntity1], 
+        action "Action1" in [Action::"Group1"]appliesTo {  principal: [NS1::PrincipalEntity],
+          resource: [NS2::SystemEntity1],
           context: {  }
         };
         }
@@ -448,8 +449,8 @@ namespace Baz {action "Foo" appliesTo {
         action "Group1" ;
         }namespace NS2 {entity SystemEntity1 in [NS1::SystemEntity2] = {  };
         action "Group1" in [NS1::Action::"Group1"];
-        action "Action1" in [Action::"\6"]appliesTo {  principal: [NS1::PrincipalEntity], 
-          resource: [NS2::SystemEntity1], 
+        action "Action1" in [Action::"\6"]appliesTo {  principal: [NS1::PrincipalEntity],
+          resource: [NS2::SystemEntity1],
           context: {  }
         };
         }
@@ -457,7 +458,11 @@ namespace Baz {action "Foo" appliesTo {
         ) {
             Ok(_) => panic!("this is not a valid schema"),
             Err(err) => {
-                assert_matches!(err, HumanSchemaError::Parsing(human_schema::parser::HumanSyntaxParseErrors::NaturalSyntaxError(errs)) => assert!(errs.to_smolstr().contains("Invalid escape codes")))
+                assert_matches!(err, HumanSchemaError::Parsing(err) => {
+                    assert_matches!(err.inner(), human_schema::parser::HumanSyntaxParseErrors::NaturalSyntaxError(errs) => {
+                        assert!(errs.to_smolstr().contains("Invalid escape codes"));
+                    });
+                });
             }
         }
     }
@@ -779,7 +784,7 @@ namespace Baz {action "Foo" appliesTo {
             editors : Team,
             Tasks : Set<{ name : String, id : Long, state : String }>
         };
-        
+
         action CreateList appliesTo {
             principal : User,
             resource : Application
@@ -840,7 +845,7 @@ namespace Baz {action "Foo" appliesTo {
                 value: String
             };
         }
-        
+
         namespace Service {
             entity Resource {
                 tag: AWS::Tag
@@ -1359,12 +1364,12 @@ mod translator_tests {
             group: String,
             name: String,
           };
-          
+
           type email_address = {
             id: String,
             domain: String,
           };
-          
+
           namespace Demo {
             entity User {
               name: id,

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -169,6 +169,16 @@ impl ValidatorSchema {
         )
     }
 
+    /// Construct a `ValidatorSchema` from a string containing JSON in the
+    /// appropriate shape.
+    pub fn from_json_str(json: &str, extensions: Extensions<'_>) -> Result<Self> {
+        Self::from_schema_frag(
+            SchemaFragment::from_json_str(json)?,
+            ActionBehavior::default(),
+            extensions,
+        )
+    }
+
     /// Construct a `ValidatorSchema` directly from a file containing JSON
     /// in the appropriate shape.
     pub fn from_file(file: impl std::io::Read, extensions: Extensions<'_>) -> Result<Self> {

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -126,7 +126,9 @@ impl std::str::FromStr for ValidatorSchema {
     type Err = SchemaError;
 
     fn from_str(s: &str) -> Result<Self> {
-        serde_json::from_str::<SchemaFragment>(s)?.try_into()
+        serde_json::from_str::<SchemaFragment>(s)
+            .map_err(|e| JsonDeserializationError::new(e, Some(s)))?
+            .try_into()
     }
 }
 
@@ -157,48 +159,54 @@ impl ValidatorSchema {
         }
     }
 
-    /// Construct a `ValidatorSchema` from a JSON value (which should be an
-    /// object matching the `SchemaFileFormat` shape).
+    /// Construct a `ValidatorSchema` from a JSON value in the appropriate
+    /// shape.
     pub fn from_json_value(json: serde_json::Value, extensions: Extensions<'_>) -> Result<Self> {
-        Self::from_schema_file(
+        Self::from_schema_frag(
             SchemaFragment::from_json_value(json)?,
             ActionBehavior::default(),
             extensions,
         )
     }
 
-    /// Construct a `ValidatorSchema` directly from a file.
+    /// Construct a `ValidatorSchema` directly from a file containing JSON
+    /// in the appropriate shape.
     pub fn from_file(file: impl std::io::Read, extensions: Extensions<'_>) -> Result<Self> {
-        Self::from_schema_file(
+        Self::from_schema_frag(
             SchemaFragment::from_file(file)?,
             ActionBehavior::default(),
             extensions,
         )
     }
 
+    /// Construct a `ValidatorSchema` directly from a file containing Cedar
+    /// "natural" schema syntax.
     pub fn from_file_natural(
         r: impl std::io::Read,
         extensions: Extensions<'_>,
     ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
         let (fragment, warnings) = SchemaFragment::from_file_natural(r)?;
         let schema_and_warnings =
-            Self::from_schema_file(fragment, ActionBehavior::default(), extensions)
+            Self::from_schema_frag(fragment, ActionBehavior::default(), extensions)
                 .map(|schema| (schema, warnings))?;
         Ok(schema_and_warnings)
     }
 
+    /// Constructor a `ValidatorSchema` from a string containing Cedar "natural"
+    /// schema syntax.
     pub fn from_str_natural(
         src: &str,
         extensions: Extensions<'_>,
     ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
         let (fragment, warnings) = SchemaFragment::from_str_natural(src)?;
         let schema_and_warnings =
-            Self::from_schema_file(fragment, ActionBehavior::default(), extensions)
+            Self::from_schema_frag(fragment, ActionBehavior::default(), extensions)
                 .map(|schema| (schema, warnings))?;
         Ok(schema_and_warnings)
     }
 
-    pub fn from_schema_file(
+    /// Helper function to construct a `ValidatorSchema` from a single `SchemaFragment`
+    pub(crate) fn from_schema_frag(
         schema_file: SchemaFragment,
         action_behavior: ActionBehavior,
         extensions: Extensions<'_>,
@@ -919,8 +927,8 @@ mod test {
         }}"#;
 
         match ValidatorSchema::from_str(src) {
-            Err(SchemaError::Serde(_)) => (),
-            _ => panic!("Expected serde error due to duplicate entity type."),
+            Err(SchemaError::JsonDeserialization(_)) => (),
+            _ => panic!("Expected JSON deserialization error due to duplicate entity type."),
         }
     }
 
@@ -954,8 +962,8 @@ mod test {
             }
         }"#;
         match ValidatorSchema::from_str(src) {
-            Err(SchemaError::Serde(_)) => (),
-            _ => panic!("Expected serde error due to duplicate action type."),
+            Err(SchemaError::JsonDeserialization(_)) => (),
+            _ => panic!("Expected JSON deserialization error due to duplicate action type."),
         }
     }
 

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1961,7 +1961,7 @@ mod test {
     }
 
     fn simple_schema() -> ValidatorSchema {
-        ValidatorSchema::from_schema_file(
+        ValidatorSchema::from_schema_frag(
             serde_json::from_value(serde_json::json!({ "":
             {
                 "entityTypes": {
@@ -2052,7 +2052,7 @@ mod test {
     }
 
     fn attr_schema() -> ValidatorSchema {
-        ValidatorSchema::from_schema_file(
+        ValidatorSchema::from_schema_frag(
             serde_json::from_value(serde_json::json!(
             {"": {
                 "entityTypes": {
@@ -2184,7 +2184,7 @@ mod test {
     // Direct test of LUB computation which causes a non-termination bug.
     #[test]
     fn record_entity_lub_non_term() {
-        let schema = ValidatorSchema::from_schema_file(
+        let schema = ValidatorSchema::from_schema_frag(
             serde_json::from_value(serde_json::json!(
             {"": {
                 "entityTypes": {
@@ -2225,7 +2225,7 @@ mod test {
     }
 
     fn rec_schema() -> ValidatorSchema {
-        ValidatorSchema::from_schema_file(
+        ValidatorSchema::from_schema_frag(
             serde_json::from_value(serde_json::json!(
                 {"": {
                     "entityTypes": {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1304,7 +1304,19 @@ impl Schema {
         ))
     }
 
-    /// Create a `Schema` directly from a file.
+    /// Create a `Schema` from a string containing JSON in the appropriate
+    /// shape.
+    pub fn from_json_str(json: &str) -> Result<Self, SchemaError> {
+        Ok(Self(
+            cedar_policy_validator::ValidatorSchema::from_json_str(
+                json,
+                Extensions::all_available(),
+            )?,
+        ))
+    }
+
+    /// Create a `Schema` directly from a file containing JSON in the
+    /// appropriate shape.
     pub fn from_file(file: impl std::io::Read) -> Result<Self, SchemaError> {
         Ok(Self(cedar_policy_validator::ValidatorSchema::from_file(
             file,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1214,14 +1214,12 @@ impl SchemaFragment {
 
     /// Serialize this [`SchemaFragment`] as a json value
     pub fn to_json_value(self) -> Result<serde_json::Value, SchemaError> {
-        let v = serde_json::to_value(self.lossless)?;
-        Ok(v)
+        serde_json::to_value(self.lossless).map_err(|e| SchemaError::JsonSerialization(e).into())
     }
 
     /// Serialize this [`SchemaFragment`] as a json value
     pub fn as_json_string(&self) -> Result<String, SchemaError> {
-        let str = serde_json::to_string(&self.lossless)?;
-        Ok(str)
+        serde_json::to_string(&self.lossless).map_err(|e| SchemaError::JsonSerialization(e).into())
     }
 
     /// Serialize this [`SchemaFragment`] into the natural syntax
@@ -1253,7 +1251,7 @@ impl FromStr for SchemaFragment {
     /// to undefined entities) because this is not required until a `Schema` is
     /// constructed.
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let lossless = serde_json::from_str::<cedar_policy_validator::SchemaFragment>(src)?;
+        let lossless = cedar_policy_validator::SchemaFragment::from_json_str(src)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -1476,7 +1476,7 @@ mod schema_tests {
                 }
             }}"#
             )),
-            Err(SchemaError::Serde(_))
+            Err(SchemaError::JsonDeserialization(_))
         );
     }
 }
@@ -2451,7 +2451,10 @@ mod schema_based_parsing_tests {
     #[test]
     fn schema_sanity_check() {
         let src = "{ , .. }";
-        assert_matches!(Schema::from_str(src), Err(super::SchemaError::Serde(_)));
+        assert_matches!(
+            Schema::from_str(src),
+            Err(super::SchemaError::JsonDeserialization(_))
+        );
     }
 
     #[test]

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3320,7 +3320,10 @@ mod issue_779 {
         assert_matches!(Schema::from_str_natural(human).map(|(s, _warnings)| s), Err(e) => {
             assert_matches!(e.help().map(|h| h.to_string()), None, "found unexpected help message on error:\n{:?}", miette::Report::new(e)); // in particular, shouldn't suggest you meant JSON format, because this doesn't look like JSON
         });
-        assert_matches!(Schema::from_str_natural("    ").map(|(s, _warnings)| s), Ok(_));
+        assert_matches!(
+            Schema::from_str_natural("    ").map(|(s, _warnings)| s),
+            Ok(_)
+        );
     }
 }
 

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3248,11 +3248,9 @@ mod error_source_tests {
         let entities = Entities::empty();
         for src in srcs {
             let expr = Expression::from_str(src).unwrap();
-            assert_matches!(eval_expression(&req, &entities, &expr), Err(_e) => {
-                /* TODO(#485): evaluation errors don't currently have source locations
+            assert_matches!(eval_expression(&req, &entities, &expr), Err(e) => {
                 assert!(e.labels().is_some(), "no source span for the evaluation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new(e));
                 assert!(e.source_code().is_some(), "no source code for the evaluation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new(e));
-                */
             });
         }
 
@@ -3294,6 +3292,35 @@ mod error_source_tests {
                 assert!(warn.source_code().is_some(), "no source code for the validation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new(warn.clone()));
             }
         }
+    }
+}
+
+mod issue_779 {
+    use crate::Schema;
+    use cool_asserts::assert_matches;
+    use miette::Diagnostic;
+
+    #[test]
+    fn issue_779() {
+        let json = r#"{ "" : { "actions": { "view": {} }, "entityTypes": { invalid } }}"#;
+        let human = r#"namespace Foo { entity User; action View; invalid }"#;
+
+        assert_matches!(Schema::from_json_str(human), Err(e) => {
+            assert_matches!(e.help().map(|h| h.to_string()), Some(h) => assert_eq!(h, "this API was expecting a schema in the JSON format; did you mean to use a different function, which expects the Cedar schema format?"));
+        });
+        assert_matches!(Schema::from_json_str(json), Err(e) => {
+            assert_matches!(e.help().map(|h| h.to_string()), None, "found unexpected help message on error:\n{:?}", miette::Report::new(e)); // in particular, shouldn't suggest you meant non-JSON format, because this looks like JSON
+        });
+        assert_matches!(Schema::from_json_str("    "), Err(e) => {
+            assert_matches!(e.help().map(|h| h.to_string()), None, "found unexpected help message on error:\n{:?}", miette::Report::new(e)); // in particular, shouldn't suggest you meant non-JSON format
+        });
+        assert_matches!(Schema::from_str_natural(json).map(|(s, _warnings)| s), Err(e) => {
+            assert_matches!(e.help().map(|h| h.to_string()), Some(h) => assert_eq!(h, "this API was expecting a schema in the Cedar schema format; did you mean to use a different function, which expects a JSON-format Cedar schema"));
+        });
+        assert_matches!(Schema::from_str_natural(human).map(|(s, _warnings)| s), Err(e) => {
+            assert_matches!(e.help().map(|h| h.to_string()), None, "found unexpected help message on error:\n{:?}", miette::Report::new(e)); // in particular, shouldn't suggest you meant JSON format, because this doesn't look like JSON
+        });
+        assert_matches!(Schema::from_str_natural("    ").map(|(s, _warnings)| s), Ok(_));
     }
 }
 


### PR DESCRIPTION
## Description of changes

Improves the error message when we think (based on simple heuristic) you might have passed a JSON schema where a human-format one is expected, or vice versa.

Breaking changes to error types.

## Issue #, if available

Fixes #779

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

