### PR TITLE
Cherry picking the new PE API

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -362,10 +362,10 @@ pub struct AuthorizeArgs {
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum PolicyFormat {
-    /// The standard human-readable Cedar policy format, documented at https://docs.cedarpolicy.com/policies/syntax-policy.html
+    /// The standard human-readable Cedar policy format, documented at <https://docs.cedarpolicy.com/policies/syntax-policy.html>
     #[default]
     Human,
-    /// Cedar's JSON policy format, documented at https://docs.cedarpolicy.com/policies/json-format.html
+    /// Cedar's JSON policy format, documented at <https://docs.cedarpolicy.com/policies/json-format.html>
     Json,
 }
 

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -490,32 +490,38 @@ impl Expr {
             })
     }
 
-    /// Substitute unknowns with values
-    /// If a definition is missing, it will be left as an unknown,
-    /// and can be filled in later.
-    pub fn substitute(
+    /// Substitute unknowns with concrete values.
+    ///
+    /// Ignores unmapped unknowns.
+    /// Ignores type annotations on unknowns.
+    pub fn substitute(&self, definitions: &HashMap<SmolStr, Value>) -> Expr {
+        match self.substitute_general::<UntypedSubstitution>(definitions) {
+            Ok(e) => e,
+            Err(empty) => match empty {},
+        }
+    }
+
+    /// Substitute unknowns with concrete values.
+    ///
+    /// Ignores unmapped unknowns.
+    /// Errors if the substituted value does not match the type annotation on the unknown.
+    pub fn substitute_typed(
         &self,
         definitions: &HashMap<SmolStr, Value>,
     ) -> Result<Expr, SubstitutionError> {
+        self.substitute_general::<TypedSubstitution>(definitions)
+    }
+
+    /// Substitute unknowns with values
+    ///
+    /// Generic over the function implementing the substitution to allow for multiple error behaviors
+    fn substitute_general<T: SubstitutionFunction>(
+        &self,
+        definitions: &HashMap<SmolStr, Value>,
+    ) -> Result<Expr, T::Err> {
         match self.expr_kind() {
             ExprKind::Lit(_) => Ok(self.clone()),
-            ExprKind::Unknown(Unknown {
-                name,
-                type_annotation,
-            }) => match (definitions.get(name), type_annotation) {
-                (None, _) => Ok(self.clone()),
-                (Some(value), None) => Ok(value.clone().into()),
-                (Some(value), Some(t)) => {
-                    if &value.type_of() == t {
-                        Ok(value.clone().into())
-                    } else {
-                        Err(SubstitutionError::TypeError {
-                            expected: t.clone(),
-                            actual: value.type_of(),
-                        })
-                    }
-                }
-            },
+            ExprKind::Unknown(u @ Unknown { name, .. }) => T::substitute(u, definitions.get(name)),
             ExprKind::Var(_) => Ok(self.clone()),
             ExprKind::Slot(_) => Ok(self.clone()),
             ExprKind::If {
@@ -523,55 +529,58 @@ impl Expr {
                 then_expr,
                 else_expr,
             } => Ok(Expr::ite(
-                test_expr.substitute(definitions)?,
-                then_expr.substitute(definitions)?,
-                else_expr.substitute(definitions)?,
+                test_expr.substitute_general::<T>(definitions)?,
+                then_expr.substitute_general::<T>(definitions)?,
+                else_expr.substitute_general::<T>(definitions)?,
             )),
             ExprKind::And { left, right } => Ok(Expr::and(
-                left.substitute(definitions)?,
-                right.substitute(definitions)?,
+                left.substitute_general::<T>(definitions)?,
+                right.substitute_general::<T>(definitions)?,
             )),
             ExprKind::Or { left, right } => Ok(Expr::or(
-                left.substitute(definitions)?,
-                right.substitute(definitions)?,
+                left.substitute_general::<T>(definitions)?,
+                right.substitute_general::<T>(definitions)?,
             )),
-            ExprKind::UnaryApp { op, arg } => {
-                Ok(Expr::unary_app(*op, arg.substitute(definitions)?))
-            }
+            ExprKind::UnaryApp { op, arg } => Ok(Expr::unary_app(
+                *op,
+                arg.substitute_general::<T>(definitions)?,
+            )),
             ExprKind::BinaryApp { op, arg1, arg2 } => Ok(Expr::binary_app(
                 *op,
-                arg1.substitute(definitions)?,
-                arg2.substitute(definitions)?,
+                arg1.substitute_general::<T>(definitions)?,
+                arg2.substitute_general::<T>(definitions)?,
             )),
             ExprKind::ExtensionFunctionApp { fn_name, args } => {
                 let args = args
                     .iter()
-                    .map(|e| e.substitute(definitions))
+                    .map(|e| e.substitute_general::<T>(definitions))
                     .collect::<Result<Vec<Expr>, _>>()?;
 
                 Ok(Expr::call_extension_fn(fn_name.clone(), args))
             }
-            ExprKind::GetAttr { expr, attr } => {
-                Ok(Expr::get_attr(expr.substitute(definitions)?, attr.clone()))
-            }
-            ExprKind::HasAttr { expr, attr } => {
-                Ok(Expr::has_attr(expr.substitute(definitions)?, attr.clone()))
-            }
+            ExprKind::GetAttr { expr, attr } => Ok(Expr::get_attr(
+                expr.substitute_general::<T>(definitions)?,
+                attr.clone(),
+            )),
+            ExprKind::HasAttr { expr, attr } => Ok(Expr::has_attr(
+                expr.substitute_general::<T>(definitions)?,
+                attr.clone(),
+            )),
             ExprKind::Like { expr, pattern } => Ok(Expr::like(
-                expr.substitute(definitions)?,
+                expr.substitute_general::<T>(definitions)?,
                 pattern.iter().cloned(),
             )),
             ExprKind::Set(members) => {
                 let members = members
                     .iter()
-                    .map(|e| e.substitute(definitions))
+                    .map(|e| e.substitute_general::<T>(definitions))
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok(Expr::set(members))
             }
             ExprKind::Record(map) => {
                 let map = map
                     .iter()
-                    .map(|(name, e)| Ok((name.clone(), e.substitute(definitions)?)))
+                    .map(|(name, e)| Ok((name.clone(), e.substitute_general::<T>(definitions)?)))
                     .collect::<Result<BTreeMap<_, _>, _>>()?;
                 // PANIC SAFETY: cannot have a duplicate key because the input was already a BTreeMap
                 #[allow(clippy::expect_used)]
@@ -579,10 +588,57 @@ impl Expr {
                     .expect("cannot have a duplicate key because the input was already a BTreeMap"))
             }
             ExprKind::Is { expr, entity_type } => Ok(Expr::is_entity_type(
-                expr.substitute(definitions)?,
+                expr.substitute_general::<T>(definitions)?,
                 entity_type.clone(),
             )),
         }
+    }
+}
+
+/// A trait for customizing the error behavior of substitution
+trait SubstitutionFunction {
+    /// The potential errors this substitution function can return
+    type Err;
+    /// The function for implementing the substitution.
+    ///
+    /// Takes the expression being substituted,
+    /// The substitution from the map (if present)
+    /// and the type annotation from the unknown (if present)
+    fn substitute(value: &Unknown, substitute: Option<&Value>) -> Result<Expr, Self::Err>;
+}
+
+struct TypedSubstitution {}
+
+impl SubstitutionFunction for TypedSubstitution {
+    type Err = SubstitutionError;
+
+    fn substitute(value: &Unknown, substitute: Option<&Value>) -> Result<Expr, Self::Err> {
+        match (substitute, &value.type_annotation) {
+            (None, _) => Ok(Expr::unknown(value.clone())),
+            (Some(v), None) => Ok(v.clone().into()),
+            (Some(v), Some(t)) => {
+                if v.type_of() == *t {
+                    Ok(v.clone().into())
+                } else {
+                    Err(SubstitutionError::TypeError {
+                        expected: t.clone(),
+                        actual: v.type_of(),
+                    })
+                }
+            }
+        }
+    }
+}
+
+struct UntypedSubstitution {}
+
+impl SubstitutionFunction for UntypedSubstitution {
+    type Err = std::convert::Infallible;
+
+    fn substitute(value: &Unknown, substitute: Option<&Value>) -> Result<Expr, Self::Err> {
+        Ok(substitute
+            .map(|v| v.clone().into())
+            .unwrap_or_else(|| Expr::unknown(value.clone())))
     }
 }
 
@@ -1358,11 +1414,9 @@ impl std::fmt::Display for Var {
 
 #[cfg(test)]
 mod test {
+    use cool_asserts::assert_matches;
     use itertools::Itertools;
-    use std::{
-        collections::{hash_map::DefaultHasher, HashSet},
-        sync::Arc,
-    };
+    use std::collections::{hash_map::DefaultHasher, HashSet};
 
     use super::{var_generator::all_vars, *};
 
@@ -1707,5 +1761,103 @@ mod test {
         let expr1 = ExprBuilder::with_data(1).val(1);
         let expr2 = ExprBuilder::with_data(1).val(2);
         assert_ne!(ExprShapeOnly::new(&expr1), ExprShapeOnly::new(&expr2));
+    }
+
+    #[test]
+    fn untyped_subst_present() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: None,
+        };
+        let r = UntypedSubstitution::substitute(&u, Some(&Value::new(1, None)));
+        match r {
+            Ok(e) => assert_eq!(e, Expr::val(1)),
+            Err(empty) => match empty {},
+        }
+    }
+
+    #[test]
+    fn untyped_subst_present_correct_type() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: Some(Type::Long),
+        };
+        let r = UntypedSubstitution::substitute(&u, Some(&Value::new(1, None)));
+        match r {
+            Ok(e) => assert_eq!(e, Expr::val(1)),
+            Err(empty) => match empty {},
+        }
+    }
+
+    #[test]
+    fn untyped_subst_present_wrong_type() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: Some(Type::Bool),
+        };
+        let r = UntypedSubstitution::substitute(&u, Some(&Value::new(1, None)));
+        match r {
+            Ok(e) => assert_eq!(e, Expr::val(1)),
+            Err(empty) => match empty {},
+        }
+    }
+
+    #[test]
+    fn untyped_subst_not_present() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: Some(Type::Bool),
+        };
+        let r = UntypedSubstitution::substitute(&u, None);
+        match r {
+            Ok(n) => assert_eq!(n, Expr::unknown(u)),
+            Err(empty) => match empty {},
+        }
+    }
+
+    #[test]
+    fn typed_subst_present() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: None,
+        };
+        let e = TypedSubstitution::substitute(&u, Some(&Value::new(1, None))).unwrap();
+        assert_eq!(e, Expr::val(1));
+    }
+
+    #[test]
+    fn typed_subst_present_correct_type() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: Some(Type::Long),
+        };
+        let e = TypedSubstitution::substitute(&u, Some(&Value::new(1, None))).unwrap();
+        assert_eq!(e, Expr::val(1));
+    }
+
+    #[test]
+    fn typed_subst_present_wrong_type() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: Some(Type::Bool),
+        };
+        let r = TypedSubstitution::substitute(&u, Some(&Value::new(1, None))).unwrap_err();
+        assert_matches!(
+            r,
+            SubstitutionError::TypeError {
+                expected: Type::Bool,
+                actual: Type::Long,
+            }
+        );
+    }
+
+    #[test]
+    fn typed_subst_not_present() {
+        let u = Unknown {
+            name: "foo".into(),
+            type_annotation: None,
+        };
+        let r = TypedSubstitution::substitute(&u, None).unwrap();
+        assert_eq!(r, Expr::unknown(u));
     }
 }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -87,6 +87,30 @@ impl Template {
         Template::from(body)
     }
 
+    /// Construct a template from an expression/annotations that are already [`std::sync::Arc`] allocated
+    pub fn new_shared(
+        id: PolicyID,
+        annotations: Arc<Annotations>,
+        effect: Effect,
+        principal_constraint: PrincipalConstraint,
+        action_constraint: ActionConstraint,
+        resource_constraint: ResourceConstraint,
+        non_head_constraint: Arc<Expr>,
+    ) -> Self {
+        let body = TemplateBody::new_shared(
+            id,
+            annotations,
+            effect,
+            principal_constraint,
+            action_constraint,
+            resource_constraint,
+            non_head_constraint,
+        );
+        // INVARIANT (slot cache correctness)
+        // This invariant is maintained in the body of the From impl
+        Template::from(body)
+    }
+
     /// Get the principal constraint on the body
     pub fn principal_constraint(&self) -> &PrincipalConstraint {
         self.body.principal_constraint()
@@ -105,6 +129,11 @@ impl Template {
     /// Get the non-head constraint on the body
     pub fn non_head_constraints(&self) -> &Expr {
         self.body.non_head_constraints()
+    }
+
+    /// Get Arc to non-head constraint on the body
+    pub fn non_head_constraints_arc(&self) -> &Arc<Expr> {
+        self.body.non_head_constraints_arc()
     }
 
     /// Get the PolicyID of this template
@@ -133,6 +162,11 @@ impl Template {
     /// Get all annotation data.
     pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.body.annotations()
+    }
+
+    /// Get [`Arc`] owning the annotation data.
+    pub fn annotations_arc(&self) -> &Arc<Annotations> {
+        self.body.annotations_arc()
     }
 
     /// Get the condition expression of this template.
@@ -191,7 +225,7 @@ impl Template {
         } else {
             Err(LinkingError::from_unbound_and_extras(
                 unbound.into_iter().map(|slot| slot.id),
-                extra.into_iter().map(|slotid| *slotid),
+                extra.into_iter().copied(),
             ))
         }
     }
@@ -345,9 +379,19 @@ impl Policy {
 
     /// Build a policy with a given effect, given when clause, and unconstrained head variables
     pub fn from_when_clause(effect: Effect, when: Expr, id: PolicyID) -> Self {
-        let t = Template::new(
+        Self::from_when_clause_annos(effect, Arc::new(when), id, Arc::new(Annotations::default()))
+    }
+
+    /// Build a policy with a given effect, given when clause, and unconstrained head variables
+    pub fn from_when_clause_annos(
+        effect: Effect,
+        when: Arc<Expr>,
+        id: PolicyID,
+        annotations: Arc<Annotations>,
+    ) -> Self {
+        let t = Template::new_shared(
             id,
-            Annotations::new(),
+            annotations,
             effect,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
@@ -380,6 +424,11 @@ impl Policy {
     /// Get all annotation data.
     pub fn annotations(&self) -> impl Iterator<Item = (&AnyId, &Annotation)> {
         self.template.annotations()
+    }
+
+    /// Get [`Arc`] owning annotation data.
+    pub fn annotations_arc(&self) -> &Arc<Annotations> {
+        self.template.annotations_arc()
     }
 
     /// Get the principal constraint for this policy.
@@ -416,6 +465,11 @@ impl Policy {
     /// Get the non-head constraints for the policy
     pub fn non_head_constraints(&self) -> &Expr {
         self.template.non_head_constraints()
+    }
+
+    /// Get the [`Arc`] owning non-head constraints for the policy
+    pub fn non_head_constraints_arc(&self) -> &Arc<Expr> {
+        self.template.non_head_constraints_arc()
     }
 
     /// Get the expression that represents this policy.
@@ -774,9 +828,9 @@ impl TryFrom<Template> for StaticPolicy {
 
     fn try_from(value: Template) -> Result<Self, Self::Error> {
         // INVARIANT (Static policy correctness): Must ensure StaticPolicy contains no slots
-        let first_slot = value.slots().next();
-        match first_slot {
-            Some(slot) => Err(Self::Error::FoundSlot(slot.clone())),
+        let o = value.slots().next().cloned();
+        match o {
+            Some(slot_id) => Err(Self::Error::FoundSlot(slot_id)),
             None => Ok(Self(value.body)),
         }
     }
@@ -805,7 +859,7 @@ pub struct TemplateBody {
     /// Annotations available for external applications, as key-value store.
     /// Note that the keys are `AnyId`, so Cedar reserved words like `if` and `has`
     /// are explicitly allowed as annotations.
-    annotations: Annotations,
+    annotations: Arc<Annotations>,
     /// `Effect` of this policy
     effect: Effect,
     /// Head constraint for principal. This will be a boolean-valued expression:
@@ -824,7 +878,7 @@ pub struct TemplateBody {
     ///
     /// This will be a conjunction of the policy's `when` conditions and the
     /// negation of each of the policy's `unless` conditions.
-    non_head_constraints: Expr,
+    non_head_constraints: Arc<Expr>,
 }
 
 impl TemplateBody {
@@ -848,6 +902,11 @@ impl TemplateBody {
     /// Get data from an annotation.
     pub fn annotation(&self, key: &AnyId) -> Option<&Annotation> {
         self.annotations.get(key)
+    }
+
+    /// Get shared ref to annotations
+    pub fn annotations_arc(&self) -> &Arc<Annotations> {
+        &self.annotations
     }
 
     /// Get all annotation data.
@@ -899,6 +958,11 @@ impl TemplateBody {
         &self.non_head_constraints
     }
 
+    /// Get the Arc owning the non head constraints
+    pub fn non_head_constraints_arc(&self) -> &Arc<Expr> {
+        &self.non_head_constraints
+    }
+
     /// Get the condition expression of this policy.
     ///
     /// This will be a conjunction of the policy's head constraints (on
@@ -913,8 +977,29 @@ impl TemplateBody {
                 ),
                 self.resource_constraint_expr(),
             ),
-            self.non_head_constraints.clone(),
+            self.non_head_constraints.as_ref().clone(),
         )
+    }
+
+    /// Construct a `Policy` from components that are already [`std::sync::Arc`] allocated
+    pub fn new_shared(
+        id: PolicyID,
+        annotations: Arc<Annotations>,
+        effect: Effect,
+        principal_constraint: PrincipalConstraint,
+        action_constraint: ActionConstraint,
+        resource_constraint: ResourceConstraint,
+        non_head_constraints: Arc<Expr>,
+    ) -> Self {
+        Self {
+            id,
+            annotations,
+            effect,
+            principal_constraint,
+            action_constraint,
+            resource_constraint,
+            non_head_constraints,
+        }
     }
 
     /// Construct a `Policy` from its components
@@ -929,12 +1014,12 @@ impl TemplateBody {
     ) -> Self {
         Self {
             id,
-            annotations,
+            annotations: Arc::new(annotations),
             effect,
             principal_constraint,
             action_constraint,
             resource_constraint,
-            non_head_constraints,
+            non_head_constraints: Arc::new(non_head_constraints),
         }
     }
 }
@@ -963,7 +1048,7 @@ impl std::fmt::Display for TemplateBody {
 }
 
 /// Struct which holds the annotations for a policy
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct Annotations(BTreeMap<AnyId, Annotation>);
 
 impl Annotations {
@@ -1024,7 +1109,7 @@ impl From<BTreeMap<AnyId, Annotation>> for Annotations {
 }
 
 /// Struct which holds the value of a particular annotation
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, PartialOrd, Ord)]
 pub struct Annotation {
     /// Annotation value
     pub val: SmolStr,
@@ -1040,7 +1125,7 @@ impl AsRef<str> for Annotation {
 }
 
 /// Template constraint on principal head variables
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct PrincipalConstraint {
     pub(crate) constraint: PrincipalOrResourceConstraint,
 }
@@ -1147,7 +1232,7 @@ impl std::fmt::Display for PrincipalConstraint {
 }
 
 /// Template constraint on resource head variables
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct ResourceConstraint {
     pub(crate) constraint: PrincipalOrResourceConstraint,
 }
@@ -1254,7 +1339,7 @@ impl std::fmt::Display for ResourceConstraint {
 }
 
 /// A reference to an EntityUID that may be a Slot
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub enum EntityReference {
     /// Reference to a literal EUID
     EUID(Arc<EntityUID>),
@@ -1338,7 +1423,7 @@ impl TryFrom<Var> for PrincipalOrResource {
 
 /// Represents the constraints for principals and resources.
 /// Can either not constrain, or constrain via `==` or `in` for a single entity literal.
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub enum PrincipalOrResourceConstraint {
     /// Unconstrained
     Any,
@@ -1475,7 +1560,7 @@ impl PrincipalOrResourceConstraint {
 
 /// Constraint for action head variables.
 /// Action variables can be constrained to be in any variable in a list.
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub enum ActionConstraint {
     /// Unconstrained
     Any,
@@ -1574,7 +1659,7 @@ impl std::fmt::Display for StaticPolicy {
 }
 
 /// A unique identifier for a policy statement
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash)]
 pub struct PolicyID(SmolStr);
 
 impl PolicyID {
@@ -1613,7 +1698,7 @@ impl<'u> arbitrary::Arbitrary<'u> for PolicyID {
 }
 
 /// the Effect of a policy
-#[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Effect {
     /// this is a Permit policy
@@ -1740,9 +1825,11 @@ mod test {
 
     use super::{test_generators::*, *};
     use crate::{
-        ast::{entity, id, name, EntityUID},
-        parser::{parse_policy, test_utils::*},
-        test_utils::*,
+        parser::{
+            parse_policy,
+            test_utils::{expect_exactly_one_error, expect_some_error_matches},
+        },
+        test_utils::ExpectedErrorMessageBuilder,
     };
 
     #[test]

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -22,15 +22,19 @@
 
 use crate::ast::*;
 use crate::entities::Entities;
-use crate::evaluator::{EvaluationError, Evaluator};
+use crate::evaluator::Evaluator;
 use crate::extensions::Extensions;
-use itertools::Either;
+use itertools::{Either, Itertools};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
-use std::iter::once;
+use std::sync::Arc;
 
 mod err;
+mod partial_response;
 pub use err::AuthorizationError;
+
+pub use partial_response::ErrorState;
+pub use partial_response::PartialResponse;
 
 /// Authorizer
 pub struct Authorizer {
@@ -40,38 +44,15 @@ pub struct Authorizer {
     error_handling: ErrorHandling,
 }
 
-/// Describes the possible Cedar error-handling modes. Note that modes other than
-/// `SkipOnError` are vestigial: the only official behavior is `SkipOnError`.
-#[allow(dead_code)]
+/// Describes the possible Cedar error-handling modes.
+/// We currently only have one mode: [`ErrorHandling::Skip`].
+/// Other modes were debated during development, so this is here as an easy
+/// way to add modes if the future if we so decide.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ErrorHandling {
-    /// Deny the entire request if _any_ policy encounters an evaluation error
-    Deny,
-    /// If a permit policy errors, skip it (implicit deny).  If a forbid policy
-    /// errors, enforce it (explicit deny).
-    Forbid,
     /// If a policy encounters an evaluation error, skip it.  The decision will
     /// be as if the erroring policy did not exist.
     Skip,
-}
-
-/// A potentially partial response from the authorizer
-#[derive(Debug, Clone)]
-pub enum ResponseKind {
-    /// A fully evaluated response
-    FullyEvaluated(Response),
-    /// A response that has some residuals
-    Partial(PartialResponse),
-}
-
-impl ResponseKind {
-    /// The decision reached, if a decision could be reached
-    pub fn decision(&self) -> Option<Decision> {
-        match self {
-            ResponseKind::FullyEvaluated(a) => Some(a.decision),
-            ResponseKind::Partial(_) => None,
-        }
-    }
 }
 
 impl Default for ErrorHandling {
@@ -94,306 +75,79 @@ impl Authorizer {
     /// The language spec and formal model give a precise definition of how this is
     /// computed.
     pub fn is_authorized(&self, q: Request, pset: &PolicySet, entities: &Entities) -> Response {
-        match self.is_authorized_core(q, pset, entities) {
-            ResponseKind::FullyEvaluated(response) => response,
-            ResponseKind::Partial(partial) => {
-                // If we get a residual, we have to treat every residual policy as an error, and obey the error semantics.
-                // This can result in an Accept in one case:
-                // `error_handling` is `SkipOnerror`, no forbids evaluated to a concrete response, and some permits evaluated to `true`
-                let mut errors = partial.diagnostics.errors;
-                errors.extend(partial.residuals.policies().map(|p| {
-                    AuthorizationError::PolicyEvaluationError {
-                        id: p.id().clone(),
-                        error: EvaluationError::non_value(p.condition()),
-                    }
-                }));
-
-                let idset = partial.residuals.policies().map(|p| p.id().clone());
-
-                match self.error_handling {
-                    ErrorHandling::Deny => Response::new(
-                        Decision::Deny,
-                        idset.chain(partial.diagnostics.reason).collect(),
-                        errors,
-                    ),
-                    ErrorHandling::Forbid => Response::new(
-                        Decision::Deny,
-                        idset.chain(partial.diagnostics.reason).collect(),
-                        errors,
-                    ),
-                    ErrorHandling::Skip => {
-                        // If there were satisfied permits in the residual, then skipping errors means returning `Allow`
-                        // This is tricky logic, but it's correct as follows:
-                        //  If any permit policy is in the diagnostics, it means it evaluated to a concrete `true` and was not overridden by a `forbid` policy
-                        //  That means that all forbid policies evaluated to one of:
-                        //    concrete `false`
-                        //    concrete error
-                        //    a residual (effectively concrete error).
-                        // Thus all residuals should be `skipped`
-                        // However, if all of the policies are `forbid`, then we still have to return `Deny`, likewise if the set is empty.
-
-                        // PANIC SAFETY: every policy in the diagnostics had to come from the policy set
-                        #[allow(clippy::unwrap_used)]
-                        if partial
-                            .diagnostics
-                            .reason
-                            .iter()
-                            .any(|pid| pset.get(pid).unwrap().effect() == Effect::Permit)
-                        {
-                            Response::new(Decision::Allow, partial.diagnostics.reason, errors)
-                        } else {
-                            Response::new(
-                                Decision::Deny,
-                                idset.chain(partial.diagnostics.reason).collect(),
-                                errors,
-                            )
-                        }
-                    }
-                }
-            }
-        }
+        self.is_authorized_core(q, pset, entities).concretize()
     }
 
     /// Returns an authorization response for `q` with respect to the given `Slice`.
     /// Partial Evaluation of is_authorized
     ///
-    /// The language spec and formal model give a precise definition of how this is
-    /// computed.
     pub fn is_authorized_core(
         &self,
         q: Request,
         pset: &PolicySet,
         entities: &Entities,
-    ) -> ResponseKind {
-        let results = self.evaluate_policies_core(pset, q, entities);
-
-        let errors = results
-            .errors
-            .into_iter()
-            .map(|(pid, err)| AuthorizationError::PolicyEvaluationError {
-                id: pid,
-                error: err,
-            })
-            .collect();
-
-        if !results.global_deny_policies.is_empty() {
-            return ResponseKind::FullyEvaluated(Response::new(
-                Decision::Deny,
-                results.global_deny_policies,
-                errors,
-            ));
-        }
-        // Semantics ask for the set C_I^+ of all satisfied Permit policies
-        // which override all satisfied Forbid policies. We call this set
-        // `satisfied_permits`.
-        // Notice that this currently differs from the semantics stated in the Language Spec,
-        // which no longer consider overrides. The implementation is however equivalent,
-        // since forbids always trump permits.
-        let mut satisfied_permits = results
-            .satisfied_permits
-            .into_iter()
-            .filter(|permit_p| {
-                results
-                    .satisfied_forbids
-                    .iter()
-                    .all(|forbid_p| Self::overrides(permit_p, forbid_p))
-            })
-            .peekable();
-
-        match (
-            satisfied_permits.peek().is_some(),
-            !results.permit_residuals.is_empty(),
-            !results.forbid_residuals.is_empty(),
-        ) {
-            // If we have a satisfied permit and _no_ residual forbids, we can return Allow (this is true regardless of residual permits)
-            (true, false | true, false) => {
-                let idset = satisfied_permits.map(|p| p.id().clone()).collect();
-                ResponseKind::FullyEvaluated(Response::new(Decision::Allow, idset, errors))
-            }
-            // If we have a satisfied permit, and there are residual forbids, we must return a residual response. (this is true regardless of residual permits)
-            (true, false | true, true) => {
-                // `idset` is non-empty as `satisified_permits.peek().is_some()` is `true`
-                let idset = satisfied_permits
-                    .map(|p| p.id().clone())
-                    .collect::<HashSet<_>>();
-                // The residual will consist of all of the residual forbids, and one trivially true `permit`.
-                // We will re-use one of the satisfied permits policy IDs to ensure uniqueness
-                // PANIC SAFETY This `unwrap` is safe as `idset` is non-empty
-                #[allow(clippy::unwrap_used)]
-                let id = idset.iter().next().unwrap().clone(); // This unwrap is safe as we know there are satisfied permits
-                let trivial_true = Policy::from_when_clause(Effect::Permit, Expr::val(true), id);
-                // PANIC SAFETY Since all of the ids in the original policy set were unique by construction, a subset will still be unique
-                #[allow(clippy::unwrap_used)]
-                let policy_set = PolicySet::try_from_iter(
-                    results
-                        .forbid_residuals
-                        .into_iter()
-                        .chain(once(trivial_true)),
-                )
-                .unwrap();
-                ResponseKind::Partial(PartialResponse::new(policy_set, idset, errors))
-            }
-            // If there are no satisfied permits, and no residual permits, then the request cannot succeed
-            (false, false, false | true) => {
-                let idset = results
-                    .satisfied_forbids
-                    .into_iter()
-                    .map(|p| p.id().clone())
-                    .collect();
-                ResponseKind::FullyEvaluated(Response::new(Decision::Deny, idset, errors))
-            }
-            // If there are no satisfied permits, but residual permits, then request may still succeed. Return residual
-            // Add in the forbid_residuals if any
-            (false, true, false | true) => {
-                // The request will definitely fail if there are satisfied forbids, check those
-                if !results.satisfied_forbids.is_empty() {
-                    let idset = results
-                        .satisfied_forbids
-                        .into_iter()
-                        .map(|p| p.id().clone())
-                        .collect();
-                    ResponseKind::FullyEvaluated(Response::new(Decision::Deny, idset, errors))
-                } else {
-                    // No satisfied forbids
-                    // PANIC SAFETY all policy IDs in the original policy are unique by construction
-                    #[allow(clippy::unwrap_used)]
-                    let all_residuals = PolicySet::try_from_iter(
-                        [results.forbid_residuals, results.permit_residuals].concat(),
-                    )
-                    .unwrap();
-                    ResponseKind::Partial(PartialResponse::new(
-                        all_residuals,
-                        HashSet::new(),
-                        errors,
-                    ))
-                }
-            }
-        }
-    }
-
-    /// Returns a policy evaluation response for `q`.
-    pub fn evaluate_policies(
-        &self,
-        pset: &PolicySet,
-        q: Request,
-        entities: &Entities,
-    ) -> EvaluationResponse {
-        let EvaluationResults {
-            satisfied_permits,
-            satisfied_forbids,
-            global_deny_policies: _,
-            errors,
-            permit_residuals,
-            forbid_residuals,
-        } = self.evaluate_policies_core(pset, q, entities);
-
-        let errors = errors
-            .into_iter()
-            .map(|(pid, err)| AuthorizationError::PolicyEvaluationError {
-                id: pid,
-                error: err,
-            })
-            .collect();
-
-        let satisfied_permits = satisfied_permits.iter().map(|p| p.id().clone()).collect();
-        let satisfied_forbids = satisfied_forbids.iter().map(|p| p.id().clone()).collect();
-
-        // PANIC SAFETY all policy IDs in the original policy are unique by construction
-        #[allow(clippy::unwrap_used)]
-        let permit_residuals = PolicySet::try_from_iter(permit_residuals).unwrap();
-        // PANIC SAFETY all policy IDs in the original policy are unique by construction
-        #[allow(clippy::unwrap_used)]
-        let forbid_residuals = PolicySet::try_from_iter(forbid_residuals).unwrap();
-
-        EvaluationResponse {
-            satisfied_permits,
-            satisfied_forbids,
-            errors,
-            permit_residuals,
-            forbid_residuals,
-        }
-    }
-
-    fn evaluate_policies_core<'a>(
-        &'a self,
-        pset: &'a PolicySet,
-        q: Request,
-        entities: &Entities,
-    ) -> EvaluationResults<'a> {
+    ) -> PartialResponse {
         let eval = Evaluator::new(q, entities, &self.extensions);
-        let mut results = EvaluationResults::default();
-        let mut satisfied_policies = vec![];
+        let mut true_permits = vec![];
+        let mut true_forbids = vec![];
+        let mut false_permits = vec![];
+        let mut false_forbids = vec![];
+        let mut residual_permits = vec![];
+        let mut residual_forbids = vec![];
+        let mut errors = vec![];
 
         for p in pset.policies() {
+            let (id, annotations) = (p.id().clone(), p.annotations_arc().clone());
             match eval.partial_evaluate(p) {
-                Ok(Either::Left(response)) => {
-                    if response {
-                        satisfied_policies.push(p)
+                Ok(Either::Left(satisfied)) => match (satisfied, p.effect()) {
+                    (true, Effect::Permit) => true_permits.push((id, annotations)),
+                    (true, Effect::Forbid) => true_forbids.push((id, annotations)),
+                    (false, Effect::Permit) => {
+                        false_permits.push((id, (ErrorState::NoError, annotations)))
                     }
-                }
+                    (false, Effect::Forbid) => {
+                        false_forbids.push((id, (ErrorState::NoError, annotations)))
+                    }
+                },
                 Ok(Either::Right(residual)) => match p.effect() {
-                    Effect::Permit => results.permit_residuals.push(Policy::from_when_clause(
-                        p.effect(),
-                        residual,
-                        p.id().clone(),
-                    )),
-                    Effect::Forbid => results.forbid_residuals.push(Policy::from_when_clause(
-                        p.effect(),
-                        residual,
-                        p.id().clone(),
-                    )),
+                    Effect::Permit => {
+                        residual_permits.push((id, (Arc::new(residual), annotations)))
+                    }
+                    Effect::Forbid => {
+                        residual_forbids.push((id, (Arc::new(residual), annotations)))
+                    }
                 },
                 Err(e) => {
-                    results.errors.push((p.id().clone(), e));
+                    errors.push(AuthorizationError::PolicyEvaluationError {
+                        id: id.clone(),
+                        error: e,
+                    });
                     let satisfied = match self.error_handling {
-                        ErrorHandling::Deny => {
-                            results.global_deny_policies.insert(p.id().clone());
-                            true
-                        }
-                        ErrorHandling::Forbid => match p.effect() {
-                            Effect::Permit => false,
-                            Effect::Forbid => true,
-                        },
                         ErrorHandling::Skip => false,
                     };
-                    if satisfied {
-                        satisfied_policies.push(p);
+                    match (satisfied, p.effect()) {
+                        (true, Effect::Permit) => true_permits.push((id, annotations)),
+                        (true, Effect::Forbid) => true_forbids.push((id, annotations)),
+                        (false, Effect::Permit) => {
+                            false_permits.push((id, (ErrorState::Error, annotations)))
+                        }
+                        (false, Effect::Forbid) => {
+                            false_forbids.push((id, (ErrorState::Error, annotations)))
+                        }
                     }
                 }
             };
         }
 
-        let (satisfied_permits, satisfied_forbids) = satisfied_policies
-            .iter()
-            .partition(|p| p.effect() == Effect::Permit);
-
-        results.satisfied_forbids = satisfied_forbids;
-        results.satisfied_permits = satisfied_permits;
-
-        results
-    }
-
-    /// Private helper function which determines if policy `p1` overrides policy
-    /// `p2`.
-    ///
-    /// INVARIANT: p1 and p2 must have differing effects.
-    /// This only makes sense to call with one `Permit` and one `Forbid` policy.
-    /// If you call this with two `Permit`s or two `Forbid`s, this will panic.
-    fn overrides(p1: &Policy, p2: &Policy) -> bool {
-        // For now, we only support the default:
-        // all Forbid policies override all Permit policies.
-        // PANIC SAFETY p1 and p2s effect cannot be equal by invariant
-        #[allow(clippy::unreachable)]
-        match (p1.effect(), p2.effect()) {
-            (Effect::Forbid, Effect::Permit) => true,
-            (Effect::Permit, Effect::Forbid) => false,
-            (Effect::Permit, Effect::Permit) => {
-                unreachable!("Shouldn't call overrides() with two Permits")
-            }
-            (Effect::Forbid, Effect::Forbid) => {
-                unreachable!("Shouldn't call overrides() with two Forbids")
-            }
-        }
+        PartialResponse::new(
+            true_permits,
+            false_permits,
+            residual_permits,
+            true_forbids,
+            false_forbids,
+            residual_forbids,
+            errors,
+        )
     }
 }
 
@@ -403,16 +157,6 @@ impl Default for Authorizer {
     }
 }
 
-#[derive(Debug, Clone, Default)]
-struct EvaluationResults<'a> {
-    satisfied_permits: Vec<&'a Policy>,
-    satisfied_forbids: Vec<&'a Policy>,
-    global_deny_policies: HashSet<PolicyID>,
-    errors: Vec<(PolicyID, EvaluationError)>,
-    permit_residuals: Vec<Policy>,
-    forbid_residuals: Vec<Policy>,
-}
-
 impl std::fmt::Debug for Authorizer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.extensions.ext_names().next().is_none() {
@@ -420,8 +164,8 @@ impl std::fmt::Debug for Authorizer {
         } else {
             write!(
                 f,
-                "<Authorizer with the following extensions: {:?}>",
-                self.extensions.ext_names().collect::<Vec<_>>()
+                "<Authorizer with the following extensions: [{}]>",
+                self.extensions.ext_names().join(", ")
             )
         }
     }
@@ -432,7 +176,6 @@ impl std::fmt::Debug for Authorizer {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ast::{Annotations, RequestSchemaAllPass};
     use crate::parser;
 
     /// Sanity unit test case for is_authorized.
@@ -672,14 +415,13 @@ mod test {
         let r = a.is_authorized_core(q.clone(), &pset, &es).decision();
         assert_eq!(r, Some(Decision::Allow));
 
-        let r = a.evaluate_policies(&pset, q, &es);
-        assert!(r.satisfied_permits.contains(&PolicyID::from_string("1")));
-        assert!(r.satisfied_forbids.is_empty());
+        let r = a.is_authorized_core(q, &pset, &es);
         assert!(r
-            .permit_residuals
-            .get(&PolicyID::from_string("3"))
-            .is_some());
-        assert!(r.forbid_residuals.is_empty());
+            .satisfied_permits
+            .contains_key(&PolicyID::from_string("1")));
+        assert!(r.satisfied_forbids.is_empty());
+        assert!(r.residual_permits.contains_key(&PolicyID::from_string("3")));
+        assert!(r.residual_forbids.is_empty());
         assert!(r.errors.is_empty());
     }
 
@@ -712,46 +454,23 @@ mod test {
             .unwrap();
 
         let r = a.is_authorized_core(q.clone(), &pset, &es);
-        match r {
-            ResponseKind::FullyEvaluated(_) => {
-                panic!("Reached response, should have gotten residual.")
-            }
-            ResponseKind::Partial(p) => {
-                let map = [("test".into(), Value::from(false))].into_iter().collect();
-                let new = p.residuals.policies().map(|p| {
-                    Policy::from_when_clause(
-                        p.effect(),
-                        p.condition().substitute(&map).unwrap(),
-                        p.id().clone(),
-                    )
-                });
-                let pset = PolicySet::try_from_iter(new).unwrap();
-                let r = a.is_authorized(q.clone(), &pset, &es);
-                assert_eq!(r.decision, Decision::Allow);
+        let map = [("test".into(), Value::from(false))].into_iter().collect();
+        let r2: Response = r.reauthorize(&map, &a, q.clone(), &es).unwrap().into();
+        assert_eq!(r2.decision, Decision::Allow);
+        drop(r2);
 
-                let map = [("test".into(), Value::from(true))].into_iter().collect();
-                let new = p.residuals.policies().map(|p| {
-                    Policy::from_when_clause(
-                        p.effect(),
-                        p.condition().substitute(&map).unwrap(),
-                        p.id().clone(),
-                    )
-                });
-                let pset = PolicySet::try_from_iter(new).unwrap();
-                let r = a.is_authorized(q.clone(), &pset, &es);
-                assert_eq!(r.decision, Decision::Deny);
-            }
-        }
+        let map = [("test".into(), Value::from(true))].into_iter().collect();
+        let r2: Response = r.reauthorize(&map, &a, q.clone(), &es).unwrap().into();
+        assert_eq!(r2.decision, Decision::Deny);
 
-        let r = a.evaluate_policies(&pset, q, &es);
-        assert!(r.satisfied_permits.contains(&PolicyID::from_string("1")));
+        let r = a.is_authorized_core(q, &pset, &es);
+        assert!(r
+            .satisfied_permits
+            .contains_key(&PolicyID::from_string("1")));
         assert!(r.satisfied_forbids.is_empty());
         assert!(r.errors.is_empty());
-        assert!(r.permit_residuals.is_empty());
-        assert!(r
-            .forbid_residuals
-            .get(&PolicyID::from_string("2"))
-            .is_some());
+        assert!(r.residual_permits.is_empty());
+        assert!(r.residual_forbids.contains_key(&PolicyID::from_string("2")));
     }
 
     #[test]
@@ -804,15 +523,16 @@ mod test {
         let r = a.is_authorized_core(q.clone(), &pset, &es);
         assert_eq!(r.decision(), Some(Decision::Deny));
 
-        let r = a.evaluate_policies(&pset, q, &es);
-        assert!(r.satisfied_permits.contains(&PolicyID::from_string("4")));
-        assert!(r.satisfied_forbids.contains(&PolicyID::from_string("3")));
-        assert!(r.errors.is_empty());
-        assert!(r.permit_residuals.is_empty());
+        let r = a.is_authorized_core(q, &pset, &es);
         assert!(r
-            .forbid_residuals
-            .get(&PolicyID::from_string("2"))
-            .is_some());
+            .satisfied_permits
+            .contains_key(&PolicyID::from_string("4")));
+        assert!(r
+            .satisfied_forbids
+            .contains_key(&PolicyID::from_string("3")));
+        assert!(r.errors.is_empty());
+        assert!(r.residual_permits.is_empty());
+        assert!(r.residual_forbids.contains_key(&PolicyID::from_string("2")));
     }
 
     #[test]
@@ -846,51 +566,27 @@ mod test {
             .unwrap();
 
         let r = a.is_authorized_core(q.clone(), &pset, &es);
-        match r {
-            ResponseKind::FullyEvaluated(_) => {
-                panic!("Reached response, should have gotten residual.")
-            }
-            ResponseKind::Partial(p) => {
-                let map = [("a".into(), Value::from(false))].into_iter().collect();
-                let new = p.residuals.policies().map(|p| {
-                    Policy::from_when_clause(
-                        p.effect(),
-                        p.condition().substitute(&map).unwrap(),
-                        p.id().clone(),
-                    )
-                });
-                let pset = PolicySet::try_from_iter(new).unwrap();
-                let r = a.is_authorized(q.clone(), &pset, &es);
-                assert_eq!(r.decision, Decision::Deny);
+        let map = [("a".into(), Value::from(false))].into_iter().collect();
+        let r2: Response = r.reauthorize(&map, &a, q.clone(), &es).unwrap().into();
+        assert_eq!(r2.decision, Decision::Deny);
 
-                let map = [("a".into(), Value::from(true))].into_iter().collect();
-                let new = p.residuals.policies().map(|p| {
-                    Policy::from_when_clause(
-                        p.effect(),
-                        p.condition().substitute(&map).unwrap(),
-                        p.id().clone(),
-                    )
-                });
-                let pset = PolicySet::try_from_iter(new).unwrap();
-                let r = a.is_authorized(q.clone(), &pset, &es);
-                assert_eq!(r.decision, Decision::Allow);
-            }
-        }
+        let map = [("a".into(), Value::from(true))].into_iter().collect();
+        let r2: Response = r.reauthorize(&map, &a, q.clone(), &es).unwrap().into();
+        assert_eq!(r2.decision, Decision::Allow);
 
         pset.add_static(parser::parse_policy(Some("3".into()), src3).unwrap())
             .unwrap();
         let r = a.is_authorized_core(q.clone(), &pset, &es);
         assert_eq!(r.decision(), Some(Decision::Deny));
 
-        let r = a.evaluate_policies(&pset, q, &es);
+        let r = a.is_authorized_core(q, &pset, &es);
         assert!(r.satisfied_permits.is_empty());
-        assert!(r.satisfied_forbids.contains(&PolicyID::from_string("3")));
-        assert!(r.errors.is_empty());
         assert!(r
-            .permit_residuals
-            .get(&PolicyID::from_string("2"))
-            .is_some());
-        assert!(r.forbid_residuals.is_empty());
+            .satisfied_forbids
+            .contains_key(&PolicyID::from_string("3")));
+        assert!(r.errors.is_empty());
+        assert!(r.residual_permits.contains_key(&PolicyID::from_string("2")));
+        assert!(r.residual_forbids.is_empty());
     }
 }
 // by default, Coverlay does not track coverage for lines after a line
@@ -906,29 +602,6 @@ pub struct Response {
     pub decision: Decision,
     /// Diagnostics providing more information on how this decision was reached
     pub diagnostics: Diagnostics,
-}
-
-/// Response that may contain a residual.
-#[derive(Debug, PartialEq, Clone)]
-pub struct PartialResponse {
-    /// Residual policies
-    pub residuals: PolicySet,
-    /// Diagnostics providing info
-    pub diagnostics: Diagnostics,
-}
-
-impl PartialResponse {
-    /// Create a partial response with a residual PolicySet
-    pub fn new(
-        pset: PolicySet,
-        reason: HashSet<PolicyID>,
-        errors: Vec<AuthorizationError>,
-    ) -> Self {
-        PartialResponse {
-            residuals: pset,
-            diagnostics: Diagnostics { reason, errors },
-        }
-    }
 }
 
 /// Policy evaluation response returned from the `Authorizer`.

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -1,0 +1,595 @@
+use std::collections::HashMap;
+
+use either::Either;
+use smol_str::SmolStr;
+use std::sync::Arc;
+
+use super::{
+    Annotations, AuthorizationError, Authorizer, Decision, Effect, Expr, Policy, PolicySet,
+    PolicySetError, Request, Response, Value,
+};
+use crate::{ast::PolicyID, entities::Entities, evaluator::EvaluationError};
+
+type PolicyComponents<'a> = (Effect, &'a PolicyID, &'a Arc<Expr>, &'a Arc<Annotations>);
+
+/// Enum representing whether a policy is not satisfied due to
+/// evaluating to `false`, or because it errored.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ErrorState {
+    /// The policy did not error
+    NoError,
+    /// The policy did error
+    Error,
+}
+
+/// A partially evaluated authorization response.
+/// Splits the results into several categories: satisfied, false, and residual for each policy effect.
+/// Also tracks all the errors that were encountered during evaluation.
+/// This structure currently has to own all of the `PolicyID` objects due to the [`Self::reauthorize`]
+/// method. If [`PolicySet`] could borrow its PolicyID/contents then this whole structured could be borrowed.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct PartialResponse {
+    /// All of the [`Effect::Permit`] policies that were satisfied
+    pub satisfied_permits: HashMap<PolicyID, Arc<Annotations>>,
+    /// All of the [`Effect::Permit`] policies that were not satisfied
+    pub false_permits: HashMap<PolicyID, (ErrorState, Arc<Annotations>)>,
+    /// All of the [`Effect::Permit`] policies that evaluated to a residual
+    pub residual_permits: HashMap<PolicyID, (Arc<Expr>, Arc<Annotations>)>,
+    /// All of the [`Effect::Forbid`] policies that were satisfied
+    pub satisfied_forbids: HashMap<PolicyID, Arc<Annotations>>,
+    /// All of the [`Effect::Forbid`] policies that were not satisfied
+    pub false_forbids: HashMap<PolicyID, (ErrorState, Arc<Annotations>)>,
+    /// All of the [`Effect::Forbid`] policies that evaluated to a residual
+    pub residual_forbids: HashMap<PolicyID, (Arc<Expr>, Arc<Annotations>)>,
+    /// All of the policy errors encountered during evaluation
+    pub errors: Vec<AuthorizationError>,
+    /// The trivial `true` expression, used for materializing a residual for satisfied policies
+    true_expr: Arc<Expr>,
+    /// The trivial `false` expression, used for materializing a residual for non-satisfied policies
+    false_expr: Arc<Expr>,
+}
+
+impl PartialResponse {
+    /// Create a partial response from each of the policy result categories
+    pub fn new(
+        true_permits: impl IntoIterator<Item = (PolicyID, Arc<Annotations>)>,
+        false_permits: impl IntoIterator<Item = (PolicyID, (ErrorState, Arc<Annotations>))>,
+        residual_permits: impl IntoIterator<Item = (PolicyID, (Arc<Expr>, Arc<Annotations>))>,
+        true_forbids: impl IntoIterator<Item = (PolicyID, Arc<Annotations>)>,
+        false_forbids: impl IntoIterator<Item = (PolicyID, (ErrorState, Arc<Annotations>))>,
+        residual_forbids: impl IntoIterator<Item = (PolicyID, (Arc<Expr>, Arc<Annotations>))>,
+        errors: impl IntoIterator<Item = AuthorizationError>,
+    ) -> Self {
+        Self {
+            satisfied_permits: true_permits.into_iter().collect(),
+            false_permits: false_permits.into_iter().collect(),
+            residual_permits: residual_permits.into_iter().collect(),
+            satisfied_forbids: true_forbids.into_iter().collect(),
+            false_forbids: false_forbids.into_iter().collect(),
+            residual_forbids: residual_forbids.into_iter().collect(),
+            errors: errors.into_iter().collect(),
+            true_expr: Arc::new(Expr::val(true)),
+            false_expr: Arc::new(Expr::val(false)),
+        }
+    }
+
+    /// Convert this response into a concrete evaluation response.
+    /// All residuals are treated as errors
+    pub fn concretize(self) -> Response {
+        self.into()
+    }
+
+    /// Attempt to reach a partial decision; the presence of residuals may result in returning [`None`],
+    /// indicating that a decision could not be reached given the unknowns
+    pub fn decision(&self) -> Option<Decision> {
+        match (
+            !self.satisfied_forbids.is_empty(),
+            !self.satisfied_permits.is_empty(),
+            !self.residual_permits.is_empty(),
+            !self.residual_forbids.is_empty(),
+        ) {
+            // Any true forbids means we will deny
+            (true, _, _, _) => Some(Decision::Deny),
+            // No potentially or trivially true permits, means we default deny
+            (_, false, false, _) => Some(Decision::Deny),
+            // Potentially true forbids, means we can't know (as that forbid may evaluate to true, overriding any permits)
+            (false, _, _, true) => None,
+            // No true permits, but some potentially true permits + no true/potentially true forbids means we don't know
+            (false, false, true, false) => None,
+            // At least one trivially true permit, and no trivially or possible true forbids, means we allow
+            (false, true, _, false) => Some(Decision::Allow),
+        }
+    }
+
+    /// All of the [`Effect::Permit`] policies that were known to be satisfied
+    fn definitely_satisfied_permits(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.satisfied_permits.iter().map(|(id, annotations)| {
+            construct_policy((Effect::Permit, id, &self.true_expr, annotations))
+        })
+    }
+
+    /// All of the [`Effect::Forbid`] policies that were known to be satisfied
+    fn definitely_satisfied_forbids(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.satisfied_forbids.iter().map(|(id, annotations)| {
+            construct_policy((Effect::Forbid, id, &self.true_expr, annotations))
+        })
+    }
+
+    /// Returns the set of [`PolicyID`]s that were definitely satisfied -- both permits and forbids
+    pub fn definitely_satisfied(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.definitely_satisfied_permits()
+            .chain(self.definitely_satisfied_forbids())
+    }
+
+    /// Returns the set of [`PolicyID`]s that encountered errors
+    pub fn definitely_errored(&self) -> impl Iterator<Item = &PolicyID> {
+        self.false_permits
+            .iter()
+            .chain(self.false_forbids.iter())
+            .filter_map(did_error)
+    }
+
+    /// Returns an over-approximation of the set of determining policies.
+    ///
+    /// This is all policies that may be determining for any substitution of the unknowns.
+    pub fn may_be_determining(&self) -> impl Iterator<Item = Policy> + '_ {
+        if self.satisfied_forbids.is_empty() {
+            // We have no definitely true forbids, so the over approx is everything that is true or potentially true
+            Either::Left(
+                self.definitely_satisfied_permits()
+                    .chain(self.residual_permits())
+                    .chain(self.residual_forbids()),
+            )
+        } else {
+            // We have definitely true forbids, so we know only things that can determine is
+            // true forbids and potentially true forbids
+            Either::Right(
+                self.definitely_satisfied_forbids()
+                    .chain(self.residual_forbids()),
+            )
+        }
+    }
+
+    fn residual_permits(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.residual_permits
+            .iter()
+            .map(|(id, (expr, annotations))| {
+                construct_policy((Effect::Permit, id, expr, annotations))
+            })
+    }
+
+    fn residual_forbids(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.residual_forbids
+            .iter()
+            .map(|(id, (expr, annotations))| {
+                construct_policy((Effect::Forbid, id, expr, annotations))
+            })
+    }
+
+    /// Returns an under-approximation of the set of determining policies.
+    ///
+    /// This is all policies that must be determining for all possible substitutions of the unknowns.
+    pub fn must_be_determining(&self) -> impl Iterator<Item = Policy> + '_ {
+        // If there are no true forbids or potentially true forbids,
+        // then the under approximation is the true permits
+        if self.satisfied_forbids.is_empty() && self.residual_forbids.is_empty() {
+            Either::Left(self.definitely_satisfied_permits())
+        } else {
+            // Otherwise it's the true forbids
+            Either::Right(self.definitely_satisfied_forbids())
+        }
+    }
+
+    /// Returns the set of non-trivial (meaning more than just `true` or `false`) residuals expressions
+    pub fn nontrivial_residuals(&'_ self) -> impl Iterator<Item = Policy> + '_ {
+        self.nontrival_permits().chain(self.nontrival_forbids())
+    }
+
+    /// Returns the set of ids of non-trivial (meaning more than just `true` or `false`) residuals expressions
+    pub fn nontrivial_residual_ids(&self) -> impl Iterator<Item = &PolicyID> {
+        self.residual_permits
+            .keys()
+            .chain(self.residual_forbids.keys())
+    }
+
+    /// Returns the set of non-trivial (meaning more than just `true` or `false`) residuals expressions from [`Effect::Permit`]
+    fn nontrival_permits(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.residual_permits
+            .iter()
+            .map(|(id, (expr, annotations))| {
+                construct_policy((Effect::Permit, id, expr, annotations))
+            })
+    }
+
+    /// Returns the set of non-trivial (meaning more than just `true` or `false`) residuals expressions from [`Effect::Forbid`]
+    pub fn nontrival_forbids(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.residual_forbids
+            .iter()
+            .map(|(id, (expr, annotations))| {
+                construct_policy((Effect::Forbid, id, expr, annotations))
+            })
+    }
+
+    /// Returns every policy residual, including trivial ones
+    pub fn all_residuals(&'_ self) -> impl Iterator<Item = Policy> + '_ {
+        self.all_permit_residuals()
+            .chain(self.all_forbid_residuals())
+            .map(construct_policy)
+    }
+
+    /// Returns all residuals expressions that come from [`Effect::Permit`] policies
+    fn all_permit_residuals(&'_ self) -> impl Iterator<Item = PolicyComponents<'_>> {
+        let trues = self
+            .satisfied_permits
+            .iter()
+            .map(|(id, a)| (id, (&self.true_expr, a)));
+        let falses = self
+            .false_permits
+            .iter()
+            .map(|(id, (_, a))| (id, (&self.false_expr, a)));
+        let nontrivial = self
+            .residual_permits
+            .iter()
+            .map(|(id, (r, a))| (id, (r, a)));
+        trues
+            .chain(falses)
+            .chain(nontrivial)
+            .map(|(id, (r, a))| (Effect::Permit, id, r, a))
+    }
+
+    /// Returns all residuals expressions that come from [`Effect::Forbid`] policies
+    fn all_forbid_residuals(&'_ self) -> impl Iterator<Item = PolicyComponents<'_>> {
+        let trues = self
+            .satisfied_forbids
+            .iter()
+            .map(|(id, a)| (id, (&self.true_expr, a)));
+        let falses = self
+            .false_forbids
+            .iter()
+            .map(|(id, (_, a))| (id, (&self.false_expr, a)));
+        let nontrivial = self
+            .residual_forbids
+            .iter()
+            .map(|(id, (r, a))| (id, (r, a)));
+        trues
+            .chain(falses)
+            .chain(nontrivial)
+            .map(|(id, (r, a))| (Effect::Forbid, id, r, a))
+    }
+
+    /// Return the residual for a given [`PolicyID`], if it exists in the response
+    pub fn get(&self, id: &PolicyID) -> Option<Policy> {
+        self.get_permit(id).or_else(|| self.get_forbid(id))
+    }
+
+    fn get_permit(&self, id: &PolicyID) -> Option<Policy> {
+        self.residual_permits
+            .get(id)
+            .map(|(a, b)| (a, b))
+            .or_else(|| self.satisfied_permits.get(id).map(|a| (&self.true_expr, a)))
+            .or_else(|| {
+                self.false_permits
+                    .get(id)
+                    .map(|(_, a)| (&self.false_expr, a))
+            })
+            .map(|(expr, a)| construct_policy((Effect::Permit, id, expr, a)))
+    }
+
+    fn get_forbid(&self, id: &PolicyID) -> Option<Policy> {
+        self.residual_forbids
+            .get(id)
+            .map(|(a, b)| (a, b))
+            .or_else(|| self.satisfied_forbids.get(id).map(|a| (&self.true_expr, a)))
+            .or_else(|| {
+                self.false_forbids
+                    .get(id)
+                    .map(|(_, a)| (&self.false_expr, a))
+            })
+            .map(|(expr, a)| construct_policy((Effect::Forbid, id, expr, a)))
+    }
+
+    /// Attempt to re-authorize this response given a mapping from unknowns to values
+    pub fn reauthorize(
+        &self,
+        mapping: &HashMap<SmolStr, Value>,
+        auth: &Authorizer,
+        r: Request,
+        es: &Entities,
+    ) -> Result<Self, PolicySetError> {
+        let policyset = self.all_policies(mapping)?;
+        Ok(auth.is_authorized_core(r, &policyset, es))
+    }
+
+    fn all_policies(&self, mapping: &HashMap<SmolStr, Value>) -> Result<PolicySet, PolicySetError> {
+        let mapper = map_unknowns(mapping);
+        PolicySet::try_from_iter(
+            self.all_permit_residuals()
+                .chain(self.all_forbid_residuals())
+                .map(mapper),
+        )
+    }
+
+    fn errors(self) -> impl Iterator<Item = AuthorizationError> {
+        self.residual_forbids
+            .into_iter()
+            .chain(self.residual_permits)
+            .map(
+                |(id, (expr, _))| AuthorizationError::PolicyEvaluationError {
+                    id: id.clone(),
+                    error: EvaluationError::non_value(expr.as_ref().clone()),
+                },
+            )
+            .chain(self.errors)
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
+impl From<PartialResponse> for Response {
+    fn from(p: PartialResponse) -> Self {
+        let decision = if !p.satisfied_permits.is_empty() && p.satisfied_forbids.is_empty() {
+            Decision::Allow
+        } else {
+            Decision::Deny
+        };
+        Response::new(
+            decision,
+            p.must_be_determining().map(|p| p.id().clone()).collect(),
+            p.errors().collect(),
+        )
+    }
+}
+
+/// Build a policy from a policy components
+fn construct_policy((effect, id, expr, annotations): PolicyComponents<'_>) -> Policy {
+    Policy::from_when_clause_annos(effect, expr.clone(), id.clone(), (*annotations).clone())
+}
+
+/// Given a mapping from unknown names to values and a policy prototype
+/// substitute the residual with the mapping and build a policy.
+/// Curried for convenience
+fn map_unknowns<'a>(
+    mapping: &'a HashMap<SmolStr, Value>,
+) -> impl Fn(PolicyComponents<'a>) -> Policy {
+    |(effect, id, expr, annotations)| {
+        Policy::from_when_clause_annos(
+            effect,
+            Arc::new(expr.substitute(mapping)),
+            id.clone(),
+            annotations.clone(),
+        )
+    }
+}
+
+/// Checks if a given residual record did error, returning the [`PolicyID`] if it did
+fn did_error<'a>(
+    (id, (state, _)): (&'a PolicyID, &'_ (ErrorState, Arc<Annotations>)),
+) -> Option<&'a PolicyID> {
+    match *state {
+        ErrorState::NoError => None,
+        ErrorState::Error => Some(id),
+    }
+}
+
+#[cfg(test)]
+// PANIC SAFETY testing
+#[allow(clippy::indexing_slicing)]
+mod test {
+    use std::{
+        collections::HashSet,
+        iter::{empty, once},
+    };
+
+    // An extremely slow and bad set, but it only requires that the contents be [`PartialEq`]
+    // Using this because I don't want to enforce an output order on the tests, but policies can't easily be Hash or Ord
+    #[derive(Debug, Default)]
+    struct SlowSet<T> {
+        contents: Vec<T>,
+    }
+
+    impl<T: PartialEq> SlowSet<T> {
+        pub fn from(iter: impl IntoIterator<Item = T>) -> Self {
+            let mut contents = vec![];
+            for item in iter.into_iter() {
+                if !contents.contains(&item) {
+                    contents.push(item)
+                }
+            }
+            Self { contents }
+        }
+
+        pub fn len(&self) -> usize {
+            self.contents.len()
+        }
+
+        pub fn contains(&self, item: &T) -> bool {
+            self.contents.contains(item)
+        }
+    }
+
+    impl<T: PartialEq> PartialEq for SlowSet<T> {
+        fn eq(&self, rhs: &Self) -> bool {
+            if self.len() == rhs.len() {
+                self.contents.iter().all(|item| rhs.contains(item))
+            } else {
+                false
+            }
+        }
+    }
+
+    impl<T: PartialEq> FromIterator<T> for SlowSet<T> {
+        fn from_iter<I>(iter: I) -> Self
+        where
+            I: IntoIterator<Item = T>,
+        {
+            Self::from(iter)
+        }
+    }
+
+    use crate::authorizer::{ActionConstraint, PrincipalConstraint, ResourceConstraint};
+
+    use super::*;
+
+    #[test]
+    fn sanity_check() {
+        let empty_annotations: Arc<Annotations> = Arc::default();
+        let one_plus_two = Arc::new(Expr::add(Expr::val(1), Expr::val(2)));
+        let three_plus_four = Arc::new(Expr::add(Expr::val(3), Expr::val(4)));
+        let a = once((PolicyID::from_string("a"), empty_annotations.clone()));
+        let bc = [
+            (
+                PolicyID::from_string("b"),
+                (ErrorState::Error, empty_annotations.clone()),
+            ),
+            (
+                PolicyID::from_string("c"),
+                (ErrorState::NoError, empty_annotations.clone()),
+            ),
+        ];
+        let d = once((
+            PolicyID::from_string("d"),
+            (one_plus_two.clone(), empty_annotations.clone()),
+        ));
+        let e = once((PolicyID::from_string("e"), empty_annotations.clone()));
+        let fg = [
+            (
+                PolicyID::from_string("f"),
+                (ErrorState::Error, empty_annotations.clone()),
+            ),
+            (
+                PolicyID::from_string("g"),
+                (ErrorState::NoError, empty_annotations.clone()),
+            ),
+        ];
+        let h = once((
+            PolicyID::from_string("h"),
+            (three_plus_four.clone(), empty_annotations.clone()),
+        ));
+        let errs = empty();
+        let pr = PartialResponse::new(a, bc, d, e, fg, h, errs);
+
+        let a =
+            Policy::from_when_clause(Effect::Permit, Expr::val(true), PolicyID::from_string("a"));
+        let b =
+            Policy::from_when_clause(Effect::Permit, Expr::val(false), PolicyID::from_string("b"));
+        let c =
+            Policy::from_when_clause(Effect::Permit, Expr::val(false), PolicyID::from_string("c"));
+        let d = Policy::from_when_clause_annos(
+            Effect::Permit,
+            one_plus_two.clone(),
+            PolicyID::from_string("d"),
+            Arc::default(),
+        );
+        let e =
+            Policy::from_when_clause(Effect::Forbid, Expr::val(true), PolicyID::from_string("e"));
+        let f =
+            Policy::from_when_clause(Effect::Forbid, Expr::val(false), PolicyID::from_string("f"));
+        let g =
+            Policy::from_when_clause(Effect::Forbid, Expr::val(false), PolicyID::from_string("g"));
+        let h = Policy::from_when_clause_annos(
+            Effect::Forbid,
+            three_plus_four.clone(),
+            PolicyID::from_string("h"),
+            Arc::default(),
+        );
+
+        assert_eq!(
+            pr.definitely_satisfied_permits().collect::<SlowSet<_>>(),
+            SlowSet::from([a.clone()])
+        );
+        assert_eq!(
+            pr.definitely_satisfied_forbids().collect::<SlowSet<_>>(),
+            SlowSet::from([e.clone()])
+        );
+        assert_eq!(
+            pr.definitely_satisfied().collect::<SlowSet<_>>(),
+            SlowSet::from([a.clone(), e.clone()])
+        );
+        assert_eq!(
+            pr.definitely_errored().collect::<HashSet<_>>(),
+            HashSet::from([&PolicyID::from_string("b"), &PolicyID::from_string("f")])
+        );
+        assert_eq!(
+            pr.may_be_determining().collect::<SlowSet<_>>(),
+            SlowSet::from([e.clone(), h.clone()])
+        );
+        assert_eq!(
+            pr.must_be_determining().collect::<SlowSet<_>>(),
+            SlowSet::from([e.clone()])
+        );
+        assert_eq!(pr.nontrivial_residuals().count(), 2);
+
+        assert_eq!(
+            pr.nontrivial_residuals().collect::<SlowSet<_>>(),
+            SlowSet::from([d.clone(), h.clone()])
+        );
+        assert_eq!(
+            pr.all_residuals().collect::<SlowSet<_>>(),
+            SlowSet::from([&a, &b, &c, &d, &e, &f, &g, &h].into_iter().cloned())
+        );
+        assert_eq!(
+            pr.nontrivial_residual_ids().collect::<HashSet<_>>(),
+            HashSet::from([&PolicyID::from_string("d"), &PolicyID::from_string("h")])
+        );
+
+        assert_eq!(pr.get(&PolicyID::from_string("a")), Some(a));
+        assert_eq!(pr.get(&PolicyID::from_string("b")), Some(b));
+        assert_eq!(pr.get(&PolicyID::from_string("c")), Some(c));
+        assert_eq!(pr.get(&PolicyID::from_string("d")), Some(d));
+        assert_eq!(pr.get(&PolicyID::from_string("e")), Some(e));
+        assert_eq!(pr.get(&PolicyID::from_string("f")), Some(f));
+        assert_eq!(pr.get(&PolicyID::from_string("g")), Some(g));
+        assert_eq!(pr.get(&PolicyID::from_string("h")), Some(h));
+        assert_eq!(pr.get(&PolicyID::from_string("i")), None);
+    }
+
+    #[test]
+    fn build_policies_trivial_permit() {
+        let e = Arc::new(Expr::add(Expr::val(1), Expr::val(2)));
+        let id = PolicyID::from_string("foo");
+        let p = construct_policy((Effect::Permit, &id, &e, &Arc::default()));
+        assert_eq!(p.effect(), Effect::Permit);
+        assert!(p.annotations().next().is_none());
+        assert_eq!(p.action_constraint(), &ActionConstraint::Any);
+        assert_eq!(p.principal_constraint(), PrincipalConstraint::any());
+        assert_eq!(p.resource_constraint(), ResourceConstraint::any());
+        assert_eq!(p.id(), &id);
+        assert_eq!(p.non_head_constraints(), e.as_ref());
+    }
+
+    #[test]
+    fn build_policies_trivial_forbid() {
+        let e = Arc::new(Expr::add(Expr::val(1), Expr::val(2)));
+        let id = PolicyID::from_string("foo");
+        let p = construct_policy((Effect::Forbid, &id, &e, &Arc::default()));
+        assert_eq!(p.effect(), Effect::Forbid);
+        assert!(p.annotations().next().is_none());
+        assert_eq!(p.action_constraint(), &ActionConstraint::Any);
+        assert_eq!(p.principal_constraint(), PrincipalConstraint::any());
+        assert_eq!(p.resource_constraint(), ResourceConstraint::any());
+        assert_eq!(p.id(), &id);
+        assert_eq!(p.non_head_constraints(), e.as_ref());
+    }
+
+    #[test]
+    fn did_error_error() {
+        assert_eq!(
+            did_error((
+                &PolicyID::from_string("foo"),
+                &(ErrorState::Error, Arc::default())
+            )),
+            Some(&PolicyID::from_string("foo"))
+        );
+    }
+
+    #[test]
+    fn did_error_noerror() {
+        assert_eq!(
+            did_error((
+                &PolicyID::from_string("foo"),
+                &(ErrorState::NoError, Arc::default())
+            )),
+            None,
+        );
+    }
+}

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -918,7 +918,7 @@ fn stack_size_check() -> Result<()> {
 #[allow(clippy::panic)]
 #[cfg(test)]
 pub mod test {
-    use std::{collections::HashMap, str::FromStr};
+    use std::str::FromStr;
 
     use super::*;
 
@@ -4569,7 +4569,7 @@ pub mod test {
                 let m: HashMap<_, _> = [("principal".into(), Value::from(euid))]
                     .into_iter()
                     .collect();
-                let new_expr = expr.substitute(&m).unwrap();
+                let new_expr = expr.substitute_typed(&m).unwrap();
                 assert_eq!(
                     e.partial_interpret(&new_expr, &HashMap::new())
                         .expect("Failed to eval"),

--- a/cedar-policy-core/src/parser/loc.rs
+++ b/cedar-policy-core/src/parser/loc.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 /// Represents a source location: index/range, and a reference to the source
 /// code which that index/range indexes into
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
 pub struct Loc {
     /// `SourceSpan` indicating a specific source code location or range
     pub span: miette::SourceSpan,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -5,11 +5,57 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+### Added
+
+- `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`, and `RestrictedExpression::new_decimal` (#661, resolving #659)
+- `wasm` Cargo feature for targeting Wasm
+- `Entity::into_inner` (resolving #636)
+- `Entities::into_iter` (resolving #680)
+- Adds an JSON representation for Policy Sets (#783, resolving #549),
+    along with methods like `::from_json_value/file/str` and `::to_json`
+    for `PolicySet`.
+- `Policy::unknown_entities`
+
+### Changed
+
+- significantly reworked `EntitiesError` to bring into conformance
+- for the `partial-eval` experimental feature: `PartialResponse` api has changed significantly
+- Moved `<PolicyId as FromStr>::Err` to `Infallible` (#588, resolving #551)
+- Overhauled the FFI interface in the `frontend` module, and renamed it to
+  `ffi`; see #757. (#760, #793, #794, #800, #824, more coming)
+- Much richer error information in the FFI interface (#800)
+- Deprecated the integration testing harness code. It will be removed from the
+  `cedar-policy` crate in the next major version.
+- Removed unnecessary lifetimes from some validation related structs (#715)
+- Deprecated error `TypeErrorKind::ImpossiblePolicy` in favor of warning
+  `ValidationWarningKind::ImpossiblePolicy` so future improvements to Cedar
+  typing precision will not result in breaking changes. (resolving #539)
+- Made `is_authorized` and `validate` functions in the frontend public, as well as their related structs: `AuthorizationAnswer`, `AuthorizationCall`, `ValidationCall`, `ValidationSettings`, `ValidationEnabled`, `ValidationError`, `ValidationWarning`, `ValidationAnswer`. (#737)
+- Changed policy validation to reject comparisons and conditionals between
+  record types that differ in whether an attribute is required or optional.
+- Improved validation error messages when incompatible types appear in
+  `if`, `==`, `contains`, `containsAll`, and `containsAny` expressions.
+- Validation error for invalid use of an action now includes a source location
+  containing the offending policy.
+- Validation error messages for unknown entity types and action entities now
+  report the precise source location where the unknown type was encountered.
+
+### Fixed
+
+- Validation error message for an invalid attribute access now reports the
+  correct attribute and entity type when accessing an optional attribute that is
+  itself an entity.
+- The error message returend when parsing an invalid action scope constraint
+  `action == ?action` no longer suggests that `action == [...]` would be a
+  valid scope constraint.
+
 ## [3.1.3] - 2024-04-15
 
 ### Changed
 
 - Improve parser errors on unexpected tokens. (#698, partially resolving #176)
+- for the `partial-eval` experimental feature: `PartialResponse` api has changed significantly
 - Validation error messages render types in the new, more readable, schema
   syntax. (#708, resolving #242)
 - Improved error messages when `null` occurs in entity json data. (#751,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -23,6 +23,8 @@
 pub use ast::Effect;
 pub use authorizer::Decision;
 use cedar_policy_core::ast;
+#[cfg(feature = "partial-eval")]
+use cedar_policy_core::ast::BorrowedRestrictedExpr;
 use cedar_policy_core::ast::{
     ContextCreationError, ExprConstructionError, Integer, RestrictedExprParseError,
 }; // `ContextCreationError` is unsuitable for `pub use` because it contains internal types like `RestrictedExpr`
@@ -33,6 +35,8 @@ use cedar_policy_core::entities::{
 };
 use cedar_policy_core::est;
 use cedar_policy_core::evaluator::Evaluator;
+#[cfg(feature = "partial-eval")]
+use cedar_policy_core::evaluator::RestrictedEvaluator;
 pub use cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind};
 pub use cedar_policy_core::extensions;
 use cedar_policy_core::extensions::Extensions;
@@ -731,38 +735,7 @@ impl Authorizer {
         let response = self
             .0
             .is_authorized_core(query.0.clone(), &policy_set.ast, &entities.0);
-        match response {
-            authorizer::ResponseKind::FullyEvaluated(a) => PartialResponse::Concrete(a.into()),
-            authorizer::ResponseKind::Partial(p) => PartialResponse::Residual(p.into()),
-        }
-    }
-
-    /// Evaluate an authorization request and respond with results that always includes
-    /// residuals even if the [`Authorizer`] already reached a decision.
-    #[doc = include_str!("../experimental_warning.md")]
-    #[cfg(feature = "partial-eval")]
-    pub fn evaluate_policies_partial(
-        &self,
-        query: &Request,
-        policy_set: &PolicySet,
-        entities: &Entities,
-    ) -> EvaluationResponse {
-        let authorizer::EvaluationResponse {
-            satisfied_permits,
-            satisfied_forbids,
-            errors,
-            permit_residuals,
-            forbid_residuals,
-        } = self
-            .0
-            .evaluate_policies(&policy_set.ast, query.0.clone(), &entities.0);
-        EvaluationResponse {
-            satisfied_permits: satisfied_permits.into_iter().map(PolicyId).collect(),
-            satisfied_forbids: satisfied_forbids.into_iter().map(PolicyId).collect(),
-            errors: errors.into_iter().map(|e| e.into()).collect(),
-            permit_residuals: PolicySet::from_ast(permit_residuals),
-            forbid_residuals: PolicySet::from_ast(forbid_residuals),
-        }
+        PartialResponse(response)
     }
 }
 
@@ -810,44 +783,125 @@ pub struct Response {
     diagnostics: Diagnostics,
 }
 
-/// Authorization response returned from `is_authorized_partial`.
-/// It can either be a full concrete response, or a residual response.
+/// A partially evaluated authorization response.
+/// Splits the results into several categories: satisfied, false, and residual for each policy effect.
+/// Also tracks all the errors that were encountered during evaluation.
 #[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum PartialResponse {
-    /// A full, concrete response.
-    Concrete(Response),
-    /// A residual response. Determining the concrete response requires further processing.
-    Residual(ResidualResponse),
+#[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, Clone, RefCast)]
+pub struct PartialResponse(cedar_policy_core::authorizer::PartialResponse);
+
+#[cfg(feature = "partial-eval")]
+impl PartialResponse {
+    /// Attempt to reach a partial decision; the presence of residuals may result in returning [`None`],
+    /// indicating that a decision could not be reached given the unknowns
+    pub fn decision(&self) -> Option<Decision> {
+        self.0.decision()
+    }
+
+    /// Convert this response into a concrete evaluation response.
+    /// All residuals are treated as errors
+    pub fn concretize(self) -> Response {
+        self.0.concretize().into()
+    }
+
+    /// Returns the set of [`Policy`]s that were definitely satisfied.
+    /// This will be the set of policies (both `permit` and `forbid`) that evaluated to `true`
+    pub fn definitely_satisfied(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.0.definitely_satisfied().map(Policy::from_ast)
+    }
+
+    /// Returns the set of [`PolicyId`]s that encountered errors
+    pub fn definitely_errored(&self) -> impl Iterator<Item = &PolicyId> {
+        self.0.definitely_errored().map(PolicyId::ref_cast)
+    }
+
+    /// Returns an over-approximation of the set of determining policies
+    ///
+    /// This is all policies that may be determining for any substitution of the unknowns.
+    /// Policies not in this set will not affect the final decision, regardless of any
+    /// substitutions.
+    ///
+    /// For more information on what counts as "determining" see: <https://docs.cedarpolicy.com/auth/authorization.html#request-authorization>
+    pub fn may_be_determining(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.0.may_be_determining().map(Policy::from_ast)
+    }
+
+    /// Returns an under-approximation of the set of determining policies
+    ///
+    /// This is all policies that must be determining for all possible substitutions of the unknowns.
+    /// This set will include policies that evaluated to `true` and are guaranteed to be
+    /// contributing to the final authorization decision.
+    ///
+    /// For more information on what counts as "determining" see: <https://docs.cedarpolicy.com/auth/authorization.html#request-authorization>
+    pub fn must_be_determining(&self) -> impl Iterator<Item = Policy> + '_ {
+        self.0.must_be_determining().map(Policy::from_ast)
+    }
+
+    /// Returns the set of non-trivial (meaning more than just `true` or `false`) residuals expressions
+    pub fn nontrivial_residuals(&'_ self) -> impl Iterator<Item = Policy> + '_ {
+        self.0.nontrivial_residuals().map(Policy::from_ast)
+    }
+
+    /// Returns every policy as a residual expression
+    pub fn all_residuals(&'_ self) -> impl Iterator<Item = Policy> + '_ {
+        self.0.all_residuals().map(Policy::from_ast)
+    }
+
+    /// Return the residual for a given [`PolicyId`], if it exists in the response
+    pub fn get(&self, id: &PolicyId) -> Option<Policy> {
+        self.0.get(&id.0).map(Policy::from_ast)
+    }
+
+    /// Attempt to re-authorize this response given a mapping from unknowns to values
+    pub fn reauthorize(
+        &self,
+        mapping: HashMap<SmolStr, RestrictedExpression>,
+        auth: &Authorizer,
+        r: Request,
+        es: &Entities,
+    ) -> Result<Self, ReAuthorizeError> {
+        let exts = Extensions::all_available();
+        let evaluator = RestrictedEvaluator::new(&exts);
+        let mapping = mapping
+            .into_iter()
+            .map(|(name, expr)| {
+                evaluator
+                    .interpret(BorrowedRestrictedExpr::new_unchecked(expr.0.as_ref()))
+                    .map(|v| (name, v))
+            })
+            .collect::<Result<HashMap<_, _>, EvaluationError>>()?;
+        let r = self.0.reauthorize(&mapping, &auth.0, r.0, &es.0)?;
+        Ok(Self(r))
+    }
 }
 
-/// A residual response obtained from `is_authorized_partial`.
-#[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct ResidualResponse {
-    /// Residual policies
-    residuals: PolicySet,
-    /// Diagnostics
-    diagnostics: Diagnostics,
+#[doc(hidden)]
+impl From<cedar_policy_core::authorizer::PartialResponse> for PartialResponse {
+    fn from(pr: cedar_policy_core::authorizer::PartialResponse) -> Self {
+        Self(pr)
+    }
 }
 
-/// A policy evaluation response obtained from `evaluate_policies_partial`.
-#[doc = include_str!("../experimental_warning.md")]
-#[cfg(feature = "partial-eval")]
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct EvaluationResponse {
-    /// `PolicyId`s of fully evaluated policies with a permit [`Effect`]
-    satisfied_permits: HashSet<PolicyId>,
-    /// `PolicyId`s of fully evaluated policies with a forbid [`Effect`]
-    satisfied_forbids: HashSet<PolicyId>,
-    /// Errors that occurred during policy evaluation.
-    errors: Vec<AuthorizationError>,
-    /// Partially evaluated policies with a permit [`Effect`]
-    permit_residuals: PolicySet,
-    /// Partially evaluated policies with a forbid [`Effect`]
-    forbid_residuals: PolicySet,
+/// Errors that can be encountered when re-evaluating a partial response
+#[derive(Debug, Error)]
+pub enum ReAuthorizeError {
+    /// An evaluation error was encountered
+    #[error("{err}")]
+    Evaluation {
+        /// The evaluation error
+        #[from]
+        err: EvaluationError,
+    },
+    /// A policy id conflict was found
+    #[error("{err}")]
+    PolicySet {
+        /// The conflicting ids
+        #[from]
+        err: cedar_policy_core::ast::PolicySetError,
+    },
 }
 
 /// Diagnostics providing more information on how a `Decision` was reached
@@ -1021,86 +1075,6 @@ impl From<authorizer::Response> for Response {
             decision: a.decision,
             diagnostics: a.diagnostics.into(),
         }
-    }
-}
-
-#[cfg(feature = "partial-eval")]
-impl ResidualResponse {
-    /// Create a new `ResidualResponse`
-    pub fn new(
-        residuals: PolicySet,
-        reason: HashSet<PolicyId>,
-        errors: Vec<AuthorizationError>,
-    ) -> Self {
-        Self {
-            residuals,
-            diagnostics: Diagnostics { reason, errors },
-        }
-    }
-
-    /// Get the residual policies needed to reach an authorization decision.
-    pub fn residuals(&self) -> &PolicySet {
-        &self.residuals
-    }
-
-    /// Get the authorization diagnostics
-    pub fn diagnostics(&self) -> &Diagnostics {
-        &self.diagnostics
-    }
-}
-
-#[cfg(feature = "partial-eval")]
-impl From<authorizer::PartialResponse> for ResidualResponse {
-    fn from(p: authorizer::PartialResponse) -> Self {
-        Self {
-            residuals: PolicySet::from_ast(p.residuals),
-            diagnostics: p.diagnostics.into(),
-        }
-    }
-}
-
-#[cfg(feature = "partial-eval")]
-impl EvaluationResponse {
-    /// Create a new `EvaluationResponse`.
-    pub fn new(
-        satisfied_permits: HashSet<PolicyId>,
-        satisfied_forbids: HashSet<PolicyId>,
-        errors: Vec<AuthorizationError>,
-        permit_residuals: PolicySet,
-        forbid_residuals: PolicySet,
-    ) -> Self {
-        Self {
-            satisfied_permits,
-            satisfied_forbids,
-            errors,
-            permit_residuals,
-            forbid_residuals,
-        }
-    }
-
-    /// Get the `PolicyId`s of fully evaluated policies with a permit [`Effect`].
-    pub fn satisfied_permits(&self) -> impl Iterator<Item = &PolicyId> {
-        self.satisfied_permits.iter()
-    }
-
-    /// Get the `PolicyId`s of fully evaluated policies with a forbid [`Effect`].
-    pub fn satisfied_forbids(&self) -> impl Iterator<Item = &PolicyId> {
-        self.satisfied_forbids.iter()
-    }
-
-    /// Get the redisual policies with a permit [`Effect`].
-    pub fn permit_residuals(&self) -> &PolicySet {
-        &self.permit_residuals
-    }
-
-    /// Get the redisual policies with a permit [`Effect`].
-    pub fn forbid_residuals(&self) -> &PolicySet {
-        &self.forbid_residuals
-    }
-
-    /// Get the evaluation errors.
-    pub fn errors(&self) -> impl Iterator<Item = &AuthorizationError> {
-        self.errors.iter()
     }
 }
 
@@ -2570,24 +2544,7 @@ impl PolicySet {
     pub fn unknown_entities(&self) -> HashSet<EntityUid> {
         let mut entity_uids = HashSet::new();
         for policy in self.policies.values() {
-            let ids: Vec<EntityUid> = policy
-                .ast
-                .condition()
-                .unknowns()
-                .filter_map(
-                    |ast::Unknown {
-                         name,
-                         type_annotation,
-                     }| {
-                        if matches!(type_annotation, Some(ast::Type::Entity { .. })) {
-                            EntityUid::from_str(name.as_str()).ok()
-                        } else {
-                            None
-                        }
-                    },
-                )
-                .collect();
-            entity_uids.extend(ids);
+            entity_uids.extend(policy.unknown_entities());
         }
         entity_uids
     }
@@ -2611,28 +2568,6 @@ impl PolicySet {
             Err(ast::PolicySetUnlinkError::UnlinkingError(_)) => {
                 panic!("Found linked policy in self.policies but not in self.ast")
             }
-        }
-    }
-
-    /// Create a `PolicySet` from its AST representation only. The EST will
-    /// reflect the AST structure. When possible, don't use this method and
-    /// create the ESTs from the policy text or CST instead, as the conversion
-    /// to AST is lossy. ESTs generated by this method will reflect the AST and
-    /// not the original policy syntax.
-    #[cfg_attr(not(feature = "partial-eval"), allow(unused))]
-    fn from_ast(ast: ast::PolicySet) -> Self {
-        let policies = ast
-            .policies()
-            .map(|p| (PolicyId(p.id().clone()), Policy::from_ast(p.clone())))
-            .collect();
-        let templates = ast
-            .templates()
-            .map(|t| (PolicyId(t.id().clone()), Template::from_ast(t.clone())))
-            .collect();
-        Self {
-            ast,
-            policies,
-            templates,
         }
     }
 }
@@ -2821,20 +2756,6 @@ impl Template {
         let json = serde_json::to_value(est)?;
         Ok::<_, PolicyToJsonError>(json)
     }
-
-    /// Create a `Template` from its AST representation only. The EST will
-    /// reflect the AST structure. When possible, don't use this method and
-    /// create the EST from the policy text or CST instead, as the conversion
-    /// to AST is lossy. ESTs generated by this method will reflect the AST and
-    /// not the original policy syntax.
-    #[cfg_attr(not(feature = "partial-eval"), allow(unused))]
-    fn from_ast(ast: ast::Template) -> Self {
-        let text = ast.to_string(); // assume that pretty-printing is faster than `est::Policy::from(ast.clone())`; is that true?
-        Self {
-            ast,
-            lossless: LosslessPolicy::policy_or_template_text(text),
-        }
-    }
 }
 
 impl std::fmt::Display for Template {
@@ -2857,13 +2778,13 @@ impl FromStr for Template {
 pub enum PrincipalConstraint {
     /// Un-constrained
     Any,
-    /// Must be In the given EntityUid
+    /// Must be In the given [`EntityUid`]
     In(EntityUid),
-    /// Must be equal to the given EntityUid
+    /// Must be equal to the given [`EntityUid`]
     Eq(EntityUid),
-    /// Must be the given EntityTypeName
+    /// Must be the given [`EntityTypeName`]
     Is(EntityTypeName),
-    /// Must be the given EntityTypeName, and `in` the EntityUID
+    /// Must be the given [`EntityTypeName`], and `in` the [`EntityUid`]
     IsIn(EntityTypeName, EntityUid),
 }
 
@@ -2872,16 +2793,16 @@ pub enum PrincipalConstraint {
 pub enum TemplatePrincipalConstraint {
     /// Un-constrained
     Any,
-    /// Must be In the given EntityUid.
+    /// Must be In the given [`EntityUid`].
     /// If [`None`], then it is a template slot.
     In(Option<EntityUid>),
-    /// Must be equal to the given EntityUid.
+    /// Must be equal to the given [`EntityUid`].
     /// If [`None`], then it is a template slot.
     Eq(Option<EntityUid>),
-    /// Must be the given EntityTypeName.
+    /// Must be the given [`EntityTypeName`].
     Is(EntityTypeName),
-    /// Must be the given EntityTypeName, and `in` the EntityUID.
-    /// If the EntityUID is [`None`], then it is a template slot.
+    /// Must be the given [`EntityTypeName`], and `in` the [`EntityUid`].
+    /// If the [`EntityUid`] is [`Option::None`], then it is a template slot.
     IsIn(EntityTypeName, Option<EntityUid>),
 }
 
@@ -2900,9 +2821,9 @@ impl TemplatePrincipalConstraint {
 pub enum ActionConstraint {
     /// Un-constrained
     Any,
-    /// Must be In the given EntityUid
+    /// Must be In the given [`EntityUid`]
     In(Vec<EntityUid>),
-    /// Must be equal to the given EntityUid
+    /// Must be equal to the given [`EntityUid]`
     Eq(EntityUid),
 }
 
@@ -2911,13 +2832,13 @@ pub enum ActionConstraint {
 pub enum ResourceConstraint {
     /// Un-constrained
     Any,
-    /// Must be In the given EntityUid
+    /// Must be In the given [`EntityUid`]
     In(EntityUid),
-    /// Must be equal to the given EntityUid
+    /// Must be equal to the given [`EntityUid`]
     Eq(EntityUid),
-    /// Must be the given EntityTypeName
+    /// Must be the given [`EntityTypeName`]
     Is(EntityTypeName),
-    /// Must be the given EntityTypeName, and `in` the EntityUID
+    /// Must be the given [`EntityTypeName`], and `in` the [`EntityUid`]
     IsIn(EntityTypeName, EntityUid),
 }
 
@@ -2926,16 +2847,16 @@ pub enum ResourceConstraint {
 pub enum TemplateResourceConstraint {
     /// Un-constrained
     Any,
-    /// Must be In the given EntityUid.
+    /// Must be In the given [`EntityUid`].
     /// If [`None`], then it is a template slot.
     In(Option<EntityUid>),
-    /// Must be equal to the given EntityUid.
+    /// Must be equal to the given [`EntityUid`].
     /// If [`None`], then it is a template slot.
     Eq(Option<EntityUid>),
-    /// Must be the given EntityTypeName.
+    /// Must be the given [`EntityTypeName`].
     Is(EntityTypeName),
-    /// Must be the given EntityTypeName, and `in` the EntityUID.
-    /// If the EntityUID is [`None`], then it is a template slot.
+    /// Must be the given [`EntityTypeName`], and `in` the [`EntityUid`].
+    /// If the [`EntityUid`] is [`Option::None`], then it is a template slot.
     IsIn(EntityTypeName, Option<EntityUid>),
 }
 
@@ -3278,6 +3199,28 @@ impl Policy {
         let est = self.lossless.est()?;
         let json = serde_json::to_value(est)?;
         Ok::<_, PolicyToJsonError>(json)
+    }
+
+    /// Get all the unknown entities from the policy
+    #[doc = include_str!("../experimental_warning.md")]
+    #[cfg(feature = "partial-eval")]
+    pub fn unknown_entities(&self) -> HashSet<EntityUid> {
+        self.ast
+            .condition()
+            .unknowns()
+            .filter_map(
+                |ast::Unknown {
+                     name,
+                     type_annotation,
+                 }| {
+                    if matches!(type_annotation, Some(ast::Type::Entity { .. })) {
+                        EntityUid::from_str(name.as_str()).ok()
+                    } else {
+                        None
+                    }
+                },
+            )
+            .collect()
     }
 
     /// Create a `Policy` from its AST representation only. The `LosslessPolicy`
@@ -4165,25 +4108,6 @@ pub fn eval_expression(
         // Evaluate under the empty slot map, as an expression should not have slots
         eval.interpret(&expr.0, &ast::SlotEnv::new())?,
     ))
-}
-
-#[cfg(test)]
-#[cfg(feature = "partial-eval")]
-mod partial_eval_test {
-    use std::collections::HashSet;
-
-    use crate::{AuthorizationError, PolicyId, PolicySet, ResidualResponse};
-
-    #[test]
-    fn test_pe_response_constructor() {
-        let p: PolicySet = "permit(principal, action, resource);".parse().unwrap();
-        let reason: HashSet<PolicyId> = std::iter::once("id1".parse().unwrap()).collect();
-        let errors: Vec<AuthorizationError> = std::iter::empty().collect();
-        let a = ResidualResponse::new(p.clone(), reason.clone(), errors.clone());
-        assert_eq!(a.diagnostics().errors, errors);
-        assert_eq!(a.diagnostics().reason, reason);
-        assert_eq!(a.residuals(), &p);
-    }
 }
 
 #[cfg(test)]

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -34,6 +34,8 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use serde_with::MapPreventDuplicates;
 use std::collections::{HashMap, HashSet};
+#[cfg(feature = "partial-eval")]
+use std::convert::Infallible;
 use std::str::FromStr;
 use thiserror::Error;
 
@@ -72,24 +74,24 @@ pub fn json_is_authorized(input: &str) -> InterfaceResult {
     )
 }
 
+/// Basic interface for partial evaluation, using `AuthorizationCall` and
+/// `PartialAuthorizationAnswer` types
+#[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 fn is_authorized_partial(call: AuthorizationCall) -> PartialAuthorizationAnswer {
     match call.get_components_partial() {
         Ok((request, policies, entities)) => AUTHORIZER.with(|authorizer| {
-            match authorizer.is_authorized_partial(&request, &policies, &entities) {
-                concrete_response @ PartialResponse::Concrete(_) => {
-                    match concrete_response.try_into() {
-                        Ok(response) => PartialAuthorizationAnswer::Concrete { response },
-                        Err(errors) => PartialAuthorizationAnswer::ParseFailed { errors },
-                    }
-                }
-                residual_response @ PartialResponse::Residual(_) => {
-                    match residual_response.try_into() {
-                        Ok(response) => PartialAuthorizationAnswer::Residuals { response },
-                        Err(errors) => PartialAuthorizationAnswer::ParseFailed { errors },
-                    }
-                }
-            }
+            let response = authorizer.is_authorized_partial(&request, &policies, &entities);
+            // Allowing this lint warning because the suggestion causes type inference to break
+            #[allow(clippy::map_unwrap_or)]
+            response
+                .try_into()
+                .map(|response| PartialAuthorizationAnswer::Residuals {
+                    response: Box::new(response),
+                })
+                .unwrap_or_else(|e| PartialAuthorizationAnswer::ParseFailed {
+                    errors: vec![e.to_string()],
+                })
         }),
         Err(errors) => PartialAuthorizationAnswer::ParseFailed { errors },
     }
@@ -105,8 +107,9 @@ pub fn json_is_authorized_partial(input: &str) -> InterfaceResult {
     serde_json::from_str::<AuthorizationCall>(input).map_or_else(
         |e| InterfaceResult::fail_internally(format!("error parsing call: {e:}")),
         |call| match is_authorized_partial(call) {
-            answer @ (PartialAuthorizationAnswer::Concrete { .. }
-            | PartialAuthorizationAnswer::Residuals { .. }) => InterfaceResult::succeed(answer),
+            answer @ PartialAuthorizationAnswer::Residuals { .. } => {
+                InterfaceResult::succeed(answer)
+            }
             PartialAuthorizationAnswer::ParseFailed { errors } => {
                 InterfaceResult::fail_bad_request(errors)
             }
@@ -169,21 +172,19 @@ impl From<Response> for InterfaceResponse {
 
 #[cfg(feature = "partial-eval")]
 impl TryFrom<PartialResponse> for InterfaceResponse {
-    type Error = Vec<String>;
+    type Error = Infallible;
 
     fn try_from(partial_response: PartialResponse) -> Result<Self, Self::Error> {
-        match partial_response {
-            PartialResponse::Concrete(concrete) => Ok(Self::new(
-                concrete.decision(),
-                concrete.diagnostics().reason().cloned().collect(),
-                concrete
-                    .diagnostics()
-                    .errors()
-                    .map(ToString::to_string)
-                    .collect(),
-            )),
-            PartialResponse::Residual(_) => Err(vec!["unsupported".into()]),
-        }
+        let concrete = partial_response.concretize();
+        Ok(Self::new(
+            concrete.decision(),
+            concrete.diagnostics().reason().cloned().collect(),
+            concrete
+                .diagnostics()
+                .errors()
+                .map(ToString::to_string)
+                .collect(),
+        ))
     }
 }
 
@@ -202,55 +203,105 @@ impl InterfaceDiagnostics {
 /// Integration version of a `PartialResponse` that uses `InterfaceDiagnistics` for simpler (de)serialization
 #[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InterfaceResidualResponse {
-    /// A residual set of policies. Determining the concrete response requires further processing.
+    decision: Option<Decision>,
+    satisfied: HashSet<PolicyId>,
+    errored: HashSet<PolicyId>,
+    may_be_determining: HashSet<PolicyId>,
+    must_be_determining: HashSet<PolicyId>,
     residuals: HashMap<PolicyId, serde_json::Value>,
-    /// Diagnostics providing more information on how this decision was reached
-    diagnostics: InterfaceDiagnostics,
+    nontrivial_residuals: HashSet<PolicyId>,
 }
 
 #[cfg(feature = "partial-eval")]
 impl InterfaceResidualResponse {
-    /// Construct an `InterfaceResidualResponse`
-    pub fn new(
-        residuals: HashMap<PolicyId, serde_json::Value>,
-        reason: HashSet<PolicyId>,
-        errors: HashSet<String>,
-    ) -> Self {
-        Self {
-            residuals,
-            diagnostics: InterfaceDiagnostics { reason, errors },
-        }
+    /// Tri-state decision
+    pub fn decision(&self) -> Option<Decision> {
+        self.decision
+    }
+
+    /// Set of all satisfied policy Ids
+    pub fn satisfied(&self) -> impl Iterator<Item = &PolicyId> {
+        self.satisfied.iter()
+    }
+
+    /// Set of all policy ids for policies that errored
+    pub fn errored(&self) -> impl Iterator<Item = &PolicyId> {
+        self.errored.iter()
+    }
+
+    /// Over approximation of policies that determine the auth decision
+    pub fn may_be_determining(&self) -> impl Iterator<Item = &PolicyId> {
+        self.may_be_determining.iter()
+    }
+
+    /// Under approximation of policies that determine the auth decision
+    pub fn must_be_determining(&self) -> impl Iterator<Item = &PolicyId> {
+        self.must_be_determining.iter()
+    }
+
+    /// (Borrowed) Iterator over the set of residual policies
+    pub fn residuals(&self) -> impl Iterator<Item = &serde_json::Value> {
+        self.residuals.values()
+    }
+
+    /// (Owned) Iterator over the set of residual policies
+    pub fn into_residuals(self) -> impl Iterator<Item = serde_json::Value> {
+        self.residuals.into_values()
+    }
+
+    /// Get the residual policy for a specified [`PolicyId`] if it exists
+    pub fn residual(&self, p: &PolicyId) -> Option<&serde_json::Value> {
+        self.residuals.get(p)
+    }
+
+    /// (Borrowed) Iterator over the set of non-trivial residual policies
+    pub fn nontrivial_residuals(&self) -> impl Iterator<Item = &serde_json::Value> {
+        self.residuals.iter().filter_map(|(id, policy)| {
+            if self.nontrivial_residuals.contains(id) {
+                Some(policy)
+            } else {
+                None
+            }
+        })
+    }
+
+    ///  Iterator over the set of non-trivial residual policy ids
+    pub fn nontrivial_residual_ids(&self) -> impl Iterator<Item = &PolicyId> {
+        self.nontrivial_residuals.iter()
     }
 }
 
 #[cfg(feature = "partial-eval")]
 impl TryFrom<PartialResponse> for InterfaceResidualResponse {
-    type Error = Vec<String>;
+    type Error = Box<dyn miette::Diagnostic>;
 
     fn try_from(partial_response: PartialResponse) -> Result<Self, Self::Error> {
-        match partial_response {
-            PartialResponse::Residual(residual) => Ok(Self::new(
-                residual
-                    .residuals()
-                    .policies()
-                    .map(|policy| match policy.to_json() {
-                        Ok(json) => Ok((policy.id().clone(), json)),
-                        Err(errors) => Err(vec![errors.to_string()]),
-                    })
-                    .collect::<Result<Vec<(PolicyId, serde_json::Value)>, Self::Error>>()?
-                    .into_iter()
-                    .collect(),
-                residual.diagnostics().reason().cloned().collect(),
-                residual
-                    .diagnostics()
-                    .errors()
-                    .map(ToString::to_string)
-                    .collect(),
-            )),
-            PartialResponse::Concrete(_) => Err(vec!["unsupported".into()]),
-        }
+        Ok(Self {
+            decision: partial_response.decision(),
+            satisfied: partial_response
+                .definitely_satisfied()
+                .map(|p| p.id().clone())
+                .collect(),
+            errored: partial_response.definitely_errored().cloned().collect(),
+            may_be_determining: partial_response
+                .may_be_determining()
+                .map(|p| p.id().clone())
+                .collect(),
+            must_be_determining: partial_response
+                .must_be_determining()
+                .map(|p| p.id().clone())
+                .collect(),
+            nontrivial_residuals: partial_response
+                .nontrivial_residuals()
+                .map(|p| p.id().clone())
+                .collect(),
+            residuals: partial_response
+                .all_residuals()
+                .map(|e| e.to_json().map(|json| (e.id().clone(), json)))
+                .collect::<Result<_, _>>()?,
+        })
     }
 }
 
@@ -265,9 +316,12 @@ enum AuthorizationAnswer {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 enum PartialAuthorizationAnswer {
-    ParseFailed { errors: Vec<String> },
-    Concrete { response: InterfaceResponse },
-    Residuals { response: InterfaceResidualResponse },
+    ParseFailed {
+        errors: Vec<String>,
+    },
+    Residuals {
+        response: Box<InterfaceResidualResponse>,
+    },
 }
 
 #[serde_as]
@@ -1676,7 +1730,7 @@ mod test {
                 "partial_evaluation": true
               }
             "#;
-            assert_is_residual(json_is_authorized_partial(call), HashSet::from(["ID1"]));
+            assert_is_residual(json_is_authorized_partial(call), &HashSet::from(["ID1"]));
         }
 
         #[test]
@@ -1701,7 +1755,7 @@ mod test {
                 "partial_evaluation": true
               }
             "#;
-            assert_is_residual(json_is_authorized_partial(call), HashSet::from(["ID1"]));
+            assert_is_residual(json_is_authorized_partial(call), &HashSet::from(["ID1"]));
         }
 
         #[test]
@@ -1727,17 +1781,19 @@ mod test {
                 "partial_evaluation": true
               }
             "#;
-            assert_is_residual(json_is_authorized_partial(call), HashSet::from(["ID1"]));
+            assert_is_residual(json_is_authorized_partial(call), &HashSet::from(["ID1"]));
         }
 
         #[track_caller] // report the caller's location as the location of the panic, not the location in this function
         fn assert_is_authorized(result: InterfaceResult) {
             assert_matches!(result, InterfaceResult::Success { result } => {
                 let parsed_result: PartialAuthorizationAnswer = serde_json::from_str(result.as_str()).unwrap();
-                assert_matches!(parsed_result, PartialAuthorizationAnswer::Concrete { response } => {
-                    assert_eq!(response.decision(), Decision::Allow);
-                    assert_eq!(response.diagnostics().errors.len(), 0);
-                });
+                assert_matches!(parsed_result,
+                    PartialAuthorizationAnswer::Residuals { response } => {
+                        assert_eq!(response.decision(), Some(Decision::Allow));
+                        assert_eq!(response.errored().count(), 0);
+                    }
+                );
             });
         }
 
@@ -1745,29 +1801,29 @@ mod test {
         fn assert_is_not_authorized(result: InterfaceResult) {
             assert_matches!(result, InterfaceResult::Success { result } => {
                 let parsed_result: PartialAuthorizationAnswer = serde_json::from_str(result.as_str()).unwrap();
-                assert_matches!(parsed_result, PartialAuthorizationAnswer::Concrete { response } => {
-                    assert_eq!(response.decision(), Decision::Deny);
-                    assert_eq!(response.diagnostics().errors.len(), 0);
+                assert_matches!(parsed_result, PartialAuthorizationAnswer::Residuals { response } => {
+                    assert_eq!(response.decision(), Some(Decision::Deny));
+                    assert_eq!(response.errored().count(), 0);
                 });
             });
         }
 
         #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-        fn assert_is_residual(result: InterfaceResult, residual_ids: HashSet<&str>) {
+        fn assert_is_residual(result: InterfaceResult, residual_ids: &HashSet<&str>) {
             assert_matches!(result, InterfaceResult::Success { result } => {
                 let parsed_result: PartialAuthorizationAnswer = serde_json::from_str(result.as_str()).unwrap();
                 assert_matches!(parsed_result, PartialAuthorizationAnswer::Residuals { response } => {
-                    let num_errors = response.diagnostics.errors().count();
+                    let num_errors = response.errored().count();
                     assert_eq!(num_errors, 0, "got {num_errors} errors");
-                    let residuals = response.residuals;
-                    for id in &residual_ids {
-                        assert!(residuals.contains_key(&PolicyId::from_str(id).ok().unwrap()), "expected residual for {id}, but it's missing")
+                    let residuals = response.nontrivial_residual_ids().collect::<HashSet<_>>();
+                    for id in residual_ids {
+                        assert!(residuals.contains(&PolicyId::from_str(id).ok().unwrap()), "expected residual for {id}, but it's missing");
                     }
-                    for key in residuals.keys() {
-                        assert!(residual_ids.contains(key.to_string().as_str()),"found unexpected residual for {key}")
+                    for key in residuals {
+                        assert!(residual_ids.contains(key.to_string().as_str()),"found unexpected residual for {key}");
                     }
-                })
-            })
+                });
+            });
         }
     }
 }


### PR DESCRIPTION
Contains the followings commits:
* 5364814ad28c70bd46e14c86369e62ab5c0da9b5
* dbf1d2a71fddd6153f4181f737c3ebcedeb3e69e
* a9dce680639d3e8c4a25edcae165a1f05b94419a

## Description of changes
Brings in the new PE apis
## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

