### PR TITLE
Align `ContextJsonError` with cedar#745

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3373,11 +3373,8 @@ impl Context {
         schema: &Schema,
         action: &EntityUid,
     ) -> Result<impl ContextSchema, ContextJsonError> {
-        cedar_policy_validator::context_schema_for_action(&schema.0, action.as_ref()).ok_or_else(
-            || ContextJsonError::MissingAction {
-                action: action.clone(),
-            },
-        )
+        cedar_policy_validator::context_schema_for_action(&schema.0, action.as_ref())
+            .ok_or_else(|| ContextJsonError::missing_action(action.clone()))
     }
 }
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -22,7 +22,6 @@ use crate::PolicyId;
 use cedar_policy_core::ast;
 use cedar_policy_core::ast::Name;
 use cedar_policy_core::authorizer;
-use cedar_policy_core::entities::json::ContextJsonDeserializationError;
 use cedar_policy_core::est;
 pub use cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind};
 use cedar_policy_core::parser;
@@ -579,11 +578,53 @@ pub enum ContextJsonError {
     /// Error deserializing the JSON into a Context
     #[error(transparent)]
     #[diagnostic(transparent)]
-    JsonDeserialization(#[from] ContextJsonDeserializationError),
+    JsonDeserialization(#[from] context_json_errors::ContextJsonDeserializationError),
     /// The supplied action doesn't exist in the supplied schema
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    MissingAction(#[from] context_json_errors::MissingActionError),
+}
+
+impl ContextJsonError {
+    /// Construct a `ContextJsonError::MissingAction`
+    pub(crate) fn missing_action(action: EntityUid) -> Self {
+        Self::MissingAction(context_json_errors::MissingActionError { action })
+    }
+}
+
+impl From<cedar_policy_core::entities::json::ContextJsonDeserializationError> for ContextJsonError {
+    fn from(error: cedar_policy_core::entities::json::ContextJsonDeserializationError) -> Self {
+        context_json_errors::ContextJsonDeserializationError::from(error).into()
+    }
+}
+
+/// Error subtypes for `ContextJsonError`
+pub mod context_json_errors {
+    use super::EntityUid;
+    use miette::Diagnostic;
+    use thiserror::Error;
+
+    /// Error deserializing the JSON into a Context
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    pub struct ContextJsonDeserializationError {
+        #[diagnostic(transparent)]
+        #[from]
+        error: cedar_policy_core::entities::json::ContextJsonDeserializationError,
+    }
+
+    /// The supplied action doesn't exist in the supplied schema
+    #[derive(Debug, Diagnostic, Error)]
     #[error("action `{action}` does not exist in the supplied schema")]
-    MissingAction {
+    pub struct MissingActionError {
         /// UID of the action which doesn't exist
-        action: EntityUid,
-    },
+        pub(super) action: EntityUid,
+    }
+
+    impl MissingActionError {
+        /// Get the [`EntityUid`] of the action which doesn't exist
+        pub fn action(&self) -> &EntityUid {
+            &self.action
+        }
+    }
 }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -592,13 +592,14 @@ impl ContextJsonError {
     }
 }
 
+#[doc(hidden)]
 impl From<cedar_policy_core::entities::json::ContextJsonDeserializationError> for ContextJsonError {
     fn from(error: cedar_policy_core::entities::json::ContextJsonDeserializationError) -> Self {
         context_json_errors::ContextJsonDeserializationError::from(error).into()
     }
 }
 
-/// Error subtypes for `ContextJsonError`
+/// Error subtypes for [`ContextJsonError`]
 pub mod context_json_errors {
     use super::EntityUid;
     use miette::Diagnostic;


### PR DESCRIPTION
## Description of changes

Implement the suggestions in #745 as applied to `ContextJsonError`

## Issue #, if available

#745 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

