### PR TITLE
Align EntityAttrEvaluationError with cedar#745

### DIFF
--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -229,12 +229,29 @@ impl From<cedar_policy_validator::SchemaError> for HumanSchemaError {
 #[error("in attribute `{attr}` of `{uid}`: {err}")]
 pub struct EntityAttrEvaluationError {
     /// Action that had the attribute with the error
-    pub uid: EntityUid,
+    uid: EntityUid,
     /// Attribute that had the error
-    pub attr: SmolStr,
+    attr: SmolStr,
     /// Underlying evaluation error
     #[diagnostic(transparent)]
-    pub err: EvaluationError,
+    err: EvaluationError,
+}
+
+impl EntityAttrEvaluationError {
+    /// Get the [`EntityUid`] of the action that had the attribute with the error
+    pub fn action(&self) -> &EntityUid {
+        &self.uid
+    }
+
+    /// Get the name of the attribute that had the error
+    pub fn attr(&self) -> &SmolStr {
+        &self.attr
+    }
+
+    /// Get the underlying evaluation error
+    pub fn inner(&self) -> &EvaluationError {
+        &self.err
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
## Description of changes

Implement the suggestions in #745 as applied to `EntityAttrEvaluationError`

This type is used both as the opaque struct in the variant of a larger error (`SchemaError`) and on its own as an error type (for `Entity::new()`).  The guidelines in #745 are ambiguous whether all errors used as standalone error types need to be enums.  I made a judgment call to not make this one a one-variant enum, at least in this case.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

