### PR TITLE
bring the `ffi` module to 3.2.x

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code'
+      RUSTFLAGS: '-D warnings -F unsafe-code -W deprecated'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -14,7 +14,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code -W deprecated'
+      RUSTFLAGS: '-D warnings -F unsafe-code --force-warn deprecated'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,7 +22,7 @@ jobs:
       - run: ./panic_safety.sh
       - run: cargo doc --all-features --no-deps
 
-      # All targets are run with the same `RUSTFLAGS
+      # All targets are run with the same `RUSTFLAGS`
       - run: cargo build --verbose
       - run: cargo test --verbose
       - run: cargo bench --no-run --profile=dev
@@ -37,7 +37,7 @@ jobs:
       cedar_policy_ref: ${{ github.ref }}
 
   # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
-  # don't effect it. As a side effect, this will run in parallel, saving some
+  # don't affect it. As a side effect, this will run in parallel, saving some
   # time.
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -24,7 +24,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code -W deprecated'
+      RUSTFLAGS: '-D warnings -F unsafe-code --force-warn deprecated'
 
     steps:
       - name: Checkout cedar

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -24,7 +24,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code'
+      RUSTFLAGS: '-D warnings -F unsafe-code -W deprecated'
 
     steps:
       - name: Checkout cedar
@@ -53,4 +53,3 @@ jobs:
       - name: Run corpus tests
         working-directory: ./cedar
         run: cargo test --verbose --features "integration-testing" -- --ignored
-      

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - upcoming
+
+### Added
+
+- New `ffi` module with an improved FFI interface. This will replace the
+  `frontend` module in the 4.0 release, but is available now for early adopters;
+  the `frontend` module is now deprecated.
+
 ## [3.1.3] - 2024-04-15
 
 ### Changed
@@ -423,7 +431,8 @@ Cedar Language Version: 2.0.0
 Cedar Language Version: 2.0.0
 - Initial release of `cedar-policy`.
 
-[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.1.3...main
+[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.2.0...main
+[3.2.0]: https://github.com/cedar-policy/cedar/compare/v3.1.3...v3.2.0
 [3.1.3]: https://github.com/cedar-policy/cedar/compare/v3.1.2...v3.1.3
 [3.1.2]: https://github.com/cedar-policy/cedar/compare/v3.1.1...v3.1.2
 [3.1.1]: https://github.com/cedar-policy/cedar/compare/v3.1.0...v3.1.1

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -844,9 +844,9 @@ impl From<authorizer::AuthorizationError> for AuthorizationError {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Response {
     /// Authorization decision
-    decision: Decision,
+    pub(crate) decision: Decision,
     /// Diagnostics providing more information on how this decision was reached
-    diagnostics: Diagnostics,
+    pub(crate) diagnostics: Diagnostics,
 }
 
 /// A partially evaluated authorization response.
@@ -1108,6 +1108,16 @@ impl Diagnostics {
     /// ```
     pub fn errors(&self) -> impl Iterator<Item = &AuthorizationError> + '_ {
         self.errors.iter()
+    }
+
+    /// Consume the `Diagnostics`, producing owned versions of `reason()` and `errors()`
+    pub(crate) fn into_components(
+        self,
+    ) -> (
+        impl Iterator<Item = PolicyId>,
+        impl Iterator<Item = AuthorizationError>,
+    ) {
+        (self.reason.into_iter(), self.errors.into_iter())
     }
 }
 
@@ -1710,6 +1720,18 @@ impl<'a> ValidationResult<'a> {
                     .first()
                     .map(|w| w as &dyn Diagnostic)
             })
+    }
+
+    pub(crate) fn into_errors_and_warnings(
+        self,
+    ) -> (
+        impl Iterator<Item = ValidationError<'static>>,
+        impl Iterator<Item = ValidationWarning<'static>>,
+    ) {
+        (
+            self.validation_errors.into_iter(),
+            self.validation_warnings.into_iter(),
+        )
     }
 }
 

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -1,0 +1,2039 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module contains the `is_authorized` entry points that other language
+//! FFIs can call
+#![allow(clippy::module_name_repetitions)]
+use super::utils::{DetailedError, PolicySet, Schema, WithWarnings};
+use crate::{
+    Authorizer, Context, Decision, Entities, EntityId, EntityTypeName, EntityUid, PolicyId,
+    Request, SlotId,
+};
+use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
+use itertools::Itertools;
+use miette::{miette, Diagnostic, WrapErr};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, MapPreventDuplicates};
+use smol_str::{SmolStr, ToSmolStr};
+use std::collections::{HashMap, HashSet};
+#[cfg(feature = "partial-eval")]
+use std::convert::Infallible;
+use std::str::FromStr;
+use thiserror::Error;
+
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
+thread_local!(
+    /// Per-thread authorizer instance, initialized on first use
+    static AUTHORIZER: Authorizer = Authorizer::new();
+);
+
+/// Basic interface, using [`AuthorizationCall`] and [`AuthorizationAnswer`] types
+pub fn is_authorized(call: AuthorizationCall) -> AuthorizationAnswer {
+    match call.get_components() {
+        WithWarnings {
+            t: Ok((request, policies, entities)),
+            warnings,
+        } => AuthorizationAnswer::Success {
+            response: AUTHORIZER.with(|authorizer| {
+                authorizer
+                    .is_authorized(&request, &policies, &entities)
+                    .into()
+            }),
+            warnings: warnings.into_iter().map(Into::into).collect(),
+        },
+        WithWarnings {
+            t: Err(errors),
+            warnings,
+        } => AuthorizationAnswer::Failure {
+            errors: errors.into_iter().map(Into::into).collect(),
+            warnings: warnings.into_iter().map(Into::into).collect(),
+        },
+    }
+}
+
+/// Input is a JSON encoding of [`AuthorizationCall`] and output is a JSON
+/// encoding of [`AuthorizationAnswer`]
+pub fn is_authorized_json(json: serde_json::Value) -> Result<serde_json::Value, serde_json::Error> {
+    let ans = is_authorized(serde_json::from_value(json)?);
+    serde_json::to_value(ans)
+}
+
+/// Input and output are strings containing serialized JSON, in the shapes
+/// expected by [`is_authorized_json()`]
+pub fn is_authorized_json_str(json: &str) -> Result<String, serde_json::Error> {
+    let ans = is_authorized(serde_json::from_str(json)?);
+    serde_json::to_string(&ans)
+}
+
+/// Basic interface for partial evaluation, using `AuthorizationCall` and
+/// `PartialAuthorizationAnswer` types
+#[doc = include_str!("../../experimental_warning.md")]
+#[cfg(feature = "partial-eval")]
+pub fn is_authorized_partial(call: AuthorizationCall) -> PartialAuthorizationAnswer {
+    match call.get_components_partial() {
+        WithWarnings {
+            t: Ok((request, policies, entities)),
+            warnings,
+        } => {
+            let response = AUTHORIZER.with(|authorizer| {
+                authorizer.is_authorized_partial(&request, &policies, &entities)
+            });
+            let warnings = warnings.into_iter().map(Into::into).collect();
+            match ResidualResponse::try_from(response) {
+                Ok(response) => PartialAuthorizationAnswer::Residuals {
+                    response: Box::new(response),
+                    warnings,
+                },
+                Err(e) => PartialAuthorizationAnswer::Failure {
+                    errors: vec![miette::Report::new_boxed(e).into()],
+                    warnings,
+                },
+            }
+        }
+        WithWarnings {
+            t: Err(errors),
+            warnings,
+        } => PartialAuthorizationAnswer::Failure {
+            errors: errors.into_iter().map(Into::into).collect(),
+            warnings: warnings.into_iter().map(Into::into).collect(),
+        },
+    }
+}
+
+/// Input is a JSON encoding of [`AuthorizationCall`] and output is a JSON
+/// encoding of [`PartialAuthorizationAnswer`]
+#[doc = include_str!("../../experimental_warning.md")]
+#[cfg(feature = "partial-eval")]
+pub fn is_authorized_partial_json(
+    json: serde_json::Value,
+) -> Result<serde_json::Value, serde_json::Error> {
+    let ans = is_authorized_partial(serde_json::from_value(json)?);
+    serde_json::to_value(ans)
+}
+
+/// Input and output are strings containing serialized JSON, in the shapes
+/// expected by [`is_authorized_partial_json()`]
+#[doc = include_str!("../../experimental_warning.md")]
+#[cfg(feature = "partial-eval")]
+pub fn is_authorized_partial_json_str(json: &str) -> Result<String, serde_json::Error> {
+    let ans = is_authorized_partial(serde_json::from_str(json)?);
+    serde_json::to_string(&ans)
+}
+
+/// Interface version of a `Response` that uses the interface version of `Diagnostics`
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct Response {
+    /// Authorization decision
+    decision: Decision,
+    /// Diagnostics providing more information on how this decision was reached
+    diagnostics: Diagnostics,
+}
+
+/// Interface version of `Diagnostics` that stores error messages and warnings
+/// in the `DetailedError` format
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct Diagnostics {
+    /// `PolicyId`s of the policies that contributed to the decision.
+    /// If no policies applied to the request, this set will be empty.
+    #[cfg_attr(feature = "wasm", tsify(type = "Set<String>"))]
+    reason: HashSet<PolicyId>,
+    /// Set of errors that occurred
+    errors: HashSet<AuthorizationError>,
+}
+
+impl Response {
+    /// Construct a `Response`
+    pub fn new(
+        decision: Decision,
+        reason: HashSet<PolicyId>,
+        errors: HashSet<AuthorizationError>,
+    ) -> Self {
+        Self {
+            decision,
+            diagnostics: Diagnostics { reason, errors },
+        }
+    }
+
+    /// Get the authorization decision
+    pub fn decision(&self) -> Decision {
+        self.decision
+    }
+
+    /// Get the authorization diagnostics
+    pub fn diagnostics(&self) -> &Diagnostics {
+        &self.diagnostics
+    }
+}
+
+impl From<crate::Response> for Response {
+    fn from(response: crate::Response) -> Self {
+        let (reason, errors) = response.diagnostics.into_components();
+        Self::new(
+            response.decision,
+            reason.collect(),
+            errors.map(Into::into).collect(),
+        )
+    }
+}
+
+#[cfg(feature = "partial-eval")]
+impl TryFrom<crate::PartialResponse> for Response {
+    type Error = Infallible;
+
+    fn try_from(partial_response: crate::PartialResponse) -> Result<Self, Self::Error> {
+        Ok(partial_response.concretize().into())
+    }
+}
+
+impl Diagnostics {
+    /// Get the policies that contributed to the decision
+    pub fn reason(&self) -> impl Iterator<Item = &PolicyId> {
+        self.reason.iter()
+    }
+
+    /// Get the errors
+    pub fn errors(&self) -> impl Iterator<Item = &AuthorizationError> + '_ {
+        self.errors.iter()
+    }
+}
+
+/// Error (or warning) which occurred in a particular policy during authorization
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationError {
+    /// Id of the policy where the error (or warning) occurred
+    pub policy_id: SmolStr,
+    /// Error (or warning).
+    /// You can look at the `severity` field to see whether it is actually an
+    /// error or a warning.
+    pub error: DetailedError,
+}
+
+impl AuthorizationError {
+    /// Create an `AuthorizationError` from a policy ID and any `miette` error
+    pub fn new(
+        policy_id: impl Into<SmolStr>,
+        error: impl miette::Diagnostic + Send + Sync + 'static,
+    ) -> Self {
+        Self::new_from_report(policy_id, miette::Report::new(error))
+    }
+
+    /// Create an `AuthorizationError` from a policy ID and a `miette::Report`
+    pub fn new_from_report(policy_id: impl Into<SmolStr>, report: miette::Report) -> Self {
+        Self {
+            policy_id: policy_id.into(),
+            error: report.into(),
+        }
+    }
+}
+
+impl From<crate::AuthorizationError> for AuthorizationError {
+    fn from(e: crate::AuthorizationError) -> Self {
+        match e {
+            crate::AuthorizationError::PolicyEvaluationError { id, error } => {
+                Self::new(id.to_smolstr(), error)
+            }
+        }
+    }
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_core::authorizer::AuthorizationError> for AuthorizationError {
+    fn from(e: cedar_policy_core::authorizer::AuthorizationError) -> Self {
+        crate::AuthorizationError::from(e).into()
+    }
+}
+
+/// FFI version of a [`crate::PartialResponse`]
+#[doc = include_str!("../../experimental_warning.md")]
+#[cfg(feature = "partial-eval")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct ResidualResponse {
+    decision: Option<Decision>,
+    satisfied: HashSet<PolicyId>,
+    errored: HashSet<PolicyId>,
+    may_be_determining: HashSet<PolicyId>,
+    must_be_determining: HashSet<PolicyId>,
+    residuals: HashMap<PolicyId, serde_json::Value>,
+    nontrivial_residuals: HashSet<PolicyId>,
+}
+
+#[cfg(feature = "partial-eval")]
+impl ResidualResponse {
+    /// Tri-state decision
+    pub fn decision(&self) -> Option<Decision> {
+        self.decision
+    }
+
+    /// Set of all satisfied policy Ids
+    pub fn satisfied(&self) -> impl Iterator<Item = &PolicyId> {
+        self.satisfied.iter()
+    }
+
+    /// Set of all policy ids for policies that errored
+    pub fn errored(&self) -> impl Iterator<Item = &PolicyId> {
+        self.errored.iter()
+    }
+
+    /// Over approximation of policies that determine the auth decision
+    pub fn may_be_determining(&self) -> impl Iterator<Item = &PolicyId> {
+        self.may_be_determining.iter()
+    }
+
+    /// Under approximation of policies that determine the auth decision
+    pub fn must_be_determining(&self) -> impl Iterator<Item = &PolicyId> {
+        self.must_be_determining.iter()
+    }
+
+    /// (Borrowed) Iterator over the set of residual policies
+    pub fn residuals(&self) -> impl Iterator<Item = &serde_json::Value> {
+        self.residuals.values()
+    }
+
+    /// (Owned) Iterator over the set of residual policies
+    pub fn into_residuals(self) -> impl Iterator<Item = serde_json::Value> {
+        self.residuals.into_values()
+    }
+
+    /// Get the residual policy for a specified [`PolicyId`] if it exists
+    pub fn residual(&self, p: &PolicyId) -> Option<&serde_json::Value> {
+        self.residuals.get(p)
+    }
+
+    /// (Borrowed) Iterator over the set of non-trivial residual policies
+    pub fn nontrivial_residuals(&self) -> impl Iterator<Item = &serde_json::Value> {
+        self.residuals.iter().filter_map(|(id, policy)| {
+            if self.nontrivial_residuals.contains(id) {
+                Some(policy)
+            } else {
+                None
+            }
+        })
+    }
+
+    ///  Iterator over the set of non-trivial residual policy ids
+    pub fn nontrivial_residual_ids(&self) -> impl Iterator<Item = &PolicyId> {
+        self.nontrivial_residuals.iter()
+    }
+}
+
+#[cfg(feature = "partial-eval")]
+impl TryFrom<crate::PartialResponse> for ResidualResponse {
+    type Error = Box<dyn miette::Diagnostic + Send + Sync + 'static>;
+
+    fn try_from(partial_response: crate::PartialResponse) -> Result<Self, Self::Error> {
+        Ok(Self {
+            decision: partial_response.decision(),
+            satisfied: partial_response
+                .definitely_satisfied()
+                .map(|p| p.id().clone())
+                .collect(),
+            errored: partial_response.definitely_errored().cloned().collect(),
+            may_be_determining: partial_response
+                .may_be_determining()
+                .map(|p| p.id().clone())
+                .collect(),
+            must_be_determining: partial_response
+                .must_be_determining()
+                .map(|p| p.id().clone())
+                .collect(),
+            nontrivial_residuals: partial_response
+                .nontrivial_residuals()
+                .map(|p| p.id().clone())
+                .collect(),
+            residuals: partial_response
+                .all_residuals()
+                .map(|e| e.to_json().map(|json| (e.id().clone(), json)))
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+/// Answer struct from authorization call
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum AuthorizationAnswer {
+    /// Represents a failure to parse or call the authorizer entirely
+    #[serde(rename_all = "camelCase")]
+    Failure {
+        /// Errors encountered
+        errors: Vec<DetailedError>,
+        /// Warnings encountered
+        warnings: Vec<DetailedError>,
+    },
+    /// Represents a successful authorization call (although individual policy
+    /// evaluation may still have errors)
+    #[serde(rename_all = "camelCase")]
+    Success {
+        /// Authorization decision and diagnostics, which may include policy
+        /// evaluation errors
+        response: Response,
+        /// Warnings encountered. These are all warnings not generated by
+        /// authorization itself -- e.g. general warnings about your schema,
+        /// entity data, etc. Warnings generated by authorization are part of
+        /// `response`.
+        warnings: Vec<DetailedError>,
+    },
+}
+
+/// Answer struct from partial-authorization call
+#[cfg(feature = "partial-eval")]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum PartialAuthorizationAnswer {
+    /// Represents a failure to parse or call the authorizer entirely
+    #[serde(rename_all = "camelCase")]
+    Failure {
+        /// Errors encountered
+        errors: Vec<DetailedError>,
+        /// Warnings encountered
+        warnings: Vec<DetailedError>,
+    },
+    /// Represents a successful authorization call with either a partial or
+    /// concrete answer.  Individual policy evaluation may still have errors.
+    #[serde(rename_all = "camelCase")]
+    Residuals {
+        /// Information about the authorization decision and residuals
+        response: Box<ResidualResponse>,
+        /// Warnings encountered. These are all warnings not generated by
+        /// authorization itself -- e.g. general warnings about your schema,
+        /// entity data, etc. Warnings generated by authorization are part of
+        /// `response`.
+        warnings: Vec<DetailedError>,
+    },
+}
+
+/// Struct containing the input data for authorization
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorizationCall {
+    /// The principal taking action
+    #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
+    principal: Option<JsonValueWithNoDuplicateKeys>,
+    /// The action the principal is taking
+    #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
+    action: JsonValueWithNoDuplicateKeys,
+    /// The resource being acted on by the principal
+    #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
+    resource: Option<JsonValueWithNoDuplicateKeys>,
+    /// The context details specific to the request
+    #[serde_as(as = "MapPreventDuplicates<_, _>")]
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson>"))]
+    /// The context details specific to the request
+    context: HashMap<String, JsonValueWithNoDuplicateKeys>,
+    /// Optional schema.
+    /// If present, this will inform the parsing: for instance, it will allow
+    /// `__entity` and `__extn` escapes to be implicit, and it will error if
+    /// attributes have the wrong types (e.g., string instead of integer).
+    #[cfg_attr(feature = "wasm", tsify(optional, type = "Schema"))]
+    schema: Option<Schema>,
+    /// If this is `true` and a schema is provided, perform request validation.
+    /// If this is `false`, the schema will only be used for schema-based
+    /// parsing of `context`, and not for request validation.
+    /// If a schema is not provided, this option has no effect.
+    #[serde(default = "constant_true")]
+    enable_request_validation: bool,
+    /// The slice containing entities and policies
+    slice: RecvdSlice,
+}
+
+fn constant_true() -> bool {
+    true
+}
+
+/// Parses the given JSON into an [`EntityUid`], or if it fails, adds an
+/// appropriate error to `errs` and returns `None`.
+fn parse_entity_uid(
+    entity_uid_json: JsonValueWithNoDuplicateKeys,
+    category: &str,
+    errs: &mut Vec<miette::Report>,
+) -> Option<EntityUid> {
+    match EntityUid::from_json(entity_uid_json.into())
+        .wrap_err_with(|| format!("Failed to parse {category}"))
+    {
+        Ok(euid) => Some(euid),
+        Err(e) => {
+            errs.push(e);
+            None
+        }
+    }
+}
+
+/// Parses the given JSON context into a [`Context`], or if it fails, adds
+/// appropriate error(s) to `errs` and returns an empty context.
+fn parse_context(
+    context_map: HashMap<String, JsonValueWithNoDuplicateKeys>,
+    schema_ref: Option<&crate::Schema>,
+    action_ref: Option<&EntityUid>,
+    errs: &mut Vec<miette::Report>,
+) -> Context {
+    match serde_json::to_value(context_map) {
+        Ok(json) => {
+            match Context::from_json_value(
+                json,
+                match (schema_ref, action_ref) {
+                    (Some(s), Some(a)) => Some((s, a)),
+                    _ => None,
+                },
+            ) {
+                Ok(context) => context,
+                Err(e) => {
+                    errs.push(miette::Report::new(e));
+                    Context::empty()
+                }
+            }
+        }
+        Err(e) => {
+            errs.push(miette!("Failed to parse context: {e}"));
+            Context::empty()
+        }
+    }
+}
+
+impl AuthorizationCall {
+    fn get_components(
+        self,
+    ) -> WithWarnings<Result<(Request, crate::PolicySet, Entities), Vec<miette::Report>>> {
+        let mut errs = vec![];
+        let mut warnings = vec![];
+        let schema = match self.schema.map(Schema::parse).transpose() {
+            Ok(None) => None,
+            Ok(Some((schema, new_warnings))) => {
+                warnings.extend(new_warnings.map(miette::Report::new));
+                Some(schema)
+            }
+            Err(e) => {
+                errs.push(e);
+                None
+            }
+        };
+        let principal = self
+            .principal
+            .and_then(|p| parse_entity_uid(p, "principal", &mut errs));
+        let action = parse_entity_uid(self.action, "action", &mut errs);
+        let resource = self
+            .resource
+            .and_then(|r| parse_entity_uid(r, "resource", &mut errs));
+        let context = parse_context(self.context, schema.as_ref(), action.as_ref(), &mut errs);
+
+        let request = match Request::new(
+            principal,
+            action,
+            resource,
+            context,
+            if self.enable_request_validation {
+                schema.as_ref()
+            } else {
+                None
+            },
+        ) {
+            Ok(req) => Some(req),
+            Err(e) => {
+                errs.push(miette::Report::new(e));
+                None
+            }
+        };
+        let (policies, entities) = match self.slice.try_into(schema.as_ref()) {
+            Ok((policies, entities)) => (Some(policies), Some(entities)),
+            Err(es) => {
+                errs.extend(es);
+                (None, None)
+            }
+        };
+
+        match (errs.is_empty(), request, policies, entities) {
+            (true, Some(req), Some(policies), Some(entities)) => WithWarnings {
+                t: Ok((req, policies, entities)),
+                warnings,
+            },
+            _ => WithWarnings {
+                t: Err(errs),
+                warnings,
+            },
+        }
+    }
+
+    #[cfg(feature = "partial-eval")]
+    fn get_components_partial(
+        self,
+    ) -> WithWarnings<Result<(Request, crate::PolicySet, Entities), Vec<miette::Report>>> {
+        let mut errs = vec![];
+        let mut warnings = vec![];
+        let schema = match self.schema.map(Schema::parse).transpose() {
+            Ok(None) => None,
+            Ok(Some((schema, new_warnings))) => {
+                warnings.extend(new_warnings.map(miette::Report::new));
+                Some(schema)
+            }
+            Err(e) => {
+                errs.push(e);
+                None
+            }
+        };
+        let principal = self
+            .principal
+            .and_then(|p| parse_entity_uid(p, "principal", &mut errs));
+        let action = parse_entity_uid(self.action, "action", &mut errs);
+        let resource = self
+            .resource
+            .and_then(|r| parse_entity_uid(r, "resource", &mut errs));
+        let context = parse_context(self.context, schema.as_ref(), action.as_ref(), &mut errs);
+
+        let mut b = Request::builder();
+        if principal.is_some() {
+            b = b.principal(principal);
+        }
+        if action.is_some() {
+            b = b.action(action);
+        }
+        if resource.is_some() {
+            b = b.resource(resource);
+        }
+        b = b.context(context);
+        let request = if self.enable_request_validation {
+            match schema.as_ref() {
+                Some(schema_ref) => match b.schema(schema_ref).build() {
+                    Ok(req) => Some(req),
+                    Err(e) => {
+                        errs.push(miette::Report::new(e));
+                        None
+                    }
+                },
+                None => Some(b.build()),
+            }
+        } else {
+            Some(b.build())
+        };
+        let (policies, entities) = match self.slice.try_into(schema.as_ref()) {
+            Ok((policies, entities)) => (Some(policies), Some(entities)),
+            Err(e) => {
+                errs.extend(e);
+                (None, None)
+            }
+        };
+
+        match (errs.is_empty(), request, policies, entities) {
+            (true, Some(req), Some(policies), Some(entities)) => WithWarnings {
+                t: Ok((req, policies, entities.partial())),
+                warnings,
+            },
+            _ => WithWarnings {
+                t: Err(errs),
+                warnings,
+            },
+        }
+    }
+}
+
+///
+/// Entity UID as strings.
+///
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+struct EntityUIDStrings {
+    ty: String,
+    eid: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+struct Link {
+    slot: String,
+    value: EntityUIDStrings,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+struct TemplateLink {
+    /// Template ID to fill in
+    template_id: String,
+
+    /// Policy ID for resulting linked policy
+    result_policy_id: String,
+
+    /// Links for all slots in policy template `template_id`
+    instantiations: Links,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(try_from = "Vec<Link>")]
+#[serde(into = "Vec<Link>")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+struct Links(Vec<Link>);
+
+/// Error returned for duplicate slot ids
+#[derive(Debug, Clone, Diagnostic, Error)]
+pub enum DuplicateLinkError {
+    /// Duplicate values for the same slot
+    #[error("duplicate values for the slot(s): {}", .0.iter().map(|s| format!("`{s}`")).join(", "))]
+    Duplicates(Vec<String>),
+}
+
+impl TryFrom<Vec<Link>> for Links {
+    type Error = DuplicateLinkError;
+
+    fn try_from(links: Vec<Link>) -> Result<Self, Self::Error> {
+        let mut slots = links.iter().map(|link| &link.slot).collect::<Vec<_>>();
+        slots.sort();
+        let duplicates = slots
+            .into_iter()
+            .dedup_with_count()
+            .filter_map(|(count, slot)| if count == 1 { None } else { Some(slot) })
+            .cloned()
+            .collect::<Vec<_>>();
+        if duplicates.is_empty() {
+            Ok(Self(links))
+        } else {
+            Err(DuplicateLinkError::Duplicates(duplicates))
+        }
+    }
+}
+
+impl From<Links> for Vec<Link> {
+    fn from(value: Links) -> Self {
+        value.0
+    }
+}
+
+/// policies must either be a single policy per entry, or only one entry with more than one policy
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+struct RecvdSlice {
+    policies: PolicySet,
+    /// JSON object containing the entities data, in "natural JSON" form -- same
+    /// format as expected by EntityJsonParser
+    #[cfg_attr(feature = "wasm", tsify(type = "Array<EntityJson>"))]
+    entities: JsonValueWithNoDuplicateKeys,
+
+    /// Optional template policies.
+    #[serde_as(as = "Option<MapPreventDuplicates<_, _>>")]
+    templates: Option<HashMap<String, String>>,
+
+    /// Optional template links
+    template_instantiations: Option<Vec<TemplateLink>>,
+}
+
+fn parse_link(v: &Link) -> Result<(SlotId, EntityUid), miette::Report> {
+    let slot = match v.slot.as_str() {
+        "?principal" => SlotId::principal(),
+        "?resource" => SlotId::resource(),
+        _ => {
+            return Err(miette!("Slot must be ?principal or ?resource"));
+        }
+    };
+    let type_name = EntityTypeName::from_str(v.value.ty.as_str()).map_err(miette::Report::new)?;
+    let eid = match EntityId::from_str(v.value.eid.as_str()) {
+        Ok(eid) => eid,
+        Err(err) => match err {},
+    };
+    let entity_uid = EntityUid::from_type_name_and_id(type_name, eid);
+    Ok((slot, entity_uid))
+}
+
+fn parse_links(policies: &mut crate::PolicySet, link: TemplateLink) -> Result<(), miette::Report> {
+    let template_id = PolicyId::from_str(link.template_id.as_str());
+    let link_id = PolicyId::from_str(link.result_policy_id.as_str());
+    match (template_id, link_id) {
+        (Err(e), _) | (_, Err(e)) => return Err(miette::Report::new(e)),
+        (Ok(template_id), Ok(link_id)) => {
+            let mut vals = HashMap::new();
+            for i in link.instantiations.0 {
+                let (slot, euid) = parse_link(&i)?;
+                vals.insert(slot, euid);
+            }
+            policies
+                .link(template_id, link_id, vals)
+                .map_err(miette::Report::new)
+        }
+    }
+}
+
+impl RecvdSlice {
+    #[allow(clippy::too_many_lines)]
+    fn try_into(
+        self,
+        schema: Option<&crate::Schema>,
+    ) -> Result<(crate::PolicySet, Entities), Vec<miette::Report>> {
+        let Self {
+            policies,
+            entities,
+            templates,
+            template_instantiations,
+        } = self;
+
+        let mut errs = Vec::new();
+
+        let mut policies: crate::PolicySet = match policies.parse(templates) {
+            Ok(policies) => policies,
+            Err(e) => {
+                errs.extend(e);
+                crate::PolicySet::new()
+            }
+        };
+        let entities = match Entities::from_json_value(entities.into(), schema) {
+            Ok(entities) => entities,
+            Err(e) => {
+                errs.push(miette::Report::new(e));
+                Entities::empty()
+            }
+        };
+
+        if let Some(links) = template_instantiations {
+            for link in links {
+                match parse_links(&mut policies, link) {
+                    Ok(()) => (),
+                    Err(e) => errs.push(e),
+                }
+            }
+        }
+
+        if errs.is_empty() {
+            Ok((policies, entities))
+        } else {
+            Err(errs)
+        }
+    }
+}
+
+// PANIC SAFETY unit tests
+#[allow(clippy::panic)]
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cool_asserts::assert_matches;
+    use serde_json::json;
+
+    /// Assert that `is_authorized_json()` returns Allow with no errors
+    #[track_caller]
+    fn assert_is_authorized_json(json: serde_json::Value) {
+        let ans_val = is_authorized_json(json).unwrap();
+        let result: Result<AuthorizationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(AuthorizationAnswer::Success { response, .. }) => {
+            assert_eq!(response.decision(), Decision::Allow);
+            let errors: Vec<&AuthorizationError> = response.diagnostics().errors().collect();
+            assert_eq!(errors.len(), 0, "{errors:?}");
+        });
+    }
+
+    /// Assert that `is_authorized_json()` returns Deny with no errors
+    #[track_caller]
+    fn assert_is_not_authorized_json(json: serde_json::Value) {
+        let ans_val = is_authorized_json(json).unwrap();
+        let result: Result<AuthorizationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(AuthorizationAnswer::Success { response, .. }) => {
+            assert_eq!(response.decision(), Decision::Deny);
+            let errors: Vec<&AuthorizationError> = response.diagnostics().errors().collect();
+            assert_eq!(errors.len(), 0, "{errors:?}");
+        });
+    }
+
+    /// Assert that `is_authorized_json()` returns
+    /// `AuthorizationAnswer::Failure` where some error contains the expected
+    /// string `err` (in its main error message)
+    #[track_caller]
+    fn assert_is_authorized_json_is_failure(json: serde_json::Value, err: &str) {
+        let ans_val =
+            is_authorized_json(json).expect("expected it to at least parse into AuthorizationCall");
+        let result: Result<AuthorizationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(AuthorizationAnswer::Failure { errors, .. }) => {
+            assert!(
+                errors.iter().any(|e| e.message.contains(err)),
+                "Expected to see error(s) containing `{err}`, but saw {errors:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn test_slice_convert() {
+        let entities = serde_json::json!(
+            [
+                {
+                    "uid" : {
+                        "type" : "user",
+                        "id" : "alice"
+                    },
+                    "attrs": { "foo": "bar" },
+                    "parents" : [
+                        {
+                            "type" : "user",
+                            "id" : "bob"
+                        }
+                    ]
+                },
+                {
+                    "uid" : {
+                        "type" : "user",
+                        "id" : "bob"
+                    },
+                    "attrs": {},
+                    "parents": []
+                }
+            ]
+        );
+        let rslice = RecvdSlice {
+            policies: PolicySet::Map(HashMap::new()),
+            entities: entities.into(),
+            templates: None,
+            template_instantiations: None,
+        };
+        let (policies, entities) = rslice.try_into(None).expect("parse failed");
+        assert!(policies.is_empty());
+        entities
+            .get(&EntityUid::from_type_name_and_id(
+                "user".parse().unwrap(),
+                "alice".parse().unwrap(),
+            ))
+            .map_or_else(
+                || panic!("Missing user::alice Entity"),
+                |alice| {
+                    assert!(entities.is_ancestor_of(
+                        &EntityUid::from_type_name_and_id(
+                            "user".parse().unwrap(),
+                            "bob".parse().unwrap()
+                        ),
+                        &alice.uid()
+                    ));
+                },
+            );
+    }
+
+    #[test]
+    fn test_failure_on_invalid_syntax() {
+        assert_matches!(is_authorized_json_str("iefjieoafiaeosij"), Err(e) => {
+            assert!(e.to_string().contains("expected value"));
+        });
+    }
+
+    #[test]
+    fn test_not_authorized_on_empty_slice() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {},
+             "entities": []
+            }
+        });
+
+        assert_is_not_authorized_json(call);
+    }
+
+    #[test]
+    fn test_not_authorized_on_unspecified() {
+        let call = json!({
+            "principal": null,
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {
+              "ID1": "permit(principal == User::\"alice\", action, resource);"
+             },
+             "entities": []
+            }
+        });
+
+        assert_is_not_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_simple_slice() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {
+              "ID1": "permit(principal == User::\"alice\", action, resource);"
+             },
+             "entities": []
+            }
+        });
+
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_simple_slice_with_string_policies() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": "permit(principal == User::\"alice\", action, resource);",
+             "entities": []
+            }
+        });
+
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_simple_slice_with_context() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {
+             "is_authenticated": true,
+             "source_ip": {
+                "__extn" : { "fn" : "ip", "arg" : "222.222.222.222" }
+             }
+            },
+            "slice": {
+             "policies": "permit(principal == User::\"alice\", action, resource) when { context.is_authenticated && context.source_ip.isInRange(ip(\"222.222.222.0/24\")) };",
+             "entities": []
+            }
+        });
+
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_simple_slice_with_attrs_and_parents() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": "permit(principal, action, resource in Folder::\"house\") when { resource.owner == principal };",
+             "entities": [
+              {
+               "uid": {
+                "__entity": {
+                 "type": "User",
+                 "id": "alice"
+                }
+               },
+               "attrs": {},
+               "parents": []
+              },
+              {
+               "uid": {
+                "__entity": {
+                 "type": "Photo",
+                 "id": "door"
+                }
+               },
+               "attrs": {
+                "owner": {
+                 "__entity": {
+                  "type": "User",
+                  "id": "alice"
+                 }
+                }
+               },
+               "parents": [
+                {
+                 "__entity": {
+                  "type": "Folder",
+                  "id": "house"
+                 }
+                }
+               ]
+              },
+              {
+               "uid": {
+                "__entity": {
+                 "type": "Folder",
+                 "id": "house"
+                }
+               },
+               "attrs": {},
+               "parents": []
+              }
+             ]
+            }
+        });
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_multi_policy_slice() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {
+              "ID0": "permit(principal == User::\"jerry\", action, resource == Photo::\"doorx\");",
+              "ID1": "permit(principal == User::\"tom\", action, resource == Photo::\"doory\");",
+              "ID2": "permit(principal == User::\"alice\", action, resource == Photo::\"door\");"
+             },
+             "entities": []
+            }
+        });
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_multi_policy_slice_with_string_policies() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": "permit(principal, action, resource in Folder::\"house\") when { resource.owner == principal };",
+             "entities": [
+              {
+               "uid": {
+                "__entity": {
+                 "type": "User",
+                 "id": "alice"
+                }
+               },
+               "attrs": {},
+               "parents": []
+              },
+              {
+               "uid": {
+                "__entity": {
+                 "type": "Photo",
+                 "id": "door"
+                }
+               },
+               "attrs": {
+                "owner": {
+                 "__entity": {
+                  "type": "User",
+                  "id": "alice"
+                 }
+                }
+               },
+               "parents": [
+                {
+                 "__entity": {
+                  "type": "Folder",
+                  "id": "house"
+                 }
+                }
+               ]
+              },
+              {
+               "uid": {
+                "__entity": {
+                 "type": "Folder",
+                 "id": "house"
+                }
+               },
+               "attrs": {},
+               "parents": []
+              }
+             ]
+            }
+        });
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_multi_policy_slice_denies_when_expected() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {
+              "ID0": "permit(principal, action, resource);",
+              "ID1": "forbid(principal == User::\"alice\", action, resource == Photo::\"door\");"
+             },
+             "entities": []
+            }
+        });
+        assert_is_not_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_on_multi_policy_slice_with_string_policies_denies_when_expected() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": "permit(principal, action, resource);forbid(principal == User::\"alice\", action, resource);",
+             "entities": []
+            }
+        });
+
+        assert_is_not_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_with_template_as_policy_should_fail() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": "permit(principal == ?principal, action, resource);",
+             "entities": [],
+             "templates": {}
+            }
+        });
+        assert_is_not_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_with_template_should_fail() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {},
+             "entities": [],
+             "templates": {
+              "ID0": "permit(principal == ?principal, action, resource);"
+             }
+            }
+        });
+        assert_is_not_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_with_template_link() {
+        let call = json!({
+            "principal": {
+             "type": "User",
+             "id": "alice"
+            },
+            "action": {
+             "type": "Photo",
+             "id": "view"
+            },
+            "resource": {
+             "type": "Photo",
+             "id": "door"
+            },
+            "context": {},
+            "slice": {
+             "policies": {},
+             "entities": [],
+             "templates": {
+              "ID0": "permit(principal == ?principal, action, resource);"
+             },
+             "templateInstantiations": [
+              {
+               "templateId": "ID0",
+               "resultPolicyId": "ID0_User_alice",
+               "instantiations": [
+                {
+                 "slot": "?principal",
+                 "value": {
+                  "ty": "User",
+                  "eid": "alice"
+                 }
+                }
+               ]
+              }
+             ]
+            }
+        });
+        assert_is_authorized_json(call);
+    }
+
+    #[test]
+    fn test_authorized_fails_on_policy_collision_with_template() {
+        let call = json!({
+            "principal" : {
+                "type" : "User",
+                "id" : "alice"
+            },
+            "action" : {
+                "type" : "Action",
+                "id" : "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context" : {},
+            "slice" : {
+                "policies" : { "ID0": "permit(principal, action, resource);" },
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : []
+            }
+        });
+        assert_is_authorized_json_is_failure(
+            call,
+            "failed to add template with id `ID0` to policy set: duplicate template or policy id `ID0`",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_link_ids() {
+        let call = json!({
+            "principal" : {
+                "type" : "User",
+                "id" : "alice"
+            },
+            "action" : {
+                "type" : "Action",
+                "id" : "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : [
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    },
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_is_authorized_json_is_failure(
+            call,
+            "unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_template_link_collision_with_template() {
+        let call = json!({
+            "principal" : {
+                "type" : "User",
+                "id" : "alice"
+            },
+            "action" : {
+                "type" : "Action",
+                "id" : "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : [
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID0",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_is_authorized_json_is_failure(
+            call,
+            "unable to link template: template-linked policy id `ID0` conflicts with an existing policy id",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_template_link_collision_with_policy() {
+        let call = json!({
+            "principal" : {
+                "type" : "User",
+                "id" : "alice"
+            },
+            "action" : {
+                "type" : "Action",
+                "id" : "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context" : {},
+            "slice" : {
+                "policies" : { "ID1": "permit(principal, action, resource);" },
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : [
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_is_authorized_json_is_failure(
+            call,
+            "unable to link template: template-linked policy id `ID1` conflicts with an existing policy id",
+        );
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_policy_ids() {
+        let call = r#"{
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {
+                  "ID0": "permit(principal, action, resource);",
+                  "ID0": "permit(principal, action, resource);"
+                },
+                "entities" : [],
+                "templates" : {},
+                "templateInstantiations" : [ ]
+            }
+        }"#;
+        assert_matches!(is_authorized_json_str(call), Err(e) => {
+            assert!(e.to_string().contains("policies as a concatenated string or multiple policies as a hashmap where the policy id is the key"));
+        });
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_template_ids() {
+        let call = r#"{
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : {
+                    "ID0": "permit(principal == ?principal, action, resource);",
+                    "ID0": "permit(principal == ?principal, action, resource);"
+                },
+                "templateInstantiations" : [ ]
+            }
+        }"#;
+        assert_matches!(is_authorized_json_str(call), Err(e) => {
+            assert!(e.to_string().contains("found duplicate key"));
+        });
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_slot_link1() {
+        let call = json!({
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : [
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            },
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_matches!(is_authorized_json(call), Err(e) => {
+            assert!(e.to_string().contains("duplicate values for the slot(s): `?principal`"));
+        });
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_slot_link2() {
+        let call = json!({
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : [
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            },
+                            {
+                                "slot" : "?resource",
+                                "value" : { "ty" : "Box", "eid" : "box" }
+                            },
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_matches!(is_authorized_json(call), Err(e) => {
+            assert!(e.to_string().contains("duplicate values for the slot(s): `?principal`"));
+        });
+    }
+
+    #[test]
+    fn test_authorized_fails_on_duplicate_slot_link3() {
+        let call = json!({
+            "principal" : "User::\"alice\"",
+            "action" : "Photo::\"view\"",
+            "resource" : "Photo::\"door\"",
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : { "ID0": "permit(principal == ?principal, action, resource);" },
+                "templateInstantiations" : [
+                    {
+                        "templateId" : "ID0",
+                        "resultPolicyId" : "ID1",
+                        "instantiations" : [
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "User", "eid" : "alice" }
+                            },
+                            {
+                                "slot" : "?resource",
+                                "value" : { "ty" : "Box", "eid" : "box" }
+                            },
+                            {
+                                "slot": "?principal",
+                                "value": { "ty" : "Team", "eid" : "bob" }
+                            },
+                            {
+                                "slot" : "?resource",
+                                "value" : { "ty" : "Box", "eid" : "box2" }
+                            }
+                        ]
+                    }
+                ]
+            }
+        });
+        assert_matches!(is_authorized_json(call), Err(e) => {
+            assert!(e.to_string().contains("duplicate values for the slot(s): `?principal`, `?resource`"));
+        });
+    }
+
+    #[test]
+    fn test_authorized_fails_duplicate_entity_uid() {
+        let call = json!({
+            "principal" : {
+                "type" : "User",
+                "id" : "alice"
+            },
+            "action" : {
+                "type" : "Photo",
+                "id" : "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context" : {},
+            "slice" : {
+                "policies" : {},
+                "entities" : [
+                    {
+                        "uid": {
+                            "type" : "User",
+                            "id" : "alice"
+                        },
+                        "attrs": {},
+                        "parents": []
+                    },
+                    {
+                        "uid": {
+                            "type" : "User",
+                            "id" : "alice"
+                        },
+                        "attrs": {},
+                        "parents": []
+                    }
+                ],
+                "templates" : {},
+                "templateInstantiations" : []
+            }
+        });
+        assert_is_authorized_json_is_failure(call, r#"duplicate entity entry `User::"alice"`"#);
+    }
+
+    #[test]
+    fn test_authorized_fails_duplicate_context_key() {
+        let call = r#"{
+            "principal" : {
+                "type" : "User",
+                "id" : "alice"
+            },
+            "action" : {
+                "type" : "Photo",
+                "id" : "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context" : {
+                "is_authenticated": true,
+                "is_authenticated": false
+            },
+            "slice" : {
+                "policies" : {},
+                "entities" : [],
+                "templates" : {},
+                "templateInstantiations" : []
+            }
+        }"#;
+        assert_matches!(is_authorized_json_str(call), Err(e) => {
+            assert!(e.to_string().contains("found duplicate key"));
+        });
+    }
+
+    #[test]
+    fn test_request_validation() {
+        let good_call = json!({
+            "principal" : {
+                "type": "User",
+                "id": "alice",
+            },
+            "action": {
+                "type": "Action",
+                "id": "view",
+            },
+            "resource": {
+                "type": "Photo",
+                "id": "door",
+            },
+            "context": {},
+            "slice": {
+                "policies": "permit(principal == User::\"alice\", action == Action::\"view\", resource);",
+                "entities": [],
+                "templates": {},
+                "templateInstantiations": [],
+            },
+            "schema": {
+                "human": "entity User, Photo; action view appliesTo { principal: User, resource: Photo };"
+            },
+        });
+        let bad_call = json!({
+            "principal" : {
+                "type": "User",
+                "id": "alice",
+            },
+            "action": {
+                "type": "Action",
+                "id": "view",
+            },
+            "resource": {
+                "type": "User",
+                "id": "bob",
+            },
+            "context": {},
+            "slice": {
+                "policies": "permit(principal == User::\"alice\", action == Action::\"view\", resource);",
+                "entities": [],
+                "templates": {},
+                "templateInstantiations": [],
+            },
+            "schema": {
+                "human": "entity User, Photo; action view appliesTo { principal: User, resource: Photo };"
+            },
+        });
+        let bad_call_req_validation_disabled = json!({
+            "principal" : {
+                "type": "User",
+                "id": "alice",
+            },
+            "action": {
+                "type": "Action",
+                "id": "view",
+            },
+            "resource": {
+                "type": "User",
+                "id": "bob",
+            },
+            "context": {},
+            "slice": {
+                "policies": "permit(principal == User::\"alice\", action == Action::\"view\", resource);",
+                "entities": [],
+                "templates": {},
+                "templateInstantiations": [],
+            },
+            "schema": {
+                "human": "entity User, Photo; action view appliesTo { principal: User, resource: Photo };"
+            },
+            "enableRequestValidation": false,
+        });
+
+        assert_is_authorized_json(good_call);
+        assert_is_authorized_json_is_failure(
+            bad_call,
+            "resource type `User` is not valid for `Action::\"view\"`",
+        );
+        assert_is_authorized_json(bad_call_req_validation_disabled);
+    }
+}
+
+#[cfg(feature = "partial-eval")]
+#[cfg(test)]
+mod partial_test {
+    use super::*;
+    use cool_asserts::assert_matches;
+    use serde_json::json;
+
+    #[track_caller]
+    fn assert_is_authorized_json_partial(call: serde_json::Value) {
+        let ans_val = is_authorized_partial_json(call).unwrap();
+        let result: Result<PartialAuthorizationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(PartialAuthorizationAnswer::Residuals { response, .. }) => {
+            assert_eq!(response.decision(), Some(Decision::Allow));
+            let errors: Vec<_> = response.errored().collect();
+            assert_eq!(errors.len(), 0, "{errors:?}");
+        });
+    }
+
+    #[track_caller]
+    fn assert_is_not_authorized_json_partial(call: serde_json::Value) {
+        let ans_val = is_authorized_partial_json(call).unwrap();
+        let result: Result<PartialAuthorizationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(PartialAuthorizationAnswer::Residuals { response, .. }) => {
+            assert_eq!(response.decision(), Some(Decision::Deny));
+            let errors: Vec<_> = response.errored().collect();
+            assert_eq!(errors.len(), 0, "{errors:?}");
+        });
+    }
+
+    #[track_caller]
+    fn assert_is_residual(call: serde_json::Value, expected_residuals: HashSet<&str>) {
+        let ans_val = is_authorized_partial_json(call).unwrap();
+        let result: Result<PartialAuthorizationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(PartialAuthorizationAnswer::Residuals { response, .. }) => {
+            assert_eq!(response.decision(), None);
+            let errors: Vec<_> = response.errored().collect();
+            assert_eq!(errors.len(), 0, "{errors:?}");
+            let actual_residuals: HashSet<_> = response.nontrivial_residual_ids().collect();
+            for id in &expected_residuals {
+                assert!(actual_residuals.contains(&PolicyId::from_str(id).ok().unwrap()), "expected nontrivial residual for {id}, but it's missing")
+            }
+            for id in &actual_residuals {
+                assert!(expected_residuals.contains(id.to_string().as_str()),"found unexpected nontrivial residual for {id}")
+            }
+        });
+    }
+
+    #[test]
+    fn test_authorized_partial_no_resource() {
+        let call = json!({
+            "principal": {
+                "type": "User",
+                "id": "alice"
+            },
+            "action": {
+                "type": "Photo",
+                "id": "view"
+            },
+            "context": {},
+            "slice": {
+                "policies": {
+                "ID1": "permit(principal == User::\"alice\", action, resource);"
+                },
+                "entities": []
+            },
+            "partial_evaluation": true
+        });
+
+        assert_is_authorized_json_partial(call);
+    }
+
+    #[test]
+    fn test_authorized_partial_not_authorized_no_resource() {
+        let call = json!({
+            "principal": {
+                "type": "User",
+                "id": "john"
+            },
+            "action": {
+                "type": "Photo",
+                "id": "view"
+            },
+            "context": {},
+            "slice": {
+                "policies": {
+                "ID1": "permit(principal == User::\"alice\", action, resource);"
+                },
+                "entities": []
+            },
+            "partial_evaluation": true
+        });
+
+        assert_is_not_authorized_json_partial(call);
+    }
+
+    #[test]
+    fn test_authorized_partial_residual_no_principal_scope() {
+        let call = json!({
+            "action": {
+                "type": "Photo",
+                "id": "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context": {},
+            "slice": {
+                "policies": {
+                "ID1": "permit(principal == User::\"alice\", action, resource);"
+                },
+                "entities": []
+            },
+            "partial_evaluation": true
+        });
+
+        assert_is_residual(call, HashSet::from(["ID1"]));
+    }
+
+    #[test]
+    fn test_authorized_partial_residual_no_principal_when() {
+        let call = json!({
+            "action": {
+                "type": "Photo",
+                "id": "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context": {},
+            "slice": {
+                "policies": {
+                "ID1": "permit(principal, action, resource) when { principal == User::\"alice\" };"
+                },
+                "entities": []
+            },
+            "partial_evaluation": true
+        });
+
+        assert_is_residual(call, HashSet::from(["ID1"]));
+    }
+
+    #[test]
+    fn test_authorized_partial_residual_no_principal_ignored_forbid() {
+        let call = json!({
+            "action": {
+                "type": "Photo",
+                "id": "view"
+            },
+            "resource" : {
+                "type" : "Photo",
+                "id" : "door"
+            },
+            "context": {},
+            "slice": {
+                "policies": {
+                "ID1": "permit(principal, action, resource) when { principal == User::\"alice\" };",
+                "ID2": "forbid(principal, action, resource) unless { resource == Photo::\"door\" };"
+                },
+                "entities": []
+            },
+            "partial_evaluation": true
+        });
+
+        assert_is_residual(call, HashSet::from(["ID1"]));
+    }
+}

--- a/cedar-policy/src/ffi/mod.rs
+++ b/cedar-policy/src/ffi/mod.rs
@@ -1,0 +1,27 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![cfg_attr(feature = "wasm", allow(non_snake_case))]
+
+//! Functions for interacting with `cedar_policy`, intended to be easier to use
+//! in an FFI context than the root-level `cedar_policy` interface
+
+mod is_authorized;
+pub use is_authorized::*;
+mod utils;
+pub use utils::{DetailedError, PolicySet, Schema, Severity, SourceLabel, SourceLocation};
+mod validate;
+pub use validate::*;

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -1,0 +1,275 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Utility functions and types for JSON interface
+use crate::{Policy, SchemaWarning, Template};
+use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
+use miette::WrapErr;
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, str::FromStr};
+
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
+/// Structure of the JSON output representing one `miette` error
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct DetailedError {
+    /// Main error message, including both the `miette` "message" and the
+    /// `miette` "causes" (uses `miette`'s default `Display` output)
+    pub message: String,
+    /// Help message, providing additional information about the error or help resolving it
+    pub help: Option<String>,
+    /// Error code
+    pub code: Option<String>,
+    /// URL for more information about the error
+    pub url: Option<String>,
+    /// Severity
+    pub severity: Option<Severity>,
+    /// Source labels (ranges)
+    #[serde(default)]
+    pub source_locations: Vec<SourceLabel>,
+    /// Related errors
+    #[serde(default)]
+    pub related: Vec<DetailedError>,
+}
+
+/// Exactly like `miette::Severity` but implements `Hash`
+///
+/// If `miette::Severity` adds `derive(Hash)` in the future, we can remove this
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum Severity {
+    /// Advice (the lowest severity)
+    Advice,
+    /// Warning
+    Warning,
+    /// Error (the highest severity)
+    Error,
+}
+
+impl From<miette::Severity> for Severity {
+    fn from(severity: miette::Severity) -> Self {
+        match severity {
+            miette::Severity::Advice => Self::Advice,
+            miette::Severity::Warning => Self::Warning,
+            miette::Severity::Error => Self::Error,
+        }
+    }
+}
+
+/// Structure of the JSON output representing a `miette` source label (range)
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct SourceLabel {
+    /// Text of the label (if any)
+    pub label: Option<String>,
+    /// Source location (range) of the label
+    #[serde(flatten)]
+    pub loc: SourceLocation,
+}
+
+/// A range of source code representing the location of an error or warning.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Deserialize, Serialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct SourceLocation {
+    /// Start of the source location (in bytes)
+    pub start: usize,
+    /// End of the source location (in bytes)
+    pub end: usize,
+}
+
+impl From<miette::LabeledSpan> for SourceLabel {
+    fn from(span: miette::LabeledSpan) -> Self {
+        Self {
+            label: span.label().map(ToString::to_string),
+            loc: SourceLocation {
+                start: span.offset(),
+                end: span.offset() + span.len(),
+            },
+        }
+    }
+}
+
+impl<'a, E: miette::Diagnostic + ?Sized> From<&'a E> for DetailedError {
+    fn from(diag: &'a E) -> Self {
+        Self {
+            message: {
+                let mut s = diag.to_string();
+                let mut source = diag.source();
+                while let Some(e) = source {
+                    s.push_str(": ");
+                    s.push_str(&e.to_string());
+                    source = e.source();
+                }
+                s
+            },
+            help: diag.help().map(|h| h.to_string()),
+            code: diag.code().map(|c| c.to_string()),
+            url: diag.url().map(|u| u.to_string()),
+            severity: diag.severity().map(Into::into),
+            source_locations: diag
+                .labels()
+                .map(|labels| labels.map(Into::into).collect())
+                .unwrap_or_default(),
+            related: diag
+                .related()
+                .map(|errs| errs.map(std::convert::Into::into).collect())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl From<miette::Report> for DetailedError {
+    fn from(report: miette::Report) -> Self {
+        let diag: &dyn miette::Diagnostic = report.as_ref();
+        diag.into()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+#[serde(
+    expecting = "policies as a concatenated string or multiple policies as a hashmap where the policy id is the key"
+)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+/// Struct defining the two possible ways to pass a set of policies to `is_authorized_json` and `validate_json`
+pub enum PolicySet {
+    /// provides multiple policies as a concatenated string
+    Concatenated(String),
+    /// provides multiple policies as a hashmap where the policyId is the key
+    #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
+    Map(HashMap<String, String>),
+}
+
+fn parse_policy_set_from_individual_policies(
+    policies: &HashMap<String, String>,
+    templates: Option<HashMap<String, String>>,
+) -> Result<crate::PolicySet, Vec<miette::Report>> {
+    let mut policy_set = crate::PolicySet::new();
+    let mut errs = Vec::new();
+    for (id, policy_src) in policies {
+        match Policy::parse(Some(id.clone()), policy_src)
+            .wrap_err_with(|| format!("failed to parse policy with id `{id}`"))
+        {
+            Ok(p) => match policy_set
+                .add(p)
+                .wrap_err_with(|| format!("failed to add policy with id `{id}` to policy set"))
+            {
+                Ok(()) => {}
+                Err(e) => {
+                    errs.push(e);
+                }
+            },
+            Err(e) => {
+                errs.push(e);
+            }
+        }
+    }
+
+    if let Some(templates) = templates {
+        for (id, policy_src) in templates {
+            match Template::parse(Some(id.clone()), policy_src)
+                .wrap_err_with(|| format!("failed to parse template with id `{id}`"))
+            {
+                Ok(p) => match policy_set.add_template(p).wrap_err_with(|| {
+                    format!("failed to add template with id `{id}` to policy set")
+                }) {
+                    Ok(()) => {}
+                    Err(e) => {
+                        errs.push(e);
+                    }
+                },
+                Err(e) => errs.push(e),
+            }
+        }
+    }
+
+    if errs.is_empty() {
+        Ok(policy_set)
+    } else {
+        Err(errs)
+    }
+}
+
+impl PolicySet {
+    /// Parse the `PolicySet` into a `crate::PolicySet`.
+    pub(super) fn parse(
+        self,
+        templates: Option<HashMap<String, String>>,
+    ) -> Result<crate::PolicySet, Vec<miette::Report>> {
+        match self {
+            Self::Concatenated(policies) => crate::PolicySet::from_str(&policies)
+                .wrap_err("failed to parse policies from string")
+                .map_err(|e| vec![e]),
+            Self::Map(policies) => parse_policy_set_from_individual_policies(&policies, templates),
+        }
+    }
+}
+
+/// Represents a schema in either schema format
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum Schema {
+    /// Schema in the Cedar schema format. See <https://docs.cedarpolicy.com/schema/human-readable-schema.html>
+    #[serde(rename = "human")]
+    Human(String),
+    /// Schema in Cedar's JSON schema format. See <https://docs.cedarpolicy.com/schema/json-schema.html>
+    #[serde(rename = "json")]
+    Json(JsonValueWithNoDuplicateKeys),
+}
+
+impl Schema {
+    pub(super) fn parse(
+        self,
+    ) -> Result<(crate::Schema, Box<dyn Iterator<Item = SchemaWarning>>), miette::Report> {
+        match self {
+            Self::Human(str) => crate::Schema::from_str_natural(&str)
+                .map(|(sch, warnings)| {
+                    (
+                        sch,
+                        Box::new(warnings) as Box<dyn Iterator<Item = SchemaWarning>>,
+                    )
+                })
+                .map_err(miette::Report::new),
+            Self::Json(val) => crate::Schema::from_json_value(val.into())
+                .map(|sch| {
+                    (
+                        sch,
+                        Box::new(std::iter::empty()) as Box<dyn Iterator<Item = SchemaWarning>>,
+                    )
+                })
+                .map_err(miette::Report::new),
+        }
+    }
+}
+
+pub(super) struct WithWarnings<T> {
+    pub t: T,
+    pub warnings: Vec<miette::Report>,
+}

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -1,0 +1,526 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module contains the validator entry points that other language FFIs can
+//! call
+#![allow(clippy::module_name_repetitions)]
+use super::utils::{DetailedError, PolicySet, Schema, WithWarnings};
+use crate::{ValidationMode, Validator};
+use serde::{Deserialize, Serialize};
+use smol_str::{SmolStr, ToSmolStr};
+
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
+/// Parse a policy set and optionally validate it against a provided schema
+///
+/// This is the basic validator interface, using [`ValidationCall`] and
+/// [`ValidationAnswer`] types
+pub fn validate(call: ValidationCall) -> ValidationAnswer {
+    match call.get_components() {
+        WithWarnings {
+            t: Ok((policies, schema)),
+            warnings,
+        } => {
+            let validator = Validator::new(schema);
+            let (validation_errors, validation_warnings) = validator
+                .validate(&policies, ValidationMode::default())
+                .into_errors_and_warnings();
+            let validation_errors: Vec<ValidationError> = validation_errors
+                .map(|error| ValidationError {
+                    policy_id: error.location().policy_id().to_smolstr(),
+                    error: miette::Report::new(error).into(),
+                })
+                .collect();
+            let validation_warnings: Vec<ValidationError> = validation_warnings
+                .map(|error| ValidationError {
+                    policy_id: error.location().policy_id().to_smolstr(),
+                    error: miette::Report::new(error).into(),
+                })
+                .collect();
+            ValidationAnswer::Success {
+                validation_errors,
+                validation_warnings,
+                other_warnings: warnings.into_iter().map(Into::into).collect(),
+            }
+        }
+        WithWarnings {
+            t: Err(errors),
+            warnings,
+        } => ValidationAnswer::Failure {
+            errors: errors.into_iter().map(Into::into).collect(),
+            warnings: warnings.into_iter().map(Into::into).collect(),
+        },
+    }
+}
+
+/// Input is a JSON encoding of [`ValidationCall`] and output is a JSON
+/// encoding of [`ValidationAnswer`]
+pub fn validate_json(json: serde_json::Value) -> Result<serde_json::Value, serde_json::Error> {
+    let ans = validate(serde_json::from_value(json)?);
+    serde_json::to_value(ans)
+}
+
+/// Input and output are strings containing serialized JSON, in the shapes
+/// expected by [`validate_json()`]
+pub fn validate_json_str(json: &str) -> Result<String, serde_json::Error> {
+    let ans = validate(serde_json::from_str(json)?);
+    serde_json::to_string(&ans)
+}
+
+/// Struct containing the input data for validation
+#[derive(Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationCall {
+    /// Validation settings
+    #[serde(default)]
+    pub validation_settings: ValidationSettings,
+    /// Schema to use for validation
+    #[cfg_attr(feature = "wasm", tsify(type = "Schema"))]
+    pub schema: Schema,
+    /// Policies to validate
+    pub policy_set: PolicySet,
+}
+
+impl ValidationCall {
+    fn get_components(
+        self,
+    ) -> WithWarnings<Result<(crate::PolicySet, crate::Schema), Vec<miette::Report>>> {
+        let mut errs = vec![];
+        let policies = match self.policy_set.parse(None) {
+            Ok(policies) => policies,
+            Err(e) => {
+                errs.extend(e);
+                crate::PolicySet::new()
+            }
+        };
+        let pair = match self.schema.parse() {
+            Ok((schema, warnings)) => Some((schema, warnings)),
+            Err(e) => {
+                errs.push(e);
+                None
+            }
+        };
+        match (errs.is_empty(), pair) {
+            (true, Some((schema, warnings))) => WithWarnings {
+                t: Ok((policies, schema)),
+                warnings: warnings.map(miette::Report::new).collect(),
+            },
+            _ => WithWarnings {
+                t: Err(errs),
+                warnings: vec![],
+            },
+        }
+    }
+}
+
+/// Configuration for the validation call
+#[derive(Default, Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationSettings {
+    /// Whether validation is enabled
+    enabled: ValidationEnabled,
+}
+
+/// String enum for validation mode
+#[derive(Serialize, Deserialize, Debug)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub enum ValidationEnabled {
+    /// Setting for which policies will be validated against the schema
+    #[serde(alias = "regular")]
+    On,
+    /// Setting for which no validation will be done
+    Off,
+}
+
+impl Default for ValidationEnabled {
+    fn default() -> Self {
+        Self::On
+    }
+}
+
+/// Error (or warning) for a specified policy after validation
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(rename_all = "camelCase")]
+pub struct ValidationError {
+    /// Id of the policy where the error (or warning) occurred
+    pub policy_id: SmolStr,
+    /// Error (or warning) itself.
+    /// You can look at the `severity` field to see whether it is actually an
+    /// error or a warning.
+    pub error: DetailedError,
+}
+
+/// Result struct for validation
+#[derive(Debug, Serialize, Deserialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+pub enum ValidationAnswer {
+    /// Represents a failure to parse or call the validator
+    #[serde(rename_all = "camelCase")]
+    Failure {
+        /// Parsing errors
+        errors: Vec<DetailedError>,
+        /// Warnings encountered
+        warnings: Vec<DetailedError>,
+    },
+    /// Represents a successful validation call
+    #[serde(rename_all = "camelCase")]
+    Success {
+        /// Errors from any issues found during validation
+        validation_errors: Vec<ValidationError>,
+        /// Warnings from any issues found during validation
+        validation_warnings: Vec<ValidationError>,
+        /// Other warnings, not associated with specific policies.
+        /// For instance, warnings about your schema itself.
+        other_warnings: Vec<DetailedError>,
+    },
+}
+
+// PANIC SAFETY unit tests
+#[allow(clippy::panic)]
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cool_asserts::assert_matches;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    /// Assert that [`validate_json()`] returns Success with no errors
+    #[track_caller]
+    fn assert_validates_without_errors(json: serde_json::Value) {
+        let ans_val = validate_json(json).unwrap();
+        let result: Result<ValidationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(ValidationAnswer::Success { validation_errors, validation_warnings: _, other_warnings: _ }) => {
+            assert_eq!(validation_errors.len(), 0, "Unexpected validation errors: {validation_errors:?}");
+        });
+    }
+
+    /// Assert that [`validate_json()`] returns Success with exactly
+    /// `expected_num_errors` errors
+    #[track_caller]
+    fn assert_validates_with_errors(json: serde_json::Value, expected_num_errors: usize) {
+        let ans_val = validate_json(json).unwrap();
+        assert_matches!(ans_val.get("validationErrors"), Some(_)); // should be present, with this camelCased name
+        assert_matches!(ans_val.get("validationWarnings"), Some(_)); // should be present, with this camelCased name
+        let result: Result<ValidationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(ValidationAnswer::Success { validation_errors, validation_warnings: _, other_warnings: _ }) => {
+            assert_eq!(validation_errors.len(), expected_num_errors, "actual validation errors were: {validation_errors:?}");
+        });
+    }
+
+    /// Assert that [`validate_json()`] returns `ValidationAnswer::Failure`
+    /// where some error contains the expected error string `err` (in its main
+    /// error message)
+    #[track_caller]
+    fn assert_is_failure(json: serde_json::Value, err: &str) {
+        let ans_val =
+            validate_json(json).expect("expected it to at least parse into ValidationCall");
+        let result: Result<ValidationAnswer, _> = serde_json::from_value(ans_val);
+        assert_matches!(result, Ok(ValidationAnswer::Failure { errors, .. }) => {
+            assert!(
+                errors.iter().any(|e| e.message.contains(err)),
+                "Expected to see error(s) containing `{err}`, but saw {errors:?}",
+            );
+        });
+    }
+
+    #[test]
+    fn test_validate_empty_policy() {
+        let call = ValidationCall {
+            validation_settings: ValidationSettings::default(),
+            schema: Schema::Json(json!({}).into()),
+            policy_set: PolicySet::Map(HashMap::new()),
+        };
+
+        assert_validates_without_errors(serde_json::to_value(&call).unwrap());
+
+        let call = ValidationCall {
+            validation_settings: ValidationSettings::default(),
+            schema: Schema::Human(String::new()),
+            policy_set: PolicySet::Map(HashMap::new()),
+        };
+
+        assert_validates_without_errors(serde_json::to_value(&call).unwrap());
+
+        let call = json!({
+            "schema": { "json": {} },
+            "policySet": {}
+        });
+
+        assert_validates_without_errors(call);
+    }
+
+    #[test]
+    fn test_nontrivial_correct_policy_validates_without_errors() {
+        let json = json!({
+        "schema": { "json": { "": {
+          "entityTypes": {
+            "User": {
+              "memberOfTypes": [ "UserGroup" ]
+            },
+            "Photo": {
+              "memberOfTypes": [ "Album", "Account" ]
+            },
+            "Album": {
+              "memberOfTypes": [ "Album", "Account" ]
+            },
+            "Account": { },
+            "UserGroup": {}
+          },
+          "actions": {
+            "readOnly": { },
+            "readWrite": { },
+            "createAlbum": {
+              "appliesTo": {
+                "resourceTypes": [ "Account", "Album" ],
+                "principalTypes": [ "User" ]
+              }
+            },
+            "addPhotoToAlbum": {
+              "appliesTo": {
+                "resourceTypes": [ "Album" ],
+                "principalTypes": [ "User" ]
+              }
+            },
+            "viewPhoto": {
+              "appliesTo": {
+                "resourceTypes": [ "Photo" ],
+                "principalTypes": [ "User" ]
+              }
+            },
+            "viewComments": {
+              "appliesTo": {
+                "resourceTypes": [ "Photo" ],
+                "principalTypes": [ "User" ]
+              }
+            }
+          }
+        }}},
+        "policySet": {
+          "policy0": "permit(principal in UserGroup::\"alice_friends\", action == Action::\"viewPhoto\", resource);"
+        }});
+
+        assert_validates_without_errors(json);
+    }
+
+    #[test]
+    fn test_policy_with_parse_error_fails_passing_on_errors() {
+        let json = json!({
+            "schema": { "json": { "": {
+                "entityTypes": {},
+                "actions": {}
+            }}},
+            "policySet": {
+                "policy0": "azfghbjknnhbud"
+            }
+        });
+
+        assert_is_failure(
+            json,
+            "failed to parse policy with id `policy0`: unexpected end of input",
+        );
+    }
+
+    #[test]
+    fn test_semantically_incorrect_policy_fails_with_errors() {
+        let json = json!({
+        "schema": { "json": { "": {
+          "entityTypes": {
+            "User": {
+              "memberOfTypes": [ ]
+            },
+            "Photo": {
+              "memberOfTypes": [ ]
+            }
+          },
+          "actions": {
+            "viewPhoto": {
+              "appliesTo": {
+                "resourceTypes": [ "Photo" ],
+                "principalTypes": [ "User" ]
+              }
+            }
+          }
+        }}},
+        "policySet": {
+          "policy0": "permit(principal == Photo::\"photo.jpg\", action == Action::\"viewPhoto\", resource == User::\"alice\");",
+          "policy1": "permit(principal == Photo::\"photo2.jpg\", action == Action::\"viewPhoto\", resource == User::\"alice2\");"
+        }});
+
+        assert_validates_with_errors(json, 2);
+    }
+
+    #[test]
+    fn test_nontrivial_correct_policy_validates_without_errors_concatenated_policies() {
+        let json = json!({
+        "schema": { "json": { "": {
+          "entityTypes": {
+            "User": {
+              "memberOfTypes": [ "UserGroup" ]
+            },
+            "Photo": {
+              "memberOfTypes": [ "Album", "Account" ]
+            },
+            "Album": {
+              "memberOfTypes": [ "Album", "Account" ]
+            },
+            "Account": { },
+            "UserGroup": {}
+          },
+          "actions": {
+            "readOnly": {},
+            "readWrite": {},
+            "createAlbum": {
+              "appliesTo": {
+                "resourceTypes": [ "Account", "Album" ],
+                "principalTypes": [ "User" ]
+              }
+            },
+            "addPhotoToAlbum": {
+              "appliesTo": {
+                "resourceTypes": [ "Album" ],
+                "principalTypes": [ "User" ]
+              }
+            },
+            "viewPhoto": {
+              "appliesTo": {
+                "resourceTypes": [ "Photo" ],
+                "principalTypes": [ "User" ]
+              }
+            },
+            "viewComments": {
+              "appliesTo": {
+                "resourceTypes": [ "Photo" ],
+                "principalTypes": [ "User" ]
+              }
+            }
+          }
+        }}},
+        "policySet": {
+          "policy0": "permit(principal in UserGroup::\"alice_friends\", action == Action::\"viewPhoto\", resource);"
+        }
+        });
+
+        assert_validates_without_errors(json);
+    }
+
+    #[test]
+    fn test_policy_with_parse_error_fails_passing_on_errors_concatenated_policies() {
+        let json = json!({
+            "schema": { "json": { "": {
+                "entityTypes": {},
+                "actions": {}
+            }}},
+            "policySet": "azfghbjknnhbud"
+        });
+
+        assert_is_failure(
+            json,
+            "failed to parse policies from string: unexpected end of input",
+        );
+    }
+
+    #[test]
+    fn test_semantically_incorrect_policy_fails_with_errors_concatenated_policies() {
+        let json = json!({
+          "schema": { "json": { "": {
+            "entityTypes": {
+              "User": {
+                "memberOfTypes": [ ]
+              },
+              "Photo": {
+                "memberOfTypes": [ ]
+              }
+            },
+            "actions": {
+              "viewPhoto": {
+                "appliesTo": {
+                  "resourceTypes": [ "Photo" ],
+                  "principalTypes": [ "User" ]
+                }
+              }
+            }
+          }}},
+          "policySet": "forbid(principal, action, resource);permit(principal == Photo::\"photo.jpg\", action == Action::\"viewPhoto\", resource == User::\"alice\");"
+        });
+
+        assert_validates_with_errors(json, 1);
+    }
+
+    #[test]
+    fn test_policy_with_parse_error_fails_concatenated_policies() {
+        let json = json!({
+            "schema": { "json": { "": {
+                "entityTypes": {},
+                "actions": {}
+            }}},
+            "policySet": "permit(principal, action, resource);forbid"
+        });
+
+        assert_is_failure(
+            json,
+            "failed to parse policies from string: unexpected end of input",
+        );
+    }
+
+    #[test]
+    fn test_bad_call_format_fails() {
+        assert_matches!(validate_json(json!("uerfheriufheiurfghtrg")), Err(e) => {
+            assert!(e.to_string().contains("invalid type: string \"uerfheriufheiurfghtrg\", expected struct ValidationCall"), "actual error message was {e}");
+        });
+    }
+
+    #[test]
+    fn test_validate_fails_on_duplicate_namespace() {
+        let json = r#"{
+            "schema": { "json": {
+              "foo": { "entityTypes": {}, "actions": {} },
+              "foo": { "entityTypes": {}, "actions": {} }
+            }},
+            "policySet": ""
+        }"#;
+
+        assert_matches!(validate_json_str(json), Err(e) => {
+          assert!(e.to_string().contains("the key `foo` occurs two or more times in the same JSON object"), "actual error message was {e}");
+        });
+    }
+
+    #[test]
+    fn test_validate_fails_on_duplicate_policy_id() {
+        let json = r#"{
+            "schema": { "json": { "": { "entityTypes": {}, "actions": {} } } },
+            "policySet": {
+              "ID0": "permit(principal, action, resource);",
+              "ID0": "permit(principal, action, resource);"
+            }
+        }"#;
+
+        assert_matches!(validate_json_str(json), Err(e) => {
+          assert!(e.to_string().contains("policies as a concatenated string or multiple policies as a hashmap where the policy id is the key"), "actual error message was {e}");
+        });
+    }
+}

--- a/cedar-policy/src/frontend/is_authorized.rs
+++ b/cedar-policy/src/frontend/is_authorized.rs
@@ -16,7 +16,10 @@
 
 //! This module contains the `json_is_authorized` entry point that other language
 //! FFI's can call in order to use Cedar functionality
+
 #![allow(clippy::module_name_repetitions)]
+#![allow(deprecated)] // all the functions and types in this module are deprecated. This `allow` ensures we don't get warnings about this module using its own functions and types.
+
 use super::utils::{InterfaceResult, PolicySpecification};
 use crate::api::EntityId;
 use crate::api::EntityTypeName;
@@ -681,6 +684,8 @@ fn parse_policy_set_from_individual_policies(
 
 // PANIC SAFETY unit tests
 #[allow(clippy::panic)]
+// all the functions and types in the parent module are deprecated. This `allow` ensures we don't get warnings about these tests using the parent module's functions and types.
+#[allow(deprecated)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/cedar-policy/src/frontend/utils.rs
+++ b/cedar-policy/src/frontend/utils.rs
@@ -15,6 +15,9 @@
  */
 
 //! Utility functions and types for JSON interface
+
+#![allow(deprecated)] // all the functions and types in this module are deprecated. This `allow` ensures we don't get warnings about this module using its own functions and types.
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/cedar-policy/src/frontend/validate.rs
+++ b/cedar-policy/src/frontend/validate.rs
@@ -15,8 +15,10 @@
  */
 
 //! This module exposes a JSON-based validate function used by other language FFI's
-//!
+
 #![allow(clippy::module_name_repetitions)]
+#![allow(deprecated)] // all the functions and types in this module are deprecated. This `allow` ensures we don't get warnings about this module using its own functions and types.
+
 use super::utils::{InterfaceResult, PolicySpecification};
 use cedar_policy_core::{
     ast::PolicySet,
@@ -143,6 +145,8 @@ enum ValidateAnswer {
 
 // PANIC SAFETY unit tests
 #[allow(clippy::panic)]
+// all the functions and types in the parent module are deprecated. This `allow` ensures we don't get warnings about these tests using the parent module's functions and types.
+#[allow(deprecated)]
 #[cfg(test)]
 mod test {
     use super::*;

--- a/cedar-policy/src/integration_testing.rs
+++ b/cedar-policy/src/integration_testing.rs
@@ -25,10 +25,11 @@
 #![allow(clippy::unwrap_used)]
 // PANIC SAFETY: This module is used only for testing.
 #![allow(clippy::expect_used)]
+#![allow(deprecated)] // Functionality in this module depends on `frontend`. https://github.com/cedar-policy/cedar/issues/821
 
 use crate::{
-    frontend::is_authorized::InterfaceResponse, AuthorizationError, Authorizer, Context, Decision,
-    Entities, EntityUid, PolicyId, PolicySet, Request, Schema, ValidationMode, Validator,
+    AuthorizationError, Authorizer, Context, Decision, Entities, EntityUid, PolicyId, PolicySet,
+    Request, Schema, ValidationMode, Validator,
 };
 use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 use serde::{Deserialize, Serialize};
@@ -161,7 +162,7 @@ pub trait CustomCedarImpl {
         q: &cedar_policy_core::ast::Request,
         p: &cedar_policy_core::ast::PolicySet,
         e: &cedar_policy_core::entities::Entities,
-    ) -> InterfaceResponse;
+    ) -> crate::frontend::is_authorized::InterfaceResponse;
 
     /// Custom validator entry point.
     ///

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -42,7 +42,13 @@ mod api;
 
 pub use api::*;
 
+pub mod ffi;
+
 /// Frontend utilities, see comments in the module itself
+#[deprecated(
+    since = "3.2.0",
+    note = "Use the functions in the `ffi` module instead"
+)]
 pub mod frontend;
 
 mod prop_test_policy_set;

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -21,6 +21,8 @@
 
 #![allow(deprecated)] // Functionality in this module depends on `frontend`. https://github.com/cedar-policy/cedar/issues/821
 
+pub use cedar_policy::frontend::is_authorized::InterfaceResponse;
+
 use cedar_policy_core::ast::{Expr, PolicySet, Request, Value};
 use cedar_policy_core::authorizer::Authorizer;
 use cedar_policy_core::entities::Entities;

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -19,7 +19,8 @@
 //! running the integration tests and for performing randomized differential
 //! testing (see <https://github.com/cedar-policy/cedar-spec>).
 
-pub use cedar_policy::frontend::is_authorized::InterfaceResponse;
+#![allow(deprecated)] // Functionality in this module depends on `frontend`. probably covered by https://github.com/cedar-policy/cedar/issues/821 ?
+
 use cedar_policy_core::ast::{Expr, PolicySet, Request, Value};
 use cedar_policy_core::authorizer::Authorizer;
 use cedar_policy_core::entities::Entities;
@@ -70,7 +71,7 @@ pub struct Micros(pub u128);
 #[derive(Debug, Deserialize)]
 pub struct TestResponse {
     /// Actual response
-    pub response: InterfaceResponse,
+    pub response: cedar_policy::frontend::is_authorized::InterfaceResponse,
     /// Timing info in microseconds. This field is a `HashMap` to allow timing
     /// multiple components (or none at all).
     pub timing_info: HashMap<String, Micros>,
@@ -200,7 +201,8 @@ impl CedarTestImplementation for RustEngine {
         // Error messages should only include the policy id to use the
         // `ErrorComparisonMode::PolicyIds` mode.
         let response = cedar_policy::Response::from(response);
-        let response = InterfaceResponse::new(
+        #[allow(deprecated)]
+        let response = cedar_policy::frontend::is_authorized::InterfaceResponse::new(
             response.decision(),
             response.diagnostics().reason().cloned().collect(),
             response

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -19,7 +19,7 @@
 //! running the integration tests and for performing randomized differential
 //! testing (see <https://github.com/cedar-policy/cedar-spec>).
 
-#![allow(deprecated)] // Functionality in this module depends on `frontend`. probably covered by https://github.com/cedar-policy/cedar/issues/821 ?
+#![allow(deprecated)] // Functionality in this module depends on `frontend`. https://github.com/cedar-policy/cedar/issues/821
 
 use cedar_policy_core::ast::{Expr, PolicySet, Request, Value};
 use cedar_policy_core::authorizer::Authorizer;

--- a/cedar-testing/src/integration_testing.rs
+++ b/cedar-testing/src/integration_testing.rs
@@ -25,6 +25,7 @@
 #![allow(clippy::unwrap_used)]
 // PANIC SAFETY: This module is used only for testing.
 #![allow(clippy::expect_used)]
+#![allow(deprecated)] // Functionality in this module depends on `frontend`. https://github.com/cedar-policy/cedar/issues/821
 
 use crate::cedar_test_impl::*;
 use cedar_policy::{extensions::Extensions, Decision, PolicyId, ValidationMode};


### PR DESCRIPTION
## Description of changes

`main` has a bunch of great FFI changes that are scheduled for release in 4.0, but some users would like a 3.x-compatible version of `cedar-wasm`.  Obviously, changes to the structs in the `cedar_policy::frontend` module are breaking, so we can’t backport them to 3.x.  But, since we are planning to rename `frontend` to `ffi` in 4.0 anyway, this PR proposes release the new FFI interface in the `ffi` module on 3.x, so that 3.2+ will have both the `frontend` and `ffi` modules and consumers can use either.  Existing users of `frontend` are not broken as there are no changes in  the `frontend` module, and since `cedar-wasm` has not been released yet, there’s no harm in having it be based on the `ffi` interface even on 3.x.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

