### PR TITLE
Use `insta` for snapshot testing of formatter output

### DIFF
--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -18,3 +18,6 @@ itertools = "0.12"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.9.1", features = ["unicode"] }
 miette = { version = "7.1.0" }
+
+[dev-dependencies]
+insta = { version = "1.38.0", features = ["glob"] }

--- a/cedar-policy-formatter/README.md
+++ b/cedar-policy-formatter/README.md
@@ -34,3 +34,18 @@ cedar format -h
 
 Generated documentation for the latest version can be accessed on
 [docs.rs](https://docs.rs/cedar-policy-formatter).
+
+## Testing
+
+Tests for this package use [`insta`](https://insta.rs/) for snapshot testing.
+Tests are executed with the usual `cargo test`, but, if your changes introduce
+a difference in how we format any of the test policies, the tests will fail,
+printing a nicely formatted diff as the error message. You can then run `cargo insta review`
+to review how formatting has changed. If the change is expected, accept it
+and commit the updated snapshot file. Otherwise, reject the change, and fix it
+as you would any other failing test case.
+
+You can add new test cases just just by placing a `.cedar` file in the `tests`
+directory. The next run of `cargo test` will fail because there is no snapshot
+file. Run `cargo insta review` to review the formatted output for the new
+tests. Accept and commit the snapshot if it is correct.

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -130,69 +130,51 @@ pub fn policies_str_to_pretty(ps: &str, config: &Config) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
+    use insta::{assert_snapshot, glob, with_settings};
+    use std::fs;
+
     use super::*;
-    const TEST_CONFIG: &Config = &Config {
-        line_width: 40,
-        indent_width: 2,
-    };
-
-    #[test]
-    fn trivial_permit() {
-        let policy = r#"permit (principal, action, resource);"#;
-        assert_eq!(policies_str_to_pretty(policy, TEST_CONFIG).unwrap(), policy);
-    }
-
-    #[test]
-    fn trivial_forbid() {
-        let policy = r#"forbid (principal, action, resource);"#;
-        assert_eq!(policies_str_to_pretty(policy, TEST_CONFIG).unwrap(), policy);
-    }
-
-    #[test]
-    fn action_in_set() {
-        let policy = r#"permit (
-        principal in UserGroup::"abc",
-        action in [Action::"viewPhoto", Action::"viewComments"],
-        resource in Album::"one"
-      );"#;
-        assert_eq!(
-            policies_str_to_pretty(policy, TEST_CONFIG).unwrap(),
-            r#"permit (
-  principal in UserGroup::"abc",
-  action in
-    [Action::"viewPhoto",
-     Action::"viewComments"],
-  resource in Album::"one"
-);"#
-        );
-    }
 
     #[test]
     fn test_format_files() {
-        use std::fs::read_to_string;
-        use std::path::Path;
-
         let config = Config {
             line_width: 80,
             indent_width: 2,
         };
-        let dir_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests");
-        let pairs = vec![
-            ("test.cedar", "test_formatted.cedar"),
-            ("policies.cedar", "policies_formatted.cedar"),
-            ("is_policies.cedar", "is_policies_formatted.cedar"),
-        ];
-        for (pf, ef) in pairs {
-            // editors or cargo run try to append a newline at the end of files
-            // we should remove them for equality testing
-            assert_eq!(
-                policies_str_to_pretty(&read_to_string(dir_path.join(pf)).unwrap(), &config)
-                    .unwrap()
-                    .trim_end_matches('\n'),
-                read_to_string(dir_path.join(ef))
-                    .unwrap()
-                    .trim_end_matches('\n')
-            );
-        }
+
+        // This test uses `insta` to test the current output of the formatter
+        // against the output from prior versions. Run the test as usual with
+        // `cargo test`.
+        //
+        // If it fails, then use `cargo insta review` to review the diff between
+        // the current output and the snapshot. If the change is expected, you
+        // can accept the changes to make `insta` update the snapshot which you
+        // should the commit to the repository.
+        //
+        // Add new tests by placing a `.cedar` file in the test directory. The
+        // next run of `cargo test` will fail. Use `cargo insta review` to check
+        // the formatted output is expected.
+        with_settings!(
+            { snapshot_path => "../../tests/snapshots/" },
+            {
+                glob!("../../tests", "*.cedar", |path| {
+                    let cedar_source = fs::read_to_string(path).unwrap();
+                    let formatted = policies_str_to_pretty(&cedar_source, &config).unwrap();
+                    assert_snapshot!(formatted);
+                });
+            }
+        );
+
+        // Also check the CLI sample files.
+        with_settings!(
+            { snapshot_path => "../../tests/cli-snapshots/" },
+            {
+                glob!("../../../cedar-policy-cli/sample-data", "**/*.cedar", |path| {
+                    let cedar_source = fs::read_to_string(path).unwrap();
+                    let formatted = policies_str_to_pretty(&cedar_source, &config).unwrap();
+                    assert_snapshot!(formatted);
+                });
+            }
+        )
     }
 }

--- a/cedar-policy-formatter/tests/action_in_set.cedar
+++ b/cedar-policy-formatter/tests/action_in_set.cedar
@@ -1,0 +1,5 @@
+permit (
+        principal in UserGroup::"abc",
+        action in [Action::"viewPhoto", Action::"viewComments"],
+        resource in Album::"one"
+      );

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_1.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_1.cedar.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_1.cedar
+---
+// Everyone in the group UserGroup::"jane_friends" can view this specific photo
+@id("jane's friends view-permission policy")
+permit (
+  principal in UserGroup::"jane_friends",
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+);
+
+// but Tim is disallowed from viewing the photo
+@id("disallow tim policy")
+forbid (
+  principal == User::"tim",
+  action,
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_1_bad.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_1_bad.cedar.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_1_bad.cedar
+---
+// Everyone in the group UserGroup::"jane_friends" can view this specific photo
+@id("jane's friends view-permission policy")
+permit (
+  principal in UsrGroup::"jane_friends",
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+);
+
+// but Tim is disallowed from viewing the photo
+@id("disallow tim policy")
+forbid (
+  principal == User::"tim",
+  action,
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_2.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_2.cedar.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_2.cedar
+---
+// Alice can view, edit, or delete any photo in the "jane_vacation" album
+@id("alice's access policy")
+permit (
+  principal == User::"alice",
+  action in [Action::"view", Action::"edit", Action::"delete"],
+  resource in Album::"jane_vacation"
+);
+
+// Bob can only view things in the "jane_vacation" album
+@id("bob's view policy")
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_3.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_a__policies_3.cedar.snap
@@ -1,0 +1,13 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_3.cedar
+---
+// Everyone can view the photos in the "jane_vacation" album
+// (and list the photos in the album)
+@id("jane_vacation public")
+permit (
+  principal,
+  action in [Action::"view", Action::"listPhotos"],
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_4.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_4.cedar.snap
@@ -1,0 +1,15 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_4.cedar
+---
+// Only members of the HardwareEngineering department with job level >= 5 can
+// view photos in device_prototypes
+@id("prototypes access policy")
+permit (
+  principal,
+  action == Action::"view",
+  resource in Album::"device_prototypes"
+)
+when
+{ principal.department == "HardwareEngineering" && principal.jobLevel >= 5 };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_5.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_5.cedar.snap
@@ -1,0 +1,19 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_5.cedar
+---
+// Alice's friends can view all of her photos
+@id("alice's friends view policy")
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
+);
+
+// but, as a general rule, anything marked private can only be viewed by the
+// account owner
+@id("privacy rule")
+forbid (principal, action, resource)
+when { resource.private }
+unless { resource.account has owner && resource.account.owner == principal };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_5_bad.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_5_bad.cedar.snap
@@ -1,0 +1,19 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_5_bad.cedar
+---
+// Alice's friends can view all of her photos
+@id("alice's friends view policy")
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
+);
+
+// but, as a general rule, anything marked private can only be viewed by the
+// account owner
+@id("privacy rule")
+forbid (principal, action, resource)
+when { resource.private }
+unless { resource.account.owner == principal };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_6.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_b__policies_6.cedar.snap
@@ -1,0 +1,17 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_6.cedar
+---
+// Alice's friends can view all of her photos
+@id("alice's friends view policy")
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
+);
+
+// but forbid all requests coming from this IP range
+@id("ip_denylist")
+forbid (principal, action, resource)
+when { context.source_ip.isInRange(ip("222.222.222.0/24")) };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_c__policies.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_c__policies.cedar.snap
@@ -1,0 +1,12 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_c/policies.cedar
+---
+// Template for permitting vacation photo access
+@id("AccessVacation")
+permit (
+  principal in ?principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_c__policies_edited.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@sandbox_c__policies_edited.cedar.snap
@@ -1,0 +1,13 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_c/policies_edited.cedar
+---
+// Template for permitting vacation photo access
+@id("AccessVacation")
+permit (
+  principal in ?principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when { principal has department && principal.department == "research" };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__format__formatted.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__format__formatted.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/format/formatted.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__format__unformatted.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__format__unformatted.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/format/unformatted.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample1__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample1__policy.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample1/policy.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample2__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample2__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample2/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action in [Action::"view", Action::"edit"],
+  resource
+)
+when { resource.owner == principal };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample3__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample3__policy.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample3/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action in [Action::"view", Action::"edit"],
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample4__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample4__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample4/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+)
+when { action == Action::"view" };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample5__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample5__policy.cedar.snap
@@ -1,0 +1,22 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample5/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+)
+when
+{
+  principal == resource.owner &&
+  ip("127.0.0.1") == ip("127.0.0.1") &&
+  principal.addr.isLoopback() &&
+  ip("192.168.0.1").isInRange(ip("192.168.0.1/24")) &&
+  [ip("127.0.0.1"), ip("127.0.0.2")].containsAny([principal.addr]) &&
+  principal.addr == ip("127.0.0.1") &&
+  principal.addr.isInRange(ip("127.0.0.1/28")) &&
+  principal.addr.isIpv4() &&
+  ip("224.0.0.0").isMulticast()
+};

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample6__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample6__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample6/policy.cedar
+---
+permit (
+  principal in UserGroup::"guardians",
+  action in [Action::"view"],
+  resource == ScreenTime::"activity"
+)
+when { principal.account.age >= 18 };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample7__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample7__policy.cedar.snap
@@ -1,0 +1,17 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample7/policy.cedar
+---
+permit (
+  principal == PhotoFlash::Data::User::"alice",
+  action == PhotoFlash::Data::Action::"view",
+  resource in PhotoFlash::Data::Album::"jane_vacation"
+)
+when
+{
+  context.role.contains("admin") &&
+  context.person.age > 17 &&
+  context.addr.city == "DC" ||
+  context.addr == {city:"DC", street:"main"}
+};

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample8__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample8__policy.cedar.snap
@@ -1,0 +1,15 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample8/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+)
+when
+{
+  principal == resource.owner &&
+  principal.score.greaterThanOrEqual(decimal("0.75"))
+};

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample9__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample9__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample9/policy.cedar
+---
+permit (
+  principal,
+  action == Action::"view",
+  resource is Photo
+)
+when { principal == resource.owner };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample9__policy_bad.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__cli_sample_data_format@tiny_sandboxes__sample9__policy_bad.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample9/policy_bad.cedar
+---
+permit (
+  principal,
+  action == Action::"view",
+  resource
+)
+when { principal == resource.owner };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_1.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_1.cedar.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_1.cedar
+---
+// Everyone in the group UserGroup::"jane_friends" can view this specific photo
+@id("jane's friends view-permission policy")
+permit (
+  principal in UserGroup::"jane_friends",
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+);
+
+// but Tim is disallowed from viewing the photo
+@id("disallow tim policy")
+forbid (
+  principal == User::"tim",
+  action,
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_1_bad.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_1_bad.cedar.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_1_bad.cedar
+---
+// Everyone in the group UserGroup::"jane_friends" can view this specific photo
+@id("jane's friends view-permission policy")
+permit (
+  principal in UsrGroup::"jane_friends",
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+);
+
+// but Tim is disallowed from viewing the photo
+@id("disallow tim policy")
+forbid (
+  principal == User::"tim",
+  action,
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_2.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_2.cedar.snap
@@ -1,0 +1,20 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_2.cedar
+---
+// Alice can view, edit, or delete any photo in the "jane_vacation" album
+@id("alice's access policy")
+permit (
+  principal == User::"alice",
+  action in [Action::"view", Action::"edit", Action::"delete"],
+  resource in Album::"jane_vacation"
+);
+
+// Bob can only view things in the "jane_vacation" album
+@id("bob's view policy")
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_3.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_a__policies_3.cedar.snap
@@ -1,0 +1,13 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_a/policies_3.cedar
+---
+// Everyone can view the photos in the "jane_vacation" album
+// (and list the photos in the album)
+@id("jane_vacation public")
+permit (
+  principal,
+  action in [Action::"view", Action::"listPhotos"],
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_4.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_4.cedar.snap
@@ -1,0 +1,15 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_4.cedar
+---
+// Only members of the HardwareEngineering department with job level >= 5 can
+// view photos in device_prototypes
+@id("prototypes access policy")
+permit (
+  principal,
+  action == Action::"view",
+  resource in Album::"device_prototypes"
+)
+when
+{ principal.department == "HardwareEngineering" && principal.jobLevel >= 5 };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_5.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_5.cedar.snap
@@ -1,0 +1,19 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_5.cedar
+---
+// Alice's friends can view all of her photos
+@id("alice's friends view policy")
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
+);
+
+// but, as a general rule, anything marked private can only be viewed by the
+// account owner
+@id("privacy rule")
+forbid (principal, action, resource)
+when { resource.private }
+unless { resource.account has owner && resource.account.owner == principal };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_5_bad.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_5_bad.cedar.snap
@@ -1,0 +1,19 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_5_bad.cedar
+---
+// Alice's friends can view all of her photos
+@id("alice's friends view policy")
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
+);
+
+// but, as a general rule, anything marked private can only be viewed by the
+// account owner
+@id("privacy rule")
+forbid (principal, action, resource)
+when { resource.private }
+unless { resource.account.owner == principal };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_6.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_b__policies_6.cedar.snap
@@ -1,0 +1,17 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_b/policies_6.cedar
+---
+// Alice's friends can view all of her photos
+@id("alice's friends view policy")
+permit (
+  principal in UserGroup::"alice_friends",
+  action == Action::"view",
+  resource in Account::"alice"
+);
+
+// but forbid all requests coming from this IP range
+@id("ip_denylist")
+forbid (principal, action, resource)
+when { context.source_ip.isInRange(ip("222.222.222.0/24")) };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_c__policies.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_c__policies.cedar.snap
@@ -1,0 +1,12 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_c/policies.cedar
+---
+// Template for permitting vacation photo access
+@id("AccessVacation")
+permit (
+  principal in ?principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_c__policies_edited.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@sandbox_c__policies_edited.cedar.snap
@@ -1,0 +1,13 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/sandbox_c/policies_edited.cedar
+---
+// Template for permitting vacation photo access
+@id("AccessVacation")
+permit (
+  principal in ?principal,
+  action == Action::"view",
+  resource == Photo::"VacationPhoto94.jpg"
+)
+when { principal has department && principal.department == "research" };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__format__formatted.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__format__formatted.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/format/formatted.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__format__unformatted.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__format__unformatted.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/format/unformatted.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample1__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample1__policy.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample1/policy.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"view",
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample2__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample2__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample2/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action in [Action::"view", Action::"edit"],
+  resource
+)
+when { resource.owner == principal };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample3__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample3__policy.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample3/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action in [Action::"view", Action::"edit"],
+  resource in Album::"jane_vacation"
+);

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample4__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample4__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample4/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+)
+when { action == Action::"view" };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample5__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample5__policy.cedar.snap
@@ -1,0 +1,22 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample5/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+)
+when
+{
+  principal == resource.owner &&
+  ip("127.0.0.1") == ip("127.0.0.1") &&
+  principal.addr.isLoopback() &&
+  ip("192.168.0.1").isInRange(ip("192.168.0.1/24")) &&
+  [ip("127.0.0.1"), ip("127.0.0.2")].containsAny([principal.addr]) &&
+  principal.addr == ip("127.0.0.1") &&
+  principal.addr.isInRange(ip("127.0.0.1/28")) &&
+  principal.addr.isIpv4() &&
+  ip("224.0.0.0").isMulticast()
+};

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample6__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample6__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample6/policy.cedar
+---
+permit (
+  principal in UserGroup::"guardians",
+  action in [Action::"view"],
+  resource == ScreenTime::"activity"
+)
+when { principal.account.age >= 18 };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample7__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample7__policy.cedar.snap
@@ -1,0 +1,17 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample7/policy.cedar
+---
+permit (
+  principal == PhotoFlash::Data::User::"alice",
+  action == PhotoFlash::Data::Action::"view",
+  resource in PhotoFlash::Data::Album::"jane_vacation"
+)
+when
+{
+  context.role.contains("admin") &&
+  context.person.age > 17 &&
+  context.addr.city == "DC" ||
+  context.addr == {city:"DC", street:"main"}
+};

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample8__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample8__policy.cedar.snap
@@ -1,0 +1,15 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample8/policy.cedar
+---
+permit (
+  principal == User::"bob",
+  action == Action::"view",
+  resource
+)
+when
+{
+  principal == resource.owner &&
+  principal.score.greaterThanOrEqual(decimal("0.75"))
+};

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample9__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample9__policy.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample9/policy.cedar
+---
+permit (
+  principal,
+  action == Action::"view",
+  resource is Photo
+)
+when { principal == resource.owner };

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample9__policy_bad.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__sample9__policy_bad.cedar.snap
@@ -1,0 +1,11 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/sample9/policy_bad.cedar
+---
+permit (
+  principal,
+  action == Action::"view",
+  resource
+)
+when { principal == resource.owner };

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@action_in_set.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@action_in_set.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/action_in_set.cedar
+---
+permit (
+  principal in UserGroup::"abc",
+  action in [Action::"viewPhoto", Action::"viewComments"],
+  resource in Album::"one"
+);

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@is_policies.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@is_policies.cedar.snap
@@ -1,3 +1,8 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/is_policies.cedar
+---
 permit (principal is User, action, resource is Photo)
 when { User::"alice" is User };
 
@@ -62,4 +67,3 @@ when // 19
     "friends" // 29
 } // 30
 ; // 31
-

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@policies.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@policies.cedar.snap
@@ -1,3 +1,8 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/policies.cedar
+---
 permit (
   principal == User::"alice",
   action == Action::"view",

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@test.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@test.cedar.snap
@@ -1,3 +1,8 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/test.cedar
+---
 permit (principal, action, resource)
 // haha
 when

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@trivial_forbid.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@trivial_forbid.cedar.snap
@@ -1,0 +1,6 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/trivial_forbid.cedar
+---
+forbid (principal, action, resource);

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@trivial_permit.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@trivial_permit.cedar.snap
@@ -1,0 +1,6 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/trivial_permit.cedar
+---
+permit (principal, action, resource);

--- a/cedar-policy-formatter/tests/trivial_forbid.cedar
+++ b/cedar-policy-formatter/tests/trivial_forbid.cedar
@@ -1,0 +1,1 @@
+forbid (principal, action, resource);

--- a/cedar-policy-formatter/tests/trivial_permit.cedar
+++ b/cedar-policy-formatter/tests/trivial_permit.cedar
@@ -1,0 +1,1 @@
+permit (principal, action, resource);


### PR DESCRIPTION
## Description of changes

Use [insta](https://insta.rs/) to make testing the formatter easier.

Our existing test for the formatter are all taking some Cedar source file, formatting it, and asserting that it's equal to some formatted policy generated by a previous commit. Updating these test requires tedious manual work to review and update the files. `inst` automates most of this.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.