### PR TITLE
Bring wasm code to 3.2.x

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -82,3 +82,18 @@ jobs:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@cargo-hack
     - run: cargo hack check --rust-version --workspace --all-targets --ignore-private
+
+  wasm-build:
+    name: run wasm build script
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+
+    env:
+      RUSTFLAGS: '-D warnings -F unsafe-code'
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: cd ./cedar-wasm && cargo install wasm-pack && ./build-wasm.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
       # `cargo semver-checks` doesn't understand `rlib` crates.
       - run: >-
-          sed -i 's/^crate_type = \["rlib"\]$/crate_type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
+          sed -i -E 's/^(crate_type = \["rlib", "cdylib"\]|crate_type = \["rlib"\])$/crate_type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo install cargo-semver-checks
       - run: cargo semver-checks check-release --package cedar-policy --baseline-root ../base

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
 	"cedar-policy-formatter",
 	"cedar-policy-cli",
 	"cedar-testing",
+	"cedar-wasm"
 ]
 
 resolver = "2"

--- a/THIRD_PARTY_LICENSES.txt
+++ b/THIRD_PARTY_LICENSES.txt
@@ -34,6 +34,8 @@ Copyright (c) 2018 Akash Kurdekar
 Copyright (c) 2016 Martin Geisler
 ** typed-arena
 Copyright (c) 2018 The typed-arena developers
+** serde-wasm-bindgen
+Copyright (c) 2019 Cloudflare, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -26,10 +26,15 @@ smol_str = { version = "0.2", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }
 miette = { version = "7.1.0", features = ["serde"] }
+nonempty = "0.10.0"
 
 # decimal extension requires regex
 regex = { version = "1.8", features = ["unicode"], optional = true }
-nonempty = "0.10"
+
+# wasm dependencies
+serde-wasm-bindgen = { version = "0.6", optional = true }
+tsify = { version = "0.4.5", optional = true }
+wasm-bindgen = { version = "0.2.82", optional = true }
 
 [features]
 # by default, enable all Cedar extensions
@@ -45,6 +50,7 @@ test-util = []
 
 # Experimental features.
 partial-eval = []
+wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [build-dependencies]
 lalrpop = "0.20.0"

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -26,6 +26,9 @@ use std::{
 };
 use thiserror::Error;
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 /// Internal AST for expressions used by the policy evaluator.
 /// This structure is a wrapper around an `ExprKind`, which is the expression
 /// variant this object contains. It also contains source information about
@@ -1353,6 +1356,8 @@ impl<T> Expr<T> {
 /// AST variables
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Var {
     /// the Principal of the given request
     #[serde(rename = "principal")]

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -24,6 +24,9 @@ use std::collections::BTreeMap;
 use std::{collections::HashMap, sync::Arc};
 use thiserror::Error;
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 /// Top level structure for a policy template.
 /// Contains both the AST for template, and the list of open slots in the template.
 ///
@@ -1738,6 +1741,8 @@ impl<'u> arbitrary::Arbitrary<'u> for PolicyID {
 /// the Effect of a policy
 #[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Effect {
     /// this is a Permit policy
     #[serde(rename = "permit")]

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -29,6 +29,9 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::sync::Arc;
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 mod err;
 mod partial_response;
 pub use err::AuthorizationError;
@@ -647,6 +650,8 @@ impl Response {
 
 /// Decision returned from the `Authorizer`
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Decision {
     /// The `Authorizer` determined that the request should be allowed
     Allow,

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -34,9 +34,14 @@ use smol_str::SmolStr;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 /// Serde JSON format for a single entity
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EntityJson {
     /// UID of the entity, specified in any form accepted by `EntityUidJson`
     uid: EntityUidJson,
@@ -47,6 +52,7 @@ pub struct EntityJson {
     /// any duplicate keys in any records that may occur in an attribute value
     /// (even nested).)
     #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson>"))]
     // the annotation covers duplicates in this `HashMap` itself, while the `JsonValueWithNoDuplicateKeys` covers duplicates in any records contained in attribute values (including recursively)
     attrs: HashMap<SmolStr, JsonValueWithNoDuplicateKeys>,
     /// Parents of the entity, specified in any form accepted by `EntityUidJson`

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -32,10 +32,15 @@ use serde_with::serde_as;
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashMap};
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 /// Serde JSON structure for policies and templates in the EST format
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Policy {
     /// `Effect` of the policy or template
     effect: ast::Effect,
@@ -51,6 +56,7 @@ pub struct Policy {
     #[serde(default)]
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, string>"))]
     annotations: BTreeMap<ast::AnyId, SmolStr>,
 }
 
@@ -58,6 +64,8 @@ pub struct Policy {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "kind", content = "body")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Clause {
     /// A `when` clause
     #[serde(rename = "when")]

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -22,10 +22,15 @@ use smol_str::SmolStr;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+#[cfg(feature = "wasm")]
+extern crate tsify;
+
 /// Serde JSON structure for a principal scope constraint in the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PrincipalConstraint {
     /// No constraint (e.g., `principal,`)
     All,
@@ -44,6 +49,8 @@ pub enum PrincipalConstraint {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ActionConstraint {
     /// No constraint (i.e., `action,`)
     All,
@@ -59,6 +66,8 @@ pub enum ActionConstraint {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "op")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ResourceConstraint {
     /// No constraint (e.g., `resource,`)
     All,
@@ -76,6 +85,8 @@ pub enum ResourceConstraint {
 /// Serde JSON structure for a `==` scope constraint in the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum EqConstraint {
     /// `==` a literal entity
     Entity {
@@ -85,6 +96,7 @@ pub enum EqConstraint {
     /// Template slot
     Slot {
         /// slot
+        #[cfg_attr(feature = "wasm", tsify(type = "string"))]
         slot: ast::SlotId,
     },
 }
@@ -93,6 +105,8 @@ pub enum EqConstraint {
 /// the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum PrincipalOrResourceInConstraint {
     /// `in` a literal entity
     Entity {
@@ -102,6 +116,7 @@ pub enum PrincipalOrResourceInConstraint {
     /// Template slot
     Slot {
         /// slot
+        #[cfg_attr(feature = "wasm", tsify(type = "string"))]
         slot: ast::SlotId,
     },
 }
@@ -110,7 +125,10 @@ pub enum PrincipalOrResourceInConstraint {
 /// the EST format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PrincipalOrResourceIsConstraint {
+    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
     entity_type: SmolStr,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "in")]
@@ -121,6 +139,8 @@ pub struct PrincipalOrResourceIsConstraint {
 /// format
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum ActionInConstraint {
     /// Single entity
     Single {

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -30,6 +30,7 @@ pub use err::{EvaluationError, EvaluationErrorKind};
 use itertools::Either;
 use smol_str::SmolStr;
 
+#[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
 // PANIC SAFETY `Name`s in here are valid `Name`s

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -248,6 +248,7 @@ impl EvaluationError {
     }
 
     /// Construct a [`RecursionLimit`] error
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn recursion_limit(source_loc: Option<Loc>) -> Self {
         Self {
             error_kind: EvaluationErrorKind::RecursionLimit,

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -27,6 +27,11 @@ lalrpop-util = { version = "0.20.0", features = ["lexer", "unicode"] }
 lazy_static = "1.4.0"
 nonempty = "0.10.0"
 
+# wasm dependencies
+serde-wasm-bindgen = { version = "0.6", optional = true }
+tsify = { version = "0.4.5", optional = true }
+wasm-bindgen = { version = "0.2.82", optional = true }
+
 [features]
 # by default, enable all Cedar extensions
 default = ["ipaddr", "decimal"]
@@ -39,6 +44,7 @@ arbitrary = ["dep:arbitrary"]
 
 # Experimental features.
 partial-validate = []
+wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -54,6 +54,7 @@ use cedar_policy_core::ast::{
     PrincipalOrResourceConstraint, SlotId, Template, UnaryOp, Var,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
 /// TypecheckAnswer holds the result of typechecking an expression.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report the precise source location where the unknown type was encountered.
   Error for invalid use of an action now includes a source location containing
   the offending policy. (#802, #808, resolving #522)
+- Deprecated the integration testing harness code. It will be removed from the
+  `cedar-policy` crate in the next major version. (#707)
 
 ### Fixed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -18,7 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `frontend` module is now deprecated.
   This should be considered a preview-release of `ffi`; more API breaking
   changes are anticipated for Cedar 4.0. (#852)
-- `wasm` Cargo feature for targeting Wasm
+- `wasm` Cargo feature for targeting Wasm (and the `cedar-wasm` crate was added
+  to this repo).
+  This should be considered a preview-release of `cedar-wasm`; more API
+  breaking changes are anticipated for Cedar 4.0. (#858)
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   report the precise source location where the unknown type was encountered.
   Error for invalid use of an action now includes a source location containing
   the offending policy. (#802, #808, resolving #522)
+- Deprecated the `frontend` module in favor of the new `ffi` module. The
+  `frontend` module will be removed from `cedar-policy` in the next major version.
+  See notes above about `ffi`. (#852)
 - Deprecated the integration testing harness code. It will be removed from the
   `cedar-policy` crate in the next major version. (#707)
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Entity::into_inner` (#685, resolving #636)
 - New `ffi` module with an improved FFI interface. This will replace the
   `frontend` module in the 4.0 release, but is available now for early adopters;
-  the `frontend` module is now deprecated. (#852)
+  the `frontend` module is now deprecated.
+  This should be considered a preview-release of `ffi`; more API breaking
+  changes are anticipated for Cedar 4.0. (#852)
+- `wasm` Cargo feature for targeting Wasm
 
 ### Changed
 
@@ -275,6 +278,33 @@ Cedar Language Version: 3.0.0
   To continue using this feature you must enable the `permissive-validate`
   feature flag. (#428)
 
+## [2.4.5] - 2023-04-01
+
+### Changed
+
+- Implement [RFC 57](https://github.com/cedar-policy/rfcs/pull/57): policies can
+  now include multiplication of arbitrary expressions, not just multiplication of
+  an expression and a constant.
+
+## [2.4.4] - 2023-03-08
+
+Cedar Language Version: 2.1.3
+
+### Changed
+
+- Calling `add_template` with a `PolicyId` that is an existing link will now error. (#671, backport of #456)
+
+### Fixed
+
+- Updated `PolicySet::link` to not mutate internal state when failing to link a static
+  policy. With this fix it is possible to create a link with a policy id
+  after previously failing to create that link with the same id from a static
+  policy. (#669, backport of #412)
+- Action entities in the store will pass schema-based validation without requiring
+  the transitive closure to be pre-computed. (#688, backport of #581)
+- Policies containing the literal `i64::MIN` can now be properly converted to the JSON policy format. (#672, backport of #601)
+- `Template::from_json` errors when there are slots in template conditions. (#672, backport of #626)
+- `Policy::to_json` does not error on policies containing special identifiers such as `principal`, `then`, and `true`. (#672, backport of #628)
 
 ## [2.4.3] - 2023-12-21
 
@@ -467,7 +497,9 @@ Cedar Language Version: 2.0.0
 [3.1.1]: https://github.com/cedar-policy/cedar/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/cedar-policy/cedar/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/cedar-policy/cedar/compare/v3.0.0...v3.0.1
-[3.0.0]: https://github.com/cedar-policy/cedar/compare/v2.4.3...v3.0.0
+[3.0.0]: https://github.com/cedar-policy/cedar/compare/v2.4.5...v3.0.0
+[2.4.5]: https://github.com/cedar-policy/cedar/compare/v2.4.4...v2.4.5
+[2.4.4]: https://github.com/cedar-policy/cedar/compare/v2.4.3...v2.4.4
 [2.4.3]: https://github.com/cedar-policy/cedar/compare/v2.4.2...v2.4.3
 [2.4.2]: https://github.com/cedar-policy/cedar/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/cedar-policy/cedar/compare/v2.4.0...v2.4.1

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -26,6 +26,10 @@ dhat = { version = "0.3.2", optional = true }
 serde_with = "3.3.0"
 nonempty = "0.10"
 
+# wasm dependencies
+serde-wasm-bindgen = { version = "0.6", optional = true }
+tsify = { version = "0.4.5", optional = true }
+wasm-bindgen = { version = "0.2.82", optional = true }
 
 [features]
 # by default, enable all Cedar extensions, but not other crate features
@@ -47,9 +51,11 @@ experimental = ["partial-eval", "permissive-validate", "partial-validate"]
 partial-eval = ["cedar-policy-core/partial-eval"]
 permissive-validate = []
 partial-validate = ["cedar-policy-validator/partial-validate"]
+wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [lib]
-crate_type = ["rlib"]
+# cdylib required for wasm
+crate_type = ["rlib", "cdylib"]
 
 [dev-dependencies]
 # Hack to enable the `integration_testing` feature for the `Cedar` integration

--- a/cedar-wasm/.cargo/config.toml
+++ b/cedar-wasm/.cargo/config.toml
@@ -1,0 +1,4 @@
+[profile.release]
+overflow-checks = true
+# Tell `rustc` to optimize for small code size
+opt-level = "s"

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+name = "cedar-wasm"
+version = "3.2.0"
+edition = "2021"
+rust-version = "1.76.0" # minimum supported Rust version is currently 1.76.0 because `cedar-policy-core` requirement. Check with `cargo install cargo-msrv && cargo msrv --min 1.75.0`
+description = "WASM bindings and typescript types for Cedar lib"
+license = "Apache-2.0"
+
+exclude = ['/build']
+
+[dependencies]
+cedar-policy = { version = "=3.2.0", path = "../cedar-policy", features = ["wasm"] }
+cedar-policy-core = { version = "=3.2.0", path = "../cedar-policy-core", features = ["wasm"] }
+cedar-policy-formatter = { version = "=3.2.0", path = "../cedar-policy-formatter" }
+cedar-policy-validator = { version = "=3.2.0", path = "../cedar-policy-validator", features = ["wasm"] }
+
+serde = { version = "1.0", features = ["derive", "rc"] }
+serde-wasm-bindgen = "0.6"
+serde_json = "1.0"
+wasm-bindgen = { version = "0.2.82" }
+console_error_panic_hook = { version = "0.1.6", optional = true }
+tsify = "0.4.5"
+
+[features]
+default = ["console_error_panic_hook"]
+
+[lib]
+crate_type = ["cdylib", "rlib"]
+
+[dev-dependencies]
+wasm-bindgen-test = "0.3.13"
+cool_asserts = "2.0"
+
+[build-dependencies]
+cargo-lock = "9.0.0"
+itertools = "0.12.1"

--- a/cedar-wasm/README.md
+++ b/cedar-wasm/README.md
@@ -1,0 +1,3 @@
+# cedar-wasm
+
+An implementation of various cedar functions to enable developers to write typescript and javascript applications using Cedar and wasm.

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Copyright Cedar Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script calls wasm-pack build and post-processes the generated TS types to fix them.
+# Without this, the built wasm still works, but the Typescript definitions made by tsify don't.
+set -e
+cargo build
+wasm-pack build --scope amzn --target web
+
+sed -i "s/[{]\s*!: /{ \"!\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*==: /{ \"==\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*!=: /{ \"!=\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*<: /{ \"<\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*<=: /{ \"<=\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*>: /{ \">\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*>=: /{ \">=\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*&&: /{ \"\&\&\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*||: /{ \"||\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*[+]: /{ \"+\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*-: /{ \"-\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*[*]: /{ \"*\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/[{]\s*\.: /{ \".\": /g" pkg/cedar_wasm.d.ts
+sed -i "s/ | __skip//g" pkg/cedar_wasm.d.ts
+sed -i "s/SchemaFragment/Schema/g" pkg/cedar_wasm.d.ts
+
+echo "type SmolStr = string;" >> pkg/cedar_wasm.d.ts
+echo "type Name = string;" >> pkg/cedar_wasm.d.ts
+echo "type Id = string;" >> pkg/cedar_wasm.d.ts
+echo "export type TypeOfAttribute = SchemaType & { required?: boolean };" >> pkg/cedar_wasm.d.ts
+echo "export type Context = Record<string, CedarValueJson>;" >> pkg/cedar_wasm.d.ts
+echo "Finished post-processing types file"

--- a/cedar-wasm/build.rs
+++ b/cedar-wasm/build.rs
@@ -1,0 +1,36 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cargo_lock::Lockfile;
+
+/// PANIC SAFETY: This is a build script so it's okay for it to panic. Build should fail if underlying assumptions of this script fail
+#[allow(clippy::expect_used)]
+fn main() {
+    println!("cargo:rerun-if-changed=../Cargo.lock");
+    let lockfile = Lockfile::load("../Cargo.lock").expect("a valid lockfile");
+    let mut iter = lockfile
+        .packages
+        .into_iter()
+        .filter(|p| p.name.as_str() == "cedar-policy");
+    let version = iter
+        .next()
+        .expect("cedar-policy is not found in manifest")
+        .version;
+
+    assert!(iter.next().is_none());
+
+    println!("cargo:rustc-env=CEDAR_VERSION={version}");
+}

--- a/cedar-wasm/src/authorizer.rs
+++ b/cedar-wasm/src/authorizer.rs
@@ -1,0 +1,24 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module contains the entry point to the wasm isAuthorized functionality.
+use cedar_policy::ffi;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = "isAuthorized")]
+pub fn wasm_is_authorized(call: ffi::AuthorizationCall) -> ffi::AuthorizationAnswer {
+    ffi::is_authorized(call)
+}

--- a/cedar-wasm/src/formatter.rs
+++ b/cedar-wasm/src/formatter.rs
@@ -1,0 +1,82 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cedar_policy_formatter::{policies_str_to_pretty, Config};
+use serde::{Deserialize, Serialize};
+
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum FormattingResult {
+    Success { formatted_policy: String },
+    Error { errors: Vec<String> },
+}
+
+#[wasm_bindgen(js_name = "formatPolicies")]
+pub fn wasm_format_policies(
+    policies_str: &str,
+    line_width: i32,
+    indent_width: i32,
+) -> FormattingResult {
+    let line_width: usize = match line_width.try_into() {
+        Ok(width) => width,
+        Err(_) => {
+            return FormattingResult::Error {
+                errors: vec!["Input size error (line width)".to_string()],
+            }
+        }
+    };
+    let indent_width: isize = match indent_width.try_into() {
+        Ok(width) => width,
+        Err(_) => {
+            return FormattingResult::Error {
+                errors: vec!["Input size error (indent width)".to_string()],
+            }
+        }
+    };
+    let config = Config {
+        line_width,
+        indent_width,
+    };
+    match policies_str_to_pretty(policies_str, &config) {
+        Ok(prettified_policy) => FormattingResult::Success {
+            formatted_policy: prettified_policy,
+        },
+        Err(err) => FormattingResult::Error {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use cool_asserts::assert_matches;
+
+    #[test]
+    fn test_format_policies() {
+        let policy = r#"permit(principal, action == Action::"view", resource in Albums::"gangsta rap") when {principal.is_gangsta == true};"#;
+        let expected = "permit (\n    principal,\n    action == Action::\"view\",\n    resource in Albums::\"gangsta rap\"\n)\nwhen { principal.is_gangsta == true };";
+        let result = wasm_format_policies(policy, 80, 4);
+        assert_matches!(result, FormattingResult::Success { formatted_policy } => {
+            assert_eq!(formatted_policy, expected.to_string());
+        });
+    }
+}

--- a/cedar-wasm/src/lib.rs
+++ b/cedar-wasm/src/lib.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#![forbid(unsafe_code)]
+
+use wasm_bindgen::prelude::*;
+
+mod authorizer;
+mod formatter;
+mod policies_and_templates;
+mod schema_and_entities_and_context;
+mod validator;
+
+pub use authorizer::wasm_is_authorized;
+pub use formatter::wasm_format_policies;
+pub use policies_and_templates::{
+    check_parse_policy_set, check_parse_template, policy_text_from_json, policy_text_to_json,
+};
+pub use schema_and_entities_and_context::{
+    check_parse_context, check_parse_entities, check_parse_schema,
+};
+pub use validator::wasm_validate;
+
+#[wasm_bindgen(js_name = "getCedarVersion")]
+pub fn get_cedar_version() -> String {
+    std::env!("CEDAR_VERSION").to_string()
+}

--- a/cedar-wasm/src/policies_and_templates.rs
+++ b/cedar-wasm/src/policies_and_templates.rs
@@ -1,0 +1,249 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use cedar_policy::{Policy, PolicySet, Template};
+use cedar_policy_core::parser::parse_policy_or_template_to_est;
+use serde::{Deserialize, Serialize};
+
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum JsonToPolicyResult {
+    #[serde(rename_all = "camelCase")]
+    Success {
+        policy_text: String,
+    },
+    Error {
+        errors: Vec<String>,
+    },
+}
+
+#[wasm_bindgen(js_name = "policyTextFromJson")]
+pub fn policy_text_from_json(json_str: &str) -> JsonToPolicyResult {
+    let parsed_json = match serde_json::from_str(json_str) {
+        Ok(v) => v,
+        Err(e) => {
+            return JsonToPolicyResult::Error {
+                errors: vec![e.to_string()],
+            }
+        }
+    };
+    let policy = Policy::from_json(None, parsed_json);
+    match policy {
+        Ok(p) => JsonToPolicyResult::Success {
+            policy_text: p.to_string(),
+        },
+        Err(e) => JsonToPolicyResult::Error {
+            errors: vec![e.to_string()],
+        },
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum PolicyToJsonResult {
+    Success {
+        policy: cedar_policy_core::est::Policy,
+    },
+    Error {
+        errors: Vec<String>,
+    },
+}
+
+#[wasm_bindgen(js_name = "policyTextToJson")]
+pub fn policy_text_to_json(cedar_str: &str) -> PolicyToJsonResult {
+    match parse_policy_or_template_to_est(cedar_str) {
+        Ok(policy) => PolicyToJsonResult::Success { policy },
+        Err(err) => PolicyToJsonResult::Error {
+            errors: err.errors_as_strings(),
+        },
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+/// struct that defines the result for the syntax validation function
+pub enum CheckParsePolicySetResult {
+    /// represents successful syntax validation
+    Success { policies: i32, templates: i32 },
+    /// represents a syntax error and encloses a vector of the errors
+    Error { errors: Vec<String> },
+}
+
+#[wasm_bindgen(js_name = "checkParsePolicySet")]
+pub fn check_parse_policy_set(input_policies_str: &str) -> CheckParsePolicySetResult {
+    match PolicySet::from_str(input_policies_str) {
+        Err(parse_errors) => CheckParsePolicySetResult::Error {
+            errors: parse_errors.errors_as_strings(),
+        },
+        Ok(policy_set) => {
+            let policies_count: Result<i32, <i32 as TryFrom<usize>>::Error> =
+                policy_set.policies().count().try_into();
+            let templates_count: Result<i32, <i32 as TryFrom<usize>>::Error> =
+                policy_set.templates().count().try_into();
+            match (policies_count, templates_count) {
+                (Ok(p), Ok(t)) => CheckParsePolicySetResult::Success {
+                    policies: p,
+                    templates: t,
+                },
+                _ => CheckParsePolicySetResult::Error {
+                    errors: vec!["Error counting policies or templates".to_string()],
+                },
+            }
+        }
+    }
+}
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+pub enum CheckParseTemplateResult {
+    /// represents successful template validation
+    Success { slots: Vec<String> },
+    /// represents errors in the template validation and encloses a vector of the errors
+    Error { errors: Vec<String> },
+}
+
+#[wasm_bindgen(js_name = "checkParseTemplate")]
+pub fn check_parse_template(template_str: &str) -> CheckParseTemplateResult {
+    match Template::from_str(template_str) {
+        Err(parse_errs) => CheckParseTemplateResult::Error {
+            errors: parse_errs.errors_as_strings(),
+        },
+        Ok(template) => match template.slots().count() {
+            1 | 2 => CheckParseTemplateResult::Success {
+                slots: template.slots().map(|slot| slot.to_string()).collect(),
+            },
+            _ => CheckParseTemplateResult::Error {
+                errors: vec!["Expected template to have one or two slots".to_string()],
+            },
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+    use cool_asserts::assert_matches;
+
+    #[test]
+    fn test_conversion_from_cedar() {
+        let cedar_repr = r#"permit(principal, action, resource) when { principal has "Email" && principal.Email == "a@a.com" };"#;
+        let json_conversion_result = policy_text_to_json(cedar_repr);
+        assert_matches!(json_conversion_result, PolicyToJsonResult::Success { .. });
+    }
+
+    #[test]
+    fn test_conversion_from_json() {
+        let est_repr = r#"{
+            "effect": "permit",
+            "action": {
+                "entity": {
+                    "id": "pop",
+                    "type": "Action"
+                },
+                "op": "=="
+            },
+            "principal": {
+                "entity": {
+                    "id": "DeathRowRecords",
+                    "type": "UserGroup"
+                },
+                "op": "in"
+            },
+            "resource": {
+                "op": "All"
+            },
+            "conditions": []
+        }"#;
+
+        let cedar_conversion_result: JsonToPolicyResult = policy_text_from_json(est_repr);
+        assert_matches!(cedar_conversion_result, JsonToPolicyResult::Success { policy_text } => {
+            assert_eq!(
+                &policy_text,
+                "permit(principal in UserGroup::\"DeathRowRecords\", action == Action::\"pop\", resource);"
+            );
+        });
+    }
+
+    #[test]
+    fn can_parse_1_policy() {
+        let stringified_result = check_parse_policy_set("permit(principal, action, resource);");
+        assert_result_is_ok(&stringified_result);
+    }
+
+    #[test]
+    fn can_parse_multi_policy() {
+        assert_result_is_ok(&check_parse_policy_set(
+            "forbid(principal, action, resource); permit(principal == User::\"alice\", action == Action::\"view\", resource in Albums::\"alice_albums\");"
+        ));
+    }
+
+    #[test]
+    fn parse_returns_parse_errors_when_expected_1_policy() {
+        assert_result_had_syntax_errors(&check_parse_policy_set("permit(2pac, action, resource)"));
+    }
+
+    #[test]
+    fn parse_returns_parse_errors_when_expected_multi_policy() {
+        assert_result_had_syntax_errors(&check_parse_policy_set(
+            "forbid(principal, action, resource);permit(2pac, action, resource)",
+        ));
+    }
+
+    fn assert_result_is_ok(result: &CheckParsePolicySetResult) {
+        assert_matches!(result, CheckParsePolicySetResult::Success { .. });
+    }
+
+    fn assert_result_had_syntax_errors(result: &CheckParsePolicySetResult) {
+        assert_matches!(result, CheckParsePolicySetResult::Error { .. });
+    }
+
+    #[test]
+    fn can_parse_template() {
+        let template_str = r#"permit (principal == ?principal, action, resource == ?resource);"#;
+        let result = check_parse_template(template_str);
+        assert_matches!(result, CheckParseTemplateResult::Success { slots } => {
+            assert_eq!(slots.len(), 2);
+        });
+    }
+
+    #[test]
+    fn parse_template_fails_for_missing_slots() {
+        let template_str = r#"permit (principal, action, resource);"#;
+        let result = check_parse_template(template_str);
+        assert_matches!(result, CheckParseTemplateResult::Error { .. });
+    }
+
+    #[test]
+    fn parse_template_fails_for_bad_slot() {
+        let template_str = r#"permit (principal, action, resource == ?principal);"#;
+        let result = check_parse_template(template_str);
+        assert_matches!(result, CheckParseTemplateResult::Error { .. });
+    }
+}

--- a/cedar-wasm/src/schema_and_entities_and_context.rs
+++ b/cedar-wasm/src/schema_and_entities_and_context.rs
@@ -1,0 +1,266 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use cedar_policy::{Context, Entities, EntityUid, Schema};
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+use wasm_bindgen::prelude::*;
+
+#[derive(Tsify, Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+/// struct that defines the result for the syntax validation function
+pub enum CheckParseResult {
+    /// represents successful syntax validation
+    Success,
+    /// represents a syntax error and encloses a vector of the errors
+    Error { errors: Vec<String> },
+}
+
+#[wasm_bindgen(js_name = "checkParseSchema")]
+pub fn check_parse_schema(input_schema: &str) -> CheckParseResult {
+    match Schema::from_str(input_schema) {
+        Ok(_schema) => CheckParseResult::Success,
+        Err(err) => CheckParseResult::Error {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[wasm_bindgen(js_name = "checkParseEntities")]
+pub fn check_parse_entities(entities_str: &str, schema_str: &str) -> CheckParseResult {
+    let parsed_schema = match Schema::from_str(schema_str) {
+        Ok(schema) => schema,
+        Err(err) => {
+            return CheckParseResult::Error {
+                errors: vec![err.to_string()],
+            }
+        }
+    };
+    match Entities::from_json_str(entities_str, Some(&parsed_schema)) {
+        Ok(_) => CheckParseResult::Success,
+        Err(err) => CheckParseResult::Error {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[wasm_bindgen(js_name = "checkParseContext")]
+pub fn check_parse_context(
+    context_str: &str,
+    action_str: &str,
+    schema_str: &str,
+) -> CheckParseResult {
+    let parsed_schema = match Schema::from_str(schema_str) {
+        Ok(schema) => schema,
+        Err(err) => {
+            return CheckParseResult::Error {
+                errors: vec![err.to_string()],
+            }
+        }
+    };
+    let parsed_action = match EntityUid::from_str(action_str) {
+        Ok(action) => action,
+        Err(err) => {
+            return CheckParseResult::Error {
+                errors: vec![err.to_string()],
+            }
+        }
+    };
+    match Context::from_json_str(context_str, Some((&parsed_schema, &parsed_action))) {
+        Ok(_entities) => CheckParseResult::Success,
+        Err(err) => CheckParseResult::Error {
+            errors: vec![err.to_string()],
+        },
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    // Schema validator
+    #[test]
+    fn validate_schema_syntax_succeeds_empty_schema() {
+        let schema_str = "{}";
+        assert_syntax_result_is_ok(&check_parse_schema(schema_str))
+    }
+    #[test]
+    fn validate_schema_syntax_succeeds_nonempty_schema() {
+        let schema_str = r#"{
+          "MyNamespace": {
+            "entityTypes": {},
+            "actions": {}
+          }
+        }"#;
+        assert_syntax_result_is_ok(&check_parse_schema(schema_str))
+    }
+
+    #[test]
+    fn validate_schema_bad_syntax_fails() {
+        let schema_str = r#"{
+            "MyNamespace": {
+              "entityTypes": {}
+            }
+          }"#;
+        assert_syntax_result_has_errors(&check_parse_schema(schema_str))
+    }
+
+    // Entities
+
+    #[test]
+    fn validate_entities_succeeds() {
+        let entities_str = r#"[
+            {
+                "uid": {
+                    "type": "TheNamespace::User",
+                    "id": "alice"
+                },
+                "attrs": {
+                    "department": "HardwareEngineering",
+                    "jobLevel": 5
+                },
+                "parents": []
+              }
+        ]"#;
+        let schema_str = r#"{
+            "TheNamespace": {
+                "entityTypes": {
+                    "User": {
+                        "memberOfTypes": [],
+                        "shape": {
+                            "attributes": {
+                                "department": {
+                                    "type": "String"
+                                },
+                                "jobLevel": {
+                                    "type": "Long"
+                                }
+                            },
+                            "type": "Record"
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        }"#;
+        assert_syntax_result_is_ok(&check_parse_entities(entities_str, schema_str));
+    }
+
+    #[test]
+    fn validate_entities_fails_on_bad_entity() {
+        let entities_str = r#"[
+            {
+                "uid": "TheNamespace::User::\"alice\"",
+                "attrs": {
+                    "benchPress": "doesn'tevenlift"
+                },
+                "parents": []
+              }
+        ]"#;
+        let schema_str = r#"{
+            "TheNamespace": {
+                "entityTypes": {
+                    "User": {
+                        "memberOfTypes": [],
+                        "shape": {
+                            "attributes": {
+                                "department": {
+                                    "type": "String"
+                                }
+                            },
+                            "type": "Record"
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        }"#;
+        assert_syntax_result_has_errors(&check_parse_entities(entities_str, schema_str));
+    }
+
+    #[test]
+    fn validate_context_succeeds() {
+        let context_str = r#"{
+            "referrer": "Morpheus"
+        }"#;
+        let action_str = r#"Ex::Action::"Join""#;
+        let schema_str = r#"{
+            "Ex": {
+                "entityTypes": {},
+                "actions": {
+                    "Join": {
+                        "appliesTo": {
+                            "context": {
+                                "type": "Record",
+                                "attributes": {
+                                    "referrer": {
+                                        "type": "String",
+                                        "required": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        assert_syntax_result_is_ok(&check_parse_context(context_str, action_str, schema_str));
+    }
+
+    #[test]
+    fn validate_context_fails_for_bad_context() {
+        let context_str = r#"{
+            "wrongAttr": true
+        }"#;
+        let action_str = r#"Ex::Action::"Join""#;
+        let schema_str = r#"{
+            "Ex": {
+                "entityTypes": {},
+                "actions": {
+                    "Join": {
+                        "appliesTo": {
+                            "context": {
+                                "type": "Record",
+                                "attributes": {
+                                    "referrer": {
+                                        "type": "String",
+                                        "required": true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }"#;
+        assert_syntax_result_has_errors(&check_parse_context(context_str, action_str, schema_str));
+    }
+
+    fn assert_syntax_result_is_ok(parse_result: &CheckParseResult) {
+        assert!(matches!(parse_result, CheckParseResult::Success))
+    }
+
+    fn assert_syntax_result_has_errors(parse_result: &CheckParseResult) {
+        assert!(matches!(
+            parse_result,
+            CheckParseResult::Error { errors: _ }
+        ))
+    }
+}

--- a/cedar-wasm/src/validator.rs
+++ b/cedar-wasm/src/validator.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cedar_policy::ffi;
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen(js_name = "validate")]
+pub fn wasm_validate(call: ffi::ValidationCall) -> ffi::ValidationAnswer {
+    ffi::validate(call)
+}


### PR DESCRIPTION
## Description of changes

Brings most of the Wasm changes from `main` to `release/3.2.x`, with the goal of creating a 3.2.0 `cedar-wasm` release.

Also brings the 2.4.4 and 2.4.5 changelogs to this branch, since I noticed they were missing.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

