### PR TITLE
Align `EvaluationError` and `ExtensionFunctionLookupError` with cedar#745

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -633,6 +633,26 @@ impl Diagnostic for RestrictedExprError {
     }
 }
 
+impl RestrictedExprError {
+    /// Get the `Loc` of this error
+    pub(crate) fn source_loc(&self) -> Option<&Loc> {
+        match self {
+            Self::InvalidRestrictedExpression { expr, .. } => expr.source_loc(),
+        }
+    }
+
+    pub(crate) fn with_maybe_source_loc(self, source_loc: Option<Loc>) -> Self {
+        match self {
+            Self::InvalidRestrictedExpression { feature, expr } => {
+                Self::InvalidRestrictedExpression {
+                    feature,
+                    expr: expr.with_maybe_source_loc(source_loc),
+                }
+            }
+        }
+    }
+}
+
 /// Errors possible from `RestrictedExpr::from_str()`
 #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
 pub enum RestrictedExprParseError {

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -18,7 +18,9 @@ use crate::ast::{
     BorrowedRestrictedExpr, EntityType, Expr, ExprKind, Literal, Name, PartialValue, Type, Unknown,
     Value, ValueKind,
 };
-use crate::extensions::{ExtensionFunctionLookupError, Extensions};
+use crate::extensions::{
+    extension_function_lookup_errors, ExtensionFunctionLookupError, Extensions,
+};
 use itertools::Itertools;
 use miette::Diagnostic;
 use smol_str::SmolStr;
@@ -351,9 +353,10 @@ pub fn schematype_of_restricted_expr(
         }
         ExprKind::ExtensionFunctionApp { fn_name, .. } => {
             let efunc = extensions.func(fn_name)?;
-            Ok(efunc.return_type().cloned().ok_or_else(|| ExtensionFunctionLookupError::HasNoType {
-                name: efunc.name().clone()
-            })?)
+            Ok(efunc.return_type().cloned().ok_or_else(|| ExtensionFunctionLookupError::HasNoType(extension_function_lookup_errors::HasNoTypeError {
+                name: efunc.name().clone(),
+                source_loc: rexpr.source_loc().cloned(),
+            }))?)
         }
         ExprKind::Unknown(u @ Unknown { type_annotation, .. }) => match type_annotation {
             None => Err(GetSchemaTypeError::UnknownInsufficientTypeInfo { unknown: u.clone() }),

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -1,3 +1,19 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /// Macro which implements the `.labels()` and `.source_code()` methods of
 /// `miette::Diagnostic` by using the `self.source_loc` field (assumed to be an
 /// `Option<Loc>`)

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -1,0 +1,19 @@
+/// Macro which implements the `.labels()` and `.source_code()` methods of
+/// `miette::Diagnostic` by using the `self.source_loc` field (assumed to be an
+/// `Option<Loc>`)
+macro_rules! impl_diagnostic_from_source_loc_field {
+    () => {
+        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+            self.source_loc
+                .as_ref()
+                .map(|loc| &loc.src as &dyn miette::SourceCode)
+        }
+
+        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+            self.source_loc.as_ref().map(|loc| {
+                Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span)))
+                    as Box<dyn Iterator<Item = _>>
+            })
+        }
+    };
+}

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -25,8 +25,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 mod err;
+pub use err::evaluation_errors;
+pub use err::EvaluationError;
 pub(crate) use err::*;
-pub use err::{EvaluationError, EvaluationErrorKind};
+use evaluation_errors::*;
 use itertools::Either;
 use nonempty::nonempty;
 use smol_str::SmolStr;
@@ -165,7 +167,7 @@ impl<'e> RestrictedEvaluator<'e> {
                 match split(args) {
                     Either::Left(values) => {
                         let values : Vec<_> = values.collect();
-                        let efunc = self.extensions.func(fn_name).map_err(|err| EvaluationError::extension_function_lookup(err, expr.source_loc().cloned()))?;
+                        let efunc = self.extensions.func(fn_name).map_err(|err| err.with_maybe_source_loc(expr.source_loc().cloned()))?;
                         efunc.call(&values)
                     },
                     Either::Right(residuals) => Ok(Expr::call_extension_fn(fn_name.clone(), residuals.collect()).into()),
@@ -376,10 +378,12 @@ impl<'e> Evaluator<'e> {
                         let i = arg.get_as_long()?;
                         match i.checked_neg() {
                             Some(v) => Ok(v.into()),
-                            None => Err(EvaluationError::integer_overflow(
-                                IntegerOverflowError::UnaryOp { op: *op, arg },
-                                loc.cloned(),
-                            )),
+                            None => Err(IntegerOverflowError::UnaryOp(UnaryOpOverflowError {
+                                op: *op,
+                                arg,
+                                source_loc: loc.cloned(),
+                            })
+                            .into()),
                         }
                     }
                 },
@@ -421,36 +425,39 @@ impl<'e> Evaluator<'e> {
                             BinaryOp::LessEq => Ok((i1 <= i2).into()),
                             BinaryOp::Add => match i1.checked_add(i2) {
                                 Some(sum) => Ok(sum.into()),
-                                None => Err(EvaluationError::integer_overflow(
-                                    IntegerOverflowError::BinaryOp {
+                                None => {
+                                    Err(IntegerOverflowError::BinaryOp(BinaryOpOverflowError {
                                         op: *op,
                                         arg1,
                                         arg2,
-                                    },
-                                    loc.cloned(),
-                                )),
+                                        source_loc: loc.cloned(),
+                                    })
+                                    .into())
+                                }
                             },
                             BinaryOp::Sub => match i1.checked_sub(i2) {
                                 Some(diff) => Ok(diff.into()),
-                                None => Err(EvaluationError::integer_overflow(
-                                    IntegerOverflowError::BinaryOp {
+                                None => {
+                                    Err(IntegerOverflowError::BinaryOp(BinaryOpOverflowError {
                                         op: *op,
                                         arg1,
                                         arg2,
-                                    },
-                                    loc.cloned(),
-                                )),
+                                        source_loc: loc.cloned(),
+                                    })
+                                    .into())
+                                }
                             },
                             BinaryOp::Mul => match i1.checked_mul(i2) {
                                 Some(prod) => Ok(prod.into()),
-                                None => Err(EvaluationError::integer_overflow(
-                                    IntegerOverflowError::BinaryOp {
+                                None => {
+                                    Err(IntegerOverflowError::BinaryOp(BinaryOpOverflowError {
                                         op: *op,
                                         arg1,
                                         arg2,
-                                    },
-                                    loc.cloned(),
-                                )),
+                                        source_loc: loc.cloned(),
+                                    })
+                                    .into())
+                                }
                             },
                             // PANIC SAFETY `op` is checked to be one of the above
                             #[allow(clippy::unreachable)]
@@ -466,7 +473,7 @@ impl<'e> Evaluator<'e> {
                                 // If arg1 is not an entity and arg2 is a set, then possibly
                                 // the user intended `arg2.contains(arg1)` rather than `arg1 in arg2`.
                                 // If arg2 is a record, then possibly they intended `arg2 has arg1`.
-                                if let EvaluationErrorKind::TypeError { advice, .. } = e.error_kind_mut() {
+                                if let EvaluationError::TypeError(TypeError { advice, .. }) = &mut e {
                                     match arg2.type_of() {
                                         Type::Set => *advice = Some("`in` is for checking the entity hierarchy; use `.contains()` to test set membership".into()),
                                         Type::Record => *advice = Some("`in` is for checking the entity hierarchy; use `has` to test if a record has a key".into()),
@@ -554,9 +561,10 @@ impl<'e> Evaluator<'e> {
                 match split(args) {
                     Either::Left(vals) => {
                         let vals: Vec<_> = vals.collect();
-                        let efunc = self.extensions.func(fn_name).map_err(|err| {
-                            EvaluationError::extension_function_lookup(err, loc.cloned())
-                        })?;
+                        let efunc = self
+                            .extensions
+                            .func(fn_name)
+                            .map_err(|err| err.with_maybe_source_loc(loc.cloned()))?;
                         efunc.call(&vals)
                     }
                     Either::Right(residuals) => Ok(PartialValue::Residual(
@@ -797,6 +805,7 @@ impl<'e> Evaluator<'e> {
                         EvaluationError::entity_attr_does_not_exist(
                             uid,
                             attr.clone(),
+                            entity.attrs().map(|(k, _)| k.clone()).collect(),
                             source_loc.cloned(),
                         )
                     })
@@ -1332,16 +1341,19 @@ pub mod test {
             Ok(Value::from(true))
         );
         // get_attr on an attr which doesn't exist
-        assert_eq!(
+        assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(
                 Expr::val(EntityUID::with_eid("entity_with_attrs")),
                 "doesnotexist".into()
             )),
-            Err(EvaluationError::entity_attr_does_not_exist(
-                Arc::new(EntityUID::with_eid("entity_with_attrs")),
-                "doesnotexist".into(),
-                None,
-            ))
+            Err(EvaluationError::EntityAttrDoesNotExist(e)) => {
+                assert_eq!(e.entity.as_ref(), &EntityUID::with_eid("entity_with_attrs"));
+                assert_eq!(&e.attr, "doesnotexist");
+                assert_eq!(e.available_attrs.len(), 3);
+                assert!(e.available_attrs.contains(&"spoon".into()));
+                assert!(e.available_attrs.contains(&"address".into()));
+                assert!(e.available_attrs.contains(&"tags".into()));
+            }
         );
         // get_attr on an attr which does exist (and has integer type)
         assert_eq!(
@@ -1443,13 +1455,11 @@ pub mod test {
                 Expr::val(3),
                 Expr::val(8)
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Bool],
-                    actual: Type::String,
-                    advice: None,
-                },
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Bool]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // if principal then 3 else 8
         assert_matches!(
@@ -1458,15 +1468,13 @@ pub mod test {
                 Expr::val(3),
                 Expr::val(8)
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Bool],
-                    actual: Type::Entity {
-                        ty: EntityUID::test_entity_type(),
-                    },
-                    advice: None,
-                },
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Bool]);
+                assert_eq!(actual, Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                });
+                assert_eq!(advice, None);
+            }
         );
         // if true then "hello" else 2
         assert_eq!(
@@ -1649,36 +1657,32 @@ pub mod test {
                 Expr::set(vec![Expr::val(8)]),
                 "hello".into()
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                    assert_eq!(expected, nonempty![
                         Type::Record,
                         Type::entity_type(
                             Name::parse_unqualified_name("any_entity_type")
                                 .expect("should be a valid identifier")
                         ),
-                    ],
-                    actual: Type::Set,
-                    advice: None,
+                    ]);
+                    assert_eq!(actual, Type::Set);
+                    assert_eq!(advice, None);
                 }
-            )
         );
         // indexing into empty set
         assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(Expr::set(vec![]), "hello".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::Set,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::Set);
+                assert_eq!(advice, None);
+            }
         );
         // set("hello", 2, true, <entity foo>)
         let mixed_set = Expr::set(vec![
@@ -1716,19 +1720,17 @@ pub mod test {
         // set("hello", 2, true, <entity foo>)["hello"]
         assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(mixed_set, "hello".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::Set,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::Set);
+                assert_eq!(advice, None);
+            }
         );
         // set(set(8, 2), set(13, 702), set(3))
         let set_of_sets = Expr::set(vec![
@@ -1780,19 +1782,17 @@ pub mod test {
         // set(set(8, 2), set(13, 702), set(3))["hello"]
         assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(set_of_sets.clone(), "hello".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::Set,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::Set);
+                assert_eq!(advice, None);
+            }
         );
         // set(set(8, 2), set(13, 702), set(3))["ham"]["eggs"]
         assert_matches!(
@@ -1800,19 +1800,17 @@ pub mod test {
                 Expr::get_attr(set_of_sets, "ham".into()),
                 "eggs".into()
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::Set,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::Set);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -2070,70 +2068,62 @@ pub mod test {
         // indexing into something that's not a record, 1010122["hello"]
         assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(Expr::val(1010122), "hello".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
         // indexing into something that's not a record, "hello"["eggs"]
         assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(Expr::val("hello"), "eggs".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // has_attr on something that's not a record, 1010122 has hello
         assert_matches!(
             eval.interpret_inline_policy(&Expr::has_attr(Expr::val(1010122), "hello".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
         // has_attr on something that's not a record, "hello" has eggs
         assert_matches!(
             eval.interpret_inline_policy(&Expr::has_attr(Expr::val("hello"), "eggs".into())),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Record,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        ),
-                    ],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Record,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    ),
+                ]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -2156,26 +2146,22 @@ pub mod test {
         // not(8)
         assert_matches!(
             eval.interpret_inline_policy(&Expr::not(Expr::val(8))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Bool],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Bool]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
         // not(action)
         assert_matches!(
             eval.interpret_inline_policy(&Expr::not(Expr::var(Var::Action))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Bool],
-                    actual: Type::Entity {
-                        ty: EntityUID::test_entity_type(),
-                    },
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Bool]);
+                assert_eq!(actual, Type::Entity {
+                    ty: EntityUID::test_entity_type(),
+                });
+                assert_eq!(advice, None);
+            }
         );
         // not(not(true))
         assert_eq!(
@@ -2240,24 +2226,21 @@ pub mod test {
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::neg(Expr::val(Integer::MIN))),
-            Err(EvaluationError::integer_overflow(
-                IntegerOverflowError::UnaryOp {
-                    op: UnaryOp::Neg,
-                    arg: Value::from(Integer::MIN)
-                },
-                None
-            )),
+            Err(IntegerOverflowError::UnaryOp(UnaryOpOverflowError {
+                op: UnaryOp::Neg,
+                arg: Value::from(Integer::MIN),
+                source_loc: None,
+            })
+            .into()),
         );
         // neg(false)
         assert_matches!(
             eval.interpret_inline_policy(&Expr::neg(Expr::val(false))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // neg([1, 2, 3])
         assert_matches!(
@@ -2266,13 +2249,11 @@ pub mod test {
                 Expr::val(2),
                 Expr::val(3)
             ]))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Set,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Set);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -2576,211 +2557,173 @@ pub mod test {
         // false < true
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(false), Expr::val(true))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // false < false
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(false), Expr::val(false))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // true <= false
         assert_matches!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val(true), Expr::val(false))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // false <= false
         assert_matches!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val(false), Expr::val(false))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // false > true
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greater(Expr::val(false), Expr::val(true))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // true > true
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greater(Expr::val(true), Expr::val(true))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // true >= false
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(true), Expr::val(false))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // true >= true
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(true), Expr::val(true))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // bc < zzz
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("bc"), Expr::val("zzz"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // banana < zzz
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("banana"), Expr::val("zzz"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // "" < zzz
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(""), Expr::val("zzz"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // a < 1
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("a"), Expr::val("1"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // a < A
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("a"), Expr::val("A"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // A < A
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("A"), Expr::val("A"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // zebra < zebras
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("zebra"), Expr::val("zebras"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // zebra <= zebras
         assert_matches!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val("zebra"), Expr::val("zebras"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // zebras <= zebras
         assert_matches!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val("zebras"), Expr::val("zebras"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // zebras <= Zebras
         assert_matches!(
             eval.interpret_inline_policy(&Expr::lesseq(Expr::val("zebras"), Expr::val("Zebras"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // 123 > 78
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greater(Expr::val("123"), Expr::val("78"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // <space>zebras >= zebras
         assert_matches!(
@@ -2788,90 +2731,74 @@ pub mod test {
                 Expr::val(" zebras"),
                 Expr::val("zebras")
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // "" >= ""
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(""), Expr::val(""))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // "" >= _hi
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val(""), Expr::val("_hi"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // 🦀 >= _hi
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(Expr::val("🦀"), Expr::val("_hi"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // 2 < "4"
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(2), Expr::val("4"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // "4" < 2
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val("4"), Expr::val(2))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // false < 1
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(false), Expr::val(1))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // 1 < false
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(1), Expr::val(false))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // [1, 2] < [47, 0]
         assert_matches!(
@@ -2879,13 +2806,11 @@ pub mod test {
                 Expr::set(vec![Expr::val(1), Expr::val(2)]),
                 Expr::set(vec![Expr::val(47), Expr::val(0)])
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::Set,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::Set);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -2904,13 +2829,11 @@ pub mod test {
                 Expr::add(Expr::val("a"), Expr::val("b")),
                 Expr::add(Expr::val(false), Expr::val(true))
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
 
         assert_matches!(
@@ -2918,13 +2841,11 @@ pub mod test {
                 Expr::add(Expr::val("a"), Expr::val("b")),
                 Expr::add(Expr::val(false), Expr::val(true))
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
 
         assert_matches!(
@@ -2932,13 +2853,11 @@ pub mod test {
                 Expr::add(Expr::val("a"), Expr::val("b")),
                 Expr::add(Expr::val(false), Expr::val(true))
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
 
         assert_matches!(
@@ -2946,13 +2865,11 @@ pub mod test {
                 Expr::add(Expr::val("a"), Expr::val("b")),
                 Expr::add(Expr::val(false), Expr::val(true))
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -2980,25 +2897,22 @@ pub mod test {
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::add(Expr::val(Integer::MAX), Expr::val(1))),
-            Err(EvaluationError::integer_overflow(
-                IntegerOverflowError::BinaryOp {
-                    op: BinaryOp::Add,
-                    arg1: Value::from(Integer::MAX),
-                    arg2: Value::from(1),
-                },
-                None
-            ))
+            Err(IntegerOverflowError::BinaryOp(BinaryOpOverflowError {
+                op: BinaryOp::Add,
+                arg1: Value::from(Integer::MAX),
+                arg2: Value::from(1),
+                source_loc: None,
+            })
+            .into())
         );
         // 7 + "3"
         assert_matches!(
             eval.interpret_inline_policy(&Expr::add(Expr::val(7), Expr::val("3"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // 44 - 31
         assert_eq!(
@@ -3013,25 +2927,22 @@ pub mod test {
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::sub(Expr::val(Integer::MIN + 2), Expr::val(3))),
-            Err(EvaluationError::integer_overflow(
-                IntegerOverflowError::BinaryOp {
-                    op: BinaryOp::Sub,
-                    arg1: Value::from(Integer::MIN + 2),
-                    arg2: Value::from(3),
-                },
-                None
-            ))
+            Err(IntegerOverflowError::BinaryOp(BinaryOpOverflowError {
+                op: BinaryOp::Sub,
+                arg1: Value::from(Integer::MIN + 2),
+                arg2: Value::from(3),
+                source_loc: None,
+            })
+            .into())
         );
         // "ham" - "ha"
         assert_matches!(
             eval.interpret_inline_policy(&Expr::sub(Expr::val("ham"), Expr::val("ha"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // 5 * (-3)
         assert_eq!(
@@ -3046,25 +2957,22 @@ pub mod test {
         // "5" * 0
         assert_matches!(
             eval.interpret_inline_policy(&Expr::mul(Expr::val("5"), Expr::val(0))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Long],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Long]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // overflow
         assert_eq!(
             eval.interpret_inline_policy(&Expr::mul(Expr::val(Integer::MAX - 1), Expr::val(3))),
-            Err(EvaluationError::integer_overflow(
-                IntegerOverflowError::BinaryOp {
-                    op: BinaryOp::Mul,
-                    arg1: Value::from(Integer::MAX - 1),
-                    arg2: Value::from(3),
-                },
-                None
-            ))
+            Err(IntegerOverflowError::BinaryOp(BinaryOpOverflowError {
+                op: BinaryOp::Mul,
+                arg1: Value::from(Integer::MAX - 1),
+                arg2: Value::from(3),
+                source_loc: None,
+            })
+            .into())
         );
     }
 
@@ -3213,13 +3121,11 @@ pub mod test {
         // 3 contains 7
         assert_matches!(
             eval.interpret_inline_policy(&Expr::contains(Expr::val(3), Expr::val(7))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
         // { ham: "eggs" } contains "ham"
         assert_matches!(
@@ -3227,13 +3133,11 @@ pub mod test {
                 Expr::record(vec![("ham".into(), Expr::val("eggs"))]).unwrap(),
                 Expr::val("ham")
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::Record,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::Record);
+                assert_eq!(advice, None);
+            }
         );
         // wrong argument order
         assert_matches!(
@@ -3241,13 +3145,11 @@ pub mod test {
                 Expr::val(3),
                 Expr::set(vec![Expr::val(1), Expr::val(3), Expr::val(7)])
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -3439,16 +3341,14 @@ pub mod test {
                     Expr::val(true),
                 ])
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::entity_type(
-                        Name::parse_unqualified_name("any_entity_type")
-                            .expect("should be a valid identifier")
-                    )],
-                    actual: Type::Bool,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::entity_type(
+                    Name::parse_unqualified_name("any_entity_type")
+                        .expect("should be a valid identifier")
+                )]);
+                assert_eq!(actual, Type::Bool);
+                assert_eq!(advice, None);
+            }
         );
         // A in [A, B] where A and B do not exist
         assert_eq!(
@@ -3497,16 +3397,14 @@ pub mod test {
         // "foo" in "foobar"
         assert_matches!(
             eval.interpret_inline_policy(&Expr::is_in(Expr::val("foo"), Expr::val("foobar"))),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::entity_type(
-                        Name::parse_unqualified_name("any_entity_type")
-                            .expect("should be a valid identifier")
-                    )],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::entity_type(
+                    Name::parse_unqualified_name("any_entity_type")
+                        .expect("should be a valid identifier")
+                )]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // "spoon" in A (where has(A.spoon))
         assert_matches!(
@@ -3514,16 +3412,14 @@ pub mod test {
                 Expr::val("spoon"),
                 Expr::val(EntityUID::with_eid("entity_with_attrs"))
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::entity_type(
-                        Name::parse_unqualified_name("any_entity_type")
-                            .expect("should be a valid identifier")
-                    )],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::entity_type(
+                    Name::parse_unqualified_name("any_entity_type")
+                        .expect("should be a valid identifier")
+                )]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // 3 in [34, -2, 7]
         assert_matches!(
@@ -3531,18 +3427,13 @@ pub mod test {
                 Expr::val(3),
                 Expr::set(vec![Expr::val(34), Expr::val(-2), Expr::val(7)])
             )),
-            Err(e) => {
-                assert_eq!(
-                    e.error_kind(),
-                    &EvaluationErrorKind::TypeError {
-                        expected: nonempty![Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        )],
-                        actual: Type::Long,
-                        advice: Some("`in` is for checking the entity hierarchy; use `.contains()` to test set membership".into()),
-                    }
-                );
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::entity_type(
+                    Name::parse_unqualified_name("any_entity_type")
+                        .expect("should be a valid identifier")
+                )]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, Some("`in` is for checking the entity hierarchy; use `.contains()` to test set membership".into()));
             }
         );
         // "foo" in { "foo": 2, "bar": true }
@@ -3554,18 +3445,13 @@ pub mod test {
                     ("bar".into(), Expr::val(true)),
                 ]).unwrap()
             )),
-            Err(e) => {
-                assert_eq!(
-                    e.error_kind(),
-                    &EvaluationErrorKind::TypeError {
-                        expected: nonempty![Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        )],
-                        actual: Type::String,
-                        advice: Some("`in` is for checking the entity hierarchy; use `has` to test if a record has a key".into()),
-                    }
-                );
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::entity_type(
+                    Name::parse_unqualified_name("any_entity_type")
+                        .expect("should be a valid identifier")
+                )]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, Some("`in` is for checking the entity hierarchy; use `has` to test if a record has a key".into()));
             }
         );
         // A in { "foo": 2, "bar": true }
@@ -3578,19 +3464,17 @@ pub mod test {
                 ])
                 .unwrap()
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![
-                        Type::Set,
-                        Type::entity_type(
-                            Name::parse_unqualified_name("any_entity_type")
-                                .expect("should be a valid identifier")
-                        )
-                    ],
-                    actual: Type::Record,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![
+                    Type::Set,
+                    Type::entity_type(
+                        Name::parse_unqualified_name("any_entity_type")
+                            .expect("should be a valid identifier")
+                    )
+                ]);
+                assert_eq!(actual, Type::Record);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -3802,13 +3686,11 @@ pub mod test {
         // type error
         assert_matches!(
             eval.interpret_inline_policy(&Expr::like(Expr::val(354), vec![])),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::String],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::String]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
         // 'contains' is not allowed on strings
         assert_matches!(
@@ -3816,13 +3698,11 @@ pub mod test {
                 Expr::val("ham and ham"),
                 Expr::val("ham")
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // '\0' should not match '*'
         assert_eq!(
@@ -3940,13 +3820,11 @@ pub mod test {
         );
         assert_matches!(
             eval.interpret_inline_policy(&parse_expr(r#"1 is Group"#).expect("parsing error")),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::entity_type(names::ANY_ENTITY_TYPE.clone())],
-                    actual: Type::Long,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::entity_type(names::ANY_ENTITY_TYPE.clone())]);
+                assert_eq!(actual, Type::Long);
+                assert_eq!(advice, None);
+            }
         );
     }
 
@@ -4069,13 +3947,11 @@ pub mod test {
                 Expr::val("ham"),
                 Expr::val("ham and eggs")
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // {"2": "ham", "3": "eggs"} containsall {"2": "ham"} ?
         assert_matches!(
@@ -4087,13 +3963,11 @@ pub mod test {
                 ])
                 .unwrap()
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::Record,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::Record);
+                assert_eq!(advice, None);
+            }
         );
         // test for [1, -22] contains_any of [1, -22, 34]
         assert_eq!(
@@ -4195,13 +4069,11 @@ pub mod test {
                 Expr::val("ham"),
                 Expr::val("ham and eggs")
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::String,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::String);
+                assert_eq!(advice, None);
+            }
         );
         // test for {"2": "ham"} contains_any of {"2": "ham", "3": "eggs"}
         assert_matches!(
@@ -4213,13 +4085,11 @@ pub mod test {
                 ])
                 .unwrap()
             )),
-            Err(e) => assert_eq!(e.error_kind(),
-                &EvaluationErrorKind::TypeError {
-                    expected: nonempty![Type::Set],
-                    actual: Type::Record,
-                    advice: None,
-                }
-            )
+            Err(EvaluationError::TypeError(TypeError { expected, actual, advice, .. })) => {
+                assert_eq!(expected, nonempty![Type::Set]);
+                assert_eq!(actual, Type::Record);
+                assert_eq!(advice, None);
+            }
         );
         Ok(())
     }
@@ -4350,10 +4220,8 @@ pub mod test {
 
         let slots = HashMap::new();
         let r = evaluator.partial_interpret(&e, &slots);
-        assert_matches!(r, Err(e) => {
-            assert_matches!(e.error_kind(), EvaluationErrorKind::UnlinkedSlot(slotid) => {
-                assert_eq!(*slotid, SlotId::principal());
-            });
+        assert_matches!(r, Err(EvaluationError::UnlinkedSlot(UnlinkedSlotError { slot, .. })) => {
+            assert_eq!(slot, SlotId::principal());
         });
 
         let mut slots = HashMap::new();
@@ -4410,9 +4278,7 @@ pub mod test {
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_restricted_expression_error(v: Result<PartialValue>) {
-        assert_matches!(v, Err(e) => {
-            assert_matches!(e.error_kind(), EvaluationErrorKind::InvalidRestrictedExpression { .. });
-        });
+        assert_matches!(v, Err(EvaluationError::InvalidRestrictedExpression { .. }));
     }
 
     #[test]

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -78,7 +78,7 @@ pub enum EvaluationError {
     #[diagnostic(transparent)]
     InvalidRestrictedExpression(#[from] RestrictedExprError),
 
-    /// A policy was evaluated but not all template slots were linked
+    /// Not all template slots were linked
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnlinkedSlot(#[from] evaluation_errors::UnlinkedSlotError),

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -637,7 +637,7 @@ pub mod evaluation_errors {
         }
     }
 
-    /// A policy was evaluated but not all template slots were linked
+    /// Not all template slots were linked
     //
     // CAUTION: this type is publically exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 
 /// Enumeration of the possible errors that can occur during evaluation
 //
-// CAUTION: this type is publically exported in `cedar-policy`.
+// CAUTION: this type is publicly exported in `cedar-policy`.
 // Don't make fields `pub`, don't make breaking changes, and use caution when
 // adding public methods.
 #[derive(Debug, PartialEq, Eq, Clone, Diagnostic, Error)]
@@ -316,7 +316,7 @@ pub mod evaluation_errors {
 
     /// Tried to lookup an entity UID, but it didn't exist in the provided entities
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -354,7 +354,7 @@ pub mod evaluation_errors {
     /// Tried to get an attribute, but the specified entity didn't have that
     /// attribute
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -393,7 +393,7 @@ pub mod evaluation_errors {
 
     /// Tried to access an attribute of an unspecified entity
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -422,7 +422,7 @@ pub mod evaluation_errors {
     /// Tried to get an attribute of a (non-entity) record, but that record didn't
     /// have that attribute
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -460,7 +460,7 @@ pub mod evaluation_errors {
     /// Tried to evaluate an operation on values with incorrect types for that
     /// operation
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -511,7 +511,7 @@ pub mod evaluation_errors {
 
     /// Wrong number of arguments provided to an extension function
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -543,7 +543,7 @@ pub mod evaluation_errors {
 
     /// Overflow during an integer operation
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Diagnostic, Error)]
@@ -577,7 +577,7 @@ pub mod evaluation_errors {
 
     /// Overflow during a binary operation
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -609,7 +609,7 @@ pub mod evaluation_errors {
 
     /// Overflow during a unary operation
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -639,7 +639,7 @@ pub mod evaluation_errors {
 
     /// Not all template slots were linked
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -667,7 +667,7 @@ pub mod evaluation_errors {
 
     /// Evaluation error thrown by an extension function
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -706,7 +706,7 @@ pub mod evaluation_errors {
     /// reduced to a [`Value`]. In order to return partial results, use the
     /// partial evaluation APIs instead.
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -734,7 +734,7 @@ pub mod evaluation_errors {
 
     /// Maximum recursion limit reached for expression evaluation
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -160,7 +160,7 @@ pub enum ExtensionFunctionLookupError {
     #[diagnostic(transparent)]
     FuncMultiplyDefined(#[from] extension_function_lookup_errors::FuncMultiplyDefinedError),
 
-    /// Attempted to typecheck an expression that had no type
+    /// Attempted to typecheck a function without a return type
     #[error(transparent)]
     #[diagnostic(transparent)]
     HasNoType(#[from] extension_function_lookup_errors::HasNoTypeError),
@@ -277,15 +277,15 @@ pub mod extension_function_lookup_errors {
         }
     }
 
-    /// Attempted to typecheck an expression that had no type
+    /// Attempted to typecheck a function without a return type
     //
     // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
-    #[error("extension function `{name}` has no type")]
+    #[error("extension function `{name}` has no return type")]
     pub struct HasNoTypeError {
-        /// Name of the function that returns no type
+        /// Name of the function that has no return type
         pub(crate) name: Name,
         /// Source location
         pub(crate) source_loc: Option<Loc>,

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -144,7 +144,7 @@ impl<'a> Extensions<'a> {
 
 /// Errors thrown when looking up an extension function in [`Extensions`].
 //
-// CAUTION: this type is publically exported in `cedar-policy`.
+// CAUTION: this type is publicly exported in `cedar-policy`.
 // Don't make fields `pub`, don't make breaking changes, and use caution
 // when adding public methods.
 #[derive(Debug, PartialEq, Eq, Clone, Diagnostic, Error)]
@@ -221,7 +221,7 @@ pub mod extension_function_lookup_errors {
 
     /// Tried to call a function that doesn't exist
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -249,7 +249,7 @@ pub mod extension_function_lookup_errors {
 
     /// Tried to call a function that doesn't exist
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -279,7 +279,7 @@ pub mod extension_function_lookup_errors {
 
     /// Attempted to typecheck an expression that had no type
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
@@ -308,7 +308,7 @@ pub mod extension_function_lookup_errors {
     /// Two extension constructors (in the same or different extensions) had
     /// exactly the same type signature.  This is currently not allowed.
     //
-    // CAUTION: this type is publically exported in `cedar-policy`.
+    // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -26,6 +26,8 @@ pub mod authorizer;
 mod from_normalized_str;
 pub use from_normalized_str::*;
 pub mod entities;
+#[macro_use]
+mod error_macros;
 pub mod est;
 pub mod evaluator;
 pub mod extensions;

--- a/cedar-policy-core/src/parser/loc.rs
+++ b/cedar-policy-core/src/parser/loc.rs
@@ -62,3 +62,39 @@ impl Loc {
         self.src.get(self.start()..self.end())
     }
 }
+
+impl From<Loc> for miette::SourceSpan {
+    fn from(loc: Loc) -> Self {
+        loc.span
+    }
+}
+
+impl From<&Loc> for miette::SourceSpan {
+    fn from(loc: &Loc) -> Self {
+        loc.span
+    }
+}
+
+impl miette::SourceCode for Loc {
+    fn read_span<'a>(
+        &'a self,
+        span: &miette::SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
+        self.src
+            .read_span(span, context_lines_before, context_lines_after)
+    }
+}
+
+impl miette::SourceCode for &Loc {
+    fn read_span<'a>(
+        &'a self,
+        span: &miette::SourceSpan,
+        context_lines_before: usize,
+        context_lines_after: usize,
+    ) -> Result<Box<dyn miette::SpanContents<'a> + 'a>, miette::MietteError> {
+        self.src
+            .read_span(span, context_lines_before, context_lines_after)
+    }
+}

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -42,7 +42,6 @@ use cedar_policy_core::est::{Link, PolicyEntry};
 use cedar_policy_core::evaluator::Evaluator;
 #[cfg(feature = "partial-eval")]
 use cedar_policy_core::evaluator::RestrictedEvaluator;
-pub use cedar_policy_core::extensions;
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::parser;
 use cedar_policy_core::FromNormalizedStr;

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -23,7 +23,10 @@ use cedar_policy_core::ast;
 use cedar_policy_core::ast::Name;
 use cedar_policy_core::authorizer;
 use cedar_policy_core::est;
-pub use cedar_policy_core::evaluator::{EvaluationError, EvaluationErrorKind};
+pub use cedar_policy_core::evaluator::{evaluation_errors, EvaluationError};
+pub use cedar_policy_core::extensions::{
+    extension_function_lookup_errors, ExtensionFunctionLookupError,
+};
 use cedar_policy_core::parser;
 pub use cedar_policy_core::parser::err::ParseErrors;
 pub use cedar_policy_validator::human_schema::SchemaWarning;

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -1825,6 +1825,7 @@ mod entity_validate_tests {
 /// (Core has similar tests, but using a stubbed implementation of Schema.)
 mod schema_based_parsing_tests {
     use super::*;
+    use cedar_policy_core::extensions::Extensions;
     use entities::conformance::err::EntitySchemaConformanceError;
     use entities::err::EntitiesError;
 
@@ -3042,7 +3043,7 @@ mod schema_based_parsing_tests {
         let schema = cedar_policy_validator::CoreSchema::new(&schema.0);
         let parser_assume_computed = entities::EntityJsonParser::new(
             Some(&schema),
-            extensions::Extensions::all_available(),
+            Extensions::all_available(),
             entities::TCComputation::AssumeAlreadyComputed,
         );
         assert!(matches!(
@@ -3054,7 +3055,7 @@ mod schema_based_parsing_tests {
 
         let parser_enforce_computed = entities::EntityJsonParser::new(
             Some(&schema),
-            extensions::Extensions::all_available(),
+            Extensions::all_available(),
             entities::TCComputation::EnforceAlreadyComputed,
         );
         assert!(matches!(

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3645,11 +3645,9 @@ mod decimal_ip_constructors {
     fn expr_bad_ip() {
         let ip = Expression::new_ip("192.168.312.3");
         assert_matches!(evaluate_empty(&ip),
-                Err(e) => assert_matches!(e.error_kind(),
-                    EvaluationErrorKind::FailedExtensionFunctionApplication {
-                        extension_name, ..
-                    } => assert_eq!(extension_name, &("ipaddr".parse().unwrap()))
-                )
+            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+                assert_eq!(e.extension_name(), "ipaddr");
+            }
         );
     }
 
@@ -3657,11 +3655,9 @@ mod decimal_ip_constructors {
     fn expr_bad_cidr() {
         let ip = Expression::new_ip("192.168.0.3/100");
         assert_matches!(evaluate_empty(&ip),
-                Err(e) => assert_matches!(e.error_kind(),
-                    EvaluationErrorKind::FailedExtensionFunctionApplication {
-                        extension_name, ..
-                    } => assert_eq!(extension_name, &("ipaddr".parse().unwrap()))
-                )
+            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+                assert_eq!(e.extension_name(), "ipaddr");
+            }
         );
     }
 
@@ -3669,11 +3665,9 @@ mod decimal_ip_constructors {
     fn expr_nonsense_ip() {
         let ip = Expression::new_ip("foobar");
         assert_matches!(evaluate_empty(&ip),
-                Err(e) => assert_matches!(e.error_kind(),
-                    EvaluationErrorKind::FailedExtensionFunctionApplication {
-                        extension_name, ..
-                    } => assert_eq!(extension_name, &("ipaddr".parse().unwrap()))
-                )
+            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+                assert_eq!(e.extension_name(), "ipaddr");
+            }
         );
     }
 
@@ -3736,11 +3730,9 @@ mod decimal_ip_constructors {
     fn invalid_decimal() {
         let decimal = Expression::new_decimal("1234.12345");
         assert_matches!(evaluate_empty(&decimal),
-                Err(e) => assert_matches!(e.error_kind(),
-                    EvaluationErrorKind::FailedExtensionFunctionApplication {
-                        extension_name, ..
-                    } => assert_eq!(extension_name, &("decimal".parse().unwrap()))
-                )
+            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+                assert_eq!(e.extension_name(), "decimal");
+            }
         );
     }
 }

--- a/cedar-testing/src/integration_testing.rs
+++ b/cedar-testing/src/integration_testing.rs
@@ -16,20 +16,16 @@
 
 //! Helper code to run Cedar integration tests
 
-// This is test code that is under `src/` only so that it can be shared between
-// packages, so it's appropriate to exclude it from coverage.
-//
-// GRCOV_STOP_COVERAGE
-
 // PANIC SAFETY: This module is used only for testing.
 #![allow(clippy::unwrap_used)]
 // PANIC SAFETY: This module is used only for testing.
 #![allow(clippy::expect_used)]
 
 use crate::cedar_test_impl::*;
-use cedar_policy::{extensions::Extensions, Decision, PolicyId, ValidationMode};
+use cedar_policy::{Decision, PolicyId, ValidationMode};
 use cedar_policy_core::ast::{Eid, EntityUID, PolicySet, Request};
 use cedar_policy_core::entities::{self, json::err::JsonDeserializationErrorContext, Entities};
+use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::{jsonvalue::JsonValueWithNoDuplicateKeys, parser};
 use cedar_policy_validator::ValidatorSchema;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
## Description of changes

Implement the suggestions in #745 for `EvaluationError` (and the previously-not-public `ExtensionFunctionLookupError`, which it references)

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

(covered by existing changelog entry)

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

