### PR TITLE
Add pub applies_to_{principals, resources} APIs to validator

### DIFF
--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -66,6 +66,16 @@ impl ValidatorActionId {
     pub fn context_type(&self) -> Type {
         self.context.clone()
     }
+
+    /// The `EntityType`s that can be the `principal` for this action.
+    pub fn applies_to_principals(&self) -> impl Iterator<Item = &EntityType> {
+        self.applies_to.principal_apply_spec.iter()
+    }
+
+    /// The `EntityType`s that can be the `resource` for this action.
+    pub fn applies_to_resources(&self) -> impl Iterator<Item = &EntityType> {
+        self.applies_to.resource_apply_spec.iter()
+    }
 }
 
 impl TCNode<EntityUID> for ValidatorActionId {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `ValidatorActionId::applies_to_principals` and `ValidatorActionId::applies_to_resources`
+   to `cedar-policy-validator`
 - `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`,
    and `RestrictedExpression::new_decimal` (#661, resolving #659)
 - `Entities::into_iter` (#713, resolving #680)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -34,8 +34,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `ValidatorActionId::applies_to_principals` and `ValidatorActionId::applies_to_resources`
-   to `cedar-policy-validator`
 - `Expression::new_ip`, `Expression::new_decimal`, `RestrictedExpression::new_ip`,
    and `RestrictedExpression::new_decimal` (#661, resolving #659)
 - `Entities::into_iter` (#713, resolving #680)


### PR DESCRIPTION
## Description of changes
Add pub `applies_to_{principals, resources}` APIs to validator

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


