### PR TITLE
Fix formatter soundness check

### DIFF
--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -164,7 +164,8 @@ mod tests {
         
         a
         " };"#;
-        let p2 = r#"permit (principal, action, resource)
+        let p2 = r#"
+        permit (principal, action, resource)
         when { "
         a
         " };
@@ -174,14 +175,15 @@ mod tests {
 
         let p1 = r#"
         permit (principal, action, resource)
-        when { "a"};
+        when { "a"   };
         permit (principal, action, resource)
         when { "b" };"#;
-        let p2 = r#"permit (principal, action, resource)
-        when { "b" };
+        let p2 = r#"
         permit (principal, action, resource)
-        when { "a"};"#;
-        assert!(soundness_check(p2, &parse_policyset(p1).unwrap()).is_err());
+        when { "a" };
+        permit (principal, action, resource)
+        when { "b"};"#;
+        assert!(soundness_check(p2, &parse_policyset(p1).unwrap()).is_ok());
     }
 
     #[test]

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -144,6 +144,47 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_soundness_check() {
+        let p1 = r#"permit (principal, action, resource)
+        when { "
+        
+        a
+        " };"#;
+        let p2 = r#"permit (principal, action, resource)
+        when { "
+        a
+        " };"#;
+        assert!(soundness_check(p2, &parse_policyset(p1).unwrap()).is_err());
+
+        let p1 = r#"
+        permit (principal, action, resource)
+        when { "a"};
+        permit (principal, action, resource)
+        when { "
+        
+        a
+        " };"#;
+        let p2 = r#"permit (principal, action, resource)
+        when { "
+        a
+        " };
+        permit (principal, action, resource)
+        when { "a"};"#;
+        assert!(soundness_check(p2, &parse_policyset(p1).unwrap()).is_err());
+
+        let p1 = r#"
+        permit (principal, action, resource)
+        when { "a"};
+        permit (principal, action, resource)
+        when { "b" };"#;
+        let p2 = r#"permit (principal, action, resource)
+        when { "b" };
+        permit (principal, action, resource)
+        when { "a"};"#;
+        assert!(soundness_check(p2, &parse_policyset(p1).unwrap()).is_err());
+    }
+
+    #[test]
     fn test_format_files() {
         let config = Config {
             line_width: 80,


### PR DESCRIPTION
## Description of changes

There were two issues with the original function.

1. It iterates over templates instead of policies.
2. It zips over iterations coming from hashmaps, whose orders are non-deterministic.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

