### PR TITLE
Removing `error` extension function

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -322,7 +322,7 @@ impl Expr {
     }
 
     /// Create a ternary (if-then-else) `Expr`.
-    /// Takes `Arc`s instead of owned `Expr`s
+    /// Takes `Arc`s instead of owned `Expr`s.
     /// `test_expr` must evaluate to a Bool type
     pub fn ite_arc(test_expr: Arc<Expr>, then_expr: Arc<Expr>, else_expr: Arc<Expr>) -> Self {
         ExprBuilder::new().ite_arc(test_expr, then_expr, else_expr)

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -835,7 +835,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a ternary (if-then-else) `Expr`.
-    /// Takes `Arc`s instead of owned `Expr`s
+    /// Takes `Arc`s instead of owned `Expr`s.
     /// `test_expr` must evaluate to a Bool type
     pub fn ite_arc(
         self,

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -321,6 +321,13 @@ impl Expr {
         ExprBuilder::new().ite(test_expr, then_expr, else_expr)
     }
 
+    /// Create a ternary (if-then-else) `Expr`.
+    /// Takes `Arc`s instead of owned `Expr`s
+    /// `test_expr` must evaluate to a Bool type
+    pub fn ite_arc(test_expr: Arc<Expr>, then_expr: Arc<Expr>, else_expr: Arc<Expr>) -> Self {
+        ExprBuilder::new().ite_arc(test_expr, then_expr, else_expr)
+    }
+
     /// Create a 'not' expression. `e` must evaluate to Bool type
     pub fn not(e: Expr) -> Self {
         ExprBuilder::new().not(e)
@@ -824,6 +831,22 @@ impl<T> ExprBuilder<T> {
             test_expr: Arc::new(test_expr),
             then_expr: Arc::new(then_expr),
             else_expr: Arc::new(else_expr),
+        })
+    }
+
+    /// Create a ternary (if-then-else) `Expr`.
+    /// Takes `Arc`s instead of owned `Expr`s
+    /// `test_expr` must evaluate to a Bool type
+    pub fn ite_arc(
+        self,
+        test_expr: Arc<Expr<T>>,
+        then_expr: Arc<Expr<T>>,
+        else_expr: Arc<Expr<T>>,
+    ) -> Expr<T> {
+        self.with_expr_kind(ExprKind::If {
+            test_expr,
+            then_expr,
+            else_expr,
         })
     }
 

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -18,7 +18,7 @@
 use crate::{
     ast::{CallStyle, Extension, ExtensionFunction, ExtensionOutputValue, Unknown, Value},
     entities::SchemaType,
-    evaluator::{self, EvaluationError},
+    evaluator,
 };
 
 /// Create a new untyped `Unknown`
@@ -28,37 +28,17 @@ fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
     )))
 }
 
-fn throw_error(v: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let msg = v.get_as_string()?;
-    // PANIC SAFETY: This name is fully static, and is a valid extension name
-    #[allow(clippy::unwrap_used)]
-    let err = EvaluationError::failed_extension_function_application(
-        "partial_evaluation".parse().unwrap(),
-        msg.to_string(),
-        None, // source loc will be added by the evaluator
-    );
-    Err(err)
-}
-
 /// Construct the extension
 // PANIC SAFETY: all uses of `unwrap` here on parsing extension names are correct names
 #[allow(clippy::unwrap_used)]
 pub fn extension() -> Extension {
     Extension::new(
         "partial_evaluation".parse().unwrap(),
-        vec![
-            ExtensionFunction::unary_never(
-                "unknown".parse().unwrap(),
-                CallStyle::FunctionStyle,
-                Box::new(create_new_unknown),
-                Some(SchemaType::String),
-            ),
-            ExtensionFunction::unary_never(
-                "error".parse().unwrap(),
-                CallStyle::FunctionStyle,
-                Box::new(throw_error),
-                Some(SchemaType::String),
-            ),
-        ],
+        vec![ExtensionFunction::unary_never(
+            "unknown".parse().unwrap(),
+            CallStyle::FunctionStyle,
+            Box::new(create_new_unknown),
+            Some(SchemaType::String),
+        )],
     )
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Reduced precision of partial evaluation for `||`, `&&`,  and conditional expressions. `if { foo : <unknown> }.foo then 1 + "hi" else false` now evaluates to `if <unknown> then 1 + "hi" else false`
+- Removed the `error` extension function, which was previously used during partial evaluation.
 - Removed integration testing harness from the `cedar-policy` crate. It is now
   in an internal crate, allowing us to make semver incompatible changes. (#857)
 - Removed the (deprecated) `frontend` module in favor of the new `ffi` module


### PR DESCRIPTION
## Description of changes
Reduces the precision of partial evaluation when reducing expressions that are lazily evaluated (`if` `and` `or` subexpressions). The primary motivation for this is removing the `error` extension function, which is impossible to type.

Increases in precision without re-introducing `error` could come later.


## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
