### PR TITLE
Remove `ParseErrors::errors_as_strings` (fix #534)

### DIFF
--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -705,11 +705,6 @@ impl ParseErrors {
     pub(super) fn push(&mut self, err: impl Into<ParseError>) {
         self.0.push(err.into());
     }
-
-    /// returns a Vec with stringified versions of the ParseErrors
-    pub fn errors_as_strings(&self) -> Vec<String> {
-        self.0.iter().map(ToString::to_string).collect()
-    }
 }
 
 impl Display for ParseErrors {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in an internal crate, allowing us to make semver incompatible changes. (#857)
 - Removed the (deprecated) `frontend` module in favor of the new `ffi` module
   introduced in 3.2.0. See #757.
+- Removed `ParseErrors::errors_as_strings`.  Callers should consider examining
+  the rich data provided by `miette::Diagnostic`, for instance `.help()` and
+  `labels()`. Callers can continue using the same behavior by calling
+  `.iter().map(ToString::to_string)`. (#882, resolving #543)
 
 ## [3.2.0] - Coming Soon
 

--- a/cedar-testing/tests/cedar-policy-cli/main.rs
+++ b/cedar-testing/tests/cedar-policy-cli/main.rs
@@ -100,9 +100,8 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
             );
             assert!(
                 parse_errs
-                    .errors_as_strings()
                     .iter()
-                    .any(|s| s.ends_with("not a function")),
+                    .any(|e| e.to_string().ends_with("not a function")),
                 "unexpected parse errors in test {}: {}",
                 jsonfile.display(),
                 parse_errs,

--- a/cedar-wasm/src/policies_and_templates.rs
+++ b/cedar-wasm/src/policies_and_templates.rs
@@ -76,7 +76,7 @@ pub fn policy_text_to_json(cedar_str: &str) -> PolicyToJsonResult {
     match parse_policy_or_template_to_est(cedar_str) {
         Ok(policy) => PolicyToJsonResult::Success { policy },
         Err(err) => PolicyToJsonResult::Error {
-            errors: err.errors_as_strings(),
+            errors: err.iter().map(ToString::to_string).collect(),
         },
     }
 }
@@ -97,7 +97,7 @@ pub enum CheckParsePolicySetResult {
 pub fn check_parse_policy_set(input_policies_str: &str) -> CheckParsePolicySetResult {
     match PolicySet::from_str(input_policies_str) {
         Err(parse_errors) => CheckParsePolicySetResult::Error {
-            errors: parse_errors.errors_as_strings(),
+            errors: parse_errors.iter().map(ToString::to_string).collect(),
         },
         Ok(policy_set) => {
             let policies_count: Result<i32, <i32 as TryFrom<usize>>::Error> =
@@ -132,7 +132,7 @@ pub enum CheckParseTemplateResult {
 pub fn check_parse_template(template_str: &str) -> CheckParseTemplateResult {
     match Template::from_str(template_str) {
         Err(parse_errs) => CheckParseTemplateResult::Error {
-            errors: parse_errs.errors_as_strings(),
+            errors: parse_errs.iter().map(ToString::to_string).collect(),
         },
         Ok(template) => match template.slots().count() {
             1 | 2 => CheckParseTemplateResult::Success {


### PR DESCRIPTION
## Description of changes

There were three callers of this function in the wasm crate, but this function is simple enough that in lining it is not a problem. Possibly those calls should be updated to use rich information from miette.

## Issue #, if available

#534

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] 
I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

