### PR TITLE
Improve performance on a record error case

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -26,7 +26,7 @@ use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, TryFromInto};
 use smol_str::SmolStr;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use thiserror::Error;
 
 /// We support two types of entities. The first is a nominal type (e.g., User, Action)
@@ -269,11 +269,12 @@ pub struct Entity {
     /// UID
     uid: EntityUID,
 
-    /// Internal HashMap of attributes.
+    /// Internal BTreMap of attributes.
+    /// We use a btreemap so that the keys have a determenistic order.
     ///
     /// In the serialized form of `Entity`, attribute values appear as
     /// `RestrictedExpr`s, for mostly historical reasons.
-    attrs: HashMap<SmolStr, PartialValueSerializedAsExpr>,
+    attrs: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
 
     /// Set of ancestors of this `Entity` (i.e., all direct and transitive
     /// parents), as UIDs
@@ -331,7 +332,7 @@ impl Entity {
     /// as `PartialValueSerializedAsExpr`.
     pub fn new_with_attr_partial_value_serialized_as_expr(
         uid: EntityUID,
-        attrs: HashMap<SmolStr, PartialValueSerializedAsExpr>,
+        attrs: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
         ancestors: HashSet<EntityUID>,
     ) -> Self {
         Entity {
@@ -361,6 +362,16 @@ impl Entity {
         self.ancestors.iter()
     }
 
+    /// Get the number of attributes on this entity
+    pub fn attrs_len(&self) -> usize {
+        self.attrs.len()
+    }
+
+    /// Iterate over this entity's attribute names
+    pub fn keys(&self) -> impl Iterator<Item = &SmolStr> {
+        self.attrs.keys()
+    }
+
     /// Iterate over this entity's attributes
     pub fn attrs(&self) -> impl Iterator<Item = (&SmolStr, &PartialValue)> {
         self.attrs.iter().map(|(k, v)| (k, v.as_ref()))
@@ -370,7 +381,7 @@ impl Entity {
     pub fn with_uid(uid: EntityUID) -> Self {
         Self {
             uid,
-            attrs: HashMap::new(),
+            attrs: BTreeMap::new(),
             ancestors: HashSet::new(),
         }
     }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -429,7 +429,7 @@ impl ValidatorSchema {
             for p_entity in action.applies_to.applicable_principal_types() {
                 match p_entity {
                     EntityType::Specified(p_entity) => {
-                        if !entity_types.contains_key(p_entity) {
+                        if !entity_types.contains_key(&p_entity) {
                             undeclared_e.insert(p_entity.to_string());
                         }
                     }
@@ -440,7 +440,7 @@ impl ValidatorSchema {
             for r_entity in action.applies_to.applicable_resource_types() {
                 match r_entity {
                     EntityType::Specified(r_entity) => {
-                        if !entity_types.contains_key(r_entity) {
+                        if !entity_types.contains_key(&r_entity) {
                             undeclared_e.insert(r_entity.to_string());
                         }
                     }

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -22,7 +22,7 @@ use cedar_policy_core::{
 };
 use serde::Serialize;
 use smol_str::SmolStr;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 
 use crate::types::{Attributes, Type};
 
@@ -56,7 +56,7 @@ pub struct ValidatorActionId {
     ///
     /// Attributes are serialized as `RestrictedExpr`s, so that roundtripping
     /// works seamlessly.
-    pub(crate) attributes: HashMap<SmolStr, PartialValueSerializedAsExpr>,
+    pub(crate) attributes: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
 }
 
 impl ValidatorActionId {

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -17,7 +17,7 @@
 //! This module contains the definition of `ValidatorNamespaceDef` and of types
 //! it relies on
 
-use std::collections::{hash_map::Entry, HashMap, HashSet};
+use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 
 use cedar_policy_core::{
     ast::{
@@ -138,7 +138,7 @@ pub struct ActionFragment {
     /// The values for the attributes defined for this actions entity, stored
     /// separately so that we can later extract use these values to construct
     /// the actual `Entity` objects defined by the schema.
-    pub(super) attributes: HashMap<SmolStr, PartialValueSerializedAsExpr>,
+    pub(super) attributes: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
 }
 
 type ResolveFunc<T> = dyn FnOnce(&HashMap<Name, Type>) -> Result<T>;
@@ -363,10 +363,9 @@ impl ValidatorNamespaceDef {
         m: HashMap<SmolStr, CedarValueJson>,
         action_id: &EntityUID,
         extensions: Extensions<'_>,
-    ) -> Result<(Attributes, HashMap<SmolStr, PartialValueSerializedAsExpr>)> {
+    ) -> Result<(Attributes, BTreeMap<SmolStr, PartialValueSerializedAsExpr>)> {
         let mut attr_types: HashMap<SmolStr, Type> = HashMap::with_capacity(m.len());
-        let mut attr_values: HashMap<SmolStr, PartialValueSerializedAsExpr> =
-            HashMap::with_capacity(m.len());
+        let mut attr_values: BTreeMap<SmolStr, PartialValueSerializedAsExpr> = BTreeMap::new();
         let evaluator = RestrictedEvaluator::new(&extensions);
 
         for (k, v) in m {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary lifetimes from some validation related structs (#715)
 - Changed policy validation to reject comparisons and conditionals between
   record types that differ in whether an attribute is required or optional.
+- Fixed a performance issue when constructing an error for accessing 
+    a non-existent attribute on sufficiently large records/entities
 
 ### Removed
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -59,12 +59,24 @@ crate-type = ["rlib", "cdylib"]
 cool_asserts = "2.0"
 criterion = "0.5"
 globset = "0.4"
-cedar-policy-core = { version = "=4.0.0", features = ["test-util"], path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.0.0", features = [
+    "test-util",
+], path = "../cedar-policy-core" }
+# NON-CRYPTOGRAPHIC random number generators
+oorandom = "11.1"
 
 proptest = "1.0.0"
 
 [[bench]]
 name = "cedar_benchmarks"
+harness = false
+
+[[bench]]
+name = "attr_errors"
+harness = false
+
+[[bench]]
+name = "entity_attr_errors"
 harness = false
 
 [package.metadata.docs.rs]

--- a/cedar-policy/benches/attr_errors.rs
+++ b/cedar-policy/benches/attr_errors.rs
@@ -1,0 +1,86 @@
+use cedar_policy::{Authorizer, Context, Entities, PolicySet, Request, RestrictedExpression};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::str::FromStr;
+
+const LARGE_SIZE: usize = 100_000;
+pub fn large_context_record(c: &mut Criterion) {
+    let large_context = Context::from_pairs(
+        (1..=LARGE_SIZE)
+            .into_iter()
+            .map(|i| (format!("a{i}"), RestrictedExpression::new_bool(true)))
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+
+    let small_context = Context::from_pairs([
+        ("a1".to_string(), RestrictedExpression::new_bool(true)),
+        ("a2".to_string(), RestrictedExpression::new_bool(true)),
+    ])
+    .unwrap();
+
+    let large_req = Request::new(None, None, None, large_context, None).unwrap();
+    let small_req = Request::new(None, None, None, small_context, None).unwrap();
+    let entities = Entities::empty();
+    let auth = Authorizer::new();
+
+    let mut group = c.benchmark_group("is_authorized large_context_record");
+
+    let policy = PolicySet::from_str(
+        r#"
+        permit( principal, action, resource)
+        when { context.a1 };
+    "#,
+    )
+    .unwrap();
+    group.bench_function("get-attr (large)", |b| {
+        b.iter(|| {
+            auth.is_authorized(
+                black_box(&large_req),
+                black_box(&policy),
+                black_box(&entities),
+            )
+        })
+    });
+
+    group.bench_function("get-attr (small)", |b| {
+        b.iter(|| {
+            auth.is_authorized(
+                black_box(&small_req),
+                black_box(&policy),
+                black_box(&entities),
+            )
+        })
+    });
+
+    let policy = PolicySet::from_str(
+        r#"
+        permit( principal, action, resource)
+        when { context.other };
+    "#,
+    )
+    .unwrap();
+    group.bench_function("get-attr err (large)", |b| {
+        b.iter(|| {
+            auth.is_authorized(
+                black_box(&large_req),
+                black_box(&policy),
+                black_box(&entities),
+            )
+        })
+    });
+
+    group.bench_function("get-attr err (small)", |b| {
+        b.iter(|| {
+            auth.is_authorized(
+                black_box(&small_req),
+                black_box(&policy),
+                black_box(&entities),
+            )
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, large_context_record);
+criterion_main!(benches);

--- a/cedar-policy/benches/entity_attr_errors.rs
+++ b/cedar-policy/benches/entity_attr_errors.rs
@@ -1,0 +1,116 @@
+use cedar_policy::{
+    Authorizer, Context, Entities, Entity, PolicySet, Request, RestrictedExpression,
+};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::iter::once;
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
+
+const LARGE_SIZE: usize = 100_000;
+const NUM_POLICIES: usize = 10;
+
+fn create_policy_array(rng: &mut oorandom::Rand32) -> Vec<PolicySet> {
+    let mut buf = vec![];
+    for _ in 0..NUM_POLICIES {
+        let attribute_number = rng.rand_range(1..((LARGE_SIZE - 1) as u32));
+        let policy = PolicySet::from_str(&format!(
+            r#"
+        permit( principal, action, resource)
+        when {{ Foo::"bar".a{attribute_number} }};
+    "#,
+        ))
+        .unwrap();
+        buf.push(policy);
+    }
+    buf
+}
+
+fn choose<'a>(policies: &'a [PolicySet], rng: &'a mut oorandom::Rand32) -> &'a PolicySet {
+    let index = rng.rand_range(0..(policies.len() as u32)) as usize;
+    &policies[index]
+}
+
+pub fn large_context_record(c: &mut Criterion) {
+    let mut rng = oorandom::Rand32::new(4); // chosen by fair dice role
+    let large_attr = (1..=LARGE_SIZE)
+        .into_iter()
+        .map(|i| (format!("a{i}"), RestrictedExpression::new_bool(true)))
+        .collect::<HashMap<_, _>>();
+    let large_entity =
+        Entity::new(r#"Foo::"bar""#.parse().unwrap(), large_attr, HashSet::new()).unwrap();
+
+    let small_attr = [
+        ("a1".to_string(), RestrictedExpression::new_bool(true)),
+        ("a2".to_string(), RestrictedExpression::new_bool(true)),
+    ]
+    .into_iter()
+    .collect::<HashMap<_, _>>();
+
+    let small_entity =
+        Entity::new(r#"Foo::"bar""#.parse().unwrap(), small_attr, HashSet::new()).unwrap();
+
+    let req = Request::new(None, None, None, Context::empty(), None).unwrap();
+    let large_entities = Entities::from_entities(once(large_entity), None).unwrap();
+    let small_entities = Entities::from_entities(once(small_entity), None).unwrap();
+    let auth = Authorizer::new();
+
+    let mut group = c.benchmark_group("is_authorized large_entity_record");
+
+    let policies = create_policy_array(&mut rng);
+
+    group.bench_function("get-attr (large)", |b| {
+        b.iter(|| {
+            let policy = choose(&policies, &mut rng);
+            auth.is_authorized(
+                black_box(&req),
+                black_box(&policy),
+                black_box(&large_entities),
+            )
+        })
+    });
+
+    group.bench_function("get-attr (small)", |b| {
+        b.iter(|| {
+            let policy = choose(&policies, &mut rng);
+            auth.is_authorized(
+                black_box(&req),
+                black_box(&policy),
+                black_box(&small_entities),
+            )
+        })
+    });
+
+    let policy = PolicySet::from_str(
+        r#"
+        permit( principal, action, resource)
+        when { Foo::"bar".other };
+    "#,
+    )
+    .unwrap();
+    group.bench_function("get-attr err (large)", |b| {
+        b.iter(|| {
+            auth.is_authorized(
+                black_box(&req),
+                black_box(&policy),
+                black_box(&large_entities),
+            )
+        })
+    });
+
+    group.bench_function("get-attr err (small)", |b| {
+        b.iter(|| {
+            auth.is_authorized(
+                black_box(&req),
+                black_box(&policy),
+                black_box(&small_entities),
+            )
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, large_context_record);
+criterion_main!(benches);


### PR DESCRIPTION
## Description of changes
Improves a performance issue with errors for accessing a record attribute that doesn't exist. The issue exists for both entities and records, this PR fixes both. It also adds a new benchmark target to ensure we don't regress.

![image](https://github.com/cedar-policy/cedar/assets/5495888/74ee2c5f-7954-4e9f-a90c-41cbece043e9)

<img width="843" alt="Screenshot 2024-05-20 at 9 30 33 AM" src="https://github.com/cedar-policy/cedar/assets/5495888/71e1c40b-2636-426e-a537-f729bbac0311">


## Issue #, if available
#754 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A non-breaking change


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
