### PR TITLE
'crate_type' -> 'crate-type' for Rust 2024

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         shell: bash
       # `cargo semver-checks` doesn't understand `rlib` crates.
       - run: >-
-          sed -i -E 's/^(crate_type = \["rlib", "cdylib"\]|crate_type = \["rlib"\])$/crate_type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
+          sed -i -E 's/^(crate-type = \["rlib", "cdylib"\]|crate-type = \["rlib"\])$/crate-type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo install cargo-semver-checks
       - run: cargo semver-checks check-release --package cedar-policy --baseline-root ../base

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -53,7 +53,7 @@ wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [lib]
 # cdylib required for wasm
-crate_type = ["rlib", "cdylib"]
+crate-type = ["rlib", "cdylib"]
 
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -26,7 +26,7 @@ tsify = "0.4.5"
 default = ["console_error_panic_hook"]
 
 [lib]
-crate_type = ["cdylib", "rlib"]
+crate-type = ["cdylib", "rlib"]
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"


### PR DESCRIPTION
## Description of changes
'crate_type' -> 'crate-type' for Rust 2024

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


