### PR TITLE
Return an error for schema with an unknown extension type

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::collections::HashSet;
+use std::{collections::HashSet, fmt::Display};
 
 use cedar_policy_core::{
     ast::{EntityAttrEvaluationError, EntityUID, Name},
@@ -202,6 +202,10 @@ pub enum SchemaError {
     #[error("the `__expr` escape is no longer supported")]
     #[diagnostic(help("to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"))]
     ExprEscapeUsed,
+    /// The schema used an extension type that the validator doesn't know about.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnknownExtensionType(UnknownExtensionType),
 }
 
 impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
@@ -292,5 +296,20 @@ impl JsonDeserializationError {
                 }
             }
         }
+    }
+}
+
+#[derive(Error, Debug)]
+#[error("unknown extension type `{actual}`")]
+pub struct UnknownExtensionType {
+    pub(crate) actual: Name,
+    pub(crate) suggested_replacement: Option<String>,
+}
+
+impl Diagnostic for UnknownExtensionType {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        self.suggested_replacement
+            .as_ref()
+            .map(|suggestion| Box::new(format!("did you mean `{suggestion}`?")) as Box<dyn Display>)
     }
 }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -136,9 +136,10 @@ impl TryFrom<NamespaceDefinition> for ValidatorSchema {
     type Error = SchemaError;
 
     fn try_from(nsd: NamespaceDefinition) -> Result<ValidatorSchema> {
-        ValidatorSchema::from_schema_fragments([ValidatorSchemaFragment::from_namespaces([
-            nsd.try_into()?
-        ])])
+        ValidatorSchema::from_schema_fragments(
+            [ValidatorSchemaFragment::from_namespaces([nsd.try_into()?])],
+            Extensions::all_available(),
+        )
     }
 }
 
@@ -146,7 +147,7 @@ impl TryFrom<SchemaFragment> for ValidatorSchema {
     type Error = SchemaError;
 
     fn try_from(frag: SchemaFragment) -> Result<ValidatorSchema> {
-        ValidatorSchema::from_schema_fragments([frag.try_into()?])
+        ValidatorSchema::from_schema_fragments([frag.try_into()?], Extensions::all_available())
     }
 }
 
@@ -221,16 +222,20 @@ impl ValidatorSchema {
         action_behavior: ActionBehavior,
         extensions: Extensions<'_>,
     ) -> Result<ValidatorSchema> {
-        Self::from_schema_fragments([ValidatorSchemaFragment::from_schema_fragment(
-            schema_file,
-            action_behavior,
+        Self::from_schema_fragments(
+            [ValidatorSchemaFragment::from_schema_fragment(
+                schema_file,
+                action_behavior,
+                extensions,
+            )?],
             extensions,
-        )?])
+        )
     }
 
     /// Construct a new `ValidatorSchema` from some number of schema fragments.
     pub fn from_schema_fragments(
         fragments: impl IntoIterator<Item = ValidatorSchemaFragment>,
+        extensions: Extensions<'_>,
     ) -> Result<ValidatorSchema> {
         let mut type_defs = HashMap::new();
         let mut entity_type_fragments = HashMap::new();
@@ -271,7 +276,7 @@ impl ValidatorSchema {
         }
 
         let resolver = CommonTypeResolver::new(&type_defs);
-        let type_defs = resolver.resolve()?;
+        let type_defs = resolver.resolve(extensions)?;
 
         // Invert the `parents` relation defined by entities and action so far
         // to get a `children` relation.
@@ -656,14 +661,17 @@ impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes {
     type Error = SchemaError;
 
     fn try_into(self) -> Result<ValidatorSchema> {
-        ValidatorSchema::from_schema_fragments([ValidatorSchemaFragment::from_namespaces([
-            ValidatorNamespaceDef::from_namespace_definition(
-                None,
-                self.0,
-                crate::ActionBehavior::PermitAttributes,
-                Extensions::all_available(),
-            )?,
-        ])])
+        ValidatorSchema::from_schema_fragments(
+            [ValidatorSchemaFragment::from_namespaces([
+                ValidatorNamespaceDef::from_namespace_definition(
+                    None,
+                    self.0,
+                    crate::ActionBehavior::PermitAttributes,
+                    Extensions::all_available(),
+                )?,
+            ])],
+            Extensions::all_available(),
+        )
     }
 }
 
@@ -819,7 +827,7 @@ impl<'a> CommonTypeResolver<'a> {
     }
 
     // Resolve common type references
-    fn resolve(&self) -> Result<HashMap<Name, Type>> {
+    fn resolve(&self, extensions: Extensions) -> Result<HashMap<Name, Type>> {
         let sorted_names = self
             .topo_sort()
             .map_err(SchemaError::CycleInCommonTypeReferences)?;
@@ -845,6 +853,7 @@ impl<'a> CommonTypeResolver<'a> {
                 ValidatorNamespaceDef::try_schema_type_into_validator_type(
                     ns.as_ref(),
                     substituted_ty,
+                    extensions,
                 )?
                 .resolve_type_defs(&HashMap::new())?,
             );
@@ -866,6 +875,7 @@ mod test {
     use crate::{SchemaType, SchemaTypeVariant};
 
     use cedar_policy_core::ast::RestrictedExpr;
+    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
     use cool_asserts::assert_matches;
     use serde_json::json;
 
@@ -1389,6 +1399,7 @@ mod test {
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
             Some(&Name::parse_unqualified_name("NS").expect("Expected namespace.")),
             schema_ty,
+            Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
         .resolve_type_defs(&HashMap::new())
@@ -1409,6 +1420,7 @@ mod test {
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
             Some(&Name::parse_unqualified_name("NS").expect("Expected namespace.")),
             schema_ty,
+            Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
         .resolve_type_defs(&HashMap::new())
@@ -1434,10 +1446,14 @@ mod test {
                 additional_attributes: false,
             }),
         );
-        let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(None, schema_ty)
-            .expect("Error converting schema type to type.")
-            .resolve_type_defs(&HashMap::new())
-            .unwrap();
+        let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
+            None,
+            schema_ty,
+            Extensions::all_available(),
+        )
+        .expect("Error converting schema type to type.")
+        .resolve_type_defs(&HashMap::new())
+        .unwrap();
         assert_eq!(ty, Type::closed_record_with_attributes(None));
     }
 
@@ -1476,7 +1492,8 @@ mod test {
 
     #[test]
     fn schema_no_fragments() {
-        let schema = ValidatorSchema::from_schema_fragments([]).unwrap();
+        let schema =
+            ValidatorSchema::from_schema_fragments([], Extensions::all_available()).unwrap();
         assert!(schema.entity_types.is_empty());
         assert!(schema.action_ids.is_empty());
     }
@@ -1771,7 +1788,11 @@ mod test {
         .unwrap()
         .try_into()
         .unwrap();
-        let schema = ValidatorSchema::from_schema_fragments([fragment1, fragment2]).unwrap();
+        let schema = ValidatorSchema::from_schema_fragments(
+            [fragment1, fragment2],
+            Extensions::all_available(),
+        )
+        .unwrap();
 
         assert_eq!(
             schema.entity_types.iter().next().unwrap().1.attributes,
@@ -1806,7 +1827,10 @@ mod test {
         .try_into()
         .unwrap();
 
-        let schema = ValidatorSchema::from_schema_fragments([fragment1, fragment2]);
+        let schema = ValidatorSchema::from_schema_fragments(
+            [fragment1, fragment2],
+            Extensions::all_available(),
+        );
 
         match schema {
             Err(SchemaError::DuplicateCommonType(s)) if s.contains("A::MyLong") => (),
@@ -2202,13 +2226,103 @@ mod test {
         assert_matches!(schema, Err(SchemaError::UndeclaredCommonTypes(types)) =>
             assert_eq!(types, HashSet::from(["Demo::id".to_string()])));
     }
+
+    #[test]
+    fn unknown_extension_type() {
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": { },
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "a": {
+                                    "type": "Extension",
+                                    "name": "ip",
+                                }
+                            }
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("unknown extension type `ip`")
+                    .help("did you mean `ipaddr`?")
+                    .build());
+        });
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": { },
+                "entityTypes": { },
+                "actions": {
+                    "A": {
+                        "appliesTo": {
+                            "context": {
+                                "type": "Record",
+                                "attributes": {
+                                    "a": {
+                                        "type": "Extension",
+                                        "name": "deciml",
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("unknown extension type `deciml`")
+                    .help("did you mean `decimal`?")
+                    .build());
+        });
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "ty": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Extension",
+                                "name": "i",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": { },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("unknown extension type `i`")
+                    .help("did you mean `ipaddr`?")
+                    .build());
+        });
+    }
 }
 
 #[cfg(test)]
 mod test_resolver {
     use std::collections::HashMap;
 
-    use cedar_policy_core::ast::Name;
+    use cedar_policy_core::{ast::Name, extensions::Extensions};
     use cool_asserts::assert_matches;
 
     use super::CommonTypeResolver;
@@ -2221,7 +2335,7 @@ mod test_resolver {
             type_defs.extend(def.type_defs.type_defs.into_iter());
         }
         let resolver = CommonTypeResolver::new(&type_defs);
-        resolver.resolve()
+        resolver.resolve(Extensions::all_available())
     }
 
     #[test]

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -2296,11 +2296,14 @@ mod test {
         println!("{type_str}");
         let parsed_schema_type = parse_type(&type_str)
             .expect("String representation should have parsed into a schema type");
-        let type_from_schema_type =
-            ValidatorNamespaceDef::try_schema_type_into_validator_type(None, parsed_schema_type)
-                .expect("Schema type should have converted to type.")
-                .resolve_type_defs(&HashMap::new())
-                .unwrap();
+        let type_from_schema_type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
+            None,
+            parsed_schema_type,
+            Extensions::all_available(),
+        )
+        .expect("Schema type should have converted to type.")
+        .resolve_type_defs(&HashMap::new())
+        .unwrap();
         assert_eq!(ty, type_from_schema_type);
     }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - JSON format Cedar schemas will now fail to parse if they reference an unknown
-  entity types. This was already an error for human-readable schema syntax. (#890, resolving #875)
+  extension type. This was already an error for human-readable schema syntax. (#890, resolving #875)
 
 ## [3.2.0] - 2024-05-17
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `labels()`. Callers can continue using the same behavior by calling
   `.iter().map(ToString::to_string)`. (#882, resolving #543)
 
+### Fixed
+
+- JSON format Cedar schemas will now fail to parse if they reference an unknown
+  entity types. This was already an error for human-readable schema syntax. (#890, resolving #875)
+
 ## [3.2.0] - 2024-05-17
 
 ### Added

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1236,7 +1236,10 @@ impl TryInto<Schema> for SchemaFragment {
     /// any undeclared entity types are referenced in the schema fragment.
     fn try_into(self) -> Result<Schema, Self::Error> {
         Ok(Schema(
-            cedar_policy_validator::ValidatorSchema::from_schema_fragments([self.value])?,
+            cedar_policy_validator::ValidatorSchema::from_schema_fragments(
+                [self.value],
+                Extensions::all_available(),
+            )?,
         ))
     }
 }
@@ -1288,6 +1291,7 @@ impl Schema {
         Ok(Self(
             cedar_policy_validator::ValidatorSchema::from_schema_fragments(
                 fragments.into_iter().map(|f| f.value),
+                Extensions::all_available(),
             )?,
         ))
     }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -191,6 +191,12 @@ pub enum SchemaError {
     /// Support for this escape form has been dropped.
     #[error("schema contained the non-supported `__expr` escape")]
     ExprEscapeUsed,
+    /// An error reported during schema parsing when an unknown extension type
+    /// is used in a common type definition, entity attribute or action context
+    /// attributes.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnknownExtensionType(UnknownExtensionType),
 }
 
 /// Errors serializing Schemas to the natural syntax
@@ -354,6 +360,23 @@ impl From<cedar_policy_validator::ContextOrShape> for ContextOrShape {
     }
 }
 
+/// An error reported during schema parsing when an unknown extension type is
+/// used in a common type definition, entity attribute or action context
+/// attributes.
+#[derive(Debug, Diagnostic, Error)]
+#[error(transparent)]
+#[diagnostic(transparent)]
+pub struct UnknownExtensionType {
+    inner: cedar_policy_validator::UnknownExtensionType,
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_validator::UnknownExtensionType> for UnknownExtensionType {
+    fn from(value: cedar_policy_validator::UnknownExtensionType) -> Self {
+        Self { inner: value }
+    }
+}
+
 #[doc(hidden)]
 impl From<cedar_policy_validator::SchemaError> for SchemaError {
     fn from(value: cedar_policy_validator::SchemaError) -> Self {
@@ -406,6 +429,9 @@ impl From<cedar_policy_validator::SchemaError> for SchemaError {
                 Self::ActionAttrEval(err.into())
             }
             cedar_policy_validator::SchemaError::ExprEscapeUsed => Self::ExprEscapeUsed,
+            cedar_policy_validator::SchemaError::UnknownExtensionType(err) => {
+                SchemaError::UnknownExtensionType(err.into())
+            }
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Fix #875.

The change as implemented is breaking because it adds a new variant of `SchemaError`. We could work around this if we felt this need to go out in a pre-4.0 patch. This is also breaking because some schema will stop parsing if they had a typo in an extension type name, but that's well within what we're ok making in a patch.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

