### PR TITLE
Refactor ValidationError and ValidationWarning

### DIFF
--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -77,32 +77,32 @@ impl ValidationResult {
 /// and provides details specific to that kind of problem. The error also records
 /// where the problem was encountered.
 #[derive(Clone, Debug, Error, Eq, PartialEq)]
-#[error("{error_kind}")]
+#[error("{kind}")]
 pub struct ValidationError {
     location: SourceLocation,
-    error_kind: ValidationErrorKind,
+    kind: ValidationErrorKind,
 }
 
 impl ValidationError {
     pub(crate) fn with_policy_id(
         id: PolicyID,
         source_loc: Option<Loc>,
-        error_kind: ValidationErrorKind,
+        kind: ValidationErrorKind,
     ) -> Self {
         Self {
-            error_kind,
+            kind,
             location: SourceLocation::new(id, source_loc),
         }
     }
 
     /// Deconstruct this into its component source location and error kind.
     pub fn into_location_and_error_kind(self) -> (SourceLocation, ValidationErrorKind) {
-        (self.location, self.error_kind)
+        (self.location, self.kind)
     }
 
     /// Extract details about the exact issue detected by the validator.
     pub fn error_kind(&self) -> &ValidationErrorKind {
-        &self.error_kind
+        &self.kind
     }
 
     /// Extract the location where the validator found the issue.
@@ -124,27 +124,27 @@ impl Diagnostic for ValidationError {
     }
 
     fn code(&self) -> Option<Box<dyn std::fmt::Display + '_>> {
-        self.error_kind.code()
+        self.kind.code()
     }
 
     fn severity(&self) -> Option<miette::Severity> {
-        self.error_kind.severity()
+        self.kind.severity()
     }
 
     fn url(&self) -> Option<Box<dyn std::fmt::Display + '_>> {
-        self.error_kind.url()
+        self.kind.url()
     }
 
     fn help(&self) -> Option<Box<dyn std::fmt::Display + '_>> {
-        self.error_kind.help()
+        self.kind.help()
     }
 
     fn related(&self) -> Option<Box<dyn Iterator<Item = &dyn Diagnostic> + '_>> {
-        self.error_kind.related()
+        self.kind.related()
     }
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
-        self.error_kind.diagnostic_source()
+        self.kind.diagnostic_source()
     }
 }
 

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -83,6 +83,34 @@ pub struct ValidationError {
     error_kind: ValidationErrorKind,
 }
 
+impl ValidationError {
+    pub(crate) fn with_policy_id(
+        id: PolicyID,
+        source_loc: Option<Loc>,
+        error_kind: ValidationErrorKind,
+    ) -> Self {
+        Self {
+            error_kind,
+            location: SourceLocation::new(id, source_loc),
+        }
+    }
+
+    /// Deconstruct this into its component source location and error kind.
+    pub fn into_location_and_error_kind(self) -> (SourceLocation, ValidationErrorKind) {
+        (self.location, self.error_kind)
+    }
+
+    /// Extract details about the exact issue detected by the validator.
+    pub fn error_kind(&self) -> &ValidationErrorKind {
+        &self.error_kind
+    }
+
+    /// Extract the location where the validator found the issue.
+    pub fn location(&self) -> &SourceLocation {
+        &self.location
+    }
+}
+
 // custom impl of `Diagnostic`: source location and source code are from
 // .location, everything else forwarded to .error_kind
 impl Diagnostic for ValidationError {
@@ -117,34 +145,6 @@ impl Diagnostic for ValidationError {
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
         self.error_kind.diagnostic_source()
-    }
-}
-
-impl ValidationError {
-    pub(crate) fn with_policy_id(
-        id: PolicyID,
-        source_loc: Option<Loc>,
-        error_kind: ValidationErrorKind,
-    ) -> Self {
-        Self {
-            error_kind,
-            location: SourceLocation::new(id, source_loc),
-        }
-    }
-
-    /// Deconstruct this into its component source location and error kind.
-    pub fn into_location_and_error_kind(self) -> (SourceLocation, ValidationErrorKind) {
-        (self.location, self.error_kind)
-    }
-
-    /// Extract details about the exact issue detected by the validator.
-    pub fn error_kind(&self) -> &ValidationErrorKind {
-        &self.error_kind
-    }
-
-    /// Extract the location where the validator found the issue.
-    pub fn location(&self) -> &SourceLocation {
-        &self.location
     }
 }
 

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -322,6 +322,7 @@ pub struct UnspecifiedEntityError {
 
 /// The structure for validation warnings.
 #[derive(Hash, Eq, PartialEq, Error, Debug, Clone)]
+#[error("validation warning on policy `{}`: {}", location.policy_id(), kind)]
 pub struct ValidationWarning {
     pub(crate) location: SourceLocation,
     pub(crate) kind: ValidationWarningKind,
@@ -349,17 +350,6 @@ impl ValidationWarning {
 
     pub fn to_kind_and_location(self) -> (SourceLocation, ValidationWarningKind) {
         (self.location, self.kind)
-    }
-}
-
-impl std::fmt::Display for ValidationWarning {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "validation warning on policy `{}`: {}",
-            self.location.policy_id(),
-            self.kind
-        )
     }
 }
 

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -332,10 +332,10 @@ impl ValidationWarning {
     pub(crate) fn with_policy_id(
         id: PolicyID,
         source_loc: Option<Loc>,
-        warning_kind: ValidationWarningKind,
+        kind: ValidationWarningKind,
     ) -> Self {
         Self {
-            kind: warning_kind,
+            kind,
             location: SourceLocation::new(id, source_loc),
         }
     }


### PR DESCRIPTION
## Description of changes

Refactoring `ValidationError` and `ValidationWarning` in _validation_result.rs_. Part 1 of 2 for below issue.

## Issue #, if available
https://github.com/cedar-policy/cedar/issues/727

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


