### PR TITLE
Supporting PE/PA testing

### DIFF
--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -177,10 +177,6 @@ pub trait CedarTestImplementation {
         expected: Option<Value>,
     ) -> TestResult<bool>;
 
-    /// Custom evaluator entry point. The bool return value indicates the whether
-    /// evaluating the provided expression produces the expected value.
-    /// `expected` is optional to allow for the case where no return value is
-    /// expected due to errors.
     fn partial_is_authorized(
         &self,
         request: &Request,
@@ -188,6 +184,10 @@ pub trait CedarTestImplementation {
         policies: &PolicySet,
     ) -> TestResult<partial::FlatPartialResponse>;
 
+    /// Custom evaluator entry point. The bool return value indicates the whether
+    /// evaluating the provided expression produces the expected value.
+    /// `expected` is optional to allow for the case where no return value is
+    /// expected due to errors.
     fn partial_evaluate(
         &self,
         request: &Request,

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -184,7 +184,7 @@ pub trait CedarTestImplementation {
         policies: &PolicySet,
     ) -> TestResult<partial::FlatPartialResponse>;
 
-    /// Custom evaluator entry point. The bool return value indicates the whether
+    /// Custom partial evaluator entry point. The bool return value indicates the whether
     /// evaluating the provided expression produces the expected value.
     /// `expected` is optional to allow for the case where no return value is
     /// expected due to errors.

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -20,6 +20,7 @@
 //! testing (see <https://github.com/cedar-policy/cedar-spec>).
 
 pub use cedar_policy::ffi;
+use cedar_policy_core::ast::PartialValue;
 use cedar_policy_core::ast::{Expr, PolicySet, Request, Value};
 use cedar_policy_core::authorizer::Authorizer;
 use cedar_policy_core::entities::Entities;
@@ -27,9 +28,10 @@ use cedar_policy_core::evaluator::Evaluator;
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_validator::{ValidationMode, Validator, ValidatorSchema};
 use miette::miette;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use smol_str::ToSmolStr;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::time::{Duration, Instant};
 
 /// Return type for `CedarTestImplementation` methods
@@ -88,10 +90,67 @@ pub struct TestValidationResult {
     pub timing_info: HashMap<String, Micros>,
 }
 
+pub mod partial {
+    use super::*;
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    pub struct FlatPartialResposne {
+        #[serde(rename = "knownPermits")]
+        pub known_permits: HashSet<String>,
+        #[serde(rename = "knownForbids")]
+        pub known_forbids: HashSet<String>,
+        #[serde(rename = "determiningUnderApprox")]
+        pub determining_under_approx: HashSet<String>,
+        #[serde(rename = "determiningOverApprox")]
+        pub determining_over_approx: HashSet<String>,
+        pub decision: Decision,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, Eq)]
+    pub enum Decision {
+        #[serde(rename = "allow")]
+        Allow,
+        #[serde(rename = "deny")]
+        Deny,
+        #[serde(rename = "unknown")]
+        Unknown,
+    }
+
+    impl Decision {
+        pub fn from_core(o: Option<cedar_policy_core::authorizer::Decision>) -> Self {
+            match o {
+                Some(cedar_policy_core::authorizer::Decision::Allow) => Self::Allow,
+                Some(cedar_policy_core::authorizer::Decision::Deny) => Self::Deny,
+                None => Self::Unknown,
+            }
+        }
+    }
+}
+
 impl TestValidationResult {
     /// Check if validation succeeded
     pub fn validation_passed(&self) -> bool {
         self.errors.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub enum ExprOrValue {
+    Expr(Expr),
+    Value(Expr),
+}
+
+impl ExprOrValue {
+    pub fn value(v: Value) -> Self {
+        Self::Value(v.into())
+    }
+}
+
+impl std::fmt::Display for ExprOrValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Expr(e) => write!(f, "Expr: `{e}`"),
+            Self::Value(v) => write!(f, "Value: `{v}`"),
+        }
     }
 }
 
@@ -116,6 +175,22 @@ pub trait CedarTestImplementation {
         expr: &Expr,
         enable_extensions: bool,
         expected: Option<Value>,
+    ) -> TestResult<bool>;
+
+    fn partial_is_authorized(
+        &self,
+        request: &Request,
+        entities: &Entities,
+        policies: &PolicySet,
+    ) -> TestResult<partial::FlatPartialResposne>;
+
+    fn partial_evaluate(
+        &self,
+        request: &Request,
+        entities: &Entities,
+        expr: &Expr,
+        enable_extensions: bool,
+        expected: Option<ExprOrValue>,
     ) -> TestResult<bool>;
 
     /// Custom validator entry point.
@@ -222,6 +297,61 @@ impl CedarTestImplementation for RustEngine {
             timing_info: HashMap::from([("authorize".into(), Micros(duration.as_micros()))]),
         };
         TestResult::Success(response)
+    }
+
+    fn partial_is_authorized(
+        &self,
+        request: &Request,
+        entities: &Entities,
+        policies: &PolicySet,
+    ) -> TestResult<partial::FlatPartialResposne> {
+        let a = Authorizer::new();
+        let pr = a.is_authorized_core(request.clone(), policies, entities);
+
+        let r = partial::FlatPartialResposne {
+            known_permits: pr.satisfied_permits.keys().map(|x| x.to_string()).collect(),
+            known_forbids: pr.satisfied_forbids.keys().map(|x| x.to_string()).collect(),
+            decision: partial::Decision::from_core(pr.decision()),
+            determining_over_approx: pr
+                .may_be_determining()
+                .map(|x| x.id().to_string())
+                .collect(),
+            determining_under_approx: pr
+                .must_be_determining()
+                .map(|x| x.id().to_string())
+                .collect(),
+        };
+
+        TestResult::Success(r)
+    }
+
+    fn partial_evaluate(
+        &self,
+        request: &Request,
+        entities: &Entities,
+        expr: &Expr,
+        enable_extensions: bool,
+        expected: Option<ExprOrValue>,
+    ) -> TestResult<bool> {
+        let exts = if enable_extensions {
+            Extensions::all_available()
+        } else {
+            Extensions::none()
+        };
+        let e = Evaluator::new(request.clone(), entities, &exts);
+        let result = e.partial_interpret(expr, &HashMap::default());
+        match (result, expected) {
+            (Ok(PartialValue::Residual(r)), Some(ExprOrValue::Expr(e))) => {
+                TestResult::Success(r == e)
+            }
+            (Ok(PartialValue::Value(v)), Some(ExprOrValue::Value(e))) => {
+                let v_as_e: Expr = v.into();
+                TestResult::Success(v_as_e == e)
+            }
+
+            (Err(_), None) => TestResult::Success(true),
+            _ => TestResult::Success(false),
+        }
     }
 
     fn interpret(

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -177,12 +177,16 @@ pub trait CedarTestImplementation {
         expected: Option<Value>,
     ) -> TestResult<bool>;
 
+    /// Custom evaluator entry point. The bool return value indicates the whether
+    /// evaluating the provided expression produces the expected value.
+    /// `expected` is optional to allow for the case where no return value is
+    /// expected due to errors.
     fn partial_is_authorized(
         &self,
         request: &Request,
         entities: &Entities,
         policies: &PolicySet,
-    ) -> TestResult<partial::FlatPartialResposne>;
+    ) -> TestResult<partial::FlatPartialResponse>;
 
     fn partial_evaluate(
         &self,
@@ -304,11 +308,11 @@ impl CedarTestImplementation for RustEngine {
         request: &Request,
         entities: &Entities,
         policies: &PolicySet,
-    ) -> TestResult<partial::FlatPartialResposne> {
+    ) -> TestResult<partial::FlatPartialResponse> {
         let a = Authorizer::new();
         let pr = a.is_authorized_core(request.clone(), policies, entities);
 
-        let r = partial::FlatPartialResposne {
+        let r = partial::FlatPartialResponse {
             known_permits: pr.satisfied_permits.keys().map(|x| x.to_string()).collect(),
             known_forbids: pr.satisfied_forbids.keys().map(|x| x.to_string()).collect(),
             decision: partial::Decision::from_core(pr.decision()),

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -93,7 +93,7 @@ pub struct TestValidationResult {
 pub mod partial {
     use super::*;
     #[derive(Debug, Deserialize, PartialEq, Eq)]
-    pub struct FlatPartialResposne {
+    pub struct FlatPartialResponse {
         #[serde(rename = "knownPermits")]
         pub known_permits: HashSet<String>,
         #[serde(rename = "knownForbids")]


### PR DESCRIPTION
## Description of changes
Adds some code to cedar testing to support the testing of PE/PA: https://github.com/cedar-policy/cedar-spec/pull/308
## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
