### PR TITLE
change npm namespace for wasm build script

### DIFF
--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -17,7 +17,7 @@
 # Without this, the built wasm still works, but the Typescript definitions made by tsify don't.
 set -e
 cargo build
-wasm-pack build --scope amzn --target bundler
+wasm-pack build --scope cedar-policy --target bundler
 
 sed -i "s/[{]\s*!: /{ \"!\": /g" pkg/cedar_wasm.d.ts
 sed -i "s/[{]\s*==: /{ \"==\": /g" pkg/cedar_wasm.d.ts


### PR DESCRIPTION
## Description of changes

The build script had the wrong npm namespace. 

## Issue #, if available

n/a

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


