### PR TITLE
Implement #745 for `SchemaWarning`

### DIFF
--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -462,8 +462,8 @@ impl Diagnostic for ShadowsEntityWarning {
 pub enum SchemaWarning {
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ShadowsBuiltin(ShadowsBuiltinWarning),
+    ShadowsBuiltin(#[from] ShadowsBuiltinWarning),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ShadowsEntity(ShadowsEntityWarning),
+    ShadowsEntity(#[from] ShadowsEntityWarning),
 }

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -607,11 +607,12 @@ fn make_warning_for_shadowing(n: &NamespaceRecord) -> impl Iterator<Item = Schem
     for (common_name, common_src_node) in n.common_types.iter() {
         // Check if it shadows a entity name in the same namespace
         if let Some(entity_src_node) = n.entities.get(common_name) {
-            let warning = SchemaWarning::ShadowsEntity(ShadowsEntityWarning {
+            let warning = ShadowsEntityWarning {
                 name: common_name.to_smolstr(),
                 entity_loc: entity_src_node.loc.clone(),
                 common_loc: common_src_node.loc.clone(),
-            });
+            }
+            .into();
             warnings.push(warning);
         }
         // Check if it shadows a bultin
@@ -633,10 +634,13 @@ fn extract_name<N: Clone>(n: Node<N>) -> (N, Node<()>) {
 
 fn shadows_builtin((name, node): (&Id, &Node<()>)) -> Option<SchemaWarning> {
     if EXTENSIONS.contains(&name.as_ref()) || BUILTIN_TYPES.contains(&name.as_ref()) {
-        Some(SchemaWarning::ShadowsBuiltin(ShadowsBuiltinWarning {
-            name: name.to_smolstr(),
-            loc: node.loc.clone(),
-        }))
+        Some(
+            ShadowsBuiltinWarning {
+                name: name.to_smolstr(),
+                loc: node.loc.clone(),
+            }
+            .into(),
+        )
     } else {
         None
     }

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -36,7 +36,10 @@ use super::{
         ActionDecl, AppDecl, AttrDecl, Decl, Declaration, EntityDecl, Namespace, PRAppDecl,
         QualName, Schema, Type, TypeDecl, BUILTIN_TYPES, CEDAR_NAMESPACE, EXTENSIONS, PR,
     },
-    err::{SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors},
+    err::{
+        SchemaWarning, ShadowsBuiltinWarning, ShadowsEntityWarning, ToJsonSchemaError,
+        ToJsonSchemaErrors,
+    },
 };
 
 /// Convert a custom schema AST into the JSON representation
@@ -604,11 +607,11 @@ fn make_warning_for_shadowing(n: &NamespaceRecord) -> impl Iterator<Item = Schem
     for (common_name, common_src_node) in n.common_types.iter() {
         // Check if it shadows a entity name in the same namespace
         if let Some(entity_src_node) = n.entities.get(common_name) {
-            let warning = SchemaWarning::ShadowsEntity {
+            let warning = SchemaWarning::ShadowsEntity(ShadowsEntityWarning {
                 name: common_name.to_smolstr(),
                 entity_loc: entity_src_node.loc.clone(),
                 common_loc: common_src_node.loc.clone(),
-            };
+            });
             warnings.push(warning);
         }
         // Check if it shadows a bultin
@@ -630,10 +633,10 @@ fn extract_name<N: Clone>(n: Node<N>) -> (N, Node<()>) {
 
 fn shadows_builtin((name, node): (&Id, &Node<()>)) -> Option<SchemaWarning> {
     if EXTENSIONS.contains(&name.as_ref()) || BUILTIN_TYPES.contains(&name.as_ref()) {
-        Some(SchemaWarning::ShadowsBuiltin {
+        Some(SchemaWarning::ShadowsBuiltin(ShadowsBuiltinWarning {
             name: name.to_smolstr(),
             loc: node.loc.clone(),
-        })
+        }))
     } else {
         None
     }


### PR DESCRIPTION
## Description of changes

#745 

This PR also removes the `UsesBuiltinNamespace` variant as it's never been used and should be an error instead of a warning.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
