### PR TITLE
Combine TypeErrorKind and ValidationErrorKind

### DIFF
--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -190,12 +190,7 @@ impl Validator {
         typecheck.typecheck_policy(t, &mut type_errors, &mut warnings);
         (
             type_errors.into_iter().map(|type_error| {
-                let (kind, location) = type_error.kind_and_location();
-                ValidationError::with_policy_id(
-                    t.id().clone(),
-                    location,
-                    ValidationErrorKind::type_error(kind),
-                )
+                ValidationError::with_policy_id(t.id().clone(), None, type_error)
             }),
             warnings.into_iter(),
         )
@@ -269,7 +264,7 @@ mod test {
         let principal_err = ValidationError::with_policy_id(
             policy_b.id().clone(),
             None,
-            ValidationErrorKind::unrecognized_entity_type(
+            TypeError::unrecognized_entity_type(
                 "foo_tye".to_string(),
                 Some("foo_type".to_string()),
             ),
@@ -277,7 +272,7 @@ mod test {
         let resource_err = ValidationError::with_policy_id(
             policy_b.id().clone(),
             None,
-            ValidationErrorKind::unrecognized_entity_type(
+            TypeError::unrecognized_entity_type(
                 "br_type".to_string(),
                 Some("bar_type".to_string()),
             ),
@@ -285,7 +280,7 @@ mod test {
         let action_err = ValidationError::with_policy_id(
             policy_a.id().clone(),
             None,
-            ValidationErrorKind::unrecognized_action_id(
+            TypeError::unrecognized_action_id(
                 "Action::\"actin\"".to_string(),
                 Some("Action::\"action\"".to_string()),
             ),
@@ -411,7 +406,7 @@ mod test {
         let undefined_err = ValidationError::with_policy_id(
             id.clone(),
             None,
-            ValidationErrorKind::unrecognized_entity_type(
+            TypeError::unrecognized_entity_type(
                 "some_namespace::Undefined".to_string(),
                 Some("some_namespace::User".to_string()),
             ),
@@ -419,7 +414,7 @@ mod test {
         let invalid_action_err = ValidationError::with_policy_id(
             id,
             loc.clone(),
-            ValidationErrorKind::invalid_action_application(false, false),
+            TypeError::invalid_action_application(false, false),
         );
         assert!(result.validation_errors().any(|x| x == &undefined_err));
         assert!(result.validation_errors().any(|x| x == &invalid_action_err));
@@ -448,7 +443,7 @@ mod test {
         let invalid_action_err = ValidationError::with_policy_id(
             id,
             loc.clone(),
-            ValidationErrorKind::invalid_action_application(false, false),
+            TypeError::invalid_action_application(false, false),
         );
         assert!(result
             .validation_errors()
@@ -497,15 +492,15 @@ mod test {
                 .validation_errors()
                 .map(|err| err.error_kind())
                 .collect::<Vec<_>>(),
-            vec![&ValidationErrorKind::type_error(
-                TypeError::expected_type(
+            vec![
+                &TypeError::expected_type(
                     Expr::val(1),
                     Type::primitive_long(),
                     Type::singleton_boolean(true),
                     None,
                 )
                 .kind
-            )]
+            ]
         );
         assert_eq!(
             result

--- a/cedar-policy-validator/src/type_error.rs
+++ b/cedar-policy-validator/src/type_error.rs
@@ -44,7 +44,7 @@ pub struct TypeError {
     // tests to only check for the correct `source_loc`.
     pub(crate) on_expr: Option<Expr>,
     pub(crate) source_loc: Option<Loc>,
-    pub(crate) kind: TypeErrorKind,
+    pub(crate) kind: ValidationErrorKind,
 }
 
 // custom impl of `Diagnostic`: source location and source code are from .source_loc(),
@@ -89,7 +89,7 @@ impl Diagnostic for TypeError {
 
 impl TypeError {
     /// Extract the type error kind for this type error.
-    pub fn type_error_kind(self) -> TypeErrorKind {
+    pub fn type_error_kind(self) -> ValidationErrorKind {
         self.kind
     }
 
@@ -102,9 +102,62 @@ impl TypeError {
     }
 
     /// Deconstruct the type error into its kind and location.
-    pub fn kind_and_location(self) -> (TypeErrorKind, Option<Loc>) {
+    pub fn kind_and_location(self) -> (ValidationErrorKind, Option<Loc>) {
         let loc = self.source_loc().cloned();
         (self.kind, loc)
+    }
+
+    pub(crate) fn unrecognized_entity_type(
+        actual_entity_type: String,
+        suggested_entity_type: Option<String>,
+    ) -> Self {
+        Self {
+            on_expr: None,
+            source_loc: None,
+            kind: UnrecognizedEntityType {
+                actual_entity_type,
+                suggested_entity_type,
+            }
+            .into(),
+        }
+    }
+
+    pub(crate) fn unrecognized_action_id(
+        actual_action_id: String,
+        suggested_action_id: Option<String>,
+    ) -> Self {
+        Self {
+            on_expr: None,
+            source_loc: None,
+            kind: UnrecognizedActionId {
+                actual_action_id,
+                suggested_action_id,
+            }
+            .into(),
+        }
+    }
+
+    pub(crate) fn invalid_action_application(
+        would_in_fix_principal: bool,
+        would_in_fix_resource: bool,
+    ) -> Self {
+        Self {
+            on_expr: None,
+            source_loc: None,
+            kind: InvalidActionApplication {
+                would_in_fix_principal,
+                would_in_fix_resource,
+            }
+            .into(),
+        }
+    }
+
+    pub(crate) fn unspecified_entity(entity_id: String) -> Self {
+        Self {
+            on_expr: None,
+            source_loc: None,
+            kind: UnspecifiedEntityError { entity_id }.into(),
+        }
     }
 
     /// Construct a type error for when an unexpected type occurs in an expression.
@@ -117,7 +170,7 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::UnexpectedType(UnexpectedType {
+            kind: ValidationErrorKind::UnexpectedType(UnexpectedType {
                 expected: expected.into_iter().collect::<BTreeSet<_>>(),
                 actual,
                 help,
@@ -136,7 +189,7 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::IncompatibleTypes(IncompatibleTypes {
+            kind: ValidationErrorKind::IncompatibleTypes(IncompatibleTypes {
                 types: types.into_iter().collect::<BTreeSet<_>>(),
                 hint,
                 context,
@@ -153,7 +206,7 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::UnsafeAttributeAccess(UnsafeAttributeAccess {
+            kind: ValidationErrorKind::UnsafeAttributeAccess(UnsafeAttributeAccess {
                 attribute_access,
                 suggestion,
                 may_exist,
@@ -168,9 +221,9 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::UnsafeOptionalAttributeAccess(UnsafeOptionalAttributeAccess {
-                attribute_access,
-            }),
+            kind: ValidationErrorKind::UnsafeOptionalAttributeAccess(
+                UnsafeOptionalAttributeAccess { attribute_access },
+            ),
         }
     }
 
@@ -178,7 +231,7 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::UndefinedFunction(UndefinedFunction { name }),
+            kind: ValidationErrorKind::UndefinedFunction(UndefinedFunction { name }),
         }
     }
 
@@ -186,7 +239,7 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::MultiplyDefinedFunction(MultiplyDefinedFunction { name }),
+            kind: ValidationErrorKind::MultiplyDefinedFunction(MultiplyDefinedFunction { name }),
         }
     }
 
@@ -194,7 +247,10 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::WrongNumberArguments(WrongNumberArguments { expected, actual }),
+            kind: ValidationErrorKind::WrongNumberArguments(WrongNumberArguments {
+                expected,
+                actual,
+            }),
         }
     }
 
@@ -202,9 +258,9 @@ impl TypeError {
         Self {
             on_expr: Some(on_expr),
             source_loc: None,
-            kind: TypeErrorKind::FunctionArgumentValidationError(FunctionArgumentValidationError {
-                msg,
-            }),
+            kind: ValidationErrorKind::FunctionArgumentValidationError(
+                FunctionArgumentValidationError { msg },
+            ),
         }
     }
 
@@ -212,7 +268,7 @@ impl TypeError {
         Self {
             on_expr: None,
             source_loc: on_expr.source_loc().cloned(),
-            kind: TypeErrorKind::EmptySetForbidden,
+            kind: ValidationErrorKind::EmptySetForbidden,
         }
     }
 
@@ -220,7 +276,7 @@ impl TypeError {
         Self {
             on_expr: None,
             source_loc: on_expr.source_loc().cloned(),
-            kind: TypeErrorKind::NonLitExtConstructor,
+            kind: ValidationErrorKind::NonLitExtConstructor,
         }
     }
 
@@ -232,7 +288,10 @@ impl TypeError {
         Self {
             on_expr: None,
             source_loc: on_expr.source_loc().cloned(),
-            kind: TypeErrorKind::HierarchyNotRespected(HierarchyNotRespected { in_lhs, in_rhs }),
+            kind: ValidationErrorKind::HierarchyNotRespected(HierarchyNotRespected {
+                in_lhs,
+                in_rhs,
+            }),
         }
     }
 }
@@ -241,7 +300,26 @@ impl TypeError {
 /// specific to that type error kind.
 #[derive(Debug, Clone, Diagnostic, Error, Hash, Eq, PartialEq)]
 #[non_exhaustive]
-pub enum TypeErrorKind {
+pub enum ValidationErrorKind {
+    /// A policy contains an entity type that is not declared in the schema.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnrecognizedEntityType(#[from] UnrecognizedEntityType),
+    /// A policy contains an action that is not declared in the schema.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnrecognizedActionId(#[from] UnrecognizedActionId),
+    /// There is no action satisfying the action scope constraint that can be
+    /// applied to a principal and resources that both satisfy their respective
+    /// scope conditions.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidActionApplication(#[from] InvalidActionApplication),
+    /// An unspecified entity was used in a policy. This should be impossible,
+    /// assuming that the policy was constructed by the parser.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnspecifiedEntity(#[from] UnspecifiedEntityError),
     /// The typechecker expected to see a subtype of one of the types in
     /// `expected`, but saw `actual`.
     #[error(transparent)]
@@ -297,6 +375,80 @@ pub enum TypeErrorKind {
     #[error(transparent)]
     #[diagnostic(transparent)]
     HierarchyNotRespected(HierarchyNotRespected),
+}
+
+/// Structure containing details about an unrecognized entity type error.
+#[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
+#[error("unrecognized entity type `{actual_entity_type}`")]
+pub struct UnrecognizedEntityType {
+    /// The entity type seen in the policy.
+    pub(crate) actual_entity_type: String,
+    /// An entity type from the schema that the user might reasonably have
+    /// intended to write.
+    pub(crate) suggested_entity_type: Option<String>,
+}
+
+impl Diagnostic for UnrecognizedEntityType {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        match &self.suggested_entity_type {
+            Some(s) => Some(Box::new(format!("did you mean `{s}`?"))),
+            None => None,
+        }
+    }
+}
+
+/// Structure containing details about an unrecognized action id error.
+#[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
+#[error("unrecognized action `{actual_action_id}`")]
+pub struct UnrecognizedActionId {
+    /// Action Id seen in the policy.
+    pub(crate) actual_action_id: String,
+    /// An action id from the schema that the user might reasonably have
+    /// intended to write.
+    pub(crate) suggested_action_id: Option<String>,
+}
+
+impl Diagnostic for UnrecognizedActionId {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        match &self.suggested_action_id {
+            Some(s) => Some(Box::new(format!("did you mean `{s}`?"))),
+            None => None,
+        }
+    }
+}
+
+/// Structure containing details about an invalid action application error.
+#[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
+#[error("unable to find an applicable action given the policy scope constraints")]
+pub struct InvalidActionApplication {
+    pub(crate) would_in_fix_principal: bool,
+    pub(crate) would_in_fix_resource: bool,
+}
+
+impl Diagnostic for InvalidActionApplication {
+    fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+        match (self.would_in_fix_principal, self.would_in_fix_resource) {
+            (true, false) => Some(Box::new(
+                "try replacing `==` with `in` in the principal clause",
+            )),
+            (false, true) => Some(Box::new(
+                "try replacing `==` with `in` in the resource clause",
+            )),
+            (true, true) => Some(Box::new(
+                "try replacing `==` with `in` in the principal clause and the resource clause",
+            )),
+            (false, false) => None,
+        }
+    }
+}
+
+/// Structure containing details about an unspecified entity error.
+#[derive(Debug, Clone, Diagnostic, Error, Hash, Eq, PartialEq)]
+#[error("unspecified entity with id `{entity_id}`")]
+#[diagnostic(help("unspecified entities cannot be used in policies"))]
+pub struct UnspecifiedEntityError {
+    /// EID of the unspecified entity.
+    pub(crate) entity_id: String,
 }
 
 /// Structure containing details about an unexpected type error.

--- a/cedar-policy-validator/src/typecheck/test_strict.rs
+++ b/cedar-policy-validator/src/typecheck/test_strict.rs
@@ -35,7 +35,7 @@ use cedar_policy_core::{
 use crate::{
     typecheck::test_utils::assert_policy_typecheck_fails,
     types::{AttributeType, EffectSet, OpenTag, RequestEnv, Type},
-    IncompatibleTypes, LubContext, LubHelp, SchemaFragment, TypeError, TypeErrorKind,
+    IncompatibleTypes, LubContext, LubHelp, SchemaFragment, TypeError, ValidationErrorKind,
     ValidationMode,
 };
 
@@ -71,7 +71,7 @@ fn assert_strict_type_error(
     e: Expr,
     e_strict: Expr,
     expected_type: Type,
-    expected_error: TypeErrorKind,
+    expected_error: ValidationErrorKind,
 ) {
     with_typechecker_from_schema(schema, |mut typechecker| {
         typechecker.mode = ValidationMode::Strict;
@@ -109,7 +109,7 @@ fn assert_types_must_match(
         e,
         e_strict,
         expected_type,
-        TypeErrorKind::IncompatibleTypes(IncompatibleTypes {
+        ValidationErrorKind::IncompatibleTypes(IncompatibleTypes {
             types: unequal_types.into_iter().collect(),
             hint,
             context,
@@ -178,7 +178,7 @@ fn strict_typecheck_catches_regular_type_error() {
             assert!(errs.len() == 1);
             assert!(matches!(
                 errs.first().unwrap().kind,
-                TypeErrorKind::UnexpectedType(_)
+                ValidationErrorKind::UnexpectedType(_)
             ));
         })
     })
@@ -385,7 +385,7 @@ fn empty_set_literal() {
             Expr::from_str(r#"[]"#).unwrap(),
             Expr::from_str(r#"[]"#).unwrap(),
             Type::any_set(),
-            TypeErrorKind::EmptySetForbidden,
+            ValidationErrorKind::EmptySetForbidden,
         )
     })
 }
@@ -400,7 +400,7 @@ fn ext_struct_non_lit() {
             Expr::from_str(r#"ip(if 1 > 0 then "a" else "b")"#).unwrap(),
             Expr::from_str(r#"ip(if 1 > 0 then "a" else "b")"#).unwrap(),
             Type::extension("ipaddr".parse().unwrap()),
-            TypeErrorKind::NonLitExtConstructor,
+            ValidationErrorKind::NonLitExtConstructor,
         )
     });
 
@@ -412,7 +412,7 @@ fn ext_struct_non_lit() {
             Expr::from_str(r#"decimal(if 1 > 0 then "0.1" else "1.0")"#).unwrap(),
             Expr::from_str(r#"decimal(if 1 > 0 then "0.1" else "1.0")"#).unwrap(),
             Type::extension("decimal".parse().unwrap()),
-            TypeErrorKind::NonLitExtConstructor,
+            ValidationErrorKind::NonLitExtConstructor,
         )
     })
 }

--- a/cedar-policy-validator/src/validation_result.rs
+++ b/cedar-policy-validator/src/validation_result.rs
@@ -85,9 +85,10 @@ pub struct ValidationError {
 
 impl ValidationError {
     pub(crate) fn with_policy_id(id: PolicyID, source_loc: Option<Loc>, err: TypeError) -> Self {
-        let source_loc = err.source_loc().cloned().or(source_loc);
+        let (kind, error_loc) = err.kind_and_location();
+        let source_loc = error_loc.or(source_loc);
         Self {
-            kind: err.kind,
+            kind,
             location: SourceLocation::new(id, source_loc),
         }
     }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -30,9 +30,7 @@ pub use cedar_policy_core::extensions::{
 use cedar_policy_core::parser;
 pub use cedar_policy_core::parser::err::ParseErrors;
 pub use cedar_policy_validator::human_schema::SchemaWarning;
-pub use cedar_policy_validator::{
-    TypeErrorKind, UnsupportedFeature, ValidationErrorKind, ValidationWarningKind,
-};
+pub use cedar_policy_validator::{UnsupportedFeature, ValidationErrorKind, ValidationWarningKind};
 use miette::Diagnostic;
 use ref_cast::RefCast;
 use smol_str::SmolStr;


### PR DESCRIPTION
## Description of changes

There's no good reason for these errors to be split, it just adds an extra level of indirection to see the specific type error variant. The distinct `TypeError` struct still exists, but it now holds a `ValidationErrorKind`. This is odd, but eliminating `TypeError` forces a lot of other changes, so I've left it in the interest of a reviewable PR. I plan to remove it in coming PRs. 

First PR leading up to #745 for validation errors.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

