### PR TITLE
Delete `SourceLocation` struct

### DIFF
--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -289,13 +289,13 @@ mod test {
         assert!(!result.validation_passed());
         assert!(result
             .validation_errors()
-            .any(|x| x.error_kind() == principal_err.error_kind()));
+            .any(|x| x.kind() == principal_err.kind()));
         assert!(result
             .validation_errors()
-            .any(|x| x.error_kind() == resource_err.error_kind()));
+            .any(|x| x.kind() == resource_err.kind()));
         assert!(result
             .validation_errors()
-            .any(|x| x.error_kind() == action_err.error_kind()));
+            .any(|x| x.kind() == action_err.kind()));
 
         Ok(())
     }
@@ -447,7 +447,7 @@ mod test {
         );
         assert!(result
             .validation_errors()
-            .any(|x| x.error_kind() == invalid_action_err.error_kind()));
+            .any(|x| x.kind() == invalid_action_err.kind()));
 
         Ok(())
     }
@@ -490,7 +490,7 @@ mod test {
         assert_eq!(
             result
                 .validation_errors()
-                .map(|err| err.error_kind())
+                .map(|err| err.kind())
                 .collect::<Vec<_>>(),
             vec![
                 &TypeError::expected_type(

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -823,7 +823,7 @@ mod test {
         let validate = Validator::new(schema);
         let notes: Vec<ValidationErrorKind> = validate
             .validate_action_ids(&policy)
-            .map(|e| e.into_location_and_error_kind().1)
+            .map(|e| e.kind)
             .collect();
         assert_eq!(notes, vec![], "Did not expect any invalid action.");
         Ok(())
@@ -894,7 +894,7 @@ mod test {
         let validate = Validator::new(schema);
         let notes: Vec<ValidationErrorKind> = validate
             .validate_entity_types(&policy)
-            .map(|e| e.into_location_and_error_kind().1)
+            .map(|e| e.kind)
             .collect();
 
         assert_eq!(notes, vec![], "Did not expect any invalid action.");
@@ -1128,7 +1128,7 @@ mod test {
             validator
                 .validate_policy(policy, ValidationMode::default())
                 .0
-                .map(|e| { e.into_location_and_error_kind().1 })
+                .map(|e| { e.kind })
                 .collect::<Vec<ValidationErrorKind>>(),
             expected.into_iter().map(|e| e.kind).collect::<Vec<_>>(),
             "Unexpected validation errors."
@@ -1141,7 +1141,7 @@ mod test {
             validator
                 .validate_policy(policy, ValidationMode::default())
                 .1
-                .map(|w| { w.to_kind_and_location().1 })
+                .map(|w| { w.kind })
                 .collect::<Vec<ValidationWarningKind>>(),
             vec![ValidationWarningKind::ImpossiblePolicy],
             "Unexpected validation warnings."
@@ -1519,7 +1519,7 @@ mod test {
         );
         let notes: Vec<ValidationErrorKind> = validate
             .validate_entity_types(&policy)
-            .map(|e| e.into_location_and_error_kind().1)
+            .map(|e| e.kind)
             .collect();
         assert_eq!(1, notes.len());
         assert_matches!(notes.first(),
@@ -1541,7 +1541,7 @@ mod test {
         );
         let notes: Vec<ValidationErrorKind> = validate
             .validate_entity_types(&policy)
-            .map(|e| e.into_location_and_error_kind().1)
+            .map(|e| e.kind)
             .collect();
         assert_eq!(1, notes.len());
         assert_matches!(notes.first(),
@@ -1573,7 +1573,7 @@ mod test {
         );
         let notes: Vec<ValidationErrorKind> = validate
             .validate_entity_types(&policy)
-            .map(|e| e.into_location_and_error_kind().1)
+            .map(|e| e.kind)
             .collect();
 
         println!("{:?}", notes);

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -148,8 +148,8 @@ mod test {
             format!("{warning}"),
             "for policy `test`, identifier `say_һello` contains mixed scripts"
         );
-        assert_eq!(warning.loc(), None,);
-        assert_eq!(warning.policy_id(), &PolicyID::from_string("test"),)
+        assert_eq!(warning.loc(), None);
+        assert_eq!(warning.policy_id(), &PolicyID::from_string("test"));
     }
 
     #[test]
@@ -190,8 +190,8 @@ mod test {
             format!("{warning}"),
             "for policy `test`, string `\"*_һello\"` contains mixed scripts"
         );
-        assert_eq!(warning.loc(), Some(&Loc::new(64..94, Arc::from(src))),);
-        assert_eq!(warning.policy_id(), &PolicyID::from_string("test"),);
+        assert_eq!(warning.loc(), Some(&Loc::new(64..94, Arc::from(src))));
+        assert_eq!(warning.policy_id(), &PolicyID::from_string("test"));
     }
 
     #[test]
@@ -216,6 +216,6 @@ mod test {
         );
         assert_eq!(format!("{warning}"), "for policy `test`, string `\"user‮ ⁦&& principal.is_admin⁩ ⁦\"` contains BIDI control characters");
         assert_eq!(warning.loc(), Some(&Loc::new(90..131, Arc::from(src))));
-        assert_eq!(warning.policy_id(), &PolicyID::from_string("test"),);
+        assert_eq!(warning.policy_id(), &PolicyID::from_string("test"));
     }
 }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -28,7 +28,6 @@ pub use cedar_policy_core::evaluator::{evaluation_errors, EvaluationError};
 pub use cedar_policy_core::extensions::{
     extension_function_lookup_errors, ExtensionFunctionLookupError,
 };
-use cedar_policy_core::parser;
 pub use cedar_policy_core::parser::err::{ParseError, ParseErrors};
 pub use cedar_policy_validator::human_schema::SchemaWarning;
 pub use cedar_policy_validator::{UnsupportedFeature, ValidationErrorKind, ValidationWarningKind};
@@ -449,12 +448,12 @@ pub struct ValidationError {
 impl ValidationError {
     /// Extract details about the exact issue detected by the validator.
     pub fn error_kind(&self) -> &ValidationErrorKind {
-        self.error.error_kind()
+        self.error.kind()
     }
 
-    /// Extract the location where the validator found the issue.
-    pub fn location(&self) -> &SourceLocation {
-        SourceLocation::ref_cast(self.error.location())
+    /// Extract the policy id of the policy where the validator found the issue.
+    pub fn policy_id(&self) -> &PolicyId {
+        PolicyId::ref_cast(self.error.policy_id())
     }
 }
 
@@ -462,56 +461,6 @@ impl ValidationError {
 impl From<cedar_policy_validator::ValidationError> for ValidationError {
     fn from(error: cedar_policy_validator::ValidationError) -> Self {
         Self { error }
-    }
-}
-
-/// Represents a location in Cedar policy source.
-#[derive(Debug, Clone, Eq, PartialEq, RefCast)]
-#[repr(transparent)]
-pub struct SourceLocation(cedar_policy_validator::SourceLocation);
-
-impl SourceLocation {
-    /// Get the `PolicyId` for the policy at this source location.
-    pub fn policy_id(&self) -> &PolicyId {
-        PolicyId::ref_cast(self.0.policy_id())
-    }
-
-    /// Get the start of the location. Returns `None` if this location does not
-    /// have a range.
-    pub fn range_start(&self) -> Option<usize> {
-        self.0.source_loc().map(parser::Loc::start)
-    }
-
-    /// Get the end of the location. Returns `None` if this location does not
-    /// have a range.
-    pub fn range_end(&self) -> Option<usize> {
-        self.0.source_loc().map(parser::Loc::end)
-    }
-
-    /// Returns a tuple of (start, end) of the location.
-    /// Returns `None` if this location does not have a range.
-    pub fn range_start_and_end(&self) -> Option<(usize, usize)> {
-        self.0
-            .source_loc()
-            .as_ref()
-            .map(|loc| (loc.start(), loc.end()))
-    }
-}
-
-impl std::fmt::Display for SourceLocation {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "policy `{}`", self.0.policy_id())?;
-        if let Some(loc) = self.0.source_loc() {
-            write!(f, " at offset {}-{}", loc.start(), loc.end())?;
-        }
-        Ok(())
-    }
-}
-
-#[doc(hidden)]
-impl From<&cedar_policy_validator::SourceLocation> for SourceLocation {
-    fn from(loc: &cedar_policy_validator::SourceLocation) -> Self {
-        Self(loc.clone())
     }
 }
 
@@ -529,9 +478,9 @@ impl ValidationWarning {
         self.warning.kind()
     }
 
-    /// Extract the location where the validator found the issue.
-    pub fn location(&self) -> &SourceLocation {
-        SourceLocation::ref_cast(self.warning.location())
+    /// Extract the policy id of the policy where the validator found the issue.
+    pub fn policy_id(&self) -> &PolicyId {
+        PolicyId::ref_cast(self.warning.policy_id())
     }
 }
 

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -41,13 +41,13 @@ pub fn validate(call: ValidationCall) -> ValidationAnswer {
                 .into_errors_and_warnings();
             let validation_errors: Vec<ValidationError> = validation_errors
                 .map(|error| ValidationError {
-                    policy_id: error.location().policy_id().to_smolstr(),
+                    policy_id: error.policy_id().to_smolstr(),
                     error: miette::Report::new(error).into(),
                 })
                 .collect();
             let validation_warnings: Vec<ValidationError> = validation_warnings
                 .map(|error| ValidationError {
-                    policy_id: error.location().policy_id().to_smolstr(),
+                    policy_id: error.policy_id().to_smolstr(),
                     error: miette::Report::new(error).into(),
                 })
                 .collect();


### PR DESCRIPTION
This wrapped a policy id and `Loc`. There's no reason to have this in the public API, and it was only used by validation errors. The source offset is still available trough miette and I've added a `policy_id` function to the id. 

More refactoring of validation diagnostics.


## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

