### PR TITLE
EST to AST conversion should fail if there are unknown function calls

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3995,3 +3995,27 @@ mod test {
         }
     }
 }
+
+#[cfg(test)]
+mod issue_891 {
+    use crate::{est::FromJsonError, parser::parse_policy_or_template_to_est};
+    use cool_asserts::assert_matches;
+
+    #[test]
+    fn invalid_extension_func() {
+        let src = "permit(principal, action, resource) when {principal == resource.ow4()};";
+        let est =
+            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "ow4".parse().unwrap());
+
+        let src = r#"permit(principal, action, resource) when {principal == resource.ownerOrEqual(decimal("0.75"))};"#;
+        let est =
+            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "ownerOrEqual".parse().unwrap());
+
+        let src = r#"permit(principal, action, resource) when {principal == resorThanOrEqual(decimal("0.75"))};"#;
+        let est =
+            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "resorThanOrEqual".parse().unwrap());
+    }
+}

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -88,6 +88,9 @@ pub enum FromJsonError {
     #[error("Error linking policy set: {0}")]
     #[diagnostic(transparent)]
     Linking(#[from] ast::LinkingError),
+    /// Error reported when the extension function name is unknown
+    #[error("Invalid extension function name: `{0}`")]
+    UnknownExtFunc(ast::Name),
 }
 
 /// Errors while linking a policy

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -702,13 +702,16 @@ impl Expr {
                             .into_iter()
                             .next()
                             .expect("already checked that len was 1");
-                        let fn_name = fn_name.parse().map_err(|errs| {
+                        let fn_name: ast::Name = fn_name.parse().map_err(|errs| {
                             JsonDeserializationError::parse_escape(
                                 EscapeKind::Extension,
                                 fn_name,
                                 errs,
                             )
                         })?;
+                        if !fn_name.is_known_extension_func_name() {
+                            return Err(FromJsonError::UnknownExtFunc(fn_name.clone()));
+                        }
                         Ok(ast::Expr::call_extension_fn(
                             fn_name,
                             args.into_iter()

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2173,6 +2173,12 @@ impl ast::Name {
         }
     }
 
+    /// If this name is a known extension function/method name or not
+    pub(crate) fn is_known_extension_func_name(&self) -> bool {
+        EXTENSION_STYLES.functions.contains(self)
+            || (self.path.is_empty() && EXTENSION_STYLES.methods.contains(self.id.as_ref()))
+    }
+
     fn into_func(
         self,
         args: Vec<ast::Expr>,


### PR DESCRIPTION
Fixes #891

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

