### PR TITLE
Followup to #870

### DIFF
--- a/cedar-policy-formatter/src/pprint/utils.rs
+++ b/cedar-policy-formatter/src/pprint/utils.rs
@@ -166,7 +166,7 @@ pub fn remove_empty_lines(text: &str) -> String {
     let comment_regex = Regex::new(r"//[^\n]*").unwrap();
     // PANIC SAFETY: this regex pattern is valid
     #[allow(clippy::unwrap_used)]
-    let string_regex = Regex::new(r#""(\\.|[^"\\])*"[^\n]*"#).unwrap();
+    let string_regex = Regex::new(r#""(\\.|[^"\\])*""#).unwrap();
 
     let mut index = 0;
     let mut final_text = String::new();

--- a/cedar-policy-formatter/tests/blank_lines.cedar
+++ b/cedar-policy-formatter/tests/blank_lines.cedar
@@ -32,3 +32,22 @@ with a newline") when // trailing comment
 // shouldn't matter "
 
 };
+
+// A fuzzer-generated policy that wasn't correctly formatter with the original fix
+permit(
+  principal is User in Group::"friends",
+  action,
+  resource is Photo in Album::"vacation"
+) when {
+(User::"alice" is User) && (User::"alice" in
+Group::"
+
+
+
+
+
+
+
+
+friends")
+};

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@blank_lines.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@blank_lines.cedar.snap
@@ -29,3 +29,21 @@ when // trailing comment
 // Quotes in comments "
 // shouldn't matter "
 };
+
+// A fuzzer-generated policy that wasn't correctly formatter with the original fix
+permit (
+  principal is User in Group::"friends",
+  action,
+  resource is Photo in Album::"vacation"
+)
+when
+{ (User::"alice" is User) && (User::"alice" in Group::"
+
+
+
+
+
+
+
+
+friends") };


### PR DESCRIPTION
## Description of changes

Followup to #870, which did not entirely fix #862, as identified by nightly fuzzing. My bad 😅

The issue was that the regular expression for strings matched all content up until the newline after the final quotation, which might end up splitting strings. I had added the extra `[^\n]*` when I was testing the original design, and forgot to remove it. The regular expression for strings now exactly matches [the one used elsewhere in the formatter](https://github.com/cedar-policy/cedar/blob/5bea470624acaed2ae1446ff94d356e29ebc1993/cedar-policy-formatter/src/pprint/token.rs#L140).

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
