### PR TITLE
Use `Option<&Loc>` instead of `&Option<Loc>`

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -157,7 +157,7 @@ impl Template {
     }
 
     /// Get the location of this policy
-    pub fn loc(&self) -> &Option<Loc> {
+    pub fn loc(&self) -> Option<&Loc> {
         self.body.loc()
     }
 
@@ -525,7 +525,7 @@ impl Policy {
     }
 
     /// Get the location of this policy
-    pub fn loc(&self) -> &Option<Loc> {
+    pub fn loc(&self) -> Option<&Loc> {
         self.template.loc()
     }
 
@@ -753,7 +753,7 @@ impl StaticPolicy {
     }
 
     /// Get the location of this policy
-    pub fn loc(&self) -> &Option<Loc> {
+    pub fn loc(&self) -> Option<&Loc> {
         self.0.loc()
     }
 
@@ -922,8 +922,8 @@ impl TemplateBody {
     }
 
     /// Get the location of this policy
-    pub fn loc(&self) -> &Option<Loc> {
-        &self.loc
+    pub fn loc(&self) -> Option<&Loc> {
+        self.loc.as_ref()
     }
 
     /// Clone this policy with a new `Id`.

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -342,7 +342,7 @@ mod test {
             r#"permit(principal == some_namespace::User::"Alice", action, resource in ?resource);"#,
         )
         .expect("Parse Error");
-        let loc = t.loc().clone();
+        let loc = t.loc().cloned();
         set.add_template(t)
             .expect("Template already present in PolicySet");
 

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -305,7 +305,7 @@ impl Validator {
     // (rather than a template) to facilitate code reuse.
     fn validate_action_application(
         &self,
-        source_loc: &Option<Loc>,
+        source_loc: Option<&Loc>,
         policy_id: &PolicyID,
         principal_constraint: &PrincipalConstraint,
         action_constraint: &ActionConstraint,
@@ -325,7 +325,7 @@ impl Validator {
             self.check_if_in_fixes_resource(resource_constraint, action_constraint);
 
         Some(ValidationError::invalid_action_application(
-            source_loc.clone(),
+            source_loc.cloned(),
             policy_id.clone(),
             would_in_fix_principal,
             would_in_fix_resource,
@@ -1154,7 +1154,7 @@ mod test {
                 .1
                 .collect::<Vec<ValidationWarning>>(),
             vec![ValidationWarning::impossible_policy(
-                policy.loc().clone(),
+                policy.loc().cloned(),
                 policy.id().clone()
             )],
             "Unexpected validation warnings."

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -304,7 +304,7 @@ impl<'a> Typechecker<'a> {
         // possibly apply to any request.
         if all_false {
             warnings.insert(ValidationWarning::impossible_policy(
-                t.loc().clone(),
+                t.loc().cloned(),
                 t.id().clone(),
             ));
         }

--- a/cedar-policy-validator/src/typecheck/test_namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test_namespace.rs
@@ -574,7 +574,7 @@ fn multi_namespace_action_eq() {
         schema.clone(),
         policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            policy.loc().clone(),
+            policy.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
     );
@@ -637,7 +637,7 @@ fn multi_namespace_action_in() {
         schema.clone(),
         policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            policy.loc().clone(),
+            policy.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
     );

--- a/cedar-policy-validator/src/typecheck/test_optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test_optional_attributes.rs
@@ -794,7 +794,7 @@ fn action_attrs_failing() {
         schema.clone(),
         failing_policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            failing_policy.loc().clone(),
+            failing_policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );

--- a/cedar-policy-validator/src/typecheck/test_policy.rs
+++ b/cedar-policy-validator/src/typecheck/test_policy.rs
@@ -419,7 +419,7 @@ fn policy_impossible_scope() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -435,7 +435,7 @@ fn policy_impossible_literal_euids() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -451,7 +451,7 @@ fn policy_impossible_not_has() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -475,7 +475,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -488,7 +488,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -501,7 +501,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -514,7 +514,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -527,7 +527,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -540,7 +540,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -553,7 +553,7 @@ fn policy_in_action_impossible() {
     assert_policy_typecheck_permissive_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -569,7 +569,7 @@ fn policy_action_in_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -668,7 +668,7 @@ fn entity_lub_cant_have_undeclared_attribute() {
     assert_policy_typecheck_permissive_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -696,7 +696,7 @@ fn is_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
     );
@@ -704,7 +704,7 @@ fn is_impossible() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
     );
@@ -735,7 +735,7 @@ fn is_entity_lub() {
     assert_policy_typecheck_permissive_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
     );
@@ -762,7 +762,7 @@ fn is_action() {
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
         vec![ValidationWarning::impossible_policy(
-            p.loc().clone(),
+            p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
     );
@@ -923,7 +923,7 @@ fn action_groups() {
         schema.clone(),
         policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            policy.loc().clone(),
+            policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -937,7 +937,7 @@ fn action_groups() {
         schema.clone(),
         policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            policy.loc().clone(),
+            policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -951,7 +951,7 @@ fn action_groups() {
         schema.clone(),
         policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            policy.loc().clone(),
+            policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -965,7 +965,7 @@ fn action_groups() {
         schema,
         policy.clone(),
         vec![ValidationWarning::impossible_policy(
-            policy.loc().clone(),
+            policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
     );
@@ -1196,7 +1196,7 @@ mod templates {
         assert_policy_typecheck_warns_simple_schema(
             template.clone(),
             vec![ValidationWarning::impossible_policy(
-                template.loc().clone(),
+                template.loc().cloned(),
                 PolicyID::from_string("policy0"),
             )],
         );


### PR DESCRIPTION
## Description of changes

Minor change to the `cedar-polciy-core` API from discussion on https://github.com/cedar-policy/cedar/pull/911#discussion_r1613742852

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

