### PR TITLE
Tweak validator test utils to better track failure location

### DIFF
--- a/cedar-policy-validator/src/typecheck/test.rs
+++ b/cedar-policy-validator/src/typecheck/test.rs
@@ -28,6 +28,7 @@ mod namespace;
 mod optional_attributes;
 #[cfg(feature = "partial-validate")]
 mod partial;
+mod policy;
 mod strict;
 mod type_annotation;
 mod unspecified_entity;


### PR DESCRIPTION
## Description of changes

Tweak validator test utils to track better track failure location. Something about the closure parameter to `with_typechecker_from_schema` caused errors to be reported where they occurred inside closure arguments at `test_utils` instead of at the actual test site.  Inlining this method doesn't make test meaningfully more complicated. 

Also fix a dumb mistake from #917 in `test.rs` where the `policies.rs` submodule was omitted, causing those test to not run.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

