### PR TITLE
Adding read/write json methods to entity

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -446,6 +446,18 @@ impl Entity {
         serde_json::to_writer_pretty(f, &ejson).map_err(JsonSerializationError::from)?;
         Ok(())
     }
+
+    pub fn to_json_value(&self) -> Result<serde_json::Value, EntitiesError> {
+        let ejson = EntityJson::from_entity(self)?;
+        let v = serde_json::to_value(ejson).map_err(JsonSerializationError::from)?;
+        Ok(v)
+    }
+
+    pub fn to_json_string(&self) -> Result<String, EntitiesError> {
+        let ejson = EntityJson::from_entity(self)?;
+        let string = serde_json::to_string(&ejson).map_err(JsonSerializationError::from)?;
+        Ok(string)
+    }
 }
 
 impl PartialEq for Entity {

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -447,12 +447,14 @@ impl Entity {
         Ok(())
     }
 
+    /// write the entity to a json value
     pub fn to_json_value(&self) -> Result<serde_json::Value, EntitiesError> {
         let ejson = EntityJson::from_entity(self)?;
         let v = serde_json::to_value(ejson).map_err(JsonSerializationError::from)?;
         Ok(v)
     }
 
+    /// write the entity to a json string
     pub fn to_json_string(&self) -> Result<String, EntitiesError> {
         let ejson = EntityJson::from_entity(self)?;
         let string = serde_json::to_string(&ejson).map_err(JsonSerializationError::from)?;

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast::*;
+use crate::entities::{err::EntitiesError, json::err::JsonSerializationError, EntityJson};
 use crate::evaluator::{EvaluationError, RestrictedEvaluator};
 use crate::extensions::Extensions;
 use crate::parser::err::ParseErrors;
@@ -437,6 +438,13 @@ impl Entity {
             attrs.into_iter().map(|(k, v)| (k, v.0)).collect(),
             ancestors,
         )
+    }
+
+    /// Write the entity to a json document
+    pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
+        let ejson = EntityJson::from_entity(self)?;
+        serde_json::to_writer_pretty(f, &ejson).map_err(JsonSerializationError::from)?;
+        Ok(())
     }
 }
 

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -22,6 +22,7 @@ use super::{
 use crate::ast::{
     BorrowedRestrictedExpr, Entity, EntityType, EntityUID, PartialValue, RestrictedExpr,
 };
+use crate::entities::conformance::EntitySchemaConformanceChecker;
 use crate::entities::{
     conformance::err::{EntitySchemaConformanceError, UnexpectedEntityTypeError},
     schematype_of_partialvalue, Entities, EntitiesError, GetSchemaTypeError, TCComputation,
@@ -218,32 +219,32 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
         &self,
         value: serde_json::Value,
     ) -> Result<Entity, EntitiesError> {
-        let ejson: EntityJson =
-            serde_json::from_value(value).map_err(JsonDeserializationError::from)?;
-        let entity = self.parse_ejson(ejson)?;
-        match self.schema {
-            Some(schema) => {
-                let checker = crate::entities::conformance::EntitySchemaConformanceChecker::new(
-                    schema,
-                    self.extensions,
-                );
-                checker.validate_entity(&entity)?;
-                Ok(entity)
-            }
-            None => Ok(entity),
-        }
+        let ejson = serde_json::from_value(value).map_err(JsonDeserializationError::from)?;
+        self.single_from_ejson(ejson)
     }
 
     /// Parse a single entity from a JSON string
     pub fn single_from_json_str(&self, src: impl AsRef<str>) -> Result<Entity, EntitiesError> {
-        let v = serde_json::from_str(src.as_ref()).map_err(JsonDeserializationError::from)?;
-        self.single_from_json_value(v)
+        let ejson = serde_json::from_str(src.as_ref()).map_err(JsonDeserializationError::from)?;
+        self.single_from_ejson(ejson)
     }
 
     /// Parse a single entity from a JSON reader
     pub fn single_from_json_file(&self, r: impl Read) -> Result<Entity, EntitiesError> {
-        let v = serde_json::from_reader(r).map_err(JsonDeserializationError::from)?;
-        self.single_from_json_value(v)
+        let ejson = serde_json::from_reader(r).map_err(JsonDeserializationError::from)?;
+        self.single_from_ejson(ejson)
+    }
+
+    fn single_from_ejson(&self, ejson: EntityJson) -> Result<Entity, EntitiesError> {
+        let entity = self.parse_ejson(ejson)?;
+        match self.schema {
+            None => Ok(entity),
+            Some(schema) => {
+                let checker = EntitySchemaConformanceChecker::new(schema, self.extensions);
+                checker.validate_entity(&entity)?;
+                Ok(entity)
+            }
+        }
     }
 
     /// Internal function that creates an [`Entities`] from a stream of [`EntityJson`].

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -31,8 +31,8 @@ use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::SmolStr;
-use std::collections::HashMap;
 use std::sync::Arc;
+use std::{collections::HashMap, io::Read};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
@@ -78,6 +78,7 @@ pub struct EntityJsonParser<'e, 's, S: Schema = NoEntitiesSchema> {
 }
 
 /// Schema information about a single entity can take one of these forms:
+#[derive(Debug)]
 enum EntitySchemaInfo<E: EntityTypeDescription> {
     /// There is no schema, i.e. we're not doing schema-based parsing
     NoSchema,
@@ -210,6 +211,39 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
             );
         }
         Ok(entities.into_iter())
+    }
+
+    /// Parse a single entity from an in-memory JSON value
+    pub fn single_from_json_value(
+        &self,
+        value: serde_json::Value,
+    ) -> Result<Entity, EntitiesError> {
+        let ejson: EntityJson =
+            serde_json::from_value(value).map_err(JsonDeserializationError::from)?;
+        let entity = self.parse_ejson(ejson)?;
+        match self.schema {
+            Some(schema) => {
+                let checker = crate::entities::conformance::EntitySchemaConformanceChecker::new(
+                    schema,
+                    self.extensions,
+                );
+                checker.validate_entity(&entity)?;
+                Ok(entity)
+            }
+            None => Ok(entity),
+        }
+    }
+
+    /// Parse a single entity from a JSON string
+    pub fn single_from_json_str(&self, src: impl AsRef<str>) -> Result<Entity, EntitiesError> {
+        let v = serde_json::from_str(src.as_ref()).map_err(JsonDeserializationError::from)?;
+        self.single_from_json_value(v)
+    }
+
+    /// Parse a single entity from a JSON reader
+    pub fn single_from_json_file(&self, r: impl Read) -> Result<Entity, EntitiesError> {
+        let v = serde_json::from_reader(r).map_err(JsonDeserializationError::from)?;
+        self.single_from_json_value(v)
     }
 
     /// Internal function that creates an [`Entities`] from a stream of [`EntityJson`].

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -82,6 +82,7 @@ impl<'a> entities::Schema for CoreSchema<'a> {
 }
 
 /// Struct which carries enough information that it can impl Core's `EntityTypeDescription`
+#[derive(Debug)]
 pub struct EntityTypeDescription {
     /// Core `EntityType` this is describing
     core_type: ast::EntityType,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON representation for Policy Sets, along with methods like
   `::from_json_value/file/str` and `::to_json` for `PolicySet`. (#783,
   resolving #549)
+- Added methods for reading and writing individual `Entity`s as JSON
+  (resolving #807)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -263,8 +263,7 @@ impl Entity {
     }
 
     /// Parse an entity from an in-memory JSON value
-    /// If a schema is provided, it is handled identically to
-    /// [Entities](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str)
+    /// If a schema is provided, it is handled identically to [`Entities::from_json_str`]
     pub fn from_json_value(
         value: serde_json::Value,
         schema: Option<&Schema>,
@@ -279,8 +278,7 @@ impl Entity {
     }
 
     /// Parse an entity from a JSON string
-    /// If a schema is provided, it is handled identically to
-    /// [Entities](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str)
+    /// If a schema is provided, it is handled identically to [`Entities::from_json_str`]
     pub fn from_json_str(
         src: impl AsRef<str>,
         schema: Option<&Schema>,
@@ -295,8 +293,7 @@ impl Entity {
     }
 
     /// Parse an entity from a JSON reader
-    /// If a schema is provided, it is handled identically to
-    /// [Entities](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str)
+    /// If a schema is provided, it is handled identically to [`Entities::from_json_str`]
     pub fn from_json_file(f: impl Read, schema: Option<&Schema>) -> Result<Self, EntitiesError> {
         let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
         let eparser = cedar_policy_core::entities::EntityJsonParser::new(
@@ -313,7 +310,7 @@ impl Entity {
     /// `from_json_*`, and will be parse-able even with no [`Schema`].
     ///
     /// To read an `Entity` object from JSON , use
-    /// [`from_json_file`], [`from_json_value`], or [`from_json_str`].
+    /// [`Self::from_json_file`], [`Self::from_json_value`], or [`Self::from_json_str`].
     pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
         self.0.write_to_json(f)
     }
@@ -324,7 +321,7 @@ impl Entity {
     /// `from_json_*`, and will be parse-able even with no `Schema`.
     ///
     /// To read an `Entity` object from JSON , use
-    /// [`from_json_file`], [`from_json_value`], or [`from_json_str`].
+    /// [`Self::from_json_file`], [`Self::from_json_value`], or [`Self::from_json_str`].
     pub fn to_json_value(&self) -> Result<serde_json::Value, EntitiesError> {
         self.0.to_json_value()
     }
@@ -335,7 +332,7 @@ impl Entity {
     /// `from_json_*`, and will be parse-able even with no `Schema`.
     ///
     /// To read an `Entity` object from JSON , use
-    /// [`from_json_file`], [`from_json_value`], or [`from_json_str`].
+    /// [`Self::from_json_file`], [`Self::from_json_value`], or [`Self::from_json_str`].
     pub fn to_json_string(&self) -> Result<String, EntitiesError> {
         self.0.to_json_string()
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -304,10 +304,10 @@ impl Entity {
     /// Dump an `Entity` object into an entity JSON file.
     ///
     /// The resulting JSON will be suitable for parsing in via
-    /// `from_json_*`, and will be parse-able even with no `Schema`.
+    /// `from_json_*`, and will be parse-able even with no [`Schema`].
     ///
     /// To read an `Entity` object from an entities JSON file, use
-    /// `from_json_file`.
+    /// [`Entity::from_json_file`].
     pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
         self.0.write_to_json(f)
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -49,6 +49,7 @@ use miette::Diagnostic;
 use ref_cast::RefCast;
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::io::Read;
 use std::str::FromStr;
 
 /// Extended functionality for `Entities` struct
@@ -259,6 +260,56 @@ impl Entity {
             attrs,
             ancestors.into_iter().map(EntityUid::new).collect(),
         )
+    }
+
+    /// Parse an entity from an in-memory JSON value
+    pub fn from_json_value(
+        value: serde_json::Value,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
+        let eparser = cedar_policy_core::entities::EntityJsonParser::new(
+            schema.as_ref(),
+            Extensions::all_available(),
+            cedar_policy_core::entities::TCComputation::ComputeNow,
+        );
+        eparser.single_from_json_value(value).map(Self)
+    }
+
+    /// Parse an entity from a JSON string
+    pub fn from_json_str(
+        src: impl AsRef<str>,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
+        let eparser = cedar_policy_core::entities::EntityJsonParser::new(
+            schema.as_ref(),
+            Extensions::all_available(),
+            cedar_policy_core::entities::TCComputation::ComputeNow,
+        );
+        eparser.single_from_json_str(src).map(Self)
+    }
+
+    /// Parse an entity from a JSON reader
+    pub fn from_json_file(f: impl Read, schema: Option<&Schema>) -> Result<Self, EntitiesError> {
+        let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
+        let eparser = cedar_policy_core::entities::EntityJsonParser::new(
+            schema.as_ref(),
+            Extensions::all_available(),
+            cedar_policy_core::entities::TCComputation::ComputeNow,
+        );
+        eparser.single_from_json_file(f).map(Self)
+    }
+
+    /// Dump an `Entity` object into an entity JSON file.
+    ///
+    /// The resulting JSON will be suitable for parsing in via
+    /// `from_json_*`, and will be parse-able even with no `Schema`.
+    ///
+    /// To read an `Entity` object from an entities JSON file, use
+    /// `from_json_file`.
+    pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
+        self.0.write_to_json(f)
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -263,6 +263,8 @@ impl Entity {
     }
 
     /// Parse an entity from an in-memory JSON value
+    /// If a schema is provided, it is handled identically to
+    /// [Entities](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str)
     pub fn from_json_value(
         value: serde_json::Value,
         schema: Option<&Schema>,
@@ -277,6 +279,8 @@ impl Entity {
     }
 
     /// Parse an entity from a JSON string
+    /// If a schema is provided, it is handled identically to
+    /// [Entities](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str)
     pub fn from_json_str(
         src: impl AsRef<str>,
         schema: Option<&Schema>,
@@ -291,6 +295,8 @@ impl Entity {
     }
 
     /// Parse an entity from a JSON reader
+    /// If a schema is provided, it is handled identically to
+    /// [Entities](https://docs.rs/cedar-policy/latest/cedar_policy/struct.Entities.html#method.from_json_str)
     pub fn from_json_file(f: impl Read, schema: Option<&Schema>) -> Result<Self, EntitiesError> {
         let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
         let eparser = cedar_policy_core::entities::EntityJsonParser::new(
@@ -306,10 +312,32 @@ impl Entity {
     /// The resulting JSON will be suitable for parsing in via
     /// `from_json_*`, and will be parse-able even with no [`Schema`].
     ///
-    /// To read an `Entity` object from an entities JSON file, use
-    /// [`Entity::from_json_file`].
+    /// To read an `Entity` object from JSON , use
+    /// [`from_json_file`], [`from_json_value`], or [`from_json_str`].
     pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
         self.0.write_to_json(f)
+    }
+
+    /// Dump an `Entity` object into an in-memory JSON object.
+    ///
+    /// The resulting JSON will be suitable for parsing in via
+    /// `from_json_*`, and will be parse-able even with no `Schema`.
+    ///
+    /// To read an `Entity` object from JSON , use
+    /// [`from_json_file`], [`from_json_value`], or [`from_json_str`].
+    pub fn to_json_value(&self) -> Result<serde_json::Value, EntitiesError> {
+        self.0.to_json_value()
+    }
+
+    /// Dump an `Entity` object into a JSON string.
+    ///
+    /// The resulting JSON will be suitable for parsing in via
+    /// `from_json_*`, and will be parse-able even with no `Schema`.
+    ///
+    /// To read an `Entity` object from JSON , use
+    /// [`from_json_file`], [`from_json_value`], or [`from_json_str`].
+    pub fn to_json_string(&self) -> Result<String, EntitiesError> {
+        self.0.to_json_string()
     }
 }
 

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -1832,6 +1832,465 @@ mod schema_based_parsing_tests {
     use cool_asserts::assert_matches;
     use serde_json::json;
 
+    #[test]
+    fn entity_parse1() {
+        let e = r#"{
+            "uid" : { "type" : "User", "id" : "Alice" },
+            "attrs" : {},
+            "parents" : []
+            }"#;
+        let e = Entity::from_json_str(e, None).unwrap();
+        let (uid, attrs, parents) = e.into_inner();
+        let expected = r#"User::"Alice""#.parse().unwrap();
+        assert_eq!(uid, expected);
+        assert!(attrs.is_empty());
+        assert!(parents.is_empty());
+    }
+
+    /// Simple test that exercises a variety of attribute types for single entities
+    #[test]
+    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::cognitive_complexity)]
+    fn signle_attr_types() {
+        let schema = Schema::from_json_value(json!(
+        {"": {
+            "entityTypes": {
+                "Employee": {
+                    "memberOfTypes": [],
+                    "shape": {
+                        "type": "Record",
+                        "attributes": {
+                            "isFullTime": { "type": "Boolean" },
+                            "numDirectReports": { "type": "Long" },
+                            "department": { "type": "String" },
+                            "manager": { "type": "Entity", "name": "Employee" },
+                            "hr_contacts": { "type": "Set", "element": {
+                                "type": "Entity", "name": "HR" } },
+                            "json_blob": { "type": "Record", "attributes": {
+                                "inner1": { "type": "Boolean" },
+                                "inner2": { "type": "String" },
+                                "inner3": { "type": "Record", "attributes": {
+                                    "innerinner": { "type": "Entity", "name": "Employee" }
+                                }}
+                            }},
+                            "home_ip": { "type": "Extension", "name": "ipaddr" },
+                            "work_ip": { "type": "Extension", "name": "ipaddr" },
+                            "trust_score": { "type": "Extension", "name": "decimal" },
+                            "tricky": { "type": "Record", "attributes": {
+                                "type": { "type": "String" },
+                                "id": { "type": "String" }
+                            }}
+                        }
+                    }
+                },
+                "HR": {
+                    "memberOfTypes": []
+                }
+            },
+            "actions": {
+                "view": { }
+            }
+        }}
+        ))
+        .expect("should be a valid schema");
+
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        // without schema-based parsing, `home_ip` and `trust_score` are
+        // strings, `manager` and `work_ip` are Records, `hr_contacts` contains
+        // Records, and `json_blob.inner3.innerinner` is a Record
+        let parsed = Entity::from_json_value(entity.clone(), None).unwrap();
+        assert_matches!(
+            parsed.attr("home_ip"),
+            Some(Ok(EvalResult::String(s))) if &s == "222.222.222.101"
+        );
+        assert_matches!(
+            parsed.attr("trust_score"),
+            Some(Ok(EvalResult::String(s))) if &s == "5.7"
+        );
+        assert_matches!(parsed.attr("manager"), Some(Ok(EvalResult::Record(_))));
+        assert_matches!(parsed.attr("work_ip"), Some(Ok(EvalResult::Record(_))));
+        {
+            let Some(Ok(EvalResult::Set(set))) = parsed.attr("hr_contacts") else {
+                panic!("expected hr_contacts attr to exist and be a Set")
+            };
+            let contact = set.iter().next().expect("should be at least one contact");
+            assert_matches!(contact, EvalResult::Record(_));
+        };
+        {
+            let Some(Ok(EvalResult::Record(rec))) = parsed.attr("json_blob") else {
+                panic!("expected json_blob attr to exist and be a Record")
+            };
+            let inner3 = rec.get("inner3").expect("expected inner3 attr to exist");
+            let EvalResult::Record(rec) = inner3 else {
+                panic!("expected inner3 to be a Record")
+            };
+            let innerinner = rec
+                .get("innerinner")
+                .expect("expected innerinner attr to exist");
+            assert_matches!(innerinner, EvalResult::Record(_));
+        };
+        // but with schema-based parsing, we get these other types
+        let parsed =
+            Entity::from_json_value(entity, Some(&schema)).expect("Should parse without error");
+        assert_matches!(parsed.attr("isFullTime"), Some(Ok(EvalResult::Bool(true))));
+        assert_matches!(
+            parsed.attr("numDirectReports"),
+            Some(Ok(EvalResult::Long(3)))
+        );
+        assert_matches!(
+            parsed.attr("department"),
+            Some(Ok(EvalResult::String(s))) if &s == "Sales"
+        );
+        assert_matches!(
+            parsed.attr("manager"),
+            Some(Ok(EvalResult::EntityUid(euid))) if euid == EntityUid::from_strs(
+                "Employee", "34FB87"
+            )
+        );
+        {
+            let Some(Ok(EvalResult::Set(set))) = parsed.attr("hr_contacts") else {
+                panic!("expected hr_contacts attr to exist and be a Set")
+            };
+            let contact = set.iter().next().expect("should be at least one contact");
+            assert_matches!(contact, EvalResult::EntityUid(_));
+        };
+        {
+            let Some(Ok(EvalResult::Record(rec))) = parsed.attr("json_blob") else {
+                panic!("expected json_blob attr to exist and be a Record")
+            };
+            let inner3 = rec.get("inner3").expect("expected inner3 attr to exist");
+            let EvalResult::Record(rec) = inner3 else {
+                panic!("expected inner3 to be a Record")
+            };
+            let innerinner = rec
+                .get("innerinner")
+                .expect("expected innerinner attr to exist");
+            assert_matches!(innerinner, EvalResult::EntityUid(_));
+        };
+        assert_matches!(
+            parsed.attr("home_ip"),
+            Some(Ok(EvalResult::ExtensionValue(ev))) if &ev == "222.222.222.101/32"
+        );
+        assert_matches!(
+            parsed.attr("work_ip"),
+            Some(Ok(EvalResult::ExtensionValue(ev))) if &ev == "2.2.2.0/24"
+        );
+        assert_matches!(
+            parsed.attr("trust_score"),
+            Some(Ok(EvalResult::ExtensionValue(ev))) if &ev == "5.7000"
+        );
+
+        // simple type mismatch with expected type
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": "3",
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to type mismatch on numDirectReports");
+        assert!(
+            err.to_string().contains(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: value was expected to have type long, but actually has type string: `"3"`"#),
+            "actual error message was: `{err}`"
+        );
+
+        // another simple type mismatch with expected type
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": "34FB87",
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to type mismatch on manager");
+        assert!(
+            err.to_string()
+                .contains(r#"in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#),
+            "actual error message was {err}"
+        );
+
+        // type mismatch where we expect a set and get just a single element
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": { "type": "HR", "id": "aaaaa" },
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to type mismatch on hr_contacts");
+        assert!(
+            err.to_string().contains(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: value was expected to have type (set of `HR`), but actually has type record with attributes: {"id" => (optional) string, "type" => (optional) string}: `{"id": "aaaaa", "type": "HR"}`"#),
+            "actual error message was {err}"
+        );
+
+        // type mismatch where we just get the wrong entity type
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "HR", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to type mismatch on manager");
+        assert!(
+            err.to_string().contains(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: value was expected to have type `Employee`, but actually has type `HR`: `HR::"34FB87"`"#),
+            "actual error message was {err}"
+        );
+
+        // type mismatch where we're expecting an extension type and get a
+        // different extension type
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": { "fn": "decimal", "arg": "3.33" },
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to type mismatch on home_ip");
+        assert!(
+            err.to_string().contains(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#),
+            "actual error message was {err}"
+        );
+
+        // missing a record attribute entirely
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to missing attribute \"inner2\"");
+        assert!(
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#),
+            "actual error message was {err}"
+        );
+
+        // record attribute has the wrong type
+        let entity = json!(
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": 33,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+        let err = Entity::from_json_value(entity, Some(&schema))
+            .expect_err("should fail due to type mismatch on attribute \"inner1\"");
+        assert!(
+            err.to_string().contains(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: value was expected to have type record with attributes: "#),
+            "actual error message was {err}"
+        );
+
+        let entity = json!(
+                {
+                    "uid": { "__entity": { "type": "Employee", "id": "12UA45" } },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "__entity": { "type": "Employee", "id": "34FB87" } },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": { "__extn": { "fn": "ip", "arg": "222.222.222.101" } },
+                        "work_ip": { "__extn": { "fn": "ip", "arg": "2.2.2.0/24" } },
+                        "trust_score": { "__extn": { "fn": "decimal", "arg": "5.7" } },
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": []
+                }
+        );
+
+        Entity::from_json_value(entity, Some(&schema))
+            .expect("this version with explicit __entity and __extn escapes should also pass");
+    }
+
+    /// Ensures that parsing multiple entities as a single entity fails
+    #[test]
+    fn entity_fails_multiple() {
+        let json = json!(
+        [
+            {
+                "uid" : { "type" : "User", "id" : "Alice" },
+                "attrs" : {},
+                "parents" : []
+            },
+            {
+                "uid" : { "type" : "User", "id" : "Bob" },
+                "attrs" : {},
+                "parents" : []
+            },
+        ]);
+        Entity::from_json_value(json, None).expect_err("Multiple entities should fail this parser");
+        let json = json!(
+        [
+            {
+                "uid" : { "type" : "User", "id" : "Alice" },
+                "attrs" : {},
+                "parents" : []
+            }
+        ]);
+        Entity::from_json_value(json, None).expect_err("Multiple entities should fail this parser");
+    }
+
     /// Simple test that exercises a variety of attribute types.
     #[test]
     #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
## Description of changes
Adds methods for reading and writing individual `Entity` objects as JSON
## Issue #, if available
#807 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
