### PR TITLE
Box `EvaluationError` when it appears in `Result`

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -627,7 +627,9 @@ pub fn evaluate(args: &EvaluateArgs) -> (CedarExitCode, EvalResult) {
             }
         },
     };
-    match eval_expression(&request, &entities, &expr).wrap_err("failed to evaluate the expression")
+    match eval_expression(&request, &entities, &expr)
+        .map_err(|boxed| *boxed)
+        .wrap_err("failed to evaluate the expression")
     {
         Err(e) => {
             println!("{e:?}");

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -306,7 +306,7 @@ impl Entity {
                     .map_err(|err| EntityAttrEvaluationError {
                         uid: uid.clone(),
                         attr: k.clone(),
-                        err,
+                        err: *err,
                     })?;
                 Ok((k, attr_val.into()))
             })
@@ -409,7 +409,7 @@ impl Entity {
         attr: SmolStr,
         val: RestrictedExpr,
         extensions: &Extensions<'_>,
-    ) -> Result<(), EvaluationError> {
+    ) -> Result<(), Box<EvaluationError>> {
         let val = RestrictedEvaluator::new(extensions).partial_interpret(val.as_borrowed())?;
         self.attrs.insert(attr, val.into());
         Ok(())

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -156,12 +156,12 @@ impl ExtensionFunction {
                 if args.is_empty() {
                     func()
                 } else {
-                    Err(evaluator::EvaluationError::wrong_num_arguments(
+                    Err(Box::new(evaluator::EvaluationError::wrong_num_arguments(
                         name.clone(),
                         0,
                         args.len(),
                         None, // evaluator will add the source location later
-                    ))
+                    )))
                 }
             }),
             Some(return_type),
@@ -181,12 +181,12 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match args.first() {
                 Some(arg) => func(arg.clone()),
-                None => Err(evaluator::EvaluationError::wrong_num_arguments(
+                None => Err(Box::new(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     1,
                     args.len(),
                     None, // evaluator will add the source location later
-                )),
+                ))),
             }),
             None,
             vec![arg_type],
@@ -206,12 +206,12 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match &args {
                 &[arg] => func(arg.clone()),
-                _ => Err(evaluator::EvaluationError::wrong_num_arguments(
+                _ => Err(Box::new(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     1,
                     args.len(),
                     None, // evaluator will add the source location later
-                )),
+                ))),
             }),
             Some(return_type),
             vec![arg_type],
@@ -233,12 +233,12 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match &args {
                 &[first, second] => func(first.clone(), second.clone()),
-                _ => Err(evaluator::EvaluationError::wrong_num_arguments(
+                _ => Err(Box::new(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     2,
                     args.len(),
                     None, // evaluator will add the source location later
-                )),
+                ))),
             }),
             Some(return_type),
             vec![arg_types.0, arg_types.1],
@@ -263,12 +263,12 @@ impl ExtensionFunction {
             style,
             Box::new(move |args: &[Value]| match &args {
                 &[first, second, third] => func(first.clone(), second.clone(), third.clone()),
-                _ => Err(evaluator::EvaluationError::wrong_num_arguments(
+                _ => Err(Box::new(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     3,
                     args.len(),
                     None, // evaluator will add the source location later
-                )),
+                ))),
             }),
             Some(return_type),
             vec![arg_types.0, arg_types.1, arg_types.2],

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -245,7 +245,7 @@ impl Context {
             // INVARIANT(ContextRecord): guaranteed by the match case
             ExprKind::Record { .. } => {
                 let evaluator = RestrictedEvaluator::new(&extensions);
-                let pval = evaluator.partial_interpret(expr)?;
+                let pval = evaluator.partial_interpret(expr).map_err(|boxed| *boxed)?;
                 Ok(Self {
                     context: pval.into(),
                 })

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -123,7 +123,7 @@ impl Authorizer {
                 Err(e) => {
                     errors.push(AuthorizationError::PolicyEvaluationError {
                         id: id.clone(),
-                        error: e,
+                        error: *e,
                     });
                     let satisfied = match self.error_handling {
                         ErrorHandling::Skip => false,

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -792,4 +792,4 @@ pub mod evaluation_errors {
 }
 
 /// Type alias for convenience
-pub type Result<T> = std::result::Result<T, EvaluationError>;
+pub type Result<T> = std::result::Result<T, Box<EvaluationError>>;

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -421,13 +421,13 @@ mod tests {
     /// `Err::ExtensionErr` with our extension name
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_ipaddr_err<T: std::fmt::Debug>(res: evaluator::Result<T>) {
-        assert_matches!(res, Err(EvaluationError::FailedExtensionFunctionExecution(evaluation_errors::ExtensionFunctionExecutionError { extension_name, .. })) => {
+        assert_matches!(res, Err(e) => assert_matches!(*e, EvaluationError::FailedExtensionFunctionExecution(evaluation_errors::ExtensionFunctionExecutionError { extension_name, .. }) => {
             assert_eq!(
                 extension_name,
                 Name::parse_unqualified_name("ipaddr")
                     .expect("should be a valid identifier")
             );
-        });
+        }));
     }
 
     /// This helper function returns an `Expr` that calls `ip()` with the given single argument
@@ -560,24 +560,24 @@ mod tests {
                     Expr::val(1)
                 ))]
             )),
-            Err(EvaluationError::TypeError(evaluation_errors::TypeError { expected, actual, advice, .. })) => {
+            Err(e) => assert_matches!(*e, EvaluationError::TypeError(evaluation_errors::TypeError { expected, actual, advice, .. }) => {
                 assert_eq!(expected, nonempty![Type::String]);
                 assert_eq!(actual, Type::Set);
                 assert_eq!(advice, None);
-            }
+            }),
         );
 
         // test that < on ipaddr values is an error
         assert_matches!(
             eval.interpret_inline_policy(&Expr::less(ip("127.0.0.1"), ip("10.0.0.10"))),
-            Err(EvaluationError::TypeError(evaluation_errors::TypeError { expected, actual, advice, .. })) => {
+            Err(e) => assert_matches!(*e, EvaluationError::TypeError(evaluation_errors::TypeError { expected, actual, advice, .. }) => {
                 assert_eq!(expected, nonempty![Type::Long]);
                 assert_eq!(actual, Type::Extension {
                     name: Name::parse_unqualified_name("ipaddr")
                         .expect("should be a valid identifier")
                 });
                 assert_eq!(advice, None);
-            }
+            }),
         );
         // test that isIpv4 on a String is an error
         assert_matches!(
@@ -585,14 +585,14 @@ mod tests {
                 Name::parse_unqualified_name("isIpv4").expect("should be a valid identifier"),
                 vec![Expr::val("127.0.0.1")]
             )),
-            Err(EvaluationError::TypeError(evaluation_errors::TypeError { expected, actual, advice, .. })) => {
+            Err(e) => assert_matches!(*e, EvaluationError::TypeError(evaluation_errors::TypeError { expected, actual, advice, .. }) => {
                 assert_eq!(expected, nonempty![Type::Extension {
                     name: Name::parse_unqualified_name("ipaddr")
                         .expect("should be a valid identifier")
                 }]);
                 assert_eq!(actual, Type::String);
                 assert_eq!(advice, Some(ADVICE_MSG.into()));
-            }
+            }),
         );
 
         // test the Display impl

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,6 +17,7 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![cfg_attr(feature = "wasm", allow(non_snake_case))]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -390,7 +390,7 @@ impl ValidatorNamespaceDef {
                     ActionAttrEvalError(EntityAttrEvaluationError {
                         uid: action_id.clone(),
                         attr: k.clone(),
-                        err,
+                        err: *err,
                     })
                 })?;
             attr_values.insert(k.clone(), pv.into());

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Significantly reworked all public-facing error types to address some issues
   and improve consistency. See issue #745.
+- Some public methods/functions that return errors now return those
+  errors `Box`ed. See issue #878.
 - Finalized the `ffi` module which was preview-released in 3.2.0.
   This involved a few additional API breaking changes in `ffi`. See #757.
 - Moved `<PolicyId as FromStr>::Err` to `Infallible` (#588, resolving #551)
@@ -25,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed policy validation to reject comparisons and conditionals between
   record types that differ in whether an attribute is required or optional.
 - Fixed a performance issue when constructing an error for accessing
-    a non-existent attribute on sufficiently large records/entities
+  a non-existent attribute on sufficiently large records/entities
 
 ### Removed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -963,7 +963,8 @@ impl PartialResponse {
                     .interpret(BorrowedRestrictedExpr::new_unchecked(expr.0.as_ref()))
                     .map(|v| (name, v))
             })
-            .collect::<Result<HashMap<_, _>, EvaluationError>>()?;
+            .collect::<Result<HashMap<_, _>, Box<EvaluationError>>>()
+            .map_err(|boxed| *boxed)?;
         let r = self.0.reauthorize(&mapping, &auth.0, r.0, &es.0)?;
         Ok(Self(r))
     }
@@ -3622,7 +3623,7 @@ pub fn eval_expression(
     request: &Request,
     entities: &Entities,
     expr: &Expression,
-) -> Result<EvalResult, EvaluationError> {
+) -> Result<EvalResult, Box<EvaluationError>> {
     let all_ext = Extensions::all_available();
     let eval = Evaluator::new(request.0.clone(), &entities.0, &all_ext);
     Ok(EvalResult::from(

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3709,8 +3709,8 @@ mod error_source_tests {
         for src in srcs {
             let expr = Expression::from_str(src).unwrap();
             assert_matches!(eval_expression(&req, &entities, &expr), Err(e) => {
-                assert!(e.labels().is_some(), "no source span for the evaluation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new(e));
-                assert!(e.source_code().is_some(), "no source code for the evaluation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new(e));
+                assert!(e.labels().is_some(), "no source span for the evaluation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new_boxed(e));
+                assert!(e.source_code().is_some(), "no source code for the evaluation error resulting from:\n  {src}\nerror was:\n{:?}", miette::Report::new_boxed(e));
             });
         }
 
@@ -4105,9 +4105,9 @@ mod decimal_ip_constructors {
     fn expr_bad_ip() {
         let ip = Expression::new_ip("192.168.312.3");
         assert_matches!(evaluate_empty(&ip),
-            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+            Err(e) => assert_matches!(*e, EvaluationError::FailedExtensionFunctionExecution(e) => {
                 assert_eq!(e.extension_name(), "ipaddr");
-            }
+            }),
         );
     }
 
@@ -4115,9 +4115,9 @@ mod decimal_ip_constructors {
     fn expr_bad_cidr() {
         let ip = Expression::new_ip("192.168.0.3/100");
         assert_matches!(evaluate_empty(&ip),
-            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+            Err(e) => assert_matches!(*e, EvaluationError::FailedExtensionFunctionExecution(e) => {
                 assert_eq!(e.extension_name(), "ipaddr");
-            }
+            }),
         );
     }
 
@@ -4125,13 +4125,13 @@ mod decimal_ip_constructors {
     fn expr_nonsense_ip() {
         let ip = Expression::new_ip("foobar");
         assert_matches!(evaluate_empty(&ip),
-            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+            Err(e) => assert_matches!(*e, EvaluationError::FailedExtensionFunctionExecution(e) => {
                 assert_eq!(e.extension_name(), "ipaddr");
-            }
+            })
         );
     }
 
-    fn evaluate_empty(expr: &Expression) -> Result<EvalResult, EvaluationError> {
+    fn evaluate_empty(expr: &Expression) -> Result<EvalResult, Box<EvaluationError>> {
         let r = Request::new(None, None, None, Context::empty(), None).unwrap();
         let e = Entities::empty();
         eval_expression(&r, &e, expr)
@@ -4190,9 +4190,9 @@ mod decimal_ip_constructors {
     fn invalid_decimal() {
         let decimal = Expression::new_decimal("1234.12345");
         assert_matches!(evaluate_empty(&decimal),
-            Err(EvaluationError::FailedExtensionFunctionExecution(e)) => {
+            Err(e) => assert_matches!(*e, EvaluationError::FailedExtensionFunctionExecution(e) => {
                 assert_eq!(e.extension_name(), "decimal");
-            }
+            }),
         );
     }
 }


### PR DESCRIPTION
## Description of changes

This PR is a trial for deciding whether we want to go all-in on the recommendation in #878.  It applies the recommendation in #878 to `EvaluationError` only.

- Ergonomics of matching on errors are slightly worse, as we see in the tests in this PR.
- Ergonomics for internal developers are slightly worse, as we see in a couple places: 
    - for one example, `IntegerOverflowError` is `Into<EvaluationError>`, but is not `Into<Box<EvaluationError>>`, so the `.into()` in places like evaluator.rs:360-ish no longer works automatically.  We could re-enable the `.into()` by writing the `impl From<IntegerOverflowError> for Box<EvaluationError>`, but this PR currently just makes the `Box::new` explicit instead.
    - this situation is slightly worse in places where we rely on `?` to apply `Into::into` automatically: for instance, around evaluator.rs:172 where we not only need to add explicit `Box::new` but also a `.into()` call.  The issue is that types like `ExtensionFunctionLookupError` are throwable with `?` in functions returning `EvaluationError`, but are not throwable with `?` in functions returning `Box<EvaluationError>`, because of the missing `Into` impl.  We also can't write the blanket `impl<T: Into<EvaluationError>> From<T> for Box<EvaluationError>` because it conflicts with the built-in blanket `impl From<T> for Box<T>`, and `EvaluationError` is one of the `impl Into<EvaluationError>` types.  We could manually write the `From` impl for each error struct individually, but this PR just puts up with the extra `.into()` and `Box::new` at the `?` site.
- We should benchmark whether there are any noticeable performance differences (either on happy paths or error paths).

## Issue #, if available

Partially addresses #878 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

