### PR TITLE
ignore the clippy result_large_err warning

### DIFF
--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,6 +17,7 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
+#![allow(clippy::result_large_err)] // see #878
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! Validator for Cedar policies
 #![forbid(unsafe_code)]
+#![allow(clippy::result_large_err)] // see #878
 
 use cedar_policy_core::ast::{Policy, PolicySet, Template};
 use serde::Serialize;

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -18,7 +18,8 @@
 #![allow(
     clippy::missing_panics_doc,
     clippy::missing_errors_doc,
-    clippy::similar_names
+    clippy::similar_names,
+    clippy::result_large_err, // see #878
 )]
 
 mod id;


### PR DESCRIPTION
## Description of changes

Ignore the Clippy warning `result_large_err`

## Issue #, if available

Follows discussion of #878; see notes there

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

