### PR TITLE
improved wasm build process

### DIFF
--- a/cedar-wasm/README.md
+++ b/cedar-wasm/README.md
@@ -4,8 +4,7 @@ An implementation of various cedar functions to enable developers to write types
 
 ## Installing
 
-Installing is simple, just run `npm i @cedar-policy/cedar-wasm` or install with whatever your favorite package manager is.
-
+Installing is simple, just run `npm i @cedar-policy/cedar-wasm --save` or install with whatever your favorite package manager is.
 
 ## Loading in webpack 5:
 
@@ -133,3 +132,20 @@ import('@cedar-policy/cedar-wasm').then(mod => {
 });
 ```
 
+## Alternate loading strategies
+
+If for some reason you cannot use es modules, we provide alternate sub-packages `web` and `nodejs` (defined as `exports` in the root package.json).
+
+The `nodejs` subpackage uses `fs` and CommonJS modules. To use it, you can import it like so:
+
+```
+const cedar = require('@cedar-policy/cedar-wasm/nodejs')
+```
+
+The `web` subpackage exposes an `initSync` function that you can use to load Cedar in scenarios where you want to load the wasm binary async for whatever reason. Using the `web` subpackage may also be necessary with some `jest` setups. Here's how you use the `web` subpackage:
+
+```
+const wasmBuffer = ... // `fetch` it or use `fs` to read it from `node_modules` in jest setupTests
+import * as cedarJsBindings from '@cedar-policy/cedar-wasm/web';
+cedarJsBindings.initSync(wasmBuffer);
+```

--- a/cedar-wasm/package.json.patch
+++ b/cedar-wasm/package.json.patch
@@ -1,0 +1,20 @@
+{
+  "files": ["esm/*", "nodejs/*", "web/*"],
+  "sideEffects": ["./snippets/*"],
+  "module": "esm/cedar_wasm.js",
+  "types": "esm/cedar_wasm.d.ts",
+  "exports": {
+    ".": {
+      "import": "esm/cedar_wasm.js",
+      "types": "esm/cedar_wasm.d.ts"
+    },
+    "./nodejs": {
+      "import": "nodejs/cedar_wasm.js",
+      "types": "nodejs/cedar_wasm.d.ts"
+    },
+    "./web": {
+      "import": "web/cedar_wasm.js",
+      "types": "web/cedar_wasm.d.ts"
+    }
+  }
+}


### PR DESCRIPTION
## Description of changes

With this new build process, we accommodate all possible mechanisms for consuming wasm. The `node` target supports the needs of teams who can't use es-modules, and the `web` target supports the needs of teams that need to read the wasm binary from a buffer for whatever reason.

## Issue #, if available

n/a

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


