### PR TITLE
Add an API to create unknown restricted expressions

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2981,6 +2981,14 @@ impl RestrictedExpression {
         ))
     }
 
+    /// Create an unknown expression
+    #[cfg(feature = "partial-eval")]
+    pub fn new_unknown(name: impl AsRef<str>) -> Self {
+        Self(ast::RestrictedExpr::unknown(ast::Unknown::new_untyped(
+            name.as_ref(),
+        )))
+    }
+
     /// Deconstruct an [`RestrictedExpression`] to get the internal type.
     /// This function is only intended to be used internally.
     #[cfg(test)]


### PR DESCRIPTION
## Description of changes

Add `RestrictedExpression::unknown` under feature `partial-eval`

## Issue #, if available

#927

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

