### PR TITLE
changelog updates for 2.4.7 and 3.2.1 releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ If you would like to propose a change to the Cedar language, or suggest a substa
 
 ## Changelog
 
-Cedar maintains changelogs for the public-facing crates [cedar-policy](./cedar-policy/CHANGELOG.md) and [cedar-policy-cli](./cedar-policy-cli/CHANGELOG.md), which adhere to the [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format. The purpose of the changelog is for the contributors and maintainers to incrementally build release notes throughout the development process to avoid the painful and error-prone process of attempting to compile the release notes at release time. On each release the "unreleased" entries of the changelog are moved under the appropriate header. Also, incrementally building the changelog provides a concise, human-readable list of significant features that have been added to the unreleased version under development.
+Cedar maintains changelogs for the public-facing crates [cedar-policy](https://github.com/cedar-policy/cedar/blob/main/cedar-policy/CHANGELOG.md) and [cedar-policy-cli](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-cli/CHANGELOG.md), which adhere to the [Keep A Changelog](https://keepachangelog.com/en/1.0.0/) format. The purpose of the changelog is for the contributors and maintainers to incrementally build release notes throughout the development process to avoid the painful and error-prone process of attempting to compile the release notes at release time. On each release the "unreleased" entries of the changelog are moved under the appropriate header. Also, incrementally building the changelog provides a concise, human-readable list of significant features that have been added to the unreleased version under development. Changelogs for all release branches and the `main` branch are all maintained on the `main` branch of this repository only; you can see the most up-to-date changelogs by following the links above.
 
 ### Which changes require a changelog entry?
 
@@ -60,7 +60,8 @@ The following are some examples where a changelog entry is not necessary:
 
 ### Where should I put my changelog entry?
 
-For a PR to the `main` branch, add your entry under the "Unreleased" section. For a PR to one of the `release/X.Y.Z` branches, add your entry under the appropriate version header. Once a version is released on crates.io, make sure to update the changelog on `main` to include the new release.
+Add your entry under the "Unreleased" section, as part of the same PR that introduces the change.
+In the (rarer) case that your PR is to a `release/X.Y.Z` branch rather than `main`, make a separate PR to `main` which adds the changelog entry under the appropriate version header of the `main` changelog.
 
 ## Review Process
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,13 @@ To build, simply run `cargo build` (or `cargo build --release`).
 
 ## What's New
 
-We maintain changelogs for our public-facing crates: [cedar-policy](./cedar-policy/CHANGELOG.md) and [cedar-policy-cli](./cedar-policy-cli/CHANGELOG.md).
+We maintain changelogs for our public-facing crates:
+[cedar-policy](https://github.com/cedar-policy/cedar/blob/main/cedar-policy/CHANGELOG.md) and
+[cedar-policy-cli](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-cli/CHANGELOG.md).
+Changelogs for all release branches and the `main` branch are all maintained on
+the `main` branch of this repository; you can see the most up-to-date changelogs
+by following the links above.
+
 For a list of the current and past releases, see [crates.io](https://crates.io/crates/cedar-policy) or [Releases](https://github.com/cedar-policy/cedar/releases).
 
 ## Backward Compatibility Considerations

--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -78,6 +78,10 @@ Now uses Cedar language version 3.0.0.
 - The short form of `--template-linked` was changed from `-t` to `-k`.
 - The `format` subcommand no longer takes a positional file argument.
 
+## 2.4.7
+
+## 2.4.6
+
 ## 2.4.5
 
 ## 2.4.4

--- a/cedar-policy-cli/README.md
+++ b/cedar-policy-cli/README.md
@@ -23,10 +23,31 @@ CLI is a command line tool. It supports the following subcommands:
 
 ### Build
 
-You will need to install Rust, via [rustup](https://rustup.rs)
+You will need to install Rust, via [rustup](https://rustup.rs).
 
-To build the CLI, run `cargo build` or `cargo build --release`
+To build the CLI, run `cargo build` or `cargo build --release`.
 
 ### Run
 
 To run the CLI, try `cargo run -- --help`. The sub-folder [`sample-data`](sample-data) contains examples for the CLI. Please refer to the instructions in each `README.md` to run the examples.
+
+## What's New
+
+Changelogs for all release branches and the `main` branch of this repository are
+all maintained on the `main` branch; the most up-to-date changelog for this
+crate is
+[here](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-cli/CHANGELOG.md).
+
+For a list of the current and past releases, see [crates.io](https://crates.io/crates/cedar-policy-cli) or [Releases](https://github.com/cedar-policy/cedar/releases).
+
+## Security
+
+See [SECURITY](../SECURITY.md) for more information.
+
+## Contributing
+
+We welcome contributions from the community. Please either file an issue, or see [CONTRIBUTING](../CONTRIBUTING.md)
+
+## License
+
+This project is licensed under the Apache-2.0 License.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -49,6 +49,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   extension type. This was already an error for human-readable schema syntax. (#890, resolving #875)
 - Fixed policy formatter dropping newlines in string literals. (#870, resolving #862)
 
+## [3.2.1] - Coming soon
+
+### Fixed
+
+- Fixed policy formatter dropping newlines in string literals. (#870, #910, resolving #862)
+- Fixed a performance issue when constructing an error for accessing
+  a non-existent attribute on sufficiently large records (#887, resolving #754)
+- Fixed identifier parsing in human-readable schemas (#914, resolving #913)
+
 ## [3.2.0] - 2024-05-17
 
 ### Added
@@ -338,6 +347,14 @@ Cedar Language Version: 3.0.0
   To continue using this feature you must enable the `permissive-validate`
   feature flag. (#428)
 
+## [2.4.7] - Coming soon
+
+### Fixed
+
+- Fixed policy formatter reordering some comments around if-then-else and
+  entity identifier expressions. (#861, resolving #787)
+- Fixed policy formatter dropping newlines in string literals. (#870, #910, resolving #862)
+
 ## [2.4.6] - 2024-05-17
 
 ### Fixed
@@ -556,7 +573,8 @@ Cedar Language Version: 2.0.0
 Cedar Language Version: 2.0.0
 - Initial release of `cedar-policy`.
 
-[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.2.0...main
+[Unreleased]: https://github.com/cedar-policy/cedar/compare/v3.2.1...main
+[3.2.1]: https://github.com/cedar-policy/cedar/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/cedar-policy/cedar/compare/v3.1.4...v3.2.0
 [3.1.4]: https://github.com/cedar-policy/cedar/compare/v3.1.3...v3.1.4
 [3.1.3]: https://github.com/cedar-policy/cedar/compare/v3.1.2...v3.1.3
@@ -564,7 +582,8 @@ Cedar Language Version: 2.0.0
 [3.1.1]: https://github.com/cedar-policy/cedar/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/cedar-policy/cedar/compare/v3.0.1...v3.1.0
 [3.0.1]: https://github.com/cedar-policy/cedar/compare/v3.0.0...v3.0.1
-[3.0.0]: https://github.com/cedar-policy/cedar/compare/v2.4.6...v3.0.0
+[3.0.0]: https://github.com/cedar-policy/cedar/compare/v2.4.7...v3.0.0
+[2.4.7]: https://github.com/cedar-policy/cedar/compare/v2.4.6...v2.4.7
 [2.4.6]: https://github.com/cedar-policy/cedar/compare/v2.4.5...v2.4.6
 [2.4.5]: https://github.com/cedar-policy/cedar/compare/v2.4.4...v2.4.5
 [2.4.4]: https://github.com/cedar-policy/cedar/compare/v2.4.3...v2.4.4

--- a/cedar-policy/README.md
+++ b/cedar-policy/README.md
@@ -77,7 +77,12 @@ To build, simply run `cargo build` (or `cargo build --release`).
 
 ## What's New
 
-See [CHANGELOG](CHANGELOG.md)
+Changelogs for all release branches and the `main` branch of this repository are
+all maintained on the `main` branch; the most up-to-date changelog for this
+crate is
+[here](https://github.com/cedar-policy/cedar/blob/main/cedar-policy/CHANGELOG.md).
+
+For a list of the current and past releases, see [crates.io](https://crates.io/crates/cedar-policy) or [Releases](https://github.com/cedar-policy/cedar/releases).
 
 ## Security
 


### PR DESCRIPTION
## Description of changes

Also bring forward the README changes from the release branches, so our messaging is consistent everywhere.
