### PR TITLE
fix wasm type override for AuthorizationCall

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolving #549)
 - Added methods for reading and writing individual `Entity`s as JSON
   (resolving #807)
-- Fixed the typescript generated type for AuthorizationCall to remmove
+- Fixed the typescript generated type for `AuthorizationCall` to remove
   unsupported string option
 - Fixed wasm build script to be multi-target in js ecosystem
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolving #549)
 - Added methods for reading and writing individual `Entity`s as JSON
   (resolving #807)
+- Fixed the typescript generated type for AuthorizationCall to remmove
+  unsupported string option
+- Fixed wasm build script to be multi-target in js ecosystem
+
 
 ### Changed
 

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -443,13 +443,13 @@ pub enum PartialAuthorizationAnswer {
 #[serde(rename_all = "camelCase")]
 pub struct AuthorizationCall {
     /// The principal taking action
-    #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
+    #[cfg_attr(feature = "wasm", tsify(type = "{type: string, id: string}"))]
     principal: Option<JsonValueWithNoDuplicateKeys>,
     /// The action the principal is taking
-    #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
+    #[cfg_attr(feature = "wasm", tsify(type = "{type: string, id: string}"))]
     action: JsonValueWithNoDuplicateKeys,
     /// The resource being acted on by the principal
-    #[cfg_attr(feature = "wasm", tsify(type = "string|{type: string, id: string}"))]
+    #[cfg_attr(feature = "wasm", tsify(type = "{type: string, id: string}"))]
     resource: Option<JsonValueWithNoDuplicateKeys>,
     /// The context details specific to the request
     #[serde_as(as = "MapPreventDuplicates<_, _>")]


### PR DESCRIPTION
## Description of changes

Removes incorrect outdated string form of P,A,R in AuthorizationCall typescript types

## Issue #, if available
n/a 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

