### PR TITLE
Check that action scope constriant do not contain non-actions entities in EST

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -574,6 +574,8 @@ pub struct EntityAttrEvaluationError {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
@@ -616,5 +618,17 @@ mod test {
 
         // e3 and e5 are displayed differently
         assert!(format!("{e3}") != format!("{e5}"));
+    }
+
+    #[test]
+    fn action_checker() {
+        let euid = EntityUID::from_str("Action::\"view\"").unwrap();
+        assert!(euid.is_action());
+        let euid = EntityUID::from_str("Foo::Action::\"view\"").unwrap();
+        assert!(euid.is_action());
+        let euid = EntityUID::from_str("Foo::\"view\"").unwrap();
+        assert!(!euid.is_action());
+        let euid = EntityUID::from_str("Action::Foo::\"view\"").unwrap();
+        assert!(!euid.is_action());
     }
 }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -18,6 +18,7 @@ use crate::ast::*;
 use crate::parser::Loc;
 use itertools::Itertools;
 use miette::Diagnostic;
+use nonempty::{nonempty, NonEmpty};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::BTreeMap;
@@ -1684,6 +1685,30 @@ impl ActionConstraint {
                 EntityType::Specified(name) => Some(name),
                 EntityType::Unspecified => None,
             })
+    }
+
+    /// Check that all of the EUIDs in an action constraint have the type
+    /// `Action`, under an arbitrary namespace.
+    pub fn contains_only_action_types(self) -> Result<Self, NonEmpty<Arc<EntityUID>>> {
+        match self {
+            ActionConstraint::Any => Ok(self),
+            ActionConstraint::In(ref euids) => {
+                if let Some(euids) =
+                    NonEmpty::collect(euids.iter().filter(|euid| !euid.is_action()).cloned())
+                {
+                    Err(euids)
+                } else {
+                    Ok(self)
+                }
+            }
+            ActionConstraint::Eq(ref euid) => {
+                if euid.is_action() {
+                    Ok(self)
+                } else {
+                    Err(nonempty![euid.clone()])
+                }
+            }
+        }
     }
 }
 

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3979,3 +3979,36 @@ mod issue_891 {
         assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "resorThanOrEqual".parse().unwrap());
     }
 }
+
+#[cfg(test)]
+mod issue_925 {
+    use crate::{est::FromJsonError, parser::parse_policy_or_template_to_est};
+    use cool_asserts::assert_matches;
+
+    #[test]
+    fn invalid_action_type() {
+        let src = r#"permit(principal, action == NotAction::"view", resource);"#;
+        let est =
+            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        assert_matches!(
+            est.try_into_ast_policy(None),
+            Err(FromJsonError::InvalidActionType(_))
+        );
+
+        let src = r#"permit(principal, action in NotAction::"view", resource);"#;
+        let est =
+            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        assert_matches!(
+            est.try_into_ast_policy(None),
+            Err(FromJsonError::InvalidActionType(_))
+        );
+
+        let src = r#"permit(principal, action in [NotAction::"view", Other::"edit"], resource);"#;
+        let est =
+            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        assert_matches!(
+            est.try_into_ast_policy(None),
+            Err(FromJsonError::InvalidActionType(_))
+        );
+    }
+}

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -14,10 +14,12 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use crate::ast;
 use crate::entities::json::err::JsonDeserializationError;
 use crate::parser::err::ParseErrors;
-use crate::parser::unescape;
+use crate::parser::{join_with_conjunction, unescape};
 use miette::Diagnostic;
 use nonempty::NonEmpty;
 use smol_str::SmolStr;
@@ -91,6 +93,27 @@ pub enum FromJsonError {
     /// Error reported when the extension function name is unknown
     #[error("Invalid extension function name: `{0}`")]
     UnknownExtFunc(ast::Name),
+    /// Returned when an Entity UID used as an action does not have the type `Action`
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidActionType(#[from] InvalidActionType),
+}
+
+/// Details about an `InvalidActionType` error.
+#[derive(Debug, Diagnostic, Error)]
+#[diagnostic(help("action entities must have type `Action`, optionally in a namespace"))]
+pub struct InvalidActionType {
+    pub(crate) euids: NonEmpty<Arc<crate::ast::EntityUID>>,
+}
+
+impl std::fmt::Display for InvalidActionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "expected that action entity uids would have the type `Action` but got"
+        )?;
+        join_with_conjunction(f, "and", self.euids.iter(), |f, e| write!(f, "`{e}`"))
+    }
 }
 
 /// Errors while linking a policy

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -110,7 +110,7 @@ impl std::fmt::Display for InvalidActionType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "expected that action entity uids would have the type `Action` but got"
+            "expected that action entity uids would have the type `Action` but got "
         )?;
         join_with_conjunction(f, "and", self.euids.iter(), |f, e| write!(f, "`{e}`"))
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - JSON format Cedar schemas will now fail to parse if they reference an unknown
   extension type. This was already an error for human-readable schema syntax. (#890, resolving #875)
+- JSON format Cedar policies will now fail to parse if the action scope
+  constraint contains a non-action entity type, matching the behavior for
+  human-readable Cedar policies. (#943, resolving #925)
 
 ## [3.2.1] - 2024-05-31
 


### PR DESCRIPTION
## Description of changes

Backwards compatible if we are happy to call this a bug fix

## Issue #, if available

#925

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

