### PR TITLE
Remove `RestrictedExpressionError` from `EvalutationError`

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -633,26 +633,6 @@ impl Diagnostic for RestrictedExprError {
     }
 }
 
-impl RestrictedExprError {
-    /// Get the `Loc` of this error
-    pub(crate) fn source_loc(&self) -> Option<&Loc> {
-        match self {
-            Self::InvalidRestrictedExpression { expr, .. } => expr.source_loc(),
-        }
-    }
-
-    pub(crate) fn with_maybe_source_loc(self, source_loc: Option<Loc>) -> Self {
-        match self {
-            Self::InvalidRestrictedExpression { feature, expr } => {
-                Self::InvalidRestrictedExpression {
-                    feature,
-                    expr: expr.with_maybe_source_loc(source_loc),
-                }
-            }
-        }
-    }
-}
-
 /// Errors possible from `RestrictedExpr::from_str()`
 //
 // CAUTION: this type is publicly exported in `cedar-policy`.

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -76,11 +76,6 @@ pub enum EvaluationError {
     #[diagnostic(transparent)]
     IntegerOverflow(#[from] evaluation_errors::IntegerOverflowError),
 
-    /// Error with the use of "restricted" expressions
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    InvalidRestrictedExpression(#[from] RestrictedExprError),
-
     /// Not all template slots were linked
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -116,7 +111,6 @@ impl EvaluationError {
             Self::TypeError(e) => e.source_loc.as_ref(),
             Self::WrongNumArguments(e) => e.source_loc.as_ref(),
             Self::IntegerOverflow(e) => e.source_loc(),
-            Self::InvalidRestrictedExpression(e) => e.source_loc(),
             Self::UnlinkedSlot(e) => e.source_loc.as_ref(),
             Self::FailedExtensionFunctionExecution(e) => e.source_loc.as_ref(),
             Self::NonValue(e) => e.source_loc.as_ref(),
@@ -162,9 +156,6 @@ impl EvaluationError {
                 })
             }
             Self::IntegerOverflow(e) => Self::IntegerOverflow(e.with_maybe_source_loc(source_loc)),
-            Self::InvalidRestrictedExpression(e) => {
-                Self::InvalidRestrictedExpression(e.with_maybe_source_loc(source_loc))
-            }
             Self::UnlinkedSlot(e) => {
                 Self::UnlinkedSlot(evaluation_errors::UnlinkedSlotError { source_loc, ..e })
             }


### PR DESCRIPTION
Fix #187

Turns out to be an easy fix, so good to get in for the 4.0 error refactoring.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
