### PR TITLE
Expose json serialization of schemas

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolving #549)
 - Added methods for reading and writing individual `Entity`s as JSON
   (resolving #807)
+- Exposed new `to_json_str` and `to_json_str_pretty` methods for schemas.
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -48,6 +48,7 @@ use cedar_policy_validator::RequestValidationError; // this type is unsuitable f
 use itertools::{Either, Itertools};
 use miette::Diagnostic;
 use ref_cast::RefCast;
+use schema_error::JsonSerializationError;
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Read;
@@ -1380,6 +1381,18 @@ impl Schema {
                 Extensions::all_available(),
             )?,
         ))
+    }
+
+    /// Serialize the `Schema` to a JSON value.
+    pub fn to_json_str(&self) -> Result<String, schema_error::SchemaError> {
+        serde_json::to_string(&self.0)
+            .map_err(|err| schema_error::SchemaError::JsonSerialization(err.into()))
+    }
+
+    /// Serialize the `Schema` to a pretty-printed JSON value.
+    pub fn to_json_str_pretty(&self) -> Result<String, schema_error::SchemaError> {
+        serde_json::to_string_pretty(&self.0)
+            .map_err(|err| schema_error::SchemaError::JsonSerialization(err.into()))
     }
 
     /// Create a `Schema` from a string containing JSON in the appropriate


### PR DESCRIPTION
## Description of changes
As far as I can tell, the json format for schemas is stable. So, this PR exposes methods to print and pretty-print json strings from schemas. I ran into this while writing my first cedar code in rust.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

