### PR TITLE
Make `parse_policy_or_template_to_est` error for CST that aren't valid AST

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -38,6 +38,11 @@ use std::collections::{BTreeMap, HashMap};
 extern crate tsify;
 
 /// Serde JSON structure for policies and templates in the EST format
+/// Note: Before attempting to build an `est::Policy` from a `cst::Policy` you
+/// must first ensure that the CST can be transformed into an AST. The
+/// CST-to-EST transformation does not duplicate all checks performed by the
+/// CST-to-AST transformation, so attempting to convert an invalid CST to an EST
+/// may succeeded.
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3991,24 +3991,62 @@ mod test {
 
 #[cfg(test)]
 mod issue_891 {
-    use crate::{est::FromJsonError, parser::parse_policy_or_template_to_est};
+    use crate::est::{self, FromJsonError};
     use cool_asserts::assert_matches;
+    use serde_json::json;
+
+    fn est_json_with_body(body: serde_json::Value) -> serde_json::Value {
+        json!(
+            {
+                "effect": "permit",
+                "principal": { "op": "All" },
+                "action": { "op": "All" },
+                "resource": { "op": "All" },
+                "conditions": [
+                    {
+                        "kind": "when",
+                        "body": body,
+                    }
+                ]
+            }
+        )
+    }
 
     #[test]
     fn invalid_extension_func() {
-        let src = "permit(principal, action, resource) when {principal == resource.ow4()};";
-        let est =
-            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        let src = est_json_with_body(json!( { "ow4": [ { "Var": "principal" } ] }));
+        let est: est::Policy = serde_json::from_value(src).expect("est JSON should deserialize");
         assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "ow4".parse().unwrap());
 
-        let src = r#"permit(principal, action, resource) when {principal == resource.ownerOrEqual(decimal("0.75"))};"#;
-        let est =
-            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        let src = est_json_with_body(json!(
+            {
+                "==": {
+                    "left": {"Var": "principal"},
+                    "right": {
+                        "ownerOrEqual": [
+                            {"Var": "resource"},
+                            {"decimal": [{ "Value": "0.75" }]}
+                        ]
+                    }
+                }
+            }
+        ));
+        let est: est::Policy = serde_json::from_value(src).expect("est JSON should deserialize");
         assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "ownerOrEqual".parse().unwrap());
 
-        let src = r#"permit(principal, action, resource) when {principal == resorThanOrEqual(decimal("0.75"))};"#;
-        let est =
-            parse_policy_or_template_to_est(src).expect("cst to est conversion should succeed");
+        let src = est_json_with_body(json!(
+            {
+                "==": {
+                    "left": {"Var": "principal"},
+                    "right": {
+                        "resorThanOrEqual": [
+                            {"decimal": [{ "Value": "0.75" }]}
+                        ]
+                    }
+                }
+            }
+        ));
+        let est: est::Policy = serde_json::from_value(src).expect("est JSON should deserialize");
         assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtFunc(n)) if n == "resorThanOrEqual".parse().unwrap());
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -42,7 +42,7 @@ extern crate tsify;
 /// must first ensure that the CST can be transformed into an AST. The
 /// CST-to-EST transformation does not duplicate all checks performed by the
 /// CST-to-AST transformation, so attempting to convert an invalid CST to an EST
-/// may succeeded.
+/// may succeed.
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -161,11 +161,10 @@ pub fn parse_policy_to_est_and_ast(
 
 /// Parse a policy or template (either one works) to its EST representation
 pub fn parse_policy_or_template_to_est(text: &str) -> Result<est::Policy, err::ParseErrors> {
-    let cst = text_to_cst::parse_policy(text)?;
-    // PANIC SAFETY Shouldn't be `none` since `parse_policy()` didn't return `Err`
-    #[allow(clippy::expect_used)]
-    let cst_node = cst.node.expect("missing policy or template node");
-    cst_node.try_into()
+    // We parse to EST and AST even though we only want the EST because some
+    // checks are only applied by the CST-to-EST conversion, and we do not want
+    // to return any EST if the policy text would not parse normally.
+    parse_policy_template_to_est_and_ast(None, text).map(|(est, _ast)| est)
 }
 
 /// parse an Expr

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -162,8 +162,9 @@ pub fn parse_policy_to_est_and_ast(
 /// Parse a policy or template (either one works) to its EST representation
 pub fn parse_policy_or_template_to_est(text: &str) -> Result<est::Policy, err::ParseErrors> {
     // We parse to EST and AST even though we only want the EST because some
-    // checks are only applied by the CST-to-EST conversion, and we do not want
-    // to return any EST if the policy text would not parse normally.
+    // checks are applied by the CST-to-AST conversion and not CST-to-EST, and
+    // we do not want to return any EST if the policy text would not parse
+    // normally.
     parse_policy_template_to_est_and_ast(None, text).map(|(est, _ast)| est)
 }
 

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -16,3 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exposed types through `tsify` for `ValidateCall` and the schema. (#692)
 - Exposed cedar-wasm functionality for formatter and schema, context, and entity parsing: `wasm_format_policies`, `check_parse_schema`, `check_parse_context`, `check_parse_entities`. (#718)
 - Exposed cedar-wasm functionality for template parsing: `check_parse_template`.
+
+### Changed
+
+- Update `policyTextToJson` so that it reliably errors for all policies that
+  error for `checkParseTemplate`. (#952)


### PR DESCRIPTION
The EST conversion does not apply the checks that we apply CST to EST conversion, and we don't want to duplicate all of them. For example, this function succeeded for expression using extension function with an incorrect call style like `"1".ip()` (cedar-policy/cedar-spec#341).

Effects `policy_text_to_json` in the WASM bindings.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model 

