### PR TITLE
Revise APIs of `PrincipalOrResourceConstraint`

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1205,7 +1205,7 @@ impl PrincipalConstraint {
     }
 
     /// Constrained to equal a specific euid.
-    pub fn is_eq(euid: EntityUID) -> Self {
+    pub fn is_eq(euid: Arc<EntityUID>) -> Self {
         PrincipalConstraint {
             constraint: PrincipalOrResourceConstraint::is_eq(euid),
         }
@@ -1219,7 +1219,7 @@ impl PrincipalConstraint {
     }
 
     /// Hierarchical constraint.
-    pub fn is_in(euid: EntityUID) -> Self {
+    pub fn is_in(euid: Arc<EntityUID>) -> Self {
         PrincipalConstraint {
             constraint: PrincipalOrResourceConstraint::is_in(euid),
         }
@@ -1233,21 +1233,21 @@ impl PrincipalConstraint {
     }
 
     /// Type constraint additionally constrained to be in a slot.
-    pub fn is_entity_type_in_slot(entity_type: Name) -> Self {
+    pub fn is_entity_type_in_slot(entity_type: Arc<Name>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in_slot(entity_type),
         }
     }
 
     /// Type constraint, with a hierarchical constraint.
-    pub fn is_entity_type_in(entity_type: Name, in_entity: EntityUID) -> Self {
+    pub fn is_entity_type_in(entity_type: Arc<Name>, in_entity: Arc<EntityUID>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in(entity_type, in_entity),
         }
     }
 
     /// Type constraint, with no hierarchical constraint or slot.
-    pub fn is_entity_type(entity_type: Name) -> Self {
+    pub fn is_entity_type(entity_type: Arc<Name>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type(entity_type),
         }
@@ -1312,7 +1312,7 @@ impl ResourceConstraint {
     }
 
     /// Constrained to equal a specific euid.
-    pub fn is_eq(euid: EntityUID) -> Self {
+    pub fn is_eq(euid: Arc<EntityUID>) -> Self {
         ResourceConstraint {
             constraint: PrincipalOrResourceConstraint::is_eq(euid),
         }
@@ -1333,28 +1333,28 @@ impl ResourceConstraint {
     }
 
     /// Hierarchical constraint.
-    pub fn is_in(euid: EntityUID) -> Self {
+    pub fn is_in(euid: Arc<EntityUID>) -> Self {
         ResourceConstraint {
             constraint: PrincipalOrResourceConstraint::is_in(euid),
         }
     }
 
     /// Type constraint additionally constrained to be in a slot.
-    pub fn is_entity_type_in_slot(entity_type: Name) -> Self {
+    pub fn is_entity_type_in_slot(entity_type: Arc<Name>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in_slot(entity_type),
         }
     }
 
     /// Type constraint, with a hierarchical constraint.
-    pub fn is_entity_type_in(entity_type: Name, in_entity: EntityUID) -> Self {
+    pub fn is_entity_type_in(entity_type: Arc<Name>, in_entity: Arc<EntityUID>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in(entity_type, in_entity),
         }
     }
 
     /// Type constraint, with no hierarchical constraint or slot.
-    pub fn is_entity_type(entity_type: Name) -> Self {
+    pub fn is_entity_type(entity_type: Arc<Name>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type(entity_type),
         }
@@ -1395,8 +1395,8 @@ pub enum EntityReference {
 
 impl EntityReference {
     /// Create an entity reference to a specific EntityUID
-    pub fn euid(euid: EntityUID) -> Self {
-        Self::EUID(Arc::new(euid))
+    pub fn euid(euid: Arc<EntityUID>) -> Self {
+        Self::EUID(euid)
     }
 
     /// Transform into an expression AST
@@ -1478,9 +1478,9 @@ pub enum PrincipalOrResourceConstraint {
     /// Equality constraint
     Eq(EntityReference),
     /// Type constraint,
-    Is(Name),
+    Is(Arc<Name>),
     /// Type constraint with a hierarchy constraint
-    IsIn(Name, EntityReference),
+    IsIn(Arc<Name>, EntityReference),
 }
 
 impl PrincipalOrResourceConstraint {
@@ -1490,7 +1490,7 @@ impl PrincipalOrResourceConstraint {
     }
 
     /// Constrained to equal a specific euid.
-    pub fn is_eq(euid: EntityUID) -> Self {
+    pub fn is_eq(euid: Arc<EntityUID>) -> Self {
         PrincipalOrResourceConstraint::Eq(EntityReference::euid(euid))
     }
 
@@ -1505,22 +1505,22 @@ impl PrincipalOrResourceConstraint {
     }
 
     /// Hierarchical constraint.
-    pub fn is_in(euid: EntityUID) -> Self {
+    pub fn is_in(euid: Arc<EntityUID>) -> Self {
         PrincipalOrResourceConstraint::In(EntityReference::euid(euid))
     }
 
     /// Type constraint additionally constrained to be in a slot.
-    pub fn is_entity_type_in_slot(entity_type: Name) -> Self {
+    pub fn is_entity_type_in_slot(entity_type: Arc<Name>) -> Self {
         PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot)
     }
 
     /// Type constraint with a hierarchical constraint.
-    pub fn is_entity_type_in(entity_type: Name, in_entity: EntityUID) -> Self {
+    pub fn is_entity_type_in(entity_type: Arc<Name>, in_entity: Arc<EntityUID>) -> Self {
         PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::euid(in_entity))
     }
 
     /// Type constraint, with no hierarchical constraint or slot.
-    pub fn is_entity_type(entity_type: Name) -> Self {
+    pub fn is_entity_type(entity_type: Arc<Name>) -> Self {
         PrincipalOrResourceConstraint::Is(entity_type)
     }
 
@@ -1537,11 +1537,11 @@ impl PrincipalOrResourceConstraint {
                 Expr::is_in(Expr::var(v.into()), euid.into_expr(v.into()))
             }
             PrincipalOrResourceConstraint::IsIn(entity_type, euid) => Expr::and(
-                Expr::is_entity_type(Expr::var(v.into()), entity_type.clone()),
+                Expr::is_entity_type(Expr::var(v.into()), entity_type.as_ref().clone()),
                 Expr::is_in(Expr::var(v.into()), euid.into_expr(v.into())),
             ),
             PrincipalOrResourceConstraint::Is(entity_type) => {
-                Expr::is_entity_type(Expr::var(v.into()), entity_type.clone())
+                Expr::is_entity_type(Expr::var(v.into()), entity_type.as_ref().clone())
             }
         }
     }
@@ -1568,7 +1568,7 @@ impl PrincipalOrResourceConstraint {
     }
 
     /// Get the entity uid in this constraint or `None` if it is impossible
-    pub fn get_euid(&self) -> Option<&EntityUID> {
+    pub fn get_euid(&self) -> Option<&Arc<EntityUID>> {
         match self {
             PrincipalOrResourceConstraint::Any => None,
             PrincipalOrResourceConstraint::In(EntityReference::EUID(euid)) => Some(euid),
@@ -1593,7 +1593,7 @@ impl PrincipalOrResourceConstraint {
             })
             .chain(match self {
                 PrincipalOrResourceConstraint::Is(entity_type)
-                | PrincipalOrResourceConstraint::IsIn(entity_type, _) => Some(entity_type),
+                | PrincipalOrResourceConstraint::IsIn(entity_type, _) => Some(entity_type.as_ref()),
                 _ => None,
             })
     }
@@ -1789,7 +1789,7 @@ pub mod test_generators {
     use super::*;
 
     pub fn all_por_constraints() -> impl Iterator<Item = PrincipalOrResourceConstraint> {
-        let euid = EntityUID::with_eid("test");
+        let euid = Arc::new(EntityUID::with_eid("test"));
         let v = vec![
             PrincipalOrResourceConstraint::any(),
             PrincipalOrResourceConstraint::is_eq(euid.clone()),
@@ -2073,7 +2073,7 @@ mod test {
         assert_eq!(PrincipalOrResourceConstraint::Any.get_euid(), None);
         assert_eq!(
             PrincipalOrResourceConstraint::In(EntityReference::EUID(e.clone())).get_euid(),
-            Some(e.as_ref())
+            Some(&e)
         );
         assert_eq!(
             PrincipalOrResourceConstraint::In(EntityReference::Slot).get_euid(),
@@ -2081,7 +2081,7 @@ mod test {
         );
         assert_eq!(
             PrincipalOrResourceConstraint::Eq(EntityReference::EUID(e.clone())).get_euid(),
-            Some(e.as_ref())
+            Some(&e)
         );
         assert_eq!(
             PrincipalOrResourceConstraint::Eq(EntityReference::Slot).get_euid(),
@@ -2089,19 +2089,22 @@ mod test {
         );
         assert_eq!(
             PrincipalOrResourceConstraint::IsIn(
-                "T".parse().unwrap(),
+                Arc::new("T".parse().unwrap()),
                 EntityReference::EUID(e.clone())
             )
             .get_euid(),
-            Some(e.as_ref())
+            Some(&e)
         );
         assert_eq!(
-            PrincipalOrResourceConstraint::Is("T".parse().unwrap()).get_euid(),
+            PrincipalOrResourceConstraint::Is(Arc::new("T".parse().unwrap())).get_euid(),
             None
         );
         assert_eq!(
-            PrincipalOrResourceConstraint::IsIn("T".parse().unwrap(), EntityReference::Slot)
-                .get_euid(),
+            PrincipalOrResourceConstraint::IsIn(
+                Arc::new("T".parse().unwrap()),
+                EntityReference::Slot
+            )
+            .get_euid(),
             None
         );
     }
@@ -2165,7 +2168,7 @@ mod test {
             e.into_expr(SlotId::principal()),
             Expr::slot(SlotId::principal())
         );
-        let e = EntityReference::euid(EntityUID::with_eid("eid"));
+        let e = EntityReference::euid(Arc::new(EntityUID::with_eid("eid")));
         assert_eq!(
             e.into_expr(SlotId::principal()),
             Expr::val(EntityUID::with_eid("eid"))
@@ -2177,8 +2180,9 @@ mod test {
         let t = PrincipalOrResourceConstraint::Eq(EntityReference::Slot);
         let s = t.display(PrincipalOrResource::Principal);
         assert_eq!(s, "principal == ?principal");
-        let t =
-            PrincipalOrResourceConstraint::Eq(EntityReference::euid(EntityUID::with_eid("test")));
+        let t = PrincipalOrResourceConstraint::Eq(EntityReference::euid(Arc::new(
+            EntityUID::with_eid("test"),
+        )));
         let s = t.display(PrincipalOrResource::Principal);
         assert_eq!(s, "principal == test_entity_type::\"test\"");
     }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1567,7 +1567,7 @@ impl PrincipalOrResourceConstraint {
         }
     }
 
-    /// Get the entity uid in this constraint or `None` if it is impossible
+    /// Get the entity uid in this constraint or `None` if there are no uids in the constraint
     pub fn get_euid(&self) -> Option<&Arc<EntityUID>> {
         match self {
             PrincipalOrResourceConstraint::Any => None,

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -845,7 +845,7 @@ mod test {
             None,
             Annotations::new(),
             Effect::Forbid,
-            PrincipalConstraint::is_eq(EntityUID::with_eid("jane")),
+            PrincipalConstraint::is_eq(Arc::new(EntityUID::with_eid("jane"))),
             ActionConstraint::any(),
             ResourceConstraint::any(),
             Expr::val(true),

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -568,15 +568,22 @@ impl TryFrom<PrincipalConstraint> for ast::PrincipalOrResourceConstraint {
                 .map_err(Self::Error::InvalidEntityType)
                 .and_then(|entity_type| {
                     Ok(match in_entity {
-                        None => ast::PrincipalOrResourceConstraint::is_entity_type(entity_type),
+                        None => ast::PrincipalOrResourceConstraint::is_entity_type(Arc::new(
+                            entity_type,
+                        )),
                         Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
                             ast::PrincipalOrResourceConstraint::is_entity_type_in(
-                                entity_type,
-                                entity.into_euid(|| JsonDeserializationErrorContext::EntityUid)?,
+                                Arc::new(entity_type),
+                                Arc::new(
+                                    entity
+                                        .into_euid(|| JsonDeserializationErrorContext::EntityUid)?,
+                                ),
                             )
                         }
                         Some(PrincipalOrResourceInConstraint::Slot { .. }) => {
-                            ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(entity_type)
+                            ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(Arc::new(
+                                entity_type,
+                            ))
                         }
                     })
                 }),
@@ -626,15 +633,22 @@ impl TryFrom<ResourceConstraint> for ast::PrincipalOrResourceConstraint {
                 .map_err(Self::Error::InvalidEntityType)
                 .and_then(|entity_type| {
                     Ok(match in_entity {
-                        None => ast::PrincipalOrResourceConstraint::is_entity_type(entity_type),
+                        None => ast::PrincipalOrResourceConstraint::is_entity_type(Arc::new(
+                            entity_type,
+                        )),
                         Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
                             ast::PrincipalOrResourceConstraint::is_entity_type_in(
-                                entity_type,
-                                entity.into_euid(|| JsonDeserializationErrorContext::EntityUid)?,
+                                Arc::new(entity_type),
+                                Arc::new(
+                                    entity
+                                        .into_euid(|| JsonDeserializationErrorContext::EntityUid)?,
+                                ),
                             )
                         }
                         Some(PrincipalOrResourceInConstraint::Slot { .. }) => {
-                            ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(entity_type)
+                            ast::PrincipalOrResourceConstraint::is_entity_type_in_slot(Arc::new(
+                                entity_type,
+                            ))
                         }
                     })
                 }),

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -48,9 +48,16 @@ pub(super) fn policy_entity_uids(template: &Template) -> impl Iterator<Item = &E
     template
         .principal_constraint()
         .as_inner()
-        .iter_euids()
+        .get_euid()
+        .into_iter()
         .chain(template.action_constraint().iter_euids())
-        .chain(template.resource_constraint().as_inner().iter_euids())
+        .chain(
+            template
+                .resource_constraint()
+                .as_inner()
+                .get_euid()
+                .into_iter(),
+        )
         .chain(expr_entity_uids(template.non_scope_constraints()))
 }
 

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -50,13 +50,15 @@ pub(super) fn policy_entity_uids(template: &Template) -> impl Iterator<Item = &E
         .as_inner()
         .get_euid()
         .into_iter()
+        .map(|euid| euid.as_ref())
         .chain(template.action_constraint().iter_euids())
         .chain(
             template
                 .resource_constraint()
                 .as_inner()
                 .get_euid()
-                .into_iter(),
+                .into_iter()
+                .map(|euid| euid.as_ref()),
         )
         .chain(expr_entity_uids(template.non_scope_constraints()))
 }

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -444,7 +444,7 @@ impl Validator {
             PrincipalOrResourceConstraint::Is(entity_type)
             | PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot) => Box::new(
                 if self.schema.is_known_entity_type(entity_type) {
-                    Some(entity_type)
+                    Some(entity_type.as_ref())
                 } else {
                     None
                 }
@@ -455,7 +455,7 @@ impl Validator {
                     self.schema
                         .get_entity_types_in(in_entity.as_ref())
                         .into_iter()
-                        .filter(move |k| &entity_type == k),
+                        .filter(move |k| &entity_type.as_ref() == k),
                 )
             }
         }
@@ -578,10 +578,10 @@ mod test {
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
-            ResourceConstraint::is_eq(
+            ResourceConstraint::is_eq(Arc::new(
                 EntityUID::with_eid_and_type(foo_type, "foo_name")
                     .expect("should be a valid identifier"),
-            ),
+            )),
             Expr::val(true),
         );
 
@@ -896,11 +896,11 @@ mod test {
             None,
             Annotations::new(),
             Effect::Permit,
-            PrincipalConstraint::is_eq(EntityUID::from_components(
+            PrincipalConstraint::is_eq(Arc::new(EntityUID::from_components(
                 entity_type,
                 Eid::new("bar"),
                 None,
-            )),
+            ))),
             ActionConstraint::any(),
             ResourceConstraint::any(),
             Expr::val(true),
@@ -1038,7 +1038,7 @@ mod test {
         let foo_type = "foo_type";
         let euid_foo = EntityUID::with_eid_and_type(foo_type, "foo_name")
             .expect("should be a valid identifier");
-        let principal_constraint = PrincipalConstraint::is_eq(euid_foo.clone());
+        let principal_constraint = PrincipalConstraint::is_eq(Arc::new(euid_foo.clone()));
 
         let schema_file = NamespaceDefinition::new(
             [(
@@ -1170,9 +1170,9 @@ mod test {
             None,
             Annotations::new(),
             Effect::Permit,
-            PrincipalConstraint::is_eq(principal),
+            PrincipalConstraint::is_eq(Arc::new(principal)),
             ActionConstraint::is_eq(action),
-            ResourceConstraint::is_eq(resource),
+            ResourceConstraint::is_eq(Arc::new(resource)),
             Expr::val(true),
         );
 
@@ -1542,7 +1542,7 @@ mod test {
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::is_in([action_grandparent_euid]),
-            ResourceConstraint::is_in(resource_grandparent_euid),
+            ResourceConstraint::is_in(Arc::new(resource_grandparent_euid)),
             Expr::val(true),
         );
 
@@ -1565,7 +1565,7 @@ mod test {
             Effect::Permit,
             PrincipalConstraint::any(),
             ActionConstraint::any(),
-            ResourceConstraint::is_eq(EntityUID::unspecified_from_eid(Eid::new("foo"))),
+            ResourceConstraint::is_eq(Arc::new(EntityUID::unspecified_from_eid(Eid::new("foo")))),
             Expr::val(true),
         );
         let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
@@ -1583,7 +1583,7 @@ mod test {
             None,
             Annotations::new(),
             Effect::Permit,
-            PrincipalConstraint::is_in(EntityUID::unspecified_from_eid(Eid::new("foo"))),
+            PrincipalConstraint::is_in(Arc::new(EntityUID::unspecified_from_eid(Eid::new("foo")))),
             ActionConstraint::any(),
             ResourceConstraint::any(),
             Expr::val(true),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2185,11 +2185,11 @@ impl Template {
                 })
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                TemplatePrincipalConstraint::Is(EntityTypeName::new(entity_type.clone()))
+                TemplatePrincipalConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 TemplatePrincipalConstraint::IsIn(
-                    EntityTypeName::new(entity_type.clone()),
+                    EntityTypeName::new(entity_type.as_ref().clone()),
                     match eref {
                         ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
                         ast::EntityReference::Slot => None,
@@ -2232,11 +2232,11 @@ impl Template {
                 })
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                TemplateResourceConstraint::Is(EntityTypeName::new(entity_type.clone()))
+                TemplateResourceConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 TemplateResourceConstraint::IsIn(
-                    EntityTypeName::new(entity_type.clone()),
+                    EntityTypeName::new(entity_type.as_ref().clone()),
                     match eref {
                         ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
                         ast::EntityReference::Slot => None,
@@ -2489,11 +2489,11 @@ impl Policy {
                 PrincipalConstraint::Eq(self.convert_entity_reference(eref, slot_id).clone())
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                PrincipalConstraint::Is(EntityTypeName::new(entity_type.clone()))
+                PrincipalConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 PrincipalConstraint::IsIn(
-                    EntityTypeName::new(entity_type.clone()),
+                    EntityTypeName::new(entity_type.as_ref().clone()),
                     self.convert_entity_reference(eref, slot_id).clone(),
                 )
             }
@@ -2528,11 +2528,11 @@ impl Policy {
                 ResourceConstraint::Eq(self.convert_entity_reference(eref, slot_id).clone())
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                ResourceConstraint::Is(EntityTypeName::new(entity_type.clone()))
+                ResourceConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 ResourceConstraint::IsIn(
-                    EntityTypeName::new(entity_type.clone()),
+                    EntityTypeName::new(entity_type.as_ref().clone()),
                     self.convert_entity_reference(eref, slot_id).clone(),
                 )
             }


### PR DESCRIPTION


## Description of changes

* Replace `PrincipalOrResourceConstraint::iter_euids` with `PrincipalOrResourceConstraint::get_euid`
  * The original function returns an iterator that works on at most one element. So, this PR replaces it with a function returning an `Option` so that we can pattern match the return value more conveniently.
* Wrap `Name` and `EntityUID` with `Arc`
   * They are mostly read only but can contain lots of bytes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

