### PR TITLE
Fix `arbitrary` feature build for `cedar-policy-validator`

### DIFF
--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -40,7 +40,7 @@ ipaddr = ["cedar-policy-core/ipaddr"]
 decimal = ["cedar-policy-core/decimal"]
 
 # Enables `Arbitrary` implementations for several types in this crate
-arbitrary = ["dep:arbitrary"]
+arbitrary = ["dep:arbitrary", "cedar-policy-core/arbitrary"]
 
 # Experimental features.
 partial-validate = []


### PR DESCRIPTION
## Description of changes

The `Arbitrary` impl for `Schema` uses the impl for `Name` in core, so the `arbitrary` feature for the validator packages should depend on the arbitrary feature in core.

This didn't matter for the DRT build because it separately enables the feature for core. It also doesn't matter for a `cargo build --features arbitrary` from the workspace root since the `--features arbitrary` gets applied to the core and validator build. It  only causes a build error for `cargo build --features arbitrary` in the validator crate.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

