### PR TITLE
Consistency pass over error types

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -275,11 +275,11 @@ impl TryFrom<PartialValue> for RestrictedExpr {
             PartialValue::Value(v) => Ok(RestrictedExpr::from(v)),
             PartialValue::Residual(expr) => match RestrictedExpr::new(expr) {
                 Ok(e) => Ok(e),
-                Err(RestrictedExprError::InvalidRestrictedExpression { expr, .. }) => {
-                    Err(PartialValueToRestrictedExprError::NontrivialResidual {
-                        residual: Box::new(expr),
-                    })
-                }
+                Err(RestrictedExprError::InvalidRestrictedExpression(
+                    restricted_expr_errors::InvalidRestrictedExpressionError { expr, .. },
+                )) => Err(PartialValueToRestrictedExprError::NontrivialResidual {
+                    residual: Box::new(expr),
+                }),
             },
         }
     }
@@ -456,50 +456,65 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExprError> {
     match expr.expr_kind() {
         ExprKind::Lit(_) => Ok(()),
         ExprKind::Unknown(_) => Ok(()),
-        ExprKind::Var(_) => Err(RestrictedExprError::InvalidRestrictedExpression {
+        ExprKind::Var(_) => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "variables".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::Slot(_) => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::Slot(_) => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "template slots".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::If { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::If { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "if-then-else".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::And { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::And { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "&&".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::Or { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::Or { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "||".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::UnaryApp { op, .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
-            feature: op.to_smolstr(),
-            expr: expr.clone(),
-        }),
-        ExprKind::BinaryApp { op, .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
-            feature: op.to_smolstr(),
-            expr: expr.clone(),
-        }),
-        ExprKind::GetAttr { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::UnaryApp { op, .. } => {
+            Err(restricted_expr_errors::InvalidRestrictedExpressionError {
+                feature: op.to_smolstr(),
+                expr: expr.clone(),
+            }
+            .into())
+        }
+        ExprKind::BinaryApp { op, .. } => {
+            Err(restricted_expr_errors::InvalidRestrictedExpressionError {
+                feature: op.to_smolstr(),
+                expr: expr.clone(),
+            }
+            .into())
+        }
+        ExprKind::GetAttr { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "attribute accesses".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::HasAttr { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::HasAttr { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "'has'".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::Like { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::Like { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "'like'".into(),
             expr: expr.clone(),
-        }),
-        ExprKind::Is { .. } => Err(RestrictedExprError::InvalidRestrictedExpression {
+        }
+        .into()),
+        ExprKind::Is { .. } => Err(restricted_expr_errors::InvalidRestrictedExpressionError {
             feature: "'is'".into(),
             expr: expr.clone(),
-        }),
+        }
+        .into()),
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
         ExprKind::Record(map) => map.values().try_for_each(is_restricted),
@@ -597,38 +612,55 @@ impl<'a> Hash for RestrictedExprShapeOnly<'a> {
 
 /// Error when constructing a restricted expression from unrestricted
 /// expression
-#[derive(Debug, Clone, PartialEq, Eq, Error)]
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
+#[derive(Debug, Clone, PartialEq, Eq, Error, Diagnostic)]
 pub enum RestrictedExprError {
     /// An expression was expected to be a "restricted" expression, but contained
-    /// a feature that is not allowed in restricted expressions. The `feature`
-    /// argument is a string description of the feature that is not allowed.
-    /// The `expr` argument is the expression that uses the disallowed feature.
-    /// Note that it is potentially a sub-expression of a larger expression.
-    #[error("not allowed to use {feature} in a restricted expression: `{expr}`")]
-    InvalidRestrictedExpression {
-        /// what disallowed feature appeared in the expression
-        feature: SmolStr,
-        /// the (sub-)expression that uses the disallowed feature
-        expr: Expr,
-    },
+    /// a feature that is not allowed in restricted expressions.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidRestrictedExpression(#[from] restricted_expr_errors::InvalidRestrictedExpressionError),
 }
 
-// custom impl of `Diagnostic`: take location info from the embedded subexpression
-impl Diagnostic for RestrictedExprError {
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        match self {
-            Self::InvalidRestrictedExpression { expr, .. } => expr.source_loc().map(|loc| {
-                Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span)))
-                    as Box<dyn Iterator<Item = _>>
-            }),
-        }
+/// Error subtypes for [`RestrictedExprError`]
+pub mod restricted_expr_errors {
+    use super::Expr;
+    use miette::Diagnostic;
+    use smol_str::SmolStr;
+    use thiserror::Error;
+
+    /// An expression was expected to be a "restricted" expression, but contained
+    /// a feature that is not allowed in restricted expressions.
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
+    #[derive(Debug, Clone, PartialEq, Eq, Error)]
+    #[error("not allowed to use {feature} in a restricted expression: `{expr}`")]
+    pub struct InvalidRestrictedExpressionError {
+        /// String description of what disallowed feature appeared in the expression
+        pub(crate) feature: SmolStr,
+        /// the (sub-)expression that uses the disallowed feature. This may be a
+        /// sub-expression of a larger expression.
+        pub(crate) expr: Expr,
     }
 
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        match self {
-            Self::InvalidRestrictedExpression { expr, .. } => expr
+    // custom impl of `Diagnostic`: take source location from the `expr` field
+    impl Diagnostic for InvalidRestrictedExpressionError {
+        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+            self.expr.source_loc().map(|loc| {
+                Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span)))
+                    as Box<dyn Iterator<Item = _>>
+            })
+        }
+
+        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+            self.expr
                 .source_loc()
-                .map(|loc| &loc.src as &dyn miette::SourceCode),
+                .map(|loc| &loc.src as &dyn miette::SourceCode)
         }
     }
 }

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -101,7 +101,7 @@ pub enum EvaluationError {
 
 impl EvaluationError {
     /// Extract the source location of the error, if one is attached
-    pub fn source_loc(&self) -> Option<&Loc> {
+    pub(crate) fn source_loc(&self) -> Option<&Loc> {
         match self {
             Self::EntityDoesNotExist(e) => e.source_loc.as_ref(),
             Self::EntityAttrDoesNotExist(e) => e.source_loc.as_ref(),
@@ -309,7 +309,7 @@ impl EvaluationError {
     }
 }
 
-/// Error subtypes for `EvaluationError`
+/// Error subtypes for [`EvaluationError`]
 pub mod evaluation_errors {
     use crate::ast::{BinaryOp, EntityUID, Expr, Name, SlotId, Type, UnaryOp, Value};
     use crate::parser::Loc;

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -211,7 +211,7 @@ impl ExtensionFunctionLookupError {
     }
 }
 
-/// Error subtypes for `ExtensionFunctionLookupError`
+/// Error subtypes for [`ExtensionFunctionLookupError`]
 pub mod extension_function_lookup_errors {
     use crate::ast::Name;
     use crate::entities::SchemaType;

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -672,7 +672,8 @@ pub fn expected_to_string(expected: &[String], config: &ExpectedTokenConfig) -> 
     Some(expected_string)
 }
 
-/// Multiple parse errors.
+/// Represents one or more [`ParseError`]s encountered when parsing a policy or
+/// template.
 //
 // CAUTION: this type is publicly exported in `cedar-policy`.
 // Don't make fields `pub`, don't make breaking changes, and use caution when

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use cedar_policy_core::{ast::EntityUID, transitive_closure};
 use miette::Diagnostic;
 use thiserror::Error;
 
@@ -23,7 +24,7 @@ use crate::human_schema;
 pub enum HumanSchemaError {
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Core(#[from] schema_error::SchemaError),
+    Schema(#[from] SchemaError),
     #[error(transparent)]
     IO(#[from] std::io::Error),
     #[error(transparent)]
@@ -105,7 +106,131 @@ impl HumanSyntaxParseError {
     }
 }
 
-pub mod schema_error {
+/// Error when constructing a schema
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
+#[derive(Debug, Diagnostic, Error)]
+pub enum SchemaError {
+    /// Error thrown by the `serde_json` crate during serialization
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    JsonSerialization(#[from] schema_errors::JsonSerializationError),
+    /// This error is thrown when `serde_json` fails to deserialize the JSON
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    JsonDeserialization(#[from] schema_errors::JsonDeserializationError),
+    /// Errors occurring while computing or enforcing transitive closure on
+    /// action hierarchy.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ActionTransitiveClosure(#[from] schema_errors::ActionTransitiveClosureError),
+    /// Errors occurring while computing or enforcing transitive closure on
+    /// entity type hierarchy.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    EntityTypeTransitiveClosure(#[from] schema_errors::EntityTypeTransitiveClosureError),
+    /// Error generated when processing a schema file that uses unsupported features
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnsupportedFeature(#[from] schema_errors::UnsupportedFeatureError),
+    /// Undeclared entity type(s) used in the `memberOf` field of an entity
+    /// type, the `appliesTo` fields of an action, or an attribute type in a
+    /// context or entity attribute record. Entity types in the error message
+    /// are fully qualified, including any implicit or explicit namespaces.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UndeclaredEntityTypes(#[from] schema_errors::UndeclaredEntityTypesError),
+    /// Undeclared action(s) used in the `memberOf` field of an action.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UndeclaredActions(#[from] schema_errors::UndeclaredActionsError),
+    /// This error occurs in either of the following cases (see discussion on #477):
+    ///     - undeclared common type(s) appearing in entity or context attributes
+    ///     - common type(s) (declared or not) appearing in declarations of other common types
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UndeclaredCommonTypes(#[from] schema_errors::UndeclaredCommonTypesError),
+    /// Duplicate specifications for an entity type. Argument is the name of
+    /// the duplicate entity type.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    DuplicateEntityType(#[from] schema_errors::DuplicateEntityTypeError),
+    /// Duplicate specifications for an action. Argument is the name of the
+    /// duplicate action.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    DuplicateAction(#[from] schema_errors::DuplicateActionError),
+    /// Duplicate specification for a reusable type declaration.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    DuplicateCommonType(#[from] schema_errors::DuplicateCommonTypeError),
+    /// Cycle in the schema's action hierarchy.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CycleInActionHierarchy(#[from] schema_errors::CycleInActionHierarchyError),
+    /// Cycle in the schema's common type declarations.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CycleInCommonTypeReferences(#[from] schema_errors::CycleInCommonTypeReferencesError),
+    /// The schema file included an entity type `Action` in the entity type
+    /// list. The `Action` entity type is always implicitly declared, and it
+    /// cannot currently have attributes or be in any groups, so there is no
+    /// purposes in adding an explicit entry.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ActionEntityTypeDeclared(#[from] schema_errors::ActionEntityTypeDeclaredError),
+    /// `context` or `shape` fields are not records
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ContextOrShapeNotRecord(#[from] schema_errors::ContextOrShapeNotRecordError),
+    /// An action entity (transitively) has an attribute that is an empty set.
+    /// The validator cannot assign a type to an empty set.
+    /// This error variant should only be used when `PermitAttributes` is enabled.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ActionAttributesContainEmptySet(#[from] schema_errors::ActionAttributesContainEmptySetError),
+    /// An action entity (transitively) has an attribute of unsupported type (`ExprEscape`, `EntityEscape` or `ExtnEscape`).
+    /// This error variant should only be used when `PermitAttributes` is enabled.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnsupportedActionAttribute(#[from] schema_errors::UnsupportedActionAttributeError),
+    /// Error when evaluating an action attribute
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ActionAttrEval(#[from] schema_errors::ActionAttrEvalError),
+    /// Error thrown when the schema contains the `__expr` escape.
+    /// Support for this escape form has been dropped.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ExprEscapeUsed(#[from] schema_errors::ExprEscapeUsedError),
+    /// The schema used an extension type that the validator doesn't know about.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnknownExtensionType(schema_errors::UnknownExtensionTypeError),
+}
+
+impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
+    fn from(e: transitive_closure::TcError<EntityUID>) -> Self {
+        // we use code in transitive_closure to check for cycles in the action
+        // hierarchy, but in case of an error we want to report the more descriptive
+        // CycleInActionHierarchy instead of ActionTransitiveClosureError
+        match e {
+            transitive_closure::TcError::MissingTcEdge { .. } => {
+                SchemaError::ActionTransitiveClosure(Box::new(e).into())
+            }
+            transitive_closure::TcError::HasCycle(err) => {
+                schema_errors::CycleInActionHierarchyError(err.vertex_with_loop().clone()).into()
+            }
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, SchemaError>;
+
+/// Error subtypes for [`SchemaError`]
+pub mod schema_errors {
     use std::{collections::HashSet, fmt::Display};
 
     use cedar_policy_core::{
@@ -118,11 +243,19 @@ pub mod schema_error {
     use thiserror::Error;
 
     /// JSON deserialization error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error(transparent)]
     pub struct JsonSerializationError(#[from] pub(crate) serde_json::Error);
 
     /// Transitive closure of action hierarchy computation or enforcement error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("transitive closure computation/enforcement error on action hierarchy: {0}")]
     #[diagnostic(transparent)]
@@ -131,6 +264,10 @@ pub mod schema_error {
     );
 
     /// Transitive closure of entity type hierarchy computation or enforcement error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("transitive closure computation/enforcement error on entity type hierarchy: {0}")]
     #[diagnostic(transparent)]
@@ -139,6 +276,10 @@ pub mod schema_error {
     );
 
     /// Undeclared entity types error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("undeclared entity type(s): {0:?}")]
     #[diagnostic(help(
@@ -147,48 +288,84 @@ pub mod schema_error {
     pub struct UndeclaredEntityTypesError(pub(crate) HashSet<Name>);
 
     /// Undeclared actions error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("undeclared action(s): {0:?}")]
     #[diagnostic(help("any actions appearing in `memberOf` need to be declared in `actions`"))]
     pub struct UndeclaredActionsError(pub(crate) HashSet<SmolStr>);
 
     /// Undeclared common types error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("undeclared common type(s), or common type(s) used in the declaration of another common type: {0:?}")]
     #[diagnostic(help("any common types used in entity or context attributes need to be declared in `commonTypes`, and currently, common types may not reference other common types"))]
     pub struct UndeclaredCommonTypesError(pub(crate) HashSet<Name>);
 
     /// Duplicate entity type error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("duplicate entity type `{0}`")]
     pub struct DuplicateEntityTypeError(pub(crate) Name);
 
     /// Duplicate action error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("duplicate action `{0}`")]
     pub struct DuplicateActionError(pub(crate) SmolStr);
 
     /// Duplicate common type error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("duplicate common type type `{0}`")]
     pub struct DuplicateCommonTypeError(pub(crate) Name);
 
     /// Cycle in action hierarchy error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("cycle in action hierarchy containing `{0}`")]
     pub struct CycleInActionHierarchyError(pub(crate) EntityUID);
 
     /// Cycle in common type hierarchy error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("cycle in common type references containing `{0}`")]
     pub struct CycleInCommonTypeReferencesError(pub(crate) Name);
 
     /// Action declared in `entityType` list error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Clone, Diagnostic, Error)]
     #[error("entity type `Action` declared in `entityTypes` list")]
     pub struct ActionEntityTypeDeclaredError {}
 
     /// Context or entity type shape not declared as record error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("{0} is declared with a type other than `Record`")]
     #[diagnostic(help("{}", match .0 {
@@ -198,6 +375,10 @@ pub mod schema_error {
     pub struct ContextOrShapeNotRecordError(pub(crate) ContextOrShape);
 
     /// Action attributes contain empty set error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("action `{0}` has an attribute that is an empty set")]
     #[diagnostic(help(
@@ -206,145 +387,43 @@ pub mod schema_error {
     pub struct ActionAttributesContainEmptySetError(pub(crate) EntityUID);
 
     /// Unsupported action attribute error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("action `{0}` has an attribute with unsupported JSON representation: {1}")]
     pub struct UnsupportedActionAttributeError(pub(crate) EntityUID, pub(crate) SmolStr);
 
     /// Unsupported `__expr` escape error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Clone, Diagnostic, Error)]
     #[error("the `__expr` escape is no longer supported")]
     #[diagnostic(help("to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"))]
     pub struct ExprEscapeUsedError {}
 
     /// Action attribute evaluation error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error(transparent)]
     #[diagnostic(transparent)]
     pub struct ActionAttrEvalError(#[from] pub(crate) EntityAttrEvaluationError);
 
     /// Unsupported feature error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("unsupported feature used in schema: {0}")]
     #[diagnostic(transparent)]
     pub struct UnsupportedFeatureError(#[from] pub(crate) UnsupportedFeature);
-
-    #[derive(Debug, Diagnostic, Error)]
-    pub enum SchemaError {
-        /// Error thrown by the `serde_json` crate during serialization
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        JsonSerialization(#[from] JsonSerializationError),
-        /// This error is thrown when `serde_json` fails to deserialize the JSON
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        JsonDeserialization(#[from] JsonDeserializationError),
-        /// Errors occurring while computing or enforcing transitive closure on
-        /// action hierarchy.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ActionTransitiveClosure(#[from] ActionTransitiveClosureError),
-        /// Errors occurring while computing or enforcing transitive closure on
-        /// entity type hierarchy.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        EntityTypeTransitiveClosure(#[from] EntityTypeTransitiveClosureError),
-        /// Error generated when processing a schema file that uses unsupported features
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        UnsupportedFeature(#[from] UnsupportedFeatureError),
-        /// Undeclared entity type(s) used in the `memberOf` field of an entity
-        /// type, the `appliesTo` fields of an action, or an attribute type in a
-        /// context or entity attribute record. Entity types in the error message
-        /// are fully qualified, including any implicit or explicit namespaces.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        UndeclaredEntityTypes(#[from] UndeclaredEntityTypesError),
-        /// Undeclared action(s) used in the `memberOf` field of an action.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        UndeclaredActions(#[from] UndeclaredActionsError),
-        /// This error occurs in either of the following cases (see discussion on #477):
-        ///     - undeclared common type(s) appearing in entity or context attributes
-        ///     - common type(s) (declared or not) appearing in declarations of other common types
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        UndeclaredCommonTypes(#[from] UndeclaredCommonTypesError),
-        /// Duplicate specifications for an entity type. Argument is the name of
-        /// the duplicate entity type.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        DuplicateEntityType(#[from] DuplicateEntityTypeError),
-        /// Duplicate specifications for an action. Argument is the name of the
-        /// duplicate action.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        DuplicateAction(#[from] DuplicateActionError),
-        /// Duplicate specification for a reusable type declaration.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        DuplicateCommonType(#[from] DuplicateCommonTypeError),
-        /// Cycle in the schema's action hierarchy.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        CycleInActionHierarchy(#[from] CycleInActionHierarchyError),
-        /// Cycle in the schema's common type declarations.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        CycleInCommonTypeReferences(#[from] CycleInCommonTypeReferencesError),
-        /// The schema file included an entity type `Action` in the entity type
-        /// list. The `Action` entity type is always implicitly declared, and it
-        /// cannot currently have attributes or be in any groups, so there is no
-        /// purposes in adding an explicit entry.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ActionEntityTypeDeclared(#[from] ActionEntityTypeDeclaredError),
-        /// `context` or `shape` fields are not records
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ContextOrShapeNotRecord(#[from] ContextOrShapeNotRecordError),
-        /// An action entity (transitively) has an attribute that is an empty set.
-        /// The validator cannot assign a type to an empty set.
-        /// This error variant should only be used when `PermitAttributes` is enabled.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ActionAttributesContainEmptySet(#[from] ActionAttributesContainEmptySetError),
-        /// An action entity (transitively) has an attribute of unsupported type (`ExprEscape`, `EntityEscape` or `ExtnEscape`).
-        /// This error variant should only be used when `PermitAttributes` is enabled.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        UnsupportedActionAttribute(#[from] UnsupportedActionAttributeError),
-        /// Error when evaluating an action attribute
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ActionAttrEval(#[from] ActionAttrEvalError),
-        /// Error thrown when the schema contains the `__expr` escape.
-        /// Support for this escape form has been dropped.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ExprEscapeUsed(#[from] ExprEscapeUsedError),
-        /// The schema used an extension type that the validator doesn't know about.
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        UnknownExtensionType(UnknownExtensionTypeError),
-    }
-
-    impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
-        fn from(e: transitive_closure::TcError<EntityUID>) -> Self {
-            // we use code in transitive_closure to check for cycles in the action
-            // hierarchy, but in case of an error we want to report the more descriptive
-            // CycleInActionHierarchy instead of ActionTransitiveClosureError
-            match e {
-                transitive_closure::TcError::MissingTcEdge { .. } => {
-                    SchemaError::ActionTransitiveClosure(Box::new(e).into())
-                }
-                transitive_closure::TcError::HasCycle(err) => {
-                    CycleInActionHierarchyError(err.vertex_with_loop().clone()).into()
-                }
-            }
-        }
-    }
-
-    pub type Result<T> = std::result::Result<T, SchemaError>;
 
     #[derive(Debug)]
     pub(crate) enum ContextOrShape {
@@ -373,6 +452,10 @@ pub mod schema_error {
     }
 
     /// This error is thrown when `serde_json` fails to deserialize the JSON
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Debug, Error)]
     #[error("failed to parse schema in JSON format: {err}")]
     pub struct JsonDeserializationError {
@@ -419,6 +502,11 @@ pub mod schema_error {
         }
     }
 
+    /// Unknown extension type error
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
     #[derive(Error, Debug)]
     #[error("unknown extension type `{actual}`")]
     pub struct UnknownExtensionTypeError {

--- a/cedar-policy-validator/src/human_schema.rs
+++ b/cedar-policy-validator/src/human_schema.rs
@@ -22,4 +22,4 @@ pub mod parser;
 mod test;
 pub mod to_json_schema;
 pub use err::ParseError;
-pub use err::SchemaWarning;
+pub use err::{schema_warnings, SchemaWarning};

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -1742,9 +1742,8 @@ mod common_type_references {
     use cool_asserts::assert_matches;
 
     use crate::{
-        schema_error::SchemaError,
         types::{AttributeType, EntityRecordKind, Type},
-        SchemaFragment, ValidatorSchema,
+        SchemaError, SchemaFragment, ValidatorSchema,
     };
 
     #[test]

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -36,10 +36,7 @@ use super::{
         ActionDecl, AppDecl, AttrDecl, Decl, Declaration, EntityDecl, Namespace, PRAppDecl,
         QualName, Schema, Type, TypeDecl, BUILTIN_TYPES, CEDAR_NAMESPACE, EXTENSIONS, PR,
     },
-    err::{
-        SchemaWarning, ShadowsBuiltinWarning, ShadowsEntityWarning, ToJsonSchemaError,
-        ToJsonSchemaErrors,
-    },
+    err::{schema_warnings, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors},
 };
 
 /// Convert a custom schema AST into the JSON representation
@@ -607,7 +604,7 @@ fn make_warning_for_shadowing(n: &NamespaceRecord) -> impl Iterator<Item = Schem
     for (common_name, common_src_node) in n.common_types.iter() {
         // Check if it shadows a entity name in the same namespace
         if let Some(entity_src_node) = n.entities.get(common_name) {
-            let warning = ShadowsEntityWarning {
+            let warning = schema_warnings::ShadowsEntityWarning {
                 name: common_name.to_smolstr(),
                 entity_loc: entity_src_node.loc.clone(),
                 common_loc: common_src_node.loc.clone(),
@@ -635,7 +632,7 @@ fn extract_name<N: Clone>(n: Node<N>) -> (N, Node<()>) {
 fn shadows_builtin((name, node): (&Id, &Node<()>)) -> Option<SchemaWarning> {
     if EXTENSIONS.contains(&name.as_ref()) || BUILTIN_TYPES.contains(&name.as_ref()) {
         Some(
-            ShadowsBuiltinWarning {
+            schema_warnings::ShadowsBuiltinWarning {
                 name: name.to_smolstr(),
                 loc: node.loc.clone(),
             }

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -192,18 +192,17 @@ impl Validator {
 
 #[cfg(test)]
 mod test {
+    use itertools::Itertools;
     use std::{collections::HashMap, sync::Arc};
 
     use crate::types::Type;
+    use crate::Result;
 
     use super::*;
     use cedar_policy_core::{
         ast::{self, Expr, PolicyID},
         parser::{self, Loc},
     };
-    use itertools::Itertools;
-
-    use crate::schema_error::Result;
 
     #[test]
     fn top_level_validate() -> Result<()> {

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -482,7 +482,6 @@ mod test {
 
     use super::*;
     use crate::{
-        err::schema_error::*,
         schema_file_format::{NamespaceDefinition, *},
         validation_errors::{UnrecognizedEntityType, UnspecifiedEntity},
         ValidationMode, ValidationWarning, Validator,
@@ -491,7 +490,7 @@ mod test {
     use cool_asserts::assert_matches;
 
     #[test]
-    fn validate_entity_type_empty_schema() -> Result<()> {
+    fn validate_entity_type_empty_schema() {
         let src = r#"permit(principal, action, resource == foo_type::"foo_name");"#;
         let policy = parse_policy_template(None, src).unwrap();
         let validate = Validator::new(ValidatorSchema::empty());
@@ -506,8 +505,6 @@ mod test {
             .build(),
         );
         assert_eq!(notes.len(), 1, "{:?}", notes);
-
-        Ok(())
     }
 
     #[test]
@@ -558,7 +555,7 @@ mod test {
     }
 
     #[test]
-    fn validate_entity_type_in_singleton_schema() -> Result<()> {
+    fn validate_entity_type_in_singleton_schema() {
         let foo_type = "foo_type";
         let schema_file = NamespaceDefinition::new(
             [(
@@ -590,12 +587,10 @@ mod test {
             validate.validate_entity_types(&policy).next().is_none(),
             "Did not expect any validation errors."
         );
-
-        Ok(())
     }
 
     #[test]
-    fn validate_entity_type_not_in_singleton_schema() -> Result<()> {
+    fn validate_entity_type_not_in_singleton_schema() {
         let schema_file = NamespaceDefinition::new(
             [(
                 "foo_type".parse().unwrap(),
@@ -623,12 +618,10 @@ mod test {
             .build(),
         );
         assert_eq!(notes.len(), 1, "{:?}", notes);
-
-        Ok(())
     }
 
     #[test]
-    fn validate_action_id_empty_schema() -> Result<()> {
+    fn validate_action_id_empty_schema() {
         let src = r#"permit(principal, action == Action::"foo_name", resource);"#;
         let policy = parse_policy_template(None, src).unwrap();
         let validate = Validator::new(ValidatorSchema::empty());
@@ -643,12 +636,10 @@ mod test {
             .build(),
         );
         assert_eq!(notes.len(), 1, "{:?}", notes);
-
-        Ok(())
     }
 
     #[test]
-    fn validate_action_id_in_singleton_schema() -> Result<()> {
+    fn validate_action_id_in_singleton_schema() {
         let foo_name = "foo_name";
         let schema_file = NamespaceDefinition::new(
             [],
@@ -680,8 +671,6 @@ mod test {
             validate.validate_action_ids(&policy).next().is_none(),
             "Did not expect any validation errors."
         );
-
-        Ok(())
     }
 
     #[test]
@@ -733,7 +722,7 @@ mod test {
     }
 
     #[test]
-    fn undefined_entity_type_in_principal_slot() -> Result<()> {
+    fn undefined_entity_type_in_principal_slot() {
         let p_name = "User";
         let schema_file = NamespaceDefinition::new(
             [(
@@ -774,12 +763,10 @@ mod test {
             }
             _ => panic!("Unexpected variant of ValidationErrorKind."),
         };
-
-        Ok(())
     }
 
     #[test]
-    fn validate_action_id_not_in_singleton_schema() -> Result<()> {
+    fn validate_action_id_not_in_singleton_schema() {
         let schema_file = NamespaceDefinition::new(
             [],
             [(
@@ -808,11 +795,10 @@ mod test {
             .build(),
         );
         assert_eq!(notes.len(), 1, "{:?}", notes);
-        Ok(())
     }
 
     #[test]
-    fn validate_namespaced_action_id_in_schema() -> Result<()> {
+    fn validate_namespaced_action_id_in_schema() {
         let descriptors: SchemaFragment = serde_json::from_str(
             r#"
                 {
@@ -841,11 +827,10 @@ mod test {
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> = validate.validate_action_ids(&policy).collect();
         assert_eq!(notes, vec![], "Did not expect any invalid action.");
-        Ok(())
     }
 
     #[test]
-    fn validate_namespaced_invalid_action() -> Result<()> {
+    fn validate_namespaced_invalid_action() {
         let descriptors: SchemaFragment = serde_json::from_str(
             r#"
                 {
@@ -873,12 +858,10 @@ mod test {
             .build(),
         );
         assert_eq!(notes.len(), 1, "{:?}", notes);
-
-        Ok(())
     }
 
     #[test]
-    fn validate_namespaced_entity_type_in_schema() -> Result<()> {
+    fn validate_namespaced_entity_type_in_schema() {
         let descriptors: SchemaFragment = serde_json::from_str(
             r#"
                 {
@@ -910,11 +893,10 @@ mod test {
         let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
 
         assert_eq!(notes, vec![], "Did not expect any invalid action.");
-        Ok(())
     }
 
     #[test]
-    fn validate_namespaced_invalid_entity_type() -> Result<()> {
+    fn validate_namespaced_invalid_entity_type() {
         let descriptors: SchemaFragment = serde_json::from_str(
             r#"
                 {
@@ -942,12 +924,10 @@ mod test {
             .build(),
         );
         assert_eq!(notes.len(), 1, "{:?}", notes);
-
-        Ok(())
     }
 
     #[test]
-    fn get_possible_actions_eq() -> Result<()> {
+    fn get_possible_actions_eq() {
         let foo_name = "foo_name";
         let euid_foo =
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
@@ -971,12 +951,10 @@ mod test {
             .get_actions_satisfying_constraint(&action_constraint)
             .collect();
         assert_eq!(HashSet::from([&euid_foo]), actions);
-
-        Ok(())
     }
 
     #[test]
-    fn get_possible_actions_in_no_parents() -> Result<()> {
+    fn get_possible_actions_in_no_parents() {
         let foo_name = "foo_name";
         let euid_foo =
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
@@ -1000,12 +978,10 @@ mod test {
             .get_actions_satisfying_constraint(&action_constraint)
             .collect();
         assert_eq!(HashSet::from([&euid_foo]), actions);
-
-        Ok(())
     }
 
     #[test]
-    fn get_possible_actions_in_set_no_parents() -> Result<()> {
+    fn get_possible_actions_in_set_no_parents() {
         let foo_name = "foo_name";
         let euid_foo =
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
@@ -1029,12 +1005,10 @@ mod test {
             .get_actions_satisfying_constraint(&action_constraint)
             .collect();
         assert_eq!(HashSet::from([&euid_foo]), actions);
-
-        Ok(())
     }
 
     #[test]
-    fn get_possible_principals_eq() -> Result<()> {
+    fn get_possible_principals_eq() {
         let foo_type = "foo_type";
         let euid_foo = EntityUID::with_eid_and_type(foo_type, "foo_name")
             .expect("should be a valid identifier");
@@ -1059,8 +1033,6 @@ mod test {
             .map(cedar_policy_core::ast::EntityType::Specified)
             .collect::<HashSet<_>>();
         assert_eq!(HashSet::from([euid_foo.components().0]), principals);
-
-        Ok(())
     }
 
     fn schema_with_single_principal_action_resource(
@@ -1162,7 +1134,7 @@ mod test {
     }
 
     #[test]
-    fn validate_action_apply_correct() -> Result<()> {
+    fn validate_action_apply_correct() {
         let (principal, action, resource, schema) = schema_with_single_principal_action_resource();
 
         let policy = Template::new(
@@ -1178,7 +1150,6 @@ mod test {
 
         let validator = Validator::new(schema);
         assert_validate_policy_succeeds(&validator, &policy);
-        Ok(())
     }
 
     #[test]
@@ -1448,7 +1419,7 @@ mod test {
     }
 
     #[test]
-    fn test_with_tc_computation() -> Result<()> {
+    fn test_with_tc_computation() {
         let action_name = "foo";
         let action_parent_name = "foo_parent";
         let action_grandparent_name = "foo_grandparent";
@@ -1548,11 +1519,10 @@ mod test {
 
         let validator = Validator::new(schema);
         assert_validate_policy_succeeds(&validator, &policy);
-        Ok(())
     }
 
     #[test]
-    fn unspecified_entity_in_scope() -> Result<()> {
+    fn unspecified_entity_in_scope() {
         // Note: it's not possible to create an unspecified entity through the parser,
         // so we have to test using manually-constructed policies.
         let validate = Validator::new(ValidatorSchema::empty());
@@ -1596,12 +1566,10 @@ mod test {
                 assert_eq!("foo", eid);
             }
         );
-
-        Ok(())
     }
 
     #[test]
-    fn unspecified_entity_in_additional_constraints() -> Result<()> {
+    fn unspecified_entity_in_additional_constraints() {
         let validate = Validator::new(ValidatorSchema::empty());
 
         // resource == Unspecified::"foo"
@@ -1628,8 +1596,6 @@ mod test {
                 assert_eq!("foo", eid);
             }
         );
-
-        Ok(())
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -34,7 +34,7 @@ use smol_str::ToSmolStr;
 
 use super::NamespaceDefinition;
 use crate::{
-    err::schema_error::*,
+    err::schema_errors::*,
     err::*,
     human_schema::SchemaWarning,
     types::{Attributes, EntityRecordKind, OpenTag, Type},
@@ -2338,9 +2338,7 @@ mod test_resolver {
     use cool_asserts::assert_matches;
 
     use super::CommonTypeResolver;
-    use crate::{
-        err::schema_error::SchemaError, types::Type, SchemaFragment, ValidatorSchemaFragment,
-    };
+    use crate::{err::SchemaError, types::Type, SchemaFragment, ValidatorSchemaFragment};
 
     fn resolve(schema: SchemaFragment) -> Result<HashMap<Name, Type>, SchemaError> {
         let schema: ValidatorSchemaFragment = schema.try_into().unwrap();

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -34,7 +34,7 @@ use smol_str::{SmolStr, ToSmolStr};
 
 use super::ValidatorApplySpec;
 use crate::{
-    err::schema_error::*,
+    err::{schema_errors::*, Result, SchemaError},
     schema_file_format,
     types::{AttributeType, Attributes, Type},
     ActionBehavior, ActionEntityUID, ActionType, NamespaceDefinition, SchemaType,

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -29,7 +29,7 @@ use smol_str::{SmolStr, ToSmolStr};
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::{
-    err::schema_error::*,
+    err::{schema_errors::*, Result},
     human_schema::{
         self, parser::parse_natural_schema_fragment, SchemaWarning, ToHumanSchemaStrError,
     },

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -34,10 +34,9 @@ use super::test_utils::{
 };
 use crate::{
     diagnostics::ValidationError,
-    schema_error::SchemaError,
     types::{EntityLUB, Type},
     validation_errors::AttributeAccess,
-    SchemaFragment, ValidationWarning, ValidatorSchema,
+    SchemaError, SchemaFragment, ValidationWarning, ValidatorSchema,
 };
 
 fn namespaced_entity_type_schema() -> SchemaFragment {

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -16,21 +16,19 @@
 
 //! This module defines the publicly exported error types.
 
-use crate::EntityUid;
-use crate::PolicyId;
-use cedar_policy_core::ast;
-pub use cedar_policy_core::ast::RestrictedExpressionParseError;
-use cedar_policy_core::authorizer;
-use cedar_policy_core::est;
+use crate::{EntityUid, PolicyId};
+pub use cedar_policy_core::ast::{
+    restricted_expr_errors, RestrictedExprError, RestrictedExpressionParseError,
+};
 pub use cedar_policy_core::evaluator::{evaluation_errors, EvaluationError};
 pub use cedar_policy_core::extensions::{
     extension_function_lookup_errors, ExtensionFunctionLookupError,
 };
 pub use cedar_policy_core::parser::err::{ParseError, ParseErrors};
-pub use cedar_policy_validator::human_schema::SchemaWarning;
-pub use cedar_policy_validator::schema_error;
+use cedar_policy_core::{ast, authorizer, est};
+pub use cedar_policy_validator::human_schema::{schema_warnings, SchemaWarning};
+pub use cedar_policy_validator::{schema_errors, SchemaError};
 use miette::Diagnostic;
-use ref_cast::RefCast;
 use smol_str::SmolStr;
 use thiserror::Error;
 
@@ -40,74 +38,82 @@ pub enum AuthorizationError {
     /// An error occurred when evaluating a policy.
     #[error(transparent)]
     #[diagnostic(transparent)]
-    PolicyEvaluationError(#[from] PolicyEvaluationError),
+    PolicyEvaluationError(#[from] authorization_errors::PolicyEvaluationError),
 }
 
-impl AuthorizationError {
-    /// Get the id of the erroring policy
-    pub fn id(&self) -> &PolicyId {
-        match self {
-            Self::PolicyEvaluationError(e) => e.id(),
+/// Error subtypes for [`AuthorizationError`]
+pub mod authorization_errors {
+    use crate::{EvaluationError, PolicyId};
+    use cedar_policy_core::{ast, authorizer};
+    use miette::Diagnostic;
+    use ref_cast::RefCast;
+    use thiserror::Error;
+
+    /// An error occurred when evaluating a policy
+    #[derive(Debug, Diagnostic, PartialEq, Eq, Error, Clone)]
+    #[error("while evaluating policy `{id}`: {error}")]
+    pub struct PolicyEvaluationError {
+        /// Id of the policy with an error
+        id: ast::PolicyID,
+        /// Underlying evaluation error
+        #[diagnostic(transparent)]
+        error: EvaluationError,
+    }
+
+    impl PolicyEvaluationError {
+        /// Get the [`PolicyId`] of the erroring policy
+        pub fn policy_id(&self) -> &PolicyId {
+            PolicyId::ref_cast(&self.id)
+        }
+
+        /// Get the underlying [`EvaluationError`]
+        pub fn inner(&self) -> &EvaluationError {
+            &self.error
+        }
+
+        /// Consume this error, producing the underlying [`EvaluationError`]
+        pub fn into_inner(self) -> EvaluationError {
+            self.error
         }
     }
-}
 
-/// An error occurred when evaluating a policy
-#[derive(Debug, Diagnostic, PartialEq, Eq, Error, Clone)]
-#[error("while evaluating policy `{id}`: {error}")]
-pub struct PolicyEvaluationError {
-    /// Id of the policy with an error
-    id: ast::PolicyID,
-    /// Underlying evaluation error
-    #[diagnostic(transparent)]
-    error: EvaluationError,
-}
-
-impl PolicyEvaluationError {
-    /// Get the [`PolicyId`] of the erroring policy
-    pub fn id(&self) -> &PolicyId {
-        PolicyId::ref_cast(&self.id)
-    }
-
-    /// Get the underlying [`EvaluationError`]
-    pub fn inner(&self) -> &EvaluationError {
-        &self.error
-    }
-
-    /// Consume this error, producing the underlying [`EvaluationError`]
-    pub fn into_inner(self) -> EvaluationError {
-        self.error
+    #[doc(hidden)]
+    impl From<authorizer::AuthorizationError> for PolicyEvaluationError {
+        fn from(e: authorizer::AuthorizationError) -> Self {
+            match e {
+                authorizer::AuthorizationError::PolicyEvaluationError { id, error } => {
+                    Self { id, error }
+                }
+            }
+        }
     }
 }
 
 #[doc(hidden)]
 impl From<authorizer::AuthorizationError> for AuthorizationError {
     fn from(value: authorizer::AuthorizationError) -> Self {
-        match value {
-            authorizer::AuthorizationError::PolicyEvaluationError { id, error } => {
-                Self::PolicyEvaluationError(PolicyEvaluationError { id, error })
-            }
-        }
+        Self::PolicyEvaluationError(value.into())
     }
 }
 
 /// Errors that can be encountered when re-evaluating a partial response
-#[derive(Debug, Error)]
-pub enum ReAuthorizeError {
+#[derive(Debug, Diagnostic, Error)]
+pub enum ReauthorizationError {
     /// An evaluation error was encountered
-    #[error("{err}")]
-    Evaluation {
-        /// The evaluation error
-        #[from]
-        err: EvaluationError,
-    },
-    /// A policy id conflict was found
-    #[error("{err}")]
-    PolicySet {
-        /// The conflicting ids
-        #[from]
-        err: cedar_policy_core::ast::PolicySetError,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Evaluation(#[from] EvaluationError),
+    /// A policy set error was encountered
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PolicySet(#[from] PolicySetError),
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_core::ast::PolicySetError> for ReauthorizationError {
+    fn from(e: cedar_policy_core::ast::PolicySetError) -> Self {
+        Self::PolicySet(e.into())
+    }
 }
 
 /// Errors serializing Schemas to the natural syntax
@@ -159,24 +165,18 @@ impl From<cedar_policy_validator::human_schema::ToHumanSchemaStrError> for ToHum
     }
 }
 
-mod human_schema_error {
-    use crate::schema_error::SchemaError;
+/// Error subtypes for [`HumanSchemaError`]
+pub mod human_schema_errors {
     use miette::Diagnostic;
     use thiserror::Error;
 
-    /// Parsing errors for human-readable schemas
+    /// Error parsing a schema in human-readable syntax
     #[derive(Debug, Error, Diagnostic)]
     #[error(transparent)]
     #[diagnostic(transparent)]
     pub struct ParseError(#[from] pub(super) cedar_policy_validator::HumanSyntaxParseError);
 
-    /// Errors when converting parsed human-readable schemas into full schemas
-    #[derive(Debug, Error, Diagnostic)]
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    pub struct CoreError(#[from] pub(super) SchemaError);
-
-    /// IO errors when parsing human-readable schemas
+    /// IO error while parsing a human-readable schema
     #[derive(Debug, Error, Diagnostic)]
     #[error(transparent)]
     pub struct IoError(#[from] pub(super) std::io::Error);
@@ -184,42 +184,34 @@ mod human_schema_error {
 
 /// Errors when parsing schemas
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum HumanSchemaError {
-    /// Error parsing a schema in natural syntax
+    /// Error parsing a schema in human-readable syntax
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Parse(#[from] human_schema_error::ParseError),
-    /// Errors combining fragments into full schemas
+    Parse(#[from] human_schema_errors::ParseError),
+    /// IO error while parsing a human-readable schema
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Core(#[from] human_schema_error::CoreError),
-    /// IO errors while parsing
+    Io(#[from] human_schema_errors::IoError),
+    /// Encountered a `SchemaError` while parsing a human-readable schema
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Io(#[from] human_schema_error::IoError),
+    Schema(#[from] SchemaError),
 }
 
 #[doc(hidden)]
 impl From<cedar_policy_validator::HumanSchemaError> for HumanSchemaError {
     fn from(value: cedar_policy_validator::HumanSchemaError) -> Self {
         match value {
-            cedar_policy_validator::HumanSchemaError::Core(core) => {
-                human_schema_error::CoreError(core).into()
-            }
-            cedar_policy_validator::HumanSchemaError::IO(io_err) => {
-                human_schema_error::IoError(io_err).into()
+            cedar_policy_validator::HumanSchemaError::Schema(e) => e.into(),
+            cedar_policy_validator::HumanSchemaError::IO(e) => {
+                human_schema_errors::IoError(e).into()
             }
             cedar_policy_validator::HumanSchemaError::Parsing(e) => {
-                human_schema_error::ParseError(e).into()
+                human_schema_errors::ParseError(e).into()
             }
         }
-    }
-}
-
-#[doc(hidden)]
-impl From<crate::schema_error::SchemaError> for HumanSchemaError {
-    fn from(value: crate::schema_error::SchemaError) -> Self {
-        human_schema_error::CoreError(value).into()
     }
 }
 
@@ -264,15 +256,12 @@ impl From<ast::EntityAttrEvaluationError> for EntityAttrEvaluationError {
     }
 }
 
-/// This module contains definitions for structs containing detailed information
-/// about each validation error. Errors are primarily documented on their
-/// variants in [`ValidationError`].
+/// Error subtypes for [`ValidationError`].
+/// Errors are primarily documented on their variants in [`ValidationError`].
 pub mod validation_errors;
 
 /// An error generated by the validator when it finds a potential problem in a
-/// policy. The error contains a enumeration that specifies the kind of problem,
-/// and provides details specific to that kind of problem. The error also records
-/// where the problem was encountered.
+/// policy.
 #[derive(Debug, Clone, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ValidationError {
@@ -430,9 +419,8 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
     }
 }
 
-/// This module contains definitions for structs containing detailed information
-/// about each validation warning. Warnings are primarily documented on their
-/// variants in [`ValidationWarning`].
+/// Error subtypes for [`ValidationWarning`].
+/// Validation warnings are primarily documented on their variants in [`ValidationWarning`].
 pub mod validation_warnings;
 
 /// Represents the different kinds of validation warnings and information
@@ -507,8 +495,8 @@ impl From<cedar_policy_validator::ValidationWarning> for ValidationWarning {
     }
 }
 
-/// Error structs for the variants of `PolicySetError`
-pub mod policy_set_error_structs {
+/// Error subtypes for [`PolicySetError`]
+pub mod policy_set_errors {
     use super::Error;
     use crate::PolicyId;
     use miette::Diagnostic;
@@ -521,15 +509,46 @@ pub mod policy_set_error_structs {
         pub(crate) id: PolicyId,
     }
 
+    impl AlreadyDefined {
+        /// Get the [`PolicyId`] for which there was a duplicate
+        pub fn duplicate_id(&self) -> &PolicyId {
+            &self.id
+        }
+    }
+
     /// Expected a static policy, but a template-linked policy was provided
     #[derive(Debug, Diagnostic, Error)]
     #[error("expected a static policy, but a template-linked policy was provided")]
-    pub struct ExpectedStatic {}
+    pub struct ExpectedStatic {
+        /// A private field, just so the public interface notes this as a
+        /// private-fields struct and not a empty-fields struct for semver
+        /// purposes (e.g., consumers cannot construct this type with
+        /// `ExpectedStatic {}`)
+        _dummy: (),
+    }
+
+    impl ExpectedStatic {
+        pub(crate) fn new() -> Self {
+            Self { _dummy: () }
+        }
+    }
 
     /// Expected a template, but a static policy was provided.
     #[derive(Debug, Diagnostic, Error)]
     #[error("expected a template, but a static policy was provided")]
-    pub struct ExpectedTemplate {}
+    pub struct ExpectedTemplate {
+        /// A private field, just so the public interface notes this as a
+        /// private-fields struct and not a empty-fields struct for semver
+        /// purposes (e.g., consumers cannot construct this type with
+        /// `ExpectedTemplate {}`)
+        _dummy: (),
+    }
+
+    impl ExpectedTemplate {
+        pub(crate) fn new() -> Self {
+            Self { _dummy: () }
+        }
+    }
 
     /// Error when removing a static policy that doesn't exist
     #[derive(Debug, Diagnostic, Error)]
@@ -538,11 +557,25 @@ pub mod policy_set_error_structs {
         pub(crate) policy_id: PolicyId,
     }
 
-    /// Error when removing a static policy that doesn't exist
+    impl PolicyNonexistentError {
+        /// Get the [`PolicyId`] of the policy which didn't exist
+        pub fn policy_id(&self) -> &PolicyId {
+            &self.policy_id
+        }
+    }
+
+    /// Error when removing a template that doesn't exist
     #[derive(Debug, Diagnostic, Error)]
     #[error("unable to remove template `{template_id}` because it does not exist")]
     pub struct TemplateNonexistentError {
         pub(crate) template_id: PolicyId,
+    }
+
+    impl TemplateNonexistentError {
+        /// Get the [`PolicyId`] of the template which didn't exist
+        pub fn template_id(&self) -> &PolicyId {
+            &self.template_id
+        }
     }
 
     /// Error when removing a template with active links
@@ -552,6 +585,13 @@ pub mod policy_set_error_structs {
         pub(crate) template_id: PolicyId,
     }
 
+    impl RemoveTemplateWithActiveLinksError {
+        /// Get the [`PolicyId`] of the template which had active links
+        pub fn template_id(&self) -> &PolicyId {
+            &self.template_id
+        }
+    }
+
     /// Error when removing a template that is not a template
     #[derive(Debug, Diagnostic, Error)]
     #[error("unable to remove policy template `{template_id}` because it is not a template")]
@@ -559,11 +599,25 @@ pub mod policy_set_error_structs {
         pub(crate) template_id: PolicyId,
     }
 
-    /// Error when unlinking a template
+    impl RemoveTemplateNotTemplateError {
+        /// Get the [`PolicyId`] of the template which is not a template
+        pub fn template_id(&self) -> &PolicyId {
+            &self.template_id
+        }
+    }
+
+    /// Error when unlinking a template-linked policy
     #[derive(Debug, Diagnostic, Error)]
     #[error("unable to unlink policy `{policy_id}` because it does not exist")]
     pub struct LinkNonexistentError {
         pub(crate) policy_id: PolicyId,
+    }
+
+    impl LinkNonexistentError {
+        /// Get the [`PolicyId`] of the link which does not exist
+        pub fn policy_id(&self) -> &PolicyId {
+            &self.policy_id
+        }
     }
 
     /// Error when removing a link that is not a link
@@ -571,6 +625,30 @@ pub mod policy_set_error_structs {
     #[error("unable to unlink `{policy_id}` because it is not a link")]
     pub struct UnlinkLinkNotLinkError {
         pub(crate) policy_id: PolicyId,
+    }
+
+    impl UnlinkLinkNotLinkError {
+        /// Get the [`PolicyId`] of the link which is not a link
+        pub fn policy_id(&self) -> &PolicyId {
+            &self.policy_id
+        }
+    }
+
+    /// Error when converting a policy from JSON format
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Error deserializing a policy/template from JSON: {inner}")]
+    #[diagnostic(transparent)]
+    pub struct FromJsonError {
+        #[from]
+        pub(crate) inner: cedar_policy_core::est::FromJsonError,
+    }
+
+    /// Error during JSON ser/de of the policy set (as opposed to individual policies)
+    #[derive(Debug, Diagnostic, Error)]
+    #[error("Error serializing / deserializing PolicySet to / from JSON: {inner})")]
+    pub struct JsonPolicySetError {
+        #[from]
+        pub(crate) inner: serde_json::Error,
     }
 }
 
@@ -582,58 +660,55 @@ pub enum PolicySetError {
     /// templates or the set of policies.
     #[error(transparent)]
     #[diagnostic(transparent)]
-    AlreadyDefined(#[from] policy_set_error_structs::AlreadyDefined),
+    AlreadyDefined(#[from] policy_set_errors::AlreadyDefined),
     /// Error when linking a template
     #[error("unable to link template: {0}")]
     #[diagnostic(transparent)]
-    LinkingError(#[from] ast::LinkingError),
+    Linking(#[from] ast::LinkingError),
     /// Expected a static policy, but a template-linked policy was provided
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ExpectedStatic(#[from] policy_set_error_structs::ExpectedStatic),
+    ExpectedStatic(#[from] policy_set_errors::ExpectedStatic),
     /// Expected a template, but a static policy was provided.
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ExpectedTemplate(#[from] policy_set_error_structs::ExpectedTemplate),
+    ExpectedTemplate(#[from] policy_set_errors::ExpectedTemplate),
     /// Error when removing a static policy that doesn't exist
     #[error(transparent)]
     #[diagnostic(transparent)]
-    PolicyNonexistentError(#[from] policy_set_error_structs::PolicyNonexistentError),
+    PolicyNonexistent(#[from] policy_set_errors::PolicyNonexistentError),
     /// Error when removing a template that doesn't exist
     #[error(transparent)]
     #[diagnostic(transparent)]
-    TemplateNonexistentError(#[from] policy_set_error_structs::TemplateNonexistentError),
+    TemplateNonexistent(#[from] policy_set_errors::TemplateNonexistentError),
     /// Error when removing a template with active links
     #[error(transparent)]
     #[diagnostic(transparent)]
-    RemoveTemplateWithActiveLinksError(
-        #[from] policy_set_error_structs::RemoveTemplateWithActiveLinksError,
-    ),
+    RemoveTemplateWithActiveLinks(#[from] policy_set_errors::RemoveTemplateWithActiveLinksError),
     /// Error when removing a template that is not a template
     #[error(transparent)]
     #[diagnostic(transparent)]
-    RemoveTemplateNotTemplateError(
-        #[from] policy_set_error_structs::RemoveTemplateNotTemplateError,
-    ),
+    RemoveTemplateNotTemplate(#[from] policy_set_errors::RemoveTemplateNotTemplateError),
     /// Error when unlinking a linked policy
     #[error(transparent)]
     #[diagnostic(transparent)]
-    LinkNonexistentError(#[from] policy_set_error_structs::LinkNonexistentError),
+    LinkNonexistent(#[from] policy_set_errors::LinkNonexistentError),
     /// Error when removing a link that is not a link
     #[error(transparent)]
     #[diagnostic(transparent)]
-    UnlinkLinkNotLinkError(#[from] policy_set_error_structs::UnlinkLinkNotLinkError),
-    /// Error when converting from EST
-    #[error("Error deserializing a policy/template from JSON: {0}")]
+    UnlinkLinkNotLink(#[from] policy_set_errors::UnlinkLinkNotLinkError),
+    /// Error when converting from JSON format
+    #[error(transparent)]
     #[diagnostic(transparent)]
-    FromJson(#[from] cedar_policy_core::est::FromJsonError),
-    /// Error when converting to EST
+    FromJson(#[from] policy_set_errors::FromJsonError),
+    /// Error when converting to JSON format
     #[error("Error serializing a policy to JSON: {0}")]
     #[diagnostic(transparent)]
     ToJson(#[from] PolicyToJsonError),
-    /// Errors encountered in JSON ser/de of the policy set (as opposed to individual policies)
-    #[error("Error serializing / deserializing PolicySet to / from JSON: {0})")]
-    Json(#[from] serde_json::Error),
+    /// Error during JSON ser/de of the policy set (as opposed to individual policies)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    JsonPolicySet(#[from] policy_set_errors::JsonPolicySetError),
 }
 
 #[doc(hidden)]
@@ -641,7 +716,7 @@ impl From<ast::PolicySetError> for PolicySetError {
     fn from(e: ast::PolicySetError) -> Self {
         match e {
             ast::PolicySetError::Occupied { id } => {
-                Self::AlreadyDefined(policy_set_error_structs::AlreadyDefined {
+                Self::AlreadyDefined(policy_set_errors::AlreadyDefined {
                     id: PolicyId::new(id),
                 })
             }
@@ -652,7 +727,7 @@ impl From<ast::PolicySetError> for PolicySetError {
 #[doc(hidden)]
 impl From<ast::UnexpectedSlotError> for PolicySetError {
     fn from(_: ast::UnexpectedSlotError) -> Self {
-        Self::ExpectedStatic(policy_set_error_structs::ExpectedStatic {})
+        Self::ExpectedStatic(policy_set_errors::ExpectedStatic::new())
     }
 }
 
@@ -666,27 +741,27 @@ pub enum PolicyToJsonError {
     /// For linked policies, error linking the JSON representation
     #[error(transparent)]
     #[diagnostic(transparent)]
-    Link(#[from] json_errors::JsonLinkError),
+    Link(#[from] policy_to_json_errors::JsonLinkError),
     /// Error in the JSON serialization
     #[error(transparent)]
-    JsonSerialization(#[from] json_errors::PolicyJsonSerializationError),
+    JsonSerialization(#[from] policy_to_json_errors::PolicyJsonSerializationError),
 }
 
 #[doc(hidden)]
 impl From<est::LinkingError> for PolicyToJsonError {
     fn from(e: est::LinkingError) -> Self {
-        json_errors::JsonLinkError::from(e).into()
+        policy_to_json_errors::JsonLinkError::from(e).into()
     }
 }
 
 impl From<serde_json::Error> for PolicyToJsonError {
     fn from(e: serde_json::Error) -> Self {
-        json_errors::PolicyJsonSerializationError::from(e).into()
+        policy_to_json_errors::PolicyJsonSerializationError::from(e).into()
     }
 }
 
-/// Error types related to JSON processing
-pub mod json_errors {
+/// Error subtypes for [`PolicyToJsonError`]
+pub mod policy_to_json_errors {
     use cedar_policy_core::est;
     use miette::Diagnostic;
     use thiserror::Error;

--- a/cedar-policy/src/api/err/validation_warnings.rs
+++ b/cedar-policy/src/api/err/validation_warnings.rs
@@ -41,7 +41,7 @@ macro_rules! wrap_core_warning {
         pub struct $s(cedar_policy_validator::validation_warnings::$s);
 
         impl $s {
-            /// Access the `[PolicyId]` for the policy where this warning was found.
+            /// Access the [`PolicyId`] for the policy where this warning was found.
             pub fn policy_id(&self) -> &PolicyId {
                 PolicyId::ref_cast(&self.0.policy_id)
             }

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -253,7 +253,7 @@ impl From<crate::AuthorizationError> for AuthorizationError {
     fn from(e: crate::AuthorizationError) -> Self {
         match e {
             crate::AuthorizationError::PolicyEvaluationError(e) => {
-                Self::new(e.id().clone(), e.into_inner())
+                Self::new(e.policy_id().clone(), e.into_inner())
             }
         }
     }

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -569,7 +569,7 @@ mod policy_set_tests {
 
         assert_matches!(
             r,
-            Err(PolicySetError::LinkingError(LinkingError::PolicyIdConflict { id })) =>{
+            Err(PolicySetError::Linking(LinkingError::PolicyIdConflict { id })) =>{
                 assert_eq!(id, ast::PolicyID::from_string("id"));
             }
         );
@@ -613,7 +613,7 @@ mod policy_set_tests {
             )
             .expect_err("Should have failed due to conflict with existing link id");
         match err {
-            PolicySetError::LinkingError(_) => (),
+            PolicySetError::Linking(_) => (),
             e => panic!("Wrong error: {e}"),
         }
 
@@ -726,7 +726,7 @@ mod policy_set_tests {
 
         assert_matches!(
             pset.remove_static(PolicyId::from_str("t").unwrap()),
-            Err(PolicySetError::PolicyNonexistentError(_))
+            Err(PolicySetError::PolicyNonexistent(_))
         );
 
         let result = pset.unlink(linked_policy_id.clone());
@@ -734,7 +734,7 @@ mod policy_set_tests {
 
         assert_matches!(
             pset.remove_static(PolicyId::from_str("t").unwrap()),
-            Err(PolicySetError::PolicyNonexistentError(_))
+            Err(PolicySetError::PolicyNonexistent(_))
         );
 
         //Deny
@@ -757,7 +757,7 @@ mod policy_set_tests {
         //Can't remove template that is still linked
         assert_matches!(
             pset.remove_template(PolicyId::from_str("t").unwrap()),
-            Err(PolicySetError::RemoveTemplateWithActiveLinksError(_))
+            Err(PolicySetError::RemoveTemplateWithActiveLinks(_))
         );
 
         //Unlink first, then remove
@@ -800,11 +800,11 @@ mod policy_set_tests {
         );
         assert_matches!(
             pset.remove_static(PolicyId::from_str("policy3").unwrap()),
-            Err(PolicySetError::PolicyNonexistentError(_))
+            Err(PolicySetError::PolicyNonexistent(_))
         );
         assert_matches!(
             pset.remove_template(PolicyId::from_str("policy3").unwrap()),
-            Err(PolicySetError::TemplateNonexistentError(_))
+            Err(PolicySetError::TemplateNonexistent(_))
         );
     }
 
@@ -990,7 +990,7 @@ mod policy_set_tests {
         assert_eq!(response.decision(), Decision::Deny);
 
         let result = pset.unlink(linked_policy_id);
-        assert_matches!(result, Err(PolicySetError::LinkNonexistentError(_)));
+        assert_matches!(result, Err(PolicySetError::LinkNonexistent(_)));
     }
 
     #[test]
@@ -1029,7 +1029,7 @@ mod policy_set_tests {
             0
         );
         let result = pset.unlink(linked_policy_id.clone());
-        assert_matches!(result, Err(PolicySetError::LinkNonexistentError(_)));
+        assert_matches!(result, Err(PolicySetError::LinkNonexistent(_)));
 
         pset.link(
             PolicyId::from_str("template").unwrap(),
@@ -1094,7 +1094,7 @@ mod policy_set_tests {
         //Can't remove template
         assert_matches!(
             pset.remove_template(PolicyId::from_str("template").unwrap()),
-            Err(PolicySetError::RemoveTemplateWithActiveLinksError(_))
+            Err(PolicySetError::RemoveTemplateWithActiveLinks(_))
         );
 
         //Can't add policy named template
@@ -1134,13 +1134,13 @@ mod policy_set_tests {
         //Cannot remove "linked"
         assert_matches!(
             pset.remove_static(PolicyId::from_str("linked").unwrap()),
-            Err(PolicySetError::PolicyNonexistentError(_))
+            Err(PolicySetError::PolicyNonexistent(_))
         );
 
         //Cannot remove "template"
         assert_matches!(
             pset.remove_static(PolicyId::from_str("template").unwrap()),
-            Err(PolicySetError::PolicyNonexistentError(_))
+            Err(PolicySetError::PolicyNonexistent(_))
         );
 
         //template count 2
@@ -1170,7 +1170,7 @@ mod policy_set_tests {
         //can't remove template1
         assert_matches!(
             pset.remove_template(PolicyId::from_str("template").unwrap()),
-            Err(PolicySetError::RemoveTemplateWithActiveLinksError(_))
+            Err(PolicySetError::RemoveTemplateWithActiveLinks(_))
         );
 
         //unlink other policy, template count 0
@@ -1194,7 +1194,7 @@ mod policy_set_tests {
             pset.get_linked_policies(PolicyId::from_str("template").unwrap())
                 .err()
                 .unwrap(),
-            PolicySetError::TemplateNonexistentError(_)
+            PolicySetError::TemplateNonexistent(_)
         );
     }
 
@@ -1334,7 +1334,7 @@ mod policy_set_tests {
                 PolicyId::from_str("policy3").unwrap(),
                 env.clone(),
             ),
-            Err(PolicySetError::LinkingError(
+            Err(PolicySetError::Linking(
                 LinkingError::PolicyIdConflict { .. }
             ))
         );
@@ -1346,7 +1346,7 @@ mod policy_set_tests {
                 PolicyId::from_str("policy0").unwrap(),
                 env.clone(),
             ),
-            Err(PolicySetError::LinkingError(
+            Err(PolicySetError::Linking(
                 LinkingError::PolicyIdConflict { .. }
             ))
         );
@@ -1364,7 +1364,7 @@ mod policy_set_tests {
                 PolicyId::from_str("policy1").unwrap(),
                 env,
             ),
-            Err(PolicySetError::LinkingError(
+            Err(PolicySetError::Linking(
                 LinkingError::PolicyIdConflict { .. }
             ))
         );
@@ -1475,7 +1475,7 @@ mod schema_tests {
                 }
             }}"#
             )),
-            Err(crate::schema_error::SchemaError::JsonDeserialization(_))
+            Err(crate::SchemaError::JsonDeserialization(_))
         );
     }
 }
@@ -2912,7 +2912,7 @@ mod schema_based_parsing_tests {
         let src = "{ , .. }";
         assert_matches!(
             Schema::from_str(src),
-            Err(crate::schema_error::SchemaError::JsonDeserialization(_))
+            Err(crate::SchemaError::JsonDeserialization(_))
         );
     }
 
@@ -4559,7 +4559,7 @@ mod policy_set_est_tests {
         let template1 = PolicyId::new("non_existent").into();
         assert_matches!(
             err,
-            PolicySetError::LinkingError(ast::LinkingError::NoSuchTemplate { id }) if id == template1
+            PolicySetError::Linking(ast::LinkingError::NoSuchTemplate { id }) if id == template1
         );
     }
 
@@ -4634,7 +4634,7 @@ mod policy_set_est_tests {
         let just_principal = vec![SlotId::principal().into()];
         assert_matches!(
             err,
-            PolicySetError::LinkingError(ast::LinkingError::ArityError {
+            PolicySetError::Linking(ast::LinkingError::ArityError {
                 unbound_values,
                 extra_values
             }) if extra_values.is_empty() && unbound_values == just_principal
@@ -4715,7 +4715,7 @@ mod policy_set_est_tests {
         let just_resource = vec![SlotId::resource().into()];
         assert_matches!(
             err,
-            PolicySetError::LinkingError(ast::LinkingError::ArityError {
+            PolicySetError::Linking(ast::LinkingError::ArityError {
                 unbound_values,
                 extra_values
             }) if unbound_values.is_empty() && extra_values == just_resource

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -288,7 +288,9 @@ impl CedarTestImplementation for RustEngine {
                 .map(|e| {
                     // Error messages should only include the policy id to use the
                     // `ErrorComparisonMode::PolicyIds` mode.
-                    let policy_id = e.id();
+                    let policy_id = match e {
+                        cedar_policy::AuthorizationError::PolicyEvaluationError(e) => e.policy_id(),
+                    };
                     ffi::AuthorizationError::new_from_report(
                         policy_id.clone(),
                         miette!("{policy_id}"),


### PR DESCRIPTION
## Description of changes

Bunch of changes related to consistency in how #745 was implemented across many PRs.
* Collect internal structs in public submodules. But, the main error struct doesn't live in a submodule.
* Remove `Error` from the end of variant names (but not the names of error structs)
* `RestrictedExprError` needs to conform with #745 since it's public now
* add the standard `CAUTION` note to some more publicly re-exported types
* rename a couple modules and errors
* add getters to some more error structs, for the ones defined in `cedar-policy` anyway
* minor tweaks to doc strings

## Issue #, if available

Mostly finishes #745 -- @khieta has some remaining work to do on `ParseError`, and we also need a pass to find errors like `RequestValidationError` that are currently returned from our public API but not re-exported; those will be separate PRs.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)


