### PR TITLE
lock url to 2.5.0

### DIFF
--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -34,4 +34,6 @@ cool_asserts = "2.0"
 
 [build-dependencies]
 cargo-lock = "9.0.0"
+# Lock `url` (dependencies of cargo-lock) to 2.5.0 until we know if Unicode 3.0 license is ok.
+url = "=2.5.0"
 itertools = "0.13.0"


### PR DESCRIPTION
## Description of changes

Fixes cargo-deny CI failure while we sort out license details

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

