### PR TITLE
Construct formatter regex in `lazy_static` block

### DIFF
--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -18,6 +18,7 @@ itertools = "0.13"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version= "1.9.1", features = ["unicode"] }
 miette = { version = "7.1.0" }
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["glob"] }

--- a/cedar-policy-formatter/src/pprint/token.rs
+++ b/cedar-policy-formatter/src/pprint/token.rs
@@ -18,15 +18,21 @@
 #![allow(clippy::indexing_slicing)]
 use itertools::Itertools;
 use logos::{Logos, Span};
-use regex::Regex;
 use smol_str::SmolStr;
 use std::fmt::{self, Display};
 
+// PANIC SAFETY: These regex patterns are valid
+#[allow(clippy::unwrap_used)]
+pub(crate) mod regex_constants {
+    use regex::Regex;
+    lazy_static::lazy_static! {
+        pub static ref COMMENT : Regex = Regex::new(r"//[^\n\r]*").unwrap();
+        pub static ref STRING : Regex = Regex::new(r#""(\\.|[^"\\])*""#).unwrap();
+    }
+}
+
 pub fn get_comment(text: &str) -> String {
-    // PANIC SAFETY: this regex pattern is valid
-    #[allow(clippy::unwrap_used)]
-    let mut comment = Regex::new(r"//[^\n\r]*")
-        .unwrap()
+    let mut comment = regex_constants::COMMENT
         .find_iter(text)
         .map(|c| c.as_str().trim_end())
         .join("\n");

--- a/cedar-policy-formatter/src/pprint/utils.rs
+++ b/cedar-policy-formatter/src/pprint/utils.rs
@@ -16,7 +16,8 @@
 
 use itertools::Itertools;
 use pretty::RcDoc;
-use regex::Regex;
+
+use crate::token::regex_constants;
 
 use super::token::{Comment, WrappedToken};
 
@@ -161,13 +162,6 @@ fn remove_empty_interior_lines(s: &str) -> String {
 
 /// Remove empty lines, safely handling newlines that occur in quotations.
 pub fn remove_empty_lines(text: &str) -> String {
-    // PANIC SAFETY: this regex pattern is valid
-    #[allow(clippy::unwrap_used)]
-    let comment_regex = Regex::new(r"//[^\n]*").unwrap();
-    // PANIC SAFETY: this regex pattern is valid
-    #[allow(clippy::unwrap_used)]
-    let string_regex = Regex::new(r#""(\\.|[^"\\])*""#).unwrap();
-
     let mut index = 0;
     let mut final_text = String::new();
 
@@ -176,8 +170,8 @@ pub fn remove_empty_lines(text: &str) -> String {
         // call `remove_empty_interior_lines` on all the text _outside_ of
         // strings. Comments should be skipped to avoid interpreting a quote in
         // a comment as a string.
-        let comment_match = comment_regex.find_at(text, index);
-        let string_match = string_regex.find_at(text, index);
+        let comment_match = regex_constants::COMMENT.find_at(text, index);
+        let string_match = regex_constants::STRING.find_at(text, index);
         match (comment_match, string_match) {
             (Some(m1), Some(m2)) => {
                 // Handle the earlier match


### PR DESCRIPTION
## Description of changes

Main offender was the regex in `get_comment` which would be constructed twice for every single token.
Didn't benchmark, but test run time goes from ~2 seconds to < 0.5 seconds.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

