### PR TITLE
Expose an opaque `ParseError` type

### DIFF
--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -45,10 +45,6 @@ pub(crate) type RawErrorRecovery<'a> = lalr::ErrorRecovery<RawLocation, RawToken
 type OwnedRawParseError = lalr::ParseError<RawLocation, String, RawUserError>;
 
 /// Errors that can occur when parsing Cedar policies or expressions.
-//
-// CAUTION: this type is publicly exported in `cedar-policy`.
-// Don't make fields `pub`, don't make breaking changes, and use caution when
-// adding public methods.
 #[derive(Clone, Debug, Diagnostic, Error, PartialEq, Eq)]
 pub enum ParseError {
     /// Error from the text -> CST parser
@@ -696,10 +692,6 @@ pub fn expected_to_string(expected: &[String], config: &ExpectedTokenConfig) -> 
 
 /// Represents one or more [`ParseError`]s encountered when parsing a policy or
 /// template.
-//
-// CAUTION: this type is publicly exported in `cedar-policy`.
-// Don't make fields `pub`, don't make breaking changes, and use caution when
-// adding public methods.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseErrors(NonEmpty<ParseError>);
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the rich data provided by `miette::Diagnostic`, for instance `.help()` and
   `labels()`. Callers can continue using the same behavior by calling
   `.iter().map(ToString::to_string)`. (#882, resolving #543)
+- Removed `ParseError::primary_source_span`. Callers should use the location
+  information provided by `miette::Diagnostic` via `.labels()` and
+  `.source_code()` instead. (#908)
 - Removed `Display` impl for `EntityId` in favor of explicit `.escaped()` and
   `.as_ref()` for escaped and unescaped representations (respectively) of the
   `EntityId`; see note there (#921, resolving #884)

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1613,7 +1613,9 @@ impl FromStr for EntityNamespace {
     type Err = ParseErrors;
 
     fn from_str(namespace_str: &str) -> Result<Self, Self::Err> {
-        ast::Name::from_normalized_str(namespace_str).map(EntityNamespace)
+        ast::Name::from_normalized_str(namespace_str)
+            .map(EntityNamespace)
+            .map_err(Into::into)
     }
 }
 
@@ -2777,7 +2779,8 @@ impl LosslessPolicy {
         match self {
             Self::Est(est) => Ok(est.clone()),
             Self::Text { text, slots } => {
-                let est = parser::parse_policy_or_template_to_est(text)?;
+                let est =
+                    parser::parse_policy_or_template_to_est(text).map_err(ParseErrors::from)?;
                 if slots.is_empty() {
                     Ok(est)
                 } else {
@@ -2907,7 +2910,9 @@ impl FromStr for Expression {
 
     /// create an Expression using Cedar syntax
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        ast::Expr::from_str(expression).map(Expression)
+        ast::Expr::from_str(expression)
+            .map(Expression)
+            .map_err(Into::into)
     }
 }
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -749,11 +749,17 @@ impl ParseErrors {
 }
 
 /// Errors that can occur when parsing policies or expressions.
+/// Marked as `non_exhaustive` to support adding additional error information
+/// in the future without a major version bump.
 #[derive(Debug, Diagnostic, Error, RefCast)]
 #[repr(transparent)]
 #[error(transparent)]
 #[diagnostic(transparent)]
-pub struct ParseError(#[from] cedar_policy_core::parser::err::ParseError);
+#[non_exhaustive]
+pub struct ParseError {
+    #[from]
+    inner: cedar_policy_core::parser::err::ParseError,
+}
 
 /// Errors that can happen when getting the JSON representation of a policy
 #[derive(Debug, Diagnostic, Error)]

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -148,7 +148,9 @@ impl FromStr for EntityTypeName {
     type Err = ParseErrors;
 
     fn from_str(namespace_type_str: &str) -> Result<Self, Self::Err> {
-        ast::Name::from_normalized_str(namespace_type_str).map(Self::new)
+        ast::Name::from_normalized_str(namespace_type_str)
+            .map(Self::new)
+            .map_err(Into::into)
     }
 }
 
@@ -279,7 +281,9 @@ impl FromStr for EntityUid {
     /// If you have separate components of an [`EntityUid`], use [`EntityUid::from_type_name_and_id`]
     fn from_str(uid_str: &str) -> Result<Self, Self::Err> {
         // INVARIANT there is no way to write down the unspecified entity
-        ast::EntityUID::from_normalized_str(uid_str).map(Self::new)
+        ast::EntityUID::from_normalized_str(uid_str)
+            .map(Self::new)
+            .map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
## Description of changes

This PR addresses #745 for `ParseErrors` by exposing the bare minimum level of detail: users can use the `miette::Diagnotic` attached to `ParseErrors`, or use `.iter()` to get an iterator over individual `ParseError`s. Each `ParseError` will expose no internal information outside of its `miette::Diagnostic`.

I think the ideal solution here is to flatten the structure of `ParseError` to remove the distinction between CST and AST errors and get rid of the "Kind" pattern, similar to what has been done for the validation & evaluation errors... but this is a large amount of work for small benefit (I find it unlikely that users will need to programmatically match against parse errors). Assuming this PR is approved, I'll make a backlog issue for the larger change. Note that this larger change can be made in a backwards-compatible way in the future.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

_(Part of the batch of breaking error structure changes for 4.0)_

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

_(Adds an undocumented breaking change made in #908.)_

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.