### PR TITLE
Optimize extension function validation by not calling expression parser

### DIFF
--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -16,6 +16,13 @@
 
 //! This module contains type information for all of the standard Cedar extensions.
 
+use cedar_policy_core::{
+    ast::{Name, RestrictedExpr, Value},
+    evaluator::{EvaluationError, RestrictedEvaluator},
+    extensions::Extensions,
+};
+use smol_str::SmolStr;
+
 use crate::extension_schema::ExtensionSchema;
 
 #[cfg(feature = "ipaddr")]
@@ -35,4 +42,17 @@ pub fn all_available_extension_schemas() -> Vec<ExtensionSchema> {
         decimal::extension_schema(),
         partial_evaluation::extension_schema(),
     ]
+}
+
+/// Evaluates ane extension function on a single string literal argument. Used
+/// to validate arguments to extension constructor functions.
+fn eval_extension_constructor(
+    constructor_name: Name,
+    lit_str_arg: SmolStr,
+) -> Result<Value, EvaluationError> {
+    let exts = Extensions::all_available();
+    let evaluator = RestrictedEvaluator::new(&exts);
+    let constructor_call_expr =
+        RestrictedExpr::call_extension_fn(constructor_name, [RestrictedExpr::val(lit_str_arg)]);
+    evaluator.interpret(constructor_call_expr.as_borrowed())
 }

--- a/cedar-policy-validator/src/extensions/ipaddr.rs
+++ b/cedar-policy-validator/src/extensions/ipaddr.rs
@@ -35,7 +35,7 @@ use super::eval_extension_constructor;
 #[allow(clippy::panic)]
 fn get_argument_types(fname: &Name, ipaddr_ty: &Type) -> Vec<types::Type> {
     if !fname.is_unqualified() {
-        panic!("unexpected decimal extension function name: {fname}")
+        panic!("unexpected ipaddr extension function name: {fname}")
     }
     match fname.basename().as_ref() {
         "ip" => vec![Type::primitive_string()],
@@ -49,7 +49,7 @@ fn get_argument_types(fname: &Name, ipaddr_ty: &Type) -> Vec<types::Type> {
 #[allow(clippy::panic)]
 fn get_return_type(fname: &Name, ipaddr_ty: &Type) -> Type {
     if !fname.is_unqualified() {
-        panic!("unexpected decimal extension function name: {fname}")
+        panic!("unexpected ipaddr extension function name: {fname}")
     }
     match fname.basename().as_ref() {
         "ip" => ipaddr_ty.clone(),
@@ -64,7 +64,7 @@ fn get_return_type(fname: &Name, ipaddr_ty: &Type) -> Type {
 #[allow(clippy::panic)]
 fn get_argument_check(fname: &Name) -> Option<ArgumentCheckFn> {
     if !fname.is_unqualified() {
-        panic!("unexpected decimal extension function name: {fname}")
+        panic!("unexpected ipaddr extension function name: {fname}")
     }
     match fname.basename().as_ref() {
         "ip" => {

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -79,6 +79,10 @@ harness = false
 name = "entity_attr_errors"
 harness = false
 
+[[bench]]
+name = "extension_fn_validation"
+harness = false
+
 [package.metadata.docs.rs]
 features = ["experimental"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/cedar-policy/benches/extension_fn_validation.rs
+++ b/cedar-policy/benches/extension_fn_validation.rs
@@ -1,0 +1,53 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::str::FromStr;
+
+use cedar_policy::{Policy, PolicySet, Schema, Validator};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+// PANIC SAFETY: benchmarking
+#[allow(clippy::unwrap_used)]
+pub fn extension_fn_validation(c: &mut Criterion) {
+    let (schema, _) = Schema::from_str_natural("action Act appliesTo { context: {}};").unwrap();
+    let validator = Validator::new(schema);
+
+    let policy_set = PolicySet::from_policies([Policy::from_str(
+        r#"permit(principal, action, resource) when { ip("127.0.0.1") };"#,
+    )
+    .unwrap()])
+    .unwrap();
+    c.bench_function("ip", |b| {
+        b.iter(|| {
+            validator.validate(black_box(&policy_set), cedar_policy::ValidationMode::Strict);
+        })
+    });
+
+    let policy_set = PolicySet::from_policies([Policy::from_str(
+        r#"permit(principal, action, resource) when { decimal("12.34") };"#,
+    )
+    .unwrap()])
+    .unwrap();
+    c.bench_function("decimal", |b| {
+        b.iter(|| {
+            validator.validate(black_box(&policy_set), cedar_policy::ValidationMode::Strict);
+        })
+    });
+}
+
+criterion_group!(benches, extension_fn_validation);
+criterion_main!(benches);


### PR DESCRIPTION
## Description of changes

Optimization to how we validate extension constructor calls by using `RestrictedExpr` constructor instead of invoking the Cedar expression parser. Also a cleaner implementation IMO. 

![image](https://github.com/cedar-policy/cedar/assets/130772734/80a13957-c044-4d4d-ad54-2f06ab2d0301)


## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

