### PR TITLE
Refine the error message when there are type name conflicts

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -209,6 +209,10 @@ pub enum SchemaError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnknownExtensionType(schema_errors::UnknownExtensionTypeError),
+    /// Common type names conflict with primitive types.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CommonTypeNameConflict(#[from] schema_errors::CommonTypeNameConflictError),
 }
 
 impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
@@ -234,7 +238,7 @@ pub mod schema_errors {
     use std::{collections::HashSet, fmt::Display};
 
     use cedar_policy_core::{
-        ast::{EntityAttrEvaluationError, EntityUID, Name},
+        ast::{EntityAttrEvaluationError, EntityUID, Id, Name},
         transitive_closure,
     };
     use itertools::Itertools;
@@ -521,4 +525,14 @@ pub mod schema_errors {
             })
         }
     }
+
+    /// This error is thrown when a common type name conflicts with a primitive
+    /// type
+    //
+    // CAUTION: this type is publicly exported in `cedar-policy`.
+    // Don't make fields `pub`, don't make breaking changes, and use caution
+    // when adding public methods.
+    #[derive(Error, Debug, Diagnostic)]
+    #[error("Common type name `{0}` conflicts with primitive type")]
+    pub struct CommonTypeNameConflictError(pub(crate) Id);
 }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2328,6 +2328,219 @@ mod test {
                     .build());
         });
     }
+
+    #[test]
+    fn test_common_type_name_conflicts() {
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "Record": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Record"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Ok(_));
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "Extension": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Extension"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Ok(_));
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "Entity": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Entity"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Ok(_));
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "Set": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Set"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Ok(_));
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "Long": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Long"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(SchemaError::CommonTypeNameConflict(CommonTypeNameConflictError(n))) if n == "Long".parse().unwrap());
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "Boolean": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Boolean"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(SchemaError::CommonTypeNameConflict(CommonTypeNameConflictError(n))) if n == "Boolean".parse().unwrap());
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "String": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "String"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(SchemaError::CommonTypeNameConflict(CommonTypeNameConflictError(n))) if n == "String".parse().unwrap());
+    }
 }
 
 #[cfg(test)]

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -38,7 +38,7 @@ use crate::{
     schema_file_format,
     types::{AttributeType, Attributes, Type},
     ActionBehavior, ActionEntityUID, ActionType, NamespaceDefinition, SchemaType,
-    SchemaTypeVariant, TypeOfAttribute, SCHEMA_TYPE_VARIANT_TAGS,
+    SchemaTypeVariant, TypeOfAttribute, PRIMITIVE_TYPES,
 };
 use crate::{fuzzy_match::fuzzy_search, types::OpenTag};
 
@@ -231,10 +231,8 @@ impl ValidatorNamespaceDef {
         })
     }
 
-    fn is_builtin_type_name(name: &str) -> bool {
-        SCHEMA_TYPE_VARIANT_TAGS
-            .iter()
-            .any(|type_name| &name == type_name)
+    fn is_primitive_type_name(name: &str) -> bool {
+        PRIMITIVE_TYPES.iter().any(|type_name| &name == type_name)
     }
 
     fn build_type_defs(
@@ -243,10 +241,10 @@ impl ValidatorNamespaceDef {
     ) -> Result<TypeDefs> {
         let mut type_defs = HashMap::with_capacity(schema_file_type_def.len());
         for (id, schema_ty) in schema_file_type_def {
-            if Self::is_builtin_type_name(id.as_ref()) {
-                return Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError(
-                    Name::unqualified_name(id),
-                )));
+            if Self::is_primitive_type_name(id.as_ref()) {
+                return Err(SchemaError::CommonTypeNameConflict(
+                    CommonTypeNameConflictError(id),
+                ));
             }
             let name = Name::from(id.clone()).prefix_namespace_if_unqualified(schema_namespace);
             match type_defs.entry(name) {

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -499,6 +499,21 @@ impl<'de> Visitor<'de> for SchemaTypeVisitor {
     }
 }
 
+lazy_static::lazy_static! {
+    // PANIC SAFETY `Set` is a valid `Name`
+    #[allow(clippy::expect_used)]
+    static ref SET_NAME : Name = Name::parse_unqualified_name("Set").expect("valid identifier");
+    // PANIC SAFETY `Record` is a valid `Name`
+    #[allow(clippy::expect_used)]
+    static ref RECORD_NAME : Name = Name::parse_unqualified_name("Record").expect("valid identifier");
+    // PANIC SAFETY `Entity` is a valid `Name`
+    #[allow(clippy::expect_used)]
+    static ref ENTITY_NAME : Name = Name::parse_unqualified_name("Entity").expect("valid identifier");
+    // PANIC SAFETY `Extension` is a valid `Name`
+    #[allow(clippy::expect_used)]
+    static ref EXTENSION_NAME : Name = Name::parse_unqualified_name("Extension").expect("valid identifier");
+}
+
 impl SchemaTypeVisitor {
     /// Construct a schema type given the name of the type and its fields.
     /// Fields which were not present are `None`. It is an error for a field
@@ -515,7 +530,7 @@ impl SchemaTypeVisitor {
         M: MapAccess<'de>,
     {
         use TypeFields::*;
-        let present_fields = [
+        let mut present_fields = [
             (Type, type_name.is_some()),
             (Element, element.is_some()),
             (Attributes, attributes.is_some()),
@@ -526,151 +541,147 @@ impl SchemaTypeVisitor {
         .filter(|(_, present)| *present)
         .map(|(field, _)| field)
         .collect::<HashSet<_>>();
-        // Used to generate the appropriate serde error if a field is present
-        // when it is not expected.
-        let error_if_fields = |fs: &[TypeFields],
-                               expected: &'static [&'static str]|
-         -> std::result::Result<(), M::Error> {
-            for f in fs {
-                if present_fields.contains(f) {
-                    return Err(serde::de::Error::unknown_field(f.as_str(), expected));
-                }
-            }
-            Ok(())
-        };
-        let error_if_any_fields = || -> std::result::Result<(), M::Error> {
-            error_if_fields(&[Element, Attributes, AdditionalAttributes, Name], &[])
-        };
 
-        match type_name.transpose()?.as_ref().map(|s| s.as_str()) {
-            Some("String") => {
-                error_if_any_fields()?;
-                Ok(SchemaType::Type(SchemaTypeVariant::String))
-            }
-            Some("Long") => {
-                error_if_any_fields()?;
-                Ok(SchemaType::Type(SchemaTypeVariant::Long))
-            }
-            Some("Boolean") => {
-                error_if_any_fields()?;
-                Ok(SchemaType::Type(SchemaTypeVariant::Boolean))
-            }
-            Some("Set") => {
-                match error_if_any_fields() {
-                    Err(_) => {}
-                    Ok(_) => {
-                        return Ok(SchemaType::TypeDef {
-                            type_name: "Set".parse().unwrap(),
-                        });
+        match type_name.transpose()?.as_ref() {
+            Some(s) => {
+                // We've concluded that type exists
+                present_fields.remove(&Type);
+                // Used to generate the appropriate serde error if a field is present
+                // when it is not expected.
+                let error_if_fields = |fs: &[TypeFields],
+                                       expected: &'static [&'static str]|
+                 -> std::result::Result<(), M::Error> {
+                    for f in fs {
+                        if present_fields.contains(f) {
+                            return Err(serde::de::Error::unknown_field(f.as_str(), expected));
+                        }
+                    }
+                    Ok(())
+                };
+                let error_if_any_fields = || -> std::result::Result<(), M::Error> {
+                    error_if_fields(&[Element, Attributes, AdditionalAttributes, Name], &[])
+                };
+                match s.as_str() {
+                    "String" => {
+                        error_if_any_fields()?;
+                        Ok(SchemaType::Type(SchemaTypeVariant::String))
+                    }
+                    "Long" => {
+                        error_if_any_fields()?;
+                        Ok(SchemaType::Type(SchemaTypeVariant::Long))
+                    }
+                    "Boolean" => {
+                        error_if_any_fields()?;
+                        Ok(SchemaType::Type(SchemaTypeVariant::Boolean))
+                    }
+                    "Set" => {
+                        if present_fields.is_empty() {
+                            Ok(SchemaType::TypeDef {
+                                type_name: SET_NAME.clone(),
+                            })
+                        } else {
+                            error_if_fields(
+                                &[Attributes, AdditionalAttributes, Name],
+                                &[type_field_name!(Element)],
+                            )?;
+
+                            // PANIC SAFETY: There are four fields allowed and the
+                            // previous function rules out three of them, ensuring
+                            // `element` exists
+                            #[allow(clippy::unwrap_used)]
+                            Ok(SchemaType::Type(SchemaTypeVariant::Set {
+                                element: Box::new(element.unwrap()?),
+                            }))
+                        }
+                    }
+                    "Record" => {
+                        if present_fields.is_empty() {
+                            Ok(SchemaType::TypeDef {
+                                type_name: RECORD_NAME.clone(),
+                            })
+                        } else {
+                            error_if_fields(
+                                &[Element, Name],
+                                &[
+                                    type_field_name!(Attributes),
+                                    type_field_name!(AdditionalAttributes),
+                                ],
+                            )?;
+
+                            if let Some(attributes) = attributes {
+                                let additional_attributes =
+                                    additional_attributes.unwrap_or(Ok(partial_schema_default()));
+                                Ok(SchemaType::Type(SchemaTypeVariant::Record {
+                                    attributes: attributes?.0,
+                                    additional_attributes: additional_attributes?,
+                                }))
+                            } else {
+                                Err(serde::de::Error::missing_field(Attributes.as_str()))
+                            }
+                        }
+                    }
+                    "Entity" => {
+                        if present_fields.is_empty() {
+                            Ok(SchemaType::TypeDef {
+                                type_name: ENTITY_NAME.clone(),
+                            })
+                        } else {
+                            error_if_fields(
+                                &[Element, Attributes, AdditionalAttributes],
+                                &[type_field_name!(Name)],
+                            )?;
+                            // PANIC SAFETY: There are four fields allowed and the
+                            // previous function rules out three of them, ensuring
+                            // `name` exists
+                            #[allow(clippy::unwrap_used)]
+                            let name = name.unwrap()?;
+                            Ok(SchemaType::Type(SchemaTypeVariant::Entity {
+                                name: cedar_policy_core::ast::Name::from_normalized_str(&name)
+                                    .map_err(|err| {
+                                        serde::de::Error::custom(format!(
+                                            "invalid entity type `{name}`: {err}"
+                                        ))
+                                    })?,
+                            }))
+                        }
+                    }
+                    "Extension" => {
+                        if present_fields.is_empty() {
+                            Ok(SchemaType::TypeDef {
+                                type_name: EXTENSION_NAME.clone(),
+                            })
+                        } else {
+                            error_if_fields(
+                                &[Element, Attributes, AdditionalAttributes],
+                                &[type_field_name!(Name)],
+                            )?;
+
+                            // PANIC SAFETY: There are four fields allowed and the
+                            // previous function rules out three of them, ensuring
+                            // `name` exists
+                            #[allow(clippy::unwrap_used)]
+                            let name = name.unwrap()?;
+                            Ok(SchemaType::Type(SchemaTypeVariant::Extension {
+                                name: Id::from_normalized_str(&name).map_err(|err| {
+                                    serde::de::Error::custom(format!(
+                                        "invalid extension type `{name}`: {err}"
+                                    ))
+                                })?,
+                            }))
+                        }
+                    }
+                    type_name => {
+                        error_if_any_fields()?;
+                        Ok(SchemaType::TypeDef {
+                            type_name: cedar_policy_core::ast::Name::from_normalized_str(type_name)
+                                .map_err(|err| {
+                                    serde::de::Error::custom(format!(
+                                        "invalid common type `{type_name}`: {err}"
+                                    ))
+                                })?,
+                        })
                     }
                 }
-                error_if_fields(
-                    &[Attributes, AdditionalAttributes, Name],
-                    &[type_field_name!(Element)],
-                )?;
-
-                if let Some(element) = element {
-                    Ok(SchemaType::Type(SchemaTypeVariant::Set {
-                        element: Box::new(element?),
-                    }))
-                } else {
-                    Err(serde::de::Error::missing_field(Element.as_str()))
-                }
-            }
-            Some("Record") => {
-                match error_if_any_fields() {
-                    Err(_) => {}
-                    Ok(_) => {
-                        return Ok(SchemaType::TypeDef {
-                            type_name: "Record".parse().unwrap(),
-                        });
-                    }
-                }
-                error_if_fields(
-                    &[Element, Name],
-                    &[
-                        type_field_name!(Attributes),
-                        type_field_name!(AdditionalAttributes),
-                    ],
-                )?;
-
-                if let Some(attributes) = attributes {
-                    let additional_attributes =
-                        additional_attributes.unwrap_or(Ok(partial_schema_default()));
-                    Ok(SchemaType::Type(SchemaTypeVariant::Record {
-                        attributes: attributes?.0,
-                        additional_attributes: additional_attributes?,
-                    }))
-                } else {
-                    Err(serde::de::Error::missing_field(Attributes.as_str()))
-                }
-            }
-            Some("Entity") => {
-                match error_if_any_fields() {
-                    Err(_) => {}
-                    Ok(_) => {
-                        return Ok(SchemaType::TypeDef {
-                            type_name: "Entity".parse().unwrap(),
-                        });
-                    }
-                }
-                error_if_fields(
-                    &[Element, Attributes, AdditionalAttributes],
-                    &[type_field_name!(Name)],
-                )?;
-
-                if let Some(name) = name {
-                    let name = name?;
-                    Ok(SchemaType::Type(SchemaTypeVariant::Entity {
-                        name: cedar_policy_core::ast::Name::from_normalized_str(&name).map_err(
-                            |err| {
-                                serde::de::Error::custom(format!(
-                                    "invalid entity type `{name}`: {err}"
-                                ))
-                            },
-                        )?,
-                    }))
-                } else {
-                    Err(serde::de::Error::missing_field(Name.as_str()))
-                }
-            }
-            Some("Extension") => {
-                match error_if_any_fields() {
-                    Err(_) => {}
-                    Ok(_) => {
-                        return Ok(SchemaType::TypeDef {
-                            type_name: "Extension".parse().unwrap(),
-                        });
-                    }
-                }
-                error_if_fields(
-                    &[Element, Attributes, AdditionalAttributes],
-                    &[type_field_name!(Name)],
-                )?;
-
-                if let Some(name) = name {
-                    let name = name?;
-                    Ok(SchemaType::Type(SchemaTypeVariant::Extension {
-                        name: Id::from_normalized_str(&name).map_err(|err| {
-                            serde::de::Error::custom(format!(
-                                "invalid extension type `{name}`: {err}"
-                            ))
-                        })?,
-                    }))
-                } else {
-                    Err(serde::de::Error::missing_field(Name.as_str()))
-                }
-            }
-            Some(type_name) => {
-                error_if_any_fields()?;
-                Ok(SchemaType::TypeDef {
-                    type_name: cedar_policy_core::ast::Name::from_normalized_str(type_name)
-                        .map_err(|err| {
-                            serde::de::Error::custom(format!(
-                                "invalid common type `{type_name}`: {err}"
-                            ))
-                        })?,
-                })
             }
             None => Err(serde::de::Error::missing_field(Type.as_str())),
         }
@@ -713,13 +724,7 @@ fn is_partial_schema_default(b: &bool) -> bool {
     *b == partial_schema_default()
 }
 
-// The possible tags for a SchemaType as written in a schema JSON document. Used
-// to forbid declaring a custom typedef with the same name as a builtin type.
-// This must be kept up to date with the variants for `SchemaTypeVariant` and
-// their actual serialization by serde. There is crate that looks like it could
-// do this automatically, but it returns an empty slice for the variants names
-// of `SchemaTypeVariant`.
-// https://docs.rs/serde-aux/latest/serde_aux/serde_introspection/fn.serde_introspect.html
+// We forbid declaring a custom typedef with the same name as a builtin type.
 pub(crate) static PRIMITIVE_TYPES: &[&str] = &["String", "Long", "Boolean"];
 
 impl SchemaType {
@@ -847,6 +852,11 @@ fn record_attribute_required_default() -> bool {
 
 #[cfg(test)]
 mod test {
+    use cedar_policy_core::extensions::Extensions;
+    use cool_asserts::assert_matches;
+
+    use crate::{SchemaError, ValidatorSchema};
+
     use super::*;
 
     #[test]
@@ -1096,22 +1106,24 @@ mod test {
     fn schema_file_with_missing_field() {
         let src = serde_json::json!(
         {
-            "entityTypes": {
-                "User": {
-                    "shape": {
-                        "type": "Record",
-                        "attributes": {
-                            "favorite": {
-                                "type": "Entity",
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "favorite": {
+                                    "type": "Entity",
+                                }
                             }
                         }
                     }
-                }
-            },
-            "actions": {}
+                },
+                "actions": {}
+            }
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
-        println!("{:#?}", schema);
+        let schema = ValidatorSchema::from_json_value(src, Extensions::all_available());
+        assert_matches!(schema, Err(SchemaError::UndeclaredCommonTypes(UndeclaredCommonTypesError(ns))) if ns.contains(&"Entity".parse().unwrap()));
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -499,19 +499,17 @@ impl<'de> Visitor<'de> for SchemaTypeVisitor {
     }
 }
 
-lazy_static::lazy_static! {
-    // PANIC SAFETY `Set` is a valid `Name`
-    #[allow(clippy::expect_used)]
-    static ref SET_NAME : Name = Name::parse_unqualified_name("Set").expect("valid identifier");
-    // PANIC SAFETY `Record` is a valid `Name`
-    #[allow(clippy::expect_used)]
-    static ref RECORD_NAME : Name = Name::parse_unqualified_name("Record").expect("valid identifier");
-    // PANIC SAFETY `Entity` is a valid `Name`
-    #[allow(clippy::expect_used)]
-    static ref ENTITY_NAME : Name = Name::parse_unqualified_name("Entity").expect("valid identifier");
-    // PANIC SAFETY `Extension` is a valid `Name`
-    #[allow(clippy::expect_used)]
-    static ref EXTENSION_NAME : Name = Name::parse_unqualified_name("Extension").expect("valid identifier");
+// PANIC SAFETY `Set`, `Record`, `Entity`, and `Extension` are valid `Name`s
+#[allow(clippy::expect_used)]
+pub(crate) mod static_names {
+    use cedar_policy_core::ast::Name;
+
+    lazy_static::lazy_static! {
+        pub(crate) static ref SET_NAME : Name = Name::parse_unqualified_name("Set").expect("valid identifier");
+        pub(crate) static ref RECORD_NAME : Name = Name::parse_unqualified_name("Record").expect("valid identifier");
+        pub(crate) static ref ENTITY_NAME : Name = Name::parse_unqualified_name("Entity").expect("valid identifier");
+        pub(crate) static ref EXTENSION_NAME : Name = Name::parse_unqualified_name("Extension").expect("valid identifier");
+    }
 }
 
 impl SchemaTypeVisitor {
@@ -529,6 +527,7 @@ impl SchemaTypeVisitor {
     where
         M: MapAccess<'de>,
     {
+        use static_names::*;
         use TypeFields::*;
         let mut present_fields = [
             (Type, type_name.is_some()),

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -529,7 +529,8 @@ impl SchemaTypeVisitor {
     {
         use static_names::*;
         use TypeFields::*;
-        let mut present_fields = [
+        // Fields that remain to be parsed
+        let mut remaining_fields = [
             (Type, type_name.is_some()),
             (Element, element.is_some()),
             (Attributes, attributes.is_some()),
@@ -544,14 +545,14 @@ impl SchemaTypeVisitor {
         match type_name.transpose()?.as_ref() {
             Some(s) => {
                 // We've concluded that type exists
-                present_fields.remove(&Type);
+                remaining_fields.remove(&Type);
                 // Used to generate the appropriate serde error if a field is present
                 // when it is not expected.
                 let error_if_fields = |fs: &[TypeFields],
                                        expected: &'static [&'static str]|
                  -> std::result::Result<(), M::Error> {
                     for f in fs {
-                        if present_fields.contains(f) {
+                        if remaining_fields.contains(f) {
                             return Err(serde::de::Error::unknown_field(f.as_str(), expected));
                         }
                     }
@@ -574,7 +575,7 @@ impl SchemaTypeVisitor {
                         Ok(SchemaType::Type(SchemaTypeVariant::Boolean))
                     }
                     "Set" => {
-                        if present_fields.is_empty() {
+                        if remaining_fields.is_empty() {
                             Ok(SchemaType::TypeDef {
                                 type_name: SET_NAME.clone(),
                             })
@@ -592,7 +593,7 @@ impl SchemaTypeVisitor {
                         }
                     }
                     "Record" => {
-                        if present_fields.is_empty() {
+                        if remaining_fields.is_empty() {
                             Ok(SchemaType::TypeDef {
                                 type_name: RECORD_NAME.clone(),
                             })
@@ -618,7 +619,7 @@ impl SchemaTypeVisitor {
                         }
                     }
                     "Entity" => {
-                        if present_fields.is_empty() {
+                        if remaining_fields.is_empty() {
                             Ok(SchemaType::TypeDef {
                                 type_name: ENTITY_NAME.clone(),
                             })
@@ -641,7 +642,7 @@ impl SchemaTypeVisitor {
                         }
                     }
                     "Extension" => {
-                        if present_fields.is_empty() {
+                        if remaining_fields.is_empty() {
                             Ok(SchemaType::TypeDef {
                                 type_name: EXTENSION_NAME.clone(),
                             })

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -585,11 +585,9 @@ impl SchemaTypeVisitor {
                                 &[type_field_name!(Element)],
                             )?;
 
-                            // PANIC SAFETY: There are four fields allowed and the
-                            // previous function rules out three of them, ensuring
-                            // `element` exists
-                            #[allow(clippy::unwrap_used)]
                             Ok(SchemaType::Type(SchemaTypeVariant::Set {
+                                // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them, ensuring `element` exists
+                                #[allow(clippy::unwrap_used)]
                                 element: Box::new(element.unwrap()?),
                             }))
                         }
@@ -630,9 +628,7 @@ impl SchemaTypeVisitor {
                                 &[Element, Attributes, AdditionalAttributes],
                                 &[type_field_name!(Name)],
                             )?;
-                            // PANIC SAFETY: There are four fields allowed and the
-                            // previous function rules out three of them, ensuring
-                            // `name` exists
+                            // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
                             #[allow(clippy::unwrap_used)]
                             let name = name.unwrap()?;
                             Ok(SchemaType::Type(SchemaTypeVariant::Entity {
@@ -656,9 +652,7 @@ impl SchemaTypeVisitor {
                                 &[type_field_name!(Name)],
                             )?;
 
-                            // PANIC SAFETY: There are four fields allowed and the
-                            // previous function rules out three of them, ensuring
-                            // `name` exists
+                            // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
                             #[allow(clippy::unwrap_used)]
                             let name = name.unwrap()?;
                             Ok(SchemaType::Type(SchemaTypeVariant::Extension {

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -556,6 +556,14 @@ impl SchemaTypeVisitor {
                 Ok(SchemaType::Type(SchemaTypeVariant::Boolean))
             }
             Some("Set") => {
+                match error_if_any_fields() {
+                    Err(_) => {}
+                    Ok(_) => {
+                        return Ok(SchemaType::TypeDef {
+                            type_name: "Set".parse().unwrap(),
+                        });
+                    }
+                }
                 error_if_fields(
                     &[Attributes, AdditionalAttributes, Name],
                     &[type_field_name!(Element)],
@@ -570,6 +578,14 @@ impl SchemaTypeVisitor {
                 }
             }
             Some("Record") => {
+                match error_if_any_fields() {
+                    Err(_) => {}
+                    Ok(_) => {
+                        return Ok(SchemaType::TypeDef {
+                            type_name: "Record".parse().unwrap(),
+                        });
+                    }
+                }
                 error_if_fields(
                     &[Element, Name],
                     &[
@@ -590,6 +606,14 @@ impl SchemaTypeVisitor {
                 }
             }
             Some("Entity") => {
+                match error_if_any_fields() {
+                    Err(_) => {}
+                    Ok(_) => {
+                        return Ok(SchemaType::TypeDef {
+                            type_name: "Entity".parse().unwrap(),
+                        });
+                    }
+                }
                 error_if_fields(
                     &[Element, Attributes, AdditionalAttributes],
                     &[type_field_name!(Name)],
@@ -611,6 +635,14 @@ impl SchemaTypeVisitor {
                 }
             }
             Some("Extension") => {
+                match error_if_any_fields() {
+                    Err(_) => {}
+                    Ok(_) => {
+                        return Ok(SchemaType::TypeDef {
+                            type_name: "Extension".parse().unwrap(),
+                        });
+                    }
+                }
                 error_if_fields(
                     &[Element, Attributes, AdditionalAttributes],
                     &[type_field_name!(Name)],
@@ -688,15 +720,7 @@ fn is_partial_schema_default(b: &bool) -> bool {
 // do this automatically, but it returns an empty slice for the variants names
 // of `SchemaTypeVariant`.
 // https://docs.rs/serde-aux/latest/serde_aux/serde_introspection/fn.serde_introspect.html
-pub(crate) static SCHEMA_TYPE_VARIANT_TAGS: &[&str] = &[
-    "String",
-    "Long",
-    "Boolean",
-    "Set",
-    "Record",
-    "Entity",
-    "Extension",
-];
+pub(crate) static PRIMITIVE_TYPES: &[&str] = &["String", "Long", "Boolean"];
 
 impl SchemaType {
     /// Is this `SchemaType` an extension type, or does it contain one
@@ -1069,7 +1093,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = "missing field `name`")]
     fn schema_file_with_missing_field() {
         let src = serde_json::json!(
         {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed unnecessary lifetimes from some validation related structs (#715)
 - Changed policy validation to reject comparisons and conditionals between
   record types that differ in whether an attribute is required or optional.
+- Changed JSON schema parser so that `Set`, `Entity`, `Record`, and `Extension`
+  can be common type names; updated the error message when common type names
+  conflict with built-in primitive type names (#974, partially resolving #973)
 
 ### Removed
 


### PR DESCRIPTION
## Description of changes
This PR addresses two issues,

* Improve the error message when a common type name conflicts with a primitive type name
* Allow `Set`, `Record`, `Entity`, and `Extension` to be common type names

## Issue #, if available
#973 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

