### PR TITLE
Eliminate mutable `add_*_comment` functions for `Comment` struct

### DIFF
--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -68,10 +68,10 @@ impl Doc for Node<Option<VariableDef>> {
                     }
                     None => get_comment_after_end(vd.variable.loc.span, &mut context.tokens)?,
                 };
-                get_leading_comment_doc_from_str(&start_comment.leading_comment).append(
+                get_leading_comment_doc_from_str(start_comment.leading_comment()).append(
                     var_doc
                         .append(get_trailing_comment_doc_from_str(
-                            &start_comment.trailing_comment,
+                            start_comment.trailing_comment(),
                             RcDoc::nil(),
                         ))
                         .append(is_doc)
@@ -105,17 +105,17 @@ impl Doc for Node<Option<Cond>> {
                 let expr_leading_comment =
                     get_leading_comment_at_start(expr.loc.span, &mut context.tokens)?;
                 let expr_doc = expr.to_doc(context)?;
-                get_leading_comment_doc_from_str(&cond_comment.leading_comment).append(
+                get_leading_comment_doc_from_str(cond_comment.leading_comment()).append(
                     cond_doc
                         .append(get_trailing_comment_doc_from_str(
-                            &cond_comment.trailing_comment,
+                            cond_comment.trailing_comment(),
                             RcDoc::line(),
                         ))
                         .append(
-                            get_leading_comment_doc_from_str(&lb_comment.leading_comment).append(
+                            get_leading_comment_doc_from_str(lb_comment.leading_comment()).append(
                                 RcDoc::text("{").append(
                                     get_trailing_comment_doc_from_str(
-                                        &lb_comment.trailing_comment,
+                                        lb_comment.trailing_comment(),
                                         RcDoc::line(),
                                     )
                                     .append(
@@ -132,17 +132,17 @@ impl Doc for Node<Option<Cond>> {
                         .group(),
                 )
             }
-            None => get_leading_comment_doc_from_str(&cond_comment.leading_comment).append(
+            None => get_leading_comment_doc_from_str(cond_comment.leading_comment()).append(
                 cond_doc
                     .append(get_trailing_comment_doc_from_str(
-                        &cond_comment.trailing_comment,
+                        cond_comment.trailing_comment(),
                         RcDoc::line(),
                     ))
                     .append(
-                        get_leading_comment_doc_from_str(&lb_comment.leading_comment).append(
+                        get_leading_comment_doc_from_str(lb_comment.leading_comment()).append(
                             RcDoc::text("{")
                                 .append(get_trailing_comment_doc_from_str(
-                                    &lb_comment.trailing_comment,
+                                    lb_comment.trailing_comment(),
                                     RcDoc::line(),
                                 ))
                                 .append(rb_doc)

--- a/cedar-policy-formatter/src/pprint/token.rs
+++ b/cedar-policy-formatter/src/pprint/token.rs
@@ -47,17 +47,24 @@ pub fn get_comment(text: &str) -> String {
 // Represent Cedar comments
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct Comment {
-    pub leading_comment: String,
-    pub trailing_comment: String,
+    leading_comment: String,
+    trailing_comment: String,
 }
 
 impl Comment {
-    pub fn add_leading_comment(&mut self, comment: &str) {
-        self.leading_comment.push_str(&get_comment(comment));
+    pub fn new(leading_comment: &str, trailing_comment: &str) -> Self {
+        Self {
+            leading_comment: get_comment(leading_comment),
+            trailing_comment: get_comment(trailing_comment),
+        }
     }
 
-    pub fn add_trailing_comment(&mut self, comment: &str) {
-        self.trailing_comment.push_str(&get_comment(comment));
+    pub fn leading_comment(&self) -> &str {
+        &self.leading_comment
+    }
+
+    pub fn trailing_comment(&self) -> &str {
+        &self.trailing_comment
     }
 }
 
@@ -296,20 +303,12 @@ pub struct WrappedToken {
 }
 
 impl WrappedToken {
-    pub fn new(token: Token, comment: Comment, span: Span) -> Self {
+    pub fn new(token: Token, span: Span, comment: Comment) -> Self {
         Self {
             token,
             comment,
             span,
         }
-    }
-
-    pub fn add_leading_comment(&mut self, comment: &str) {
-        self.comment.add_leading_comment(comment);
-    }
-
-    pub fn add_trailing_comment(&mut self, comment: &str) {
-        self.comment.add_trailing_comment(comment);
     }
 
     fn clear_leading_comment(&mut self) {

--- a/cedar-policy-formatter/src/pprint/utils.rs
+++ b/cedar-policy-formatter/src/pprint/utils.rs
@@ -131,10 +131,10 @@ pub fn get_comment_in_range(span: miette::SourceSpan, tokens: &mut [WrappedToken
 /// will introduce a newline bat the start of the `RcDoc`. If there is a
 /// trailing comment, then it will introduce a newline at the end.
 pub fn add_comment<'a>(d: RcDoc<'a>, comment: Comment, next_doc: RcDoc<'a>) -> RcDoc<'a> {
-    let leading_comment = comment.leading_comment;
-    let trailing_comment = comment.trailing_comment;
-    let leading_comment_doc = get_leading_comment_doc_from_str(&leading_comment);
-    let trailing_comment_doc = get_trailing_comment_doc_from_str(&trailing_comment, next_doc);
+    let leading_comment = comment.leading_comment();
+    let trailing_comment = comment.trailing_comment();
+    let leading_comment_doc = get_leading_comment_doc_from_str(leading_comment);
+    let trailing_comment_doc = get_trailing_comment_doc_from_str(trailing_comment, next_doc);
     leading_comment_doc.append(d).append(trailing_comment_doc)
 }
 


### PR DESCRIPTION
A leading and trailing comment were each only added once per comment struct. Using mutable updates obscured this and made the `add_comments` function tricky to follow.

Also simplifies the logic for attaching the end-of-file comments and merges this into the main comment-finding code.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

