### PR TITLE
Implement RFC 55

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -28,38 +28,72 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, TryFromInto};
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::str::FromStr;
 use thiserror::Error;
 
-/// We support two types of entities. The first is a nominal type (e.g., User, Action)
-/// and the second is an unspecified type, which is used (internally) to represent cases
-/// where the input request does not provide a principal, action, and/or resource.
+/// The entity type that Actions must have
+pub static ACTION_ENTITY_TYPE: &str = "Action";
+
+/// Entity type names are just [`Name`]s, but we have some operations on them specific to entity types.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub enum EntityType {
-    /// Concrete nominal type
-    Specified(Name),
-    /// Unspecified
-    Unspecified,
-}
+#[serde(transparent)]
+pub struct EntityType(Name);
 
 impl EntityType {
-    /// Is this an Action entity type
+    /// Is this an Action entity type?
+    /// Returns true when an entity type is an action entity type. This compares the
+    /// base name for the type, so this will return true for any entity type named
+    /// `Action` regardless of namespaces.
     pub fn is_action(&self) -> bool {
-        match self {
-            Self::Specified(name) => name.basename() == &Id::new_unchecked("Action"),
-            Self::Unspecified => false,
-        }
+        self.0.basename() == &Id::new_unchecked(ACTION_ENTITY_TYPE)
+    }
+
+    /// The name of this entity type
+    pub fn name(&self) -> &Name {
+        &self.0
+    }
+
+    /// The source location of this entity type
+    pub fn loc(&self) -> Option<&Loc> {
+        self.0.loc()
+    }
+
+    /// Calls [`Name::prefix_namespace_if_unqualified`] on the underlying [`Name`]
+    pub fn prefix_namespace_if_unqualified(&self, namespace: Option<&Name>) -> Self {
+        Self(self.0.prefix_namespace_if_unqualified(namespace))
+    }
+
+    /// Wraps [`Name::from_normalized_str`]
+    pub fn from_normalized_str(src: &str) -> Result<Self, ParseErrors> {
+        Name::from_normalized_str(src).map(Self)
     }
 }
 
-// Note: the characters '<' and '>' are not allowed in `Name`s, so the display for
-// `Unspecified` never conflicts with `Specified(name)`.
+impl From<Name> for EntityType {
+    fn from(n: Name) -> Self {
+        Self(n)
+    }
+}
+
+impl AsRef<Name> for EntityType {
+    fn as_ref(&self) -> &Name {
+        &self.0
+    }
+}
+
+impl FromStr for EntityType {
+    type Err = <Name as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let name: Name = s.parse()?;
+        Ok(Self(name))
+    }
+}
+
 impl std::fmt::Display for EntityType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Unspecified => write!(f, "<Unspecified>"),
-            Self::Specified(name) => write!(f, "{}", name),
-        }
+        write!(f, "{}", self.0)
     }
 }
 
@@ -133,7 +167,7 @@ impl EntityUID {
     pub(crate) fn test_entity_type() -> EntityType {
         let name = Name::parse_unqualified_name("test_entity_type")
             .expect("test_entity_type should be a valid identifier");
-        EntityType::Specified(name)
+        EntityType(name)
     }
     // by default, Coverlay does not track coverage for lines after a line
     // containing #[cfg(test)].
@@ -144,7 +178,7 @@ impl EntityUID {
     /// Create an `EntityUID` with the given (unqualified) typename, and the given string as its EID.
     pub fn with_eid_and_type(typename: &str, eid: &str) -> Result<Self, ParseErrors> {
         Ok(Self {
-            ty: EntityType::Specified(Name::parse_unqualified_name(typename)?),
+            ty: EntityType(Name::parse_unqualified_name(typename)?),
             eid: Eid(eid.into()),
             loc: None,
         })
@@ -161,22 +195,9 @@ impl EntityUID {
         self.loc.as_ref()
     }
 
-    /// Create a nominally-typed `EntityUID` with the given typename and EID
-    pub fn from_components(name: Name, eid: Eid, loc: Option<Loc>) -> Self {
-        Self {
-            ty: EntityType::Specified(name),
-            eid,
-            loc,
-        }
-    }
-
-    /// Create an unspecified `EntityUID` with the given EID
-    pub fn unspecified_from_eid(eid: Eid) -> Self {
-        Self {
-            ty: EntityType::Unspecified,
-            eid,
-            loc: None,
-        }
+    /// Create an [`EntityUID`] with the given typename and [`Eid`]
+    pub fn from_components(ty: EntityType, eid: Eid, loc: Option<Loc>) -> Self {
+        Self { ty, eid, loc }
     }
 
     /// Get the type component.
@@ -588,14 +609,16 @@ mod test {
     fn test_euid_equality() {
         let e1 = EntityUID::with_eid("foo");
         let e2 = EntityUID::from_components(
-            Name::parse_unqualified_name("test_entity_type").expect("should be a valid identifier"),
+            Name::parse_unqualified_name("test_entity_type")
+                .expect("should be a valid identifier")
+                .into(),
             Eid("foo".into()),
             None,
         );
-        let e3 = EntityUID::unspecified_from_eid(Eid("foo".into()));
-        let e4 = EntityUID::unspecified_from_eid(Eid("bar".into()));
-        let e5 = EntityUID::from_components(
-            Name::parse_unqualified_name("Unspecified").expect("should be a valid identifier"),
+        let e3 = EntityUID::from_components(
+            Name::parse_unqualified_name("Unspecified")
+                .expect("should be a valid identifier")
+                .into(),
             Eid("foo".into()),
             None,
         );
@@ -603,21 +626,12 @@ mod test {
         // an EUID is equal to itself
         assert_eq!(e1, e1);
         assert_eq!(e2, e2);
-        assert_eq!(e3, e3);
 
         // constructing with `with_euid` or `from_components` is the same
         assert_eq!(e1, e2);
 
         // other pairs are not equal
         assert!(e1 != e3);
-        assert!(e1 != e4);
-        assert!(e1 != e5);
-        assert!(e3 != e4);
-        assert!(e3 != e5);
-        assert!(e4 != e5);
-
-        // e3 and e5 are displayed differently
-        assert!(format!("{e3}") != format!("{e5}"));
     }
 
     #[test]
@@ -630,5 +644,10 @@ mod test {
         assert!(!euid.is_action());
         let euid = EntityUID::from_str("Action::Foo::\"view\"").unwrap();
         assert!(!euid.is_action());
+    }
+
+    #[test]
+    fn action_type_is_valid_id() {
+        assert!(Id::from_normalized_str(ACTION_ENTITY_TYPE).is_ok());
     }
 }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -133,8 +133,8 @@ pub enum ExprKind<T = ()> {
     Is {
         /// Expression to test. Must evaluate to an Entity.
         expr: Arc<Expr<T>>,
-        /// The entity type `Name` used for the type membership test.
-        entity_type: Name,
+        /// The [`EntityType`] used for the type membership test.
+        entity_type: EntityType,
     },
     /// Set (whose elements may be arbitrary expressions)
     //
@@ -481,7 +481,7 @@ impl Expr {
     }
 
     /// Create an `is` expression.
-    pub fn is_entity_type(expr: Expr, entity_type: Name) -> Self {
+    pub fn is_entity_type(expr: Expr, entity_type: EntityType) -> Self {
         ExprBuilder::new().is_entity_type(expr, entity_type)
     }
 
@@ -1090,7 +1090,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'is' expression.
-    pub fn is_entity_type(self, expr: Expr<T>, entity_type: Name) -> Expr<T> {
+    pub fn is_entity_type(self, expr: Expr<T>, entity_type: EntityType) -> Expr<T> {
         self.with_expr_kind(ExprKind::Is {
             expr: Arc::new(expr),
             entity_type,

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1234,21 +1234,21 @@ impl PrincipalConstraint {
     }
 
     /// Type constraint additionally constrained to be in a slot.
-    pub fn is_entity_type_in_slot(entity_type: Arc<Name>) -> Self {
+    pub fn is_entity_type_in_slot(entity_type: Arc<EntityType>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in_slot(entity_type),
         }
     }
 
     /// Type constraint, with a hierarchical constraint.
-    pub fn is_entity_type_in(entity_type: Arc<Name>, in_entity: Arc<EntityUID>) -> Self {
+    pub fn is_entity_type_in(entity_type: Arc<EntityType>, in_entity: Arc<EntityUID>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in(entity_type, in_entity),
         }
     }
 
     /// Type constraint, with no hierarchical constraint or slot.
-    pub fn is_entity_type(entity_type: Arc<Name>) -> Self {
+    pub fn is_entity_type(entity_type: Arc<EntityType>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type(entity_type),
         }
@@ -1341,21 +1341,21 @@ impl ResourceConstraint {
     }
 
     /// Type constraint additionally constrained to be in a slot.
-    pub fn is_entity_type_in_slot(entity_type: Arc<Name>) -> Self {
+    pub fn is_entity_type_in_slot(entity_type: Arc<EntityType>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in_slot(entity_type),
         }
     }
 
     /// Type constraint, with a hierarchical constraint.
-    pub fn is_entity_type_in(entity_type: Arc<Name>, in_entity: Arc<EntityUID>) -> Self {
+    pub fn is_entity_type_in(entity_type: Arc<EntityType>, in_entity: Arc<EntityUID>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type_in(entity_type, in_entity),
         }
     }
 
     /// Type constraint, with no hierarchical constraint or slot.
-    pub fn is_entity_type(entity_type: Arc<Name>) -> Self {
+    pub fn is_entity_type(entity_type: Arc<EntityType>) -> Self {
         Self {
             constraint: PrincipalOrResourceConstraint::is_entity_type(entity_type),
         }
@@ -1479,9 +1479,9 @@ pub enum PrincipalOrResourceConstraint {
     /// Equality constraint
     Eq(EntityReference),
     /// Type constraint,
-    Is(Arc<Name>),
+    Is(Arc<EntityType>),
     /// Type constraint with a hierarchy constraint
-    IsIn(Arc<Name>, EntityReference),
+    IsIn(Arc<EntityType>, EntityReference),
 }
 
 impl PrincipalOrResourceConstraint {
@@ -1511,17 +1511,17 @@ impl PrincipalOrResourceConstraint {
     }
 
     /// Type constraint additionally constrained to be in a slot.
-    pub fn is_entity_type_in_slot(entity_type: Arc<Name>) -> Self {
+    pub fn is_entity_type_in_slot(entity_type: Arc<EntityType>) -> Self {
         PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot)
     }
 
     /// Type constraint with a hierarchical constraint.
-    pub fn is_entity_type_in(entity_type: Arc<Name>, in_entity: Arc<EntityUID>) -> Self {
+    pub fn is_entity_type_in(entity_type: Arc<EntityType>, in_entity: Arc<EntityUID>) -> Self {
         PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::euid(in_entity))
     }
 
     /// Type constraint, with no hierarchical constraint or slot.
-    pub fn is_entity_type(entity_type: Arc<Name>) -> Self {
+    pub fn is_entity_type(entity_type: Arc<EntityType>) -> Self {
         PrincipalOrResourceConstraint::Is(entity_type)
     }
 
@@ -1583,15 +1583,10 @@ impl PrincipalOrResourceConstraint {
     }
 
     /// Get an iterator over all of the entity type names in this constraint.
-    /// The Unspecified entity type does not have a `Name`, so it is excluded
-    /// from this iter.
-    pub fn iter_entity_type_names(&self) -> impl Iterator<Item = &'_ Name> {
+    pub fn iter_entity_type_names(&self) -> impl Iterator<Item = &'_ EntityType> {
         self.get_euid()
             .into_iter()
-            .filter_map(|euid| match euid.entity_type() {
-                EntityType::Specified(name) => Some(name),
-                EntityType::Unspecified => None,
-            })
+            .map(|euid| euid.entity_type())
             .chain(match self {
                 PrincipalOrResourceConstraint::Is(entity_type)
                 | PrincipalOrResourceConstraint::IsIn(entity_type, _) => Some(entity_type.as_ref()),
@@ -1672,14 +1667,8 @@ impl ActionConstraint {
     }
 
     /// Get an iterator over all of the entity types in this constraint.
-    /// The Unspecified entity type does not have a `Name`, so it is excluded
-    /// from this iter.
-    pub fn iter_entity_type_names(&self) -> impl Iterator<Item = &'_ Name> {
-        self.iter_euids()
-            .filter_map(|euid| match euid.entity_type() {
-                EntityType::Specified(name) => Some(name),
-                EntityType::Unspecified => None,
-            })
+    pub fn iter_entity_type_names(&self) -> impl Iterator<Item = &'_ EntityType> {
+        self.iter_euids().map(|euid| euid.entity_type())
     }
 
     /// Check that all of the EUIDs in an action constraint have the type
@@ -2157,7 +2146,7 @@ mod test {
     #[test]
     fn test_iter_once() {
         let id = EntityUID::from_components(
-            name::Name::unqualified_name(id::Id::new_unchecked("s")),
+            name::Name::unqualified_name(id::Id::new_unchecked("s")).into(),
             entity::Eid::new("eid"),
             None,
         );
@@ -2169,12 +2158,12 @@ mod test {
     #[test]
     fn test_iter_mult() {
         let id1 = EntityUID::from_components(
-            name::Name::unqualified_name(id::Id::new_unchecked("s")),
+            name::Name::unqualified_name(id::Id::new_unchecked("s")).into(),
             entity::Eid::new("eid1"),
             None,
         );
         let id2 = EntityUID::from_components(
-            name::Name::unqualified_name(id::Id::new_unchecked("s")),
+            name::Name::unqualified_name(id::Id::new_unchecked("s")).into(),
             entity::Eid::new("eid2"),
             None,
         );

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -53,7 +53,7 @@ pub struct Request {
 /// or an unknown in the case of partial evaluation
 #[derive(Debug, Clone, Serialize)]
 pub enum EntityUIDEntry {
-    /// A concrete (but perhaps unspecified) EntityUID
+    /// A concrete EntityUID
     Known {
         /// The concrete `EntityUID`
         euid: Arc<EntityUID>,
@@ -83,7 +83,7 @@ impl EntityUIDEntry {
     }
 
     /// Create an entry with a concrete EntityUID and the given source location
-    pub fn concrete(euid: EntityUID, loc: Option<Loc>) -> Self {
+    pub fn known(euid: EntityUID, loc: Option<Loc>) -> Self {
         Self::Known {
             euid: Arc::new(euid),
             loc,
@@ -113,9 +113,9 @@ impl Request {
         extensions: Extensions<'_>,
     ) -> Result<Self, S::Error> {
         let req = Self {
-            principal: EntityUIDEntry::concrete(principal.0, principal.1),
-            action: EntityUIDEntry::concrete(action.0, action.1),
-            resource: EntityUIDEntry::concrete(resource.0, resource.1),
+            principal: EntityUIDEntry::known(principal.0, principal.1),
+            action: EntityUIDEntry::known(action.0, action.1),
+            resource: EntityUIDEntry::known(resource.0, resource.1),
             context: Some(context),
         };
         if let Some(schema) = schema {

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -625,7 +625,7 @@ pub enum RestrictedExpressionError {
     InvalidRestrictedExpression(#[from] restricted_expr_errors::InvalidRestrictedExpressionError),
 }
 
-/// Error subtypes for [`RestrictedExprError`]
+/// Error subtypes for [`RestrictedExpressionError`]
 pub mod restricted_expr_errors {
     use super::Expr;
     use miette::Diagnostic;

--- a/cedar-policy-core/src/ast/types.rs
+++ b/cedar-policy-core/src/ast/types.rs
@@ -40,8 +40,8 @@ pub enum Type {
     Entity {
         /// Entity type.
         ///
-        /// Entities can be unspecified or nominally typed. Unspecified entity types
-        /// are equal and nominal entity types are equal if they have the same typename.
+        /// Entities are nominally typed.
+        /// Nominal entity types are equal if they have the same typename.
         ty: EntityType,
     },
     /// Extension type. This is different from entity type.
@@ -65,9 +65,7 @@ pub enum Type {
 impl Type {
     /// Shorthand for constructing an entity type.
     pub fn entity_type(name: Name) -> Self {
-        Type::Entity {
-            ty: EntityType::Specified(name),
-        }
+        Type::Entity { ty: name.into() }
     }
 }
 
@@ -79,10 +77,7 @@ impl std::fmt::Display for Type {
             Self::String => write!(f, "string"),
             Self::Set => write!(f, "set"),
             Self::Record => write!(f, "record"),
-            Self::Entity { ty } => match ty {
-                EntityType::Unspecified => write!(f, "(entity of unspecified type)"),
-                EntityType::Specified(name) => write!(f, "(entity of type `{}`)", name),
-            },
+            Self::Entity { ty } => write!(f, "(entity of type `{ty}`)"),
             Self::Extension { name } => write!(f, "{}", name),
         }
     }

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1949,12 +1949,12 @@ mod schema_based_parsing_tests {
             basename: &'a Id,
         ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
             match basename.as_ref() {
-                "Employee" => Box::new(std::iter::once(EntityType::Specified(
-                    Name::unqualified_name(basename.clone()),
-                ))),
-                "Action" => Box::new(std::iter::once(EntityType::Specified(
-                    Name::unqualified_name(basename.clone()),
-                ))),
+                "Employee" => Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+                    basename.clone(),
+                )))),
+                "Action" => Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+                    basename.clone(),
+                )))),
                 _ => Box::new(std::iter::empty()),
             }
         }
@@ -1967,7 +1967,7 @@ mod schema_based_parsing_tests {
     struct MockEmployeeDescription;
     impl EntityTypeDescription for MockEmployeeDescription {
         fn entity_type(&self) -> EntityType {
-            EntityType::Specified(Name::parse_unqualified_name("Employee").expect("valid"))
+            EntityType::from(Name::parse_unqualified_name("Employee").expect("valid"))
         }
 
         fn attr_type(&self, attr: &str) -> Option<SchemaType> {
@@ -1975,7 +1975,7 @@ mod schema_based_parsing_tests {
                 ty: self.entity_type(),
             };
             let hr_ty = || SchemaType::Entity {
-                ty: EntityType::Specified(Name::parse_unqualified_name("HR").expect("valid")),
+                ty: EntityType::from(Name::parse_unqualified_name("HR").expect("valid")),
             };
             match attr {
                 "isFullTime" => Some(SchemaType::Bool),
@@ -3035,7 +3035,7 @@ mod schema_based_parsing_tests {
                 basename: &'a Id,
             ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
                 match basename.as_ref() {
-                    "Employee" => Box::new(std::iter::once(EntityType::Specified(
+                    "Employee" => Box::new(std::iter::once(EntityType::from(
                         Name::from_str("XYZCorp::Employee").expect("valid name"),
                     ))),
                     _ => Box::new(std::iter::empty()),
@@ -3049,7 +3049,7 @@ mod schema_based_parsing_tests {
         struct MockEmployeeDescription;
         impl EntityTypeDescription for MockEmployeeDescription {
             fn entity_type(&self) -> EntityType {
-                EntityType::Specified("XYZCorp::Employee".parse().expect("valid"))
+                "XYZCorp::Employee".parse().expect("valid")
             }
 
             fn attr_type(&self, attr: &str) -> Option<SchemaType> {

--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -19,8 +19,7 @@ use super::{
     GetSchemaTypeError, HeterogeneousSetError, Schema, SchemaType,
 };
 use crate::ast::{
-    BorrowedRestrictedExpr, Entity, EntityType, PartialValue, PartialValueToRestrictedExprError,
-    RestrictedExpr,
+    BorrowedRestrictedExpr, Entity, PartialValue, PartialValueToRestrictedExprError, RestrictedExpr,
 };
 use crate::extensions::{ExtensionFunctionLookupError, Extensions};
 use either::Either;
@@ -63,13 +62,10 @@ impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
             }
         } else {
             let schema_etype = self.schema.entity_type(etype).ok_or_else(|| {
-                let suggested_types = match etype {
-                    EntityType::Specified(name) => self
-                        .schema
-                        .entity_types_with_basename(name.basename())
-                        .collect(),
-                    EntityType::Unspecified => vec![],
-                };
+                let suggested_types = self
+                    .schema
+                    .entity_types_with_basename(etype.name().basename())
+                    .collect();
                 UnexpectedEntityTypeError {
                     uid: uid.clone(),
                     suggested_types,

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -19,9 +19,7 @@ use super::{
     CedarValueJson, EntityTypeDescription, EntityUidJson, NoEntitiesSchema, Schema, TypeAndId,
     ValueParser,
 };
-use crate::ast::{
-    BorrowedRestrictedExpr, Entity, EntityType, EntityUID, PartialValue, RestrictedExpr,
-};
+use crate::ast::{BorrowedRestrictedExpr, Entity, EntityUID, PartialValue, RestrictedExpr};
 use crate::entities::conformance::EntitySchemaConformanceChecker;
 use crate::entities::{
     conformance::err::{EntitySchemaConformanceError, UnexpectedEntityTypeError},
@@ -283,12 +281,9 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                     )?)
                 } else {
                     EntitySchemaInfo::NonAction(schema.entity_type(etype).ok_or_else(|| {
-                        let suggested_types = match etype {
-                            EntityType::Specified(name) => {
-                                schema.entity_types_with_basename(name.basename()).collect()
-                            }
-                            EntityType::Unspecified => vec![],
-                        };
+                        let suggested_types = schema
+                            .entity_types_with_basename(etype.name().basename())
+                            .collect();
                         JsonDeserializationError::EntitySchemaConformance(
                             UnexpectedEntityTypeError {
                                 uid: uid.clone(),

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -102,9 +102,9 @@ impl Schema for AllEntitiesNoAttrsSchema {
         &'a self,
         basename: &'a Id,
     ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
-        Box::new(std::iter::once(EntityType::Specified(
-            Name::unqualified_name(basename.clone()),
-        )))
+        Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+            basename.clone(),
+        ))))
     }
     fn action_entities(&self) -> std::iter::Empty<Arc<Entity>> {
         std::iter::empty()

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -234,10 +234,7 @@ impl std::fmt::Display for SchemaType {
                     Ok(())
                 }
             }
-            Self::Entity { ty } => match ty {
-                EntityType::Unspecified => write!(f, "(entity of unspecified type)"),
-                EntityType::Specified(name) => write!(f, "`{}`", name),
-            },
+            Self::Entity { ty } => write!(f, "`{ty}`"),
             Self::Extension { name } => write!(f, "{}", name),
         }
     }

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -199,7 +199,7 @@ impl TryFrom<TypeAndId> for EntityUID {
 
     fn try_from(e: TypeAndId) -> Result<EntityUID, Self::Error> {
         Ok(EntityUID::from_components(
-            Name::from_normalized_str(&e.entity_type)?,
+            Name::from_normalized_str(&e.entity_type)?.into(),
             Eid::new(e.id),
             None,
         ))

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -15,6 +15,7 @@
  */
 
 use super::FromJsonError;
+use crate::ast;
 use crate::ast::InputInteger;
 use crate::entities::json::{
     err::EscapeKind, err::JsonDeserializationError, err::JsonDeserializationErrorContext,
@@ -26,7 +27,6 @@ use crate::parser::err::{ParseErrors, ToASTError, ToASTErrorKind};
 use crate::parser::unescape::to_unescaped_string;
 use crate::parser::util::flatten_tuple_2;
 use crate::parser::{Loc, Node};
-use crate::{ast, FromNormalizedStr};
 use either::Either;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -653,7 +653,7 @@ impl Expr {
                 left,
                 entity_type,
                 in_expr,
-            }) => ast::Name::from_normalized_str(entity_type.as_str())
+            }) => ast::EntityType::from_normalized_str(entity_type.as_str())
                 .map_err(FromJsonError::InvalidEntityType)
                 .and_then(|entity_type_name| {
                     let left: ast::Expr = (*left).clone().try_into_ast(id.clone())?;
@@ -1077,7 +1077,7 @@ fn interpret_primary(
                 path,
                 eid: eid_node,
             } => {
-                let maybe_name = path.to_name();
+                let maybe_name = path.to_name().map(ast::EntityType::from);
                 let maybe_eid = eid_node.as_valid_string();
 
                 let (name, eid) = flatten_tuple_2(maybe_name, maybe_eid)?;

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -15,9 +15,9 @@
  */
 
 use super::{FromJsonError, LinkingError};
+use crate::ast;
 use crate::entities::json::{err::JsonDeserializationErrorContext, EntityUidJson};
 use crate::parser::err::parse_errors;
-use crate::{ast, FromNormalizedStr};
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::HashMap;
@@ -565,7 +565,7 @@ impl TryFrom<PrincipalConstraint> for ast::PrincipalOrResourceConstraint {
             PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
                 entity_type,
                 in_entity,
-            }) => ast::Name::from_normalized_str(entity_type.as_str())
+            }) => ast::EntityType::from_normalized_str(entity_type.as_str())
                 .map_err(Self::Error::InvalidEntityType)
                 .and_then(|entity_type| {
                     Ok(match in_entity {
@@ -630,7 +630,7 @@ impl TryFrom<ResourceConstraint> for ast::PrincipalOrResourceConstraint {
             ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
                 entity_type,
                 in_entity,
-            }) => ast::Name::from_normalized_str(entity_type.as_str())
+            }) => ast::EntityType::from_normalized_str(entity_type.as_str())
                 .map_err(Self::Error::InvalidEntityType)
                 .and_then(|entity_type| {
                     Ok(match in_entity {

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -584,11 +584,9 @@ impl<'e> Evaluator<'e> {
             ExprKind::Is { expr, entity_type } => {
                 let v = self.partial_interpret(expr, slots)?;
                 match v {
-                    PartialValue::Value(v) => Ok(match v.get_as_entity()?.entity_type() {
-                        EntityType::Specified(expr_entity_type) => entity_type == expr_entity_type,
-                        EntityType::Unspecified => false,
+                    PartialValue::Value(v) => {
+                        Ok((v.get_as_entity()?.entity_type() == entity_type).into())
                     }
-                    .into()),
                     PartialValue::Residual(r) => {
                         Ok(Expr::is_entity_type(r, entity_type.clone()).into())
                     }
@@ -758,16 +756,10 @@ impl<'e> Evaluator<'e> {
                 value: ValueKind::Lit(Literal::EntityUID(uid)),
                 loc,
             }) => match self.entities.entity(uid.as_ref()) {
-                Dereference::NoSuchEntity => Err(match *uid.entity_type() {
-                    EntityType::Unspecified => EvaluationError::unspecified_entity_access(
-                        attr.clone(),
-                        source_loc.cloned(),
-                    ),
-                    EntityType::Specified(_) => {
-                        // intentionally using the location of the euid (the LHS) and not the entire GetAttr expression
-                        EvaluationError::entity_does_not_exist(uid.clone(), loc)
-                    }
-                }),
+                Dereference::NoSuchEntity => {
+                    // intentionally using the location of the euid (the LHS) and not the entire GetAttr expression
+                    Err(EvaluationError::entity_does_not_exist(uid.clone(), loc))
+                }
                 Dereference::Residual(r) => {
                     Ok(PartialValue::Residual(Expr::get_attr(r, attr.clone())))
                 }
@@ -1248,18 +1240,6 @@ pub mod test {
                 loc: None,
             }),
         );
-        // unspecified entities should not result in an error.
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::val(EntityUID::unspecified_from_eid(Eid::new(
-                "foo"
-            )))),
-            Ok(Value {
-                value: ValueKind::Lit(Literal::EntityUID(Arc::new(
-                    EntityUID::unspecified_from_eid(Eid::new("foo"))
-                ))),
-                loc: None,
-            }),
-        );
     }
 
     #[test]
@@ -1363,25 +1343,6 @@ pub mod test {
             )),
             Err(EvaluationError::entity_does_not_exist(
                 Arc::new(EntityUID::with_eid("doesnotexist")),
-                None
-            ))
-        );
-        // has_attr on an unspecified entity
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::has_attr(
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
-                "foo".into()
-            )),
-            Ok(Value::from(false))
-        );
-        // get_attr on an unspecified entity
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::get_attr(
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
-                "bar".into()
-            )),
-            Err(EvaluationError::unspecified_entity_access(
-                "bar".into(),
                 None
             ))
         );
@@ -3265,14 +3226,6 @@ pub mod test {
             )),
             Ok(Value::from(true))
         );
-        // A in A, where A is unspecified
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::is_in(
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
-            )),
-            Ok(Value::from(true))
-        );
         // A in B, where actually B in A
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_in(
@@ -3302,22 +3255,6 @@ pub mod test {
             eval.interpret_inline_policy(&Expr::is_in(
                 Expr::val(EntityUID::with_eid("parent")),
                 Expr::val(EntityUID::with_eid("doesnotexist"))
-            )),
-            Ok(Value::from(false))
-        );
-        // A in B, where A is unspecified but B exists
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::is_in(
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
-                Expr::val(EntityUID::with_eid("parent"))
-            )),
-            Ok(Value::from(false))
-        );
-        // A in B, where A exists but B is unspecified
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::is_in(
-                Expr::val(EntityUID::with_eid("parent")),
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo")))
             )),
             Ok(Value::from(false))
         );
@@ -3853,13 +3790,6 @@ pub mod test {
             eval.interpret_inline_policy(
                 &parse_expr(r#"N::S::User::"alice" is User"#).expect("parsing error")
             ),
-            Ok(Value::from(false))
-        );
-        assert_eq!(
-            eval.interpret_inline_policy(&Expr::is_entity_type(
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("thing"))),
-                "User".parse().unwrap()
-            )),
             Ok(Value::from(false))
         );
         assert_matches!(

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -44,11 +44,6 @@ pub enum EvaluationError {
     #[diagnostic(transparent)]
     EntityAttrDoesNotExist(#[from] evaluation_errors::EntityAttrDoesNotExistError),
 
-    /// Tried to access an attribute of an unspecified entity
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    UnspecifiedEntityAccess(#[from] evaluation_errors::UnspecifiedEntityAccessError),
-
     /// Tried to get an attribute of a (non-entity) record, but that record
     /// didn't have that attribute
     #[error(transparent)]
@@ -105,7 +100,6 @@ impl EvaluationError {
         match self {
             Self::EntityDoesNotExist(e) => e.source_loc.as_ref(),
             Self::EntityAttrDoesNotExist(e) => e.source_loc.as_ref(),
-            Self::UnspecifiedEntityAccess(e) => e.source_loc.as_ref(),
             Self::RecordAttrDoesNotExist(e) => e.source_loc.as_ref(),
             Self::FailedExtensionFunctionLookup(e) => e.source_loc(),
             Self::TypeError(e) => e.source_loc.as_ref(),
@@ -129,12 +123,6 @@ impl EvaluationError {
             }
             Self::EntityAttrDoesNotExist(e) => {
                 Self::EntityAttrDoesNotExist(evaluation_errors::EntityAttrDoesNotExistError {
-                    source_loc,
-                    ..e
-                })
-            }
-            Self::UnspecifiedEntityAccess(e) => {
-                Self::UnspecifiedEntityAccess(evaluation_errors::UnspecifiedEntityAccessError {
                     source_loc,
                     ..e
                 })
@@ -196,11 +184,6 @@ impl EvaluationError {
             source_loc,
         }
         .into()
-    }
-
-    /// Construct a [`UnspecifiedEntityAccess`] error
-    pub(crate) fn unspecified_entity_access(attr: SmolStr, source_loc: Option<Loc>) -> Self {
-        evaluation_errors::UnspecifiedEntityAccessError { attr, source_loc }.into()
     }
 
     /// Construct a [`RecordAttrDoesNotExist`] error
@@ -398,34 +381,6 @@ pub mod evaluation_errors {
             }
         }
 
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-    }
-
-    /// Tried to access an attribute of an unspecified entity
-    //
-    // CAUTION: this type is publicly exported in `cedar-policy`.
-    // Don't make fields `pub`, don't make breaking changes, and use caution
-    // when adding public methods.
-    #[derive(Debug, PartialEq, Eq, Clone, Error)]
-    #[error("cannot access attribute `{attr}` of unspecified entity")]
-    pub struct UnspecifiedEntityAccessError {
-        /// Name of the attribute we tried to access
-        pub(crate) attr: SmolStr,
-        /// Source location
-        pub(crate) source_loc: Option<Loc>,
-    }
-
-    impl Diagnostic for UnspecifiedEntityAccessError {
-        impl_diagnostic_from_source_loc_field!();
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
         fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
         }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -540,7 +540,7 @@ impl Node<Option<cst::VariableDef>> {
                 (cst::RelOp::Eq, Some(_)) => Err(self.to_ast_err(ToASTErrorKind::IsWithEq)),
                 (cst::RelOp::In, None) => Ok(PrincipalOrResourceConstraint::In(eref)),
                 (cst::RelOp::In, Some(entity_type)) => Ok(PrincipalOrResourceConstraint::IsIn(
-                    Arc::new(entity_type.to_expr_or_special()?.into_name()?),
+                    Arc::new(entity_type.to_expr_or_special()?.into_entity_type()?),
                     eref,
                 )),
                 (cst::RelOp::InvalidSingleEq, _) => {
@@ -550,7 +550,7 @@ impl Node<Option<cst::VariableDef>> {
             }
         } else if let Some(entity_type) = &vardef.entity_type {
             Ok(PrincipalOrResourceConstraint::Is(Arc::new(
-                entity_type.to_expr_or_special()?.into_name()?,
+                entity_type.to_expr_or_special()?.into_entity_type()?,
             )))
         } else {
             Ok(PrincipalOrResourceConstraint::Any)
@@ -793,6 +793,10 @@ impl ExprOrSpecial<'_> {
                 .to_ast_err(ToASTErrorKind::InvalidString(expr.to_string()))
                 .into()),
         }
+    }
+
+    fn into_entity_type(self) -> Result<ast::EntityType> {
+        self.into_name().map(ast::EntityType::from)
     }
 
     fn into_name(self) -> Result<ast::Name> {
@@ -1132,7 +1136,7 @@ impl Node<Option<cst::Relation>> {
                 in_entity,
             } => {
                 let maybe_target = target.to_expr();
-                let maybe_entity_type = entity_type.to_expr_or_special()?.into_name();
+                let maybe_entity_type = entity_type.to_expr_or_special()?.into_entity_type();
                 let (t, n) = flatten_tuple_2(maybe_target, maybe_entity_type)?;
                 match in_entity {
                     Some(in_entity) => {
@@ -1841,7 +1845,7 @@ impl Node<Option<cst::Ref>> {
 
         match refr {
             cst::Ref::Uid { path, eid } => {
-                let maybe_path = path.to_name();
+                let maybe_path = path.to_name().map(ast::EntityType::from);
                 let maybe_eid = eid.as_valid_string().and_then(|s| {
                     to_unescaped_string(s).map_err(|escape_errs| {
                         ParseErrors::new_from_nonempty(
@@ -1962,7 +1966,7 @@ fn construct_name(path: Vec<ast::Id>, id: ast::Id, loc: Loc) -> ast::Name {
         loc: Some(loc),
     }
 }
-fn construct_refr(p: ast::Name, n: SmolStr, loc: Loc) -> ast::EntityUID {
+fn construct_refr(p: ast::EntityType, n: SmolStr, loc: Loc) -> ast::EntityUID {
     let eid = ast::Eid::new(n);
     ast::EntityUID::from_components(p, eid, Some(loc))
 }
@@ -2074,7 +2078,7 @@ fn construct_expr_attr(e: ast::Expr, s: SmolStr, loc: Loc) -> ast::Expr {
 fn construct_expr_like(e: ast::Expr, s: Vec<PatternElem>, loc: Loc) -> ast::Expr {
     ast::ExprBuilder::new().with_source_loc(loc).like(e, s)
 }
-fn construct_expr_is(e: ast::Expr, n: ast::Name, loc: Loc) -> ast::Expr {
+fn construct_expr_is(e: ast::Expr, n: ast::EntityType, loc: Loc) -> ast::Expr {
     ast::ExprBuilder::new()
         .with_source_loc(loc)
         .is_entity_type(e, n)
@@ -4095,7 +4099,7 @@ mod tests {
                     .build(),
             ),
             (
-                // `_ in _ is _` in the policy condition is an error in the text->CST parser 
+                // `_ in _ is _` in the policy condition is an error in the text->CST parser
                 r#"permit(principal, action, resource) when { principal in Group::"friends" is User };"#,
                 ExpectedErrorMessageBuilder::error("unexpected token `is`")
                     .exactly_one_underline_with_label(r#"is"#, "expected `!=`, `&&`, `<`, `<=`, `==`, `>`, `>=`, `||`, `}`, or `in`")

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -178,6 +178,8 @@ mod test {
         assert_eq!(errs.len(), 2);
     }
 
+    // PANIC SAFETY: testing
+    #[allow(clippy::indexing_slicing)]
     #[test]
     fn test_pattern_escape() {
         // valid ASCII escapes

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 
 use std::collections::BTreeSet;
 
-use cedar_policy_core::ast::{Eid, Expr, Name, PolicyID};
+use cedar_policy_core::ast::{EntityType, Expr, PolicyID};
 use cedar_policy_core::parser::Loc;
 
 use crate::types::Type;
@@ -101,11 +101,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionApplication(#[from] validation_errors::InvalidActionApplication),
-    /// An unspecified entity was used in a policy. This should be impossible,
-    /// assuming that the policy was constructed by the parser.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    UnspecifiedEntity(#[from] validation_errors::UnspecifiedEntity),
     /// The typechecker expected to see a subtype of one of the types in
     /// `expected`, but saw `actual`.
     #[error(transparent)]
@@ -202,19 +197,6 @@ impl ValidationError {
             policy_id,
             would_in_fix_principal,
             would_in_fix_resource,
-        }
-        .into()
-    }
-
-    pub(crate) fn unspecified_entity(
-        source_loc: Option<Loc>,
-        policy_id: PolicyID,
-        entity_id: Eid,
-    ) -> Self {
-        validation_errors::UnspecifiedEntity {
-            source_loc,
-            policy_id,
-            entity_id,
         }
         .into()
     }
@@ -357,8 +339,8 @@ impl ValidationError {
         source_loc: Option<Loc>,
 
         policy_id: PolicyID,
-        in_lhs: Option<Name>,
-        in_rhs: Option<Name>,
+        in_lhs: Option<EntityType>,
+        in_rhs: Option<EntityType>,
     ) -> Self {
         validation_errors::HierarchyNotRespected {
             source_loc,

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -237,7 +237,7 @@ pub mod schema_errors {
     use std::{collections::BTreeSet, fmt::Display};
 
     use cedar_policy_core::{
-        ast::{EntityAttrEvaluationError, EntityUID, Id, Name},
+        ast::{EntityAttrEvaluationError, EntityType, EntityUID, Id, Name},
         parser::join_with_conjunction,
         transitive_closure,
     };
@@ -276,7 +276,7 @@ pub mod schema_errors {
     #[error("transitive closure computation/enforcement error on entity type hierarchy: {0}")]
     #[diagnostic(transparent)]
     pub struct EntityTypeTransitiveClosureError(
-        #[from] pub(crate) Box<transitive_closure::TcError<Name>>,
+        #[from] pub(crate) Box<transitive_closure::TcError<EntityType>>,
     );
 
     /// Undeclared entity types error
@@ -288,7 +288,7 @@ pub mod schema_errors {
     #[diagnostic(help(
         "any entity types appearing anywhere in a schema need to be declared in `entityTypes`"
     ))]
-    pub struct UndeclaredEntityTypesError(pub(crate) BTreeSet<Name>);
+    pub struct UndeclaredEntityTypesError(pub(crate) BTreeSet<EntityType>);
 
     impl Display for UndeclaredEntityTypesError {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -338,7 +338,7 @@ pub mod schema_errors {
     // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
     #[error("duplicate entity type `{0}`")]
-    pub struct DuplicateEntityTypeError(pub(crate) Name);
+    pub struct DuplicateEntityTypeError(pub(crate) EntityType);
 
     /// Duplicate action error
     //
@@ -452,7 +452,7 @@ pub mod schema_errors {
     #[derive(Debug)]
     pub(crate) enum ContextOrShape {
         ActionContext(EntityUID),
-        EntityTypeShape(Name),
+        EntityTypeShape(EntityType),
     }
 
     impl std::fmt::Display for ContextOrShape {

--- a/cedar-policy-validator/src/expr_iterator.rs
+++ b/cedar-policy-validator/src/expr_iterator.rs
@@ -28,14 +28,9 @@ pub(super) fn expr_entity_uids(expr: &Expr) -> impl Iterator<Item = &EntityUID> 
 }
 
 /// Returns an iterator over all entity type names in the expression.
-/// The Unspecified entity type does not have a `Name`, so it is excluded
-/// from this iter.
-pub(super) fn expr_entity_type_names(expr: &Expr) -> impl Iterator<Item = &Name> {
+pub(super) fn expr_entity_type_names(expr: &Expr) -> impl Iterator<Item = &EntityType> {
     expr.subexpressions().filter_map(|e| match e.expr_kind() {
-        ExprKind::Lit(Literal::EntityUID(uid)) => match uid.entity_type() {
-            EntityType::Specified(entity_type) => Some(entity_type),
-            EntityType::Unspecified => None,
-        },
+        ExprKind::Lit(Literal::EntityUID(uid)) => Some(uid.entity_type()),
         ExprKind::Is { entity_type, .. } => Some(entity_type),
         _ => None,
     })
@@ -65,9 +60,7 @@ pub(super) fn policy_entity_uids(template: &Template) -> impl Iterator<Item = &E
 
 /// Returns an iterator over all entity type names in the policy. This iterates
 /// over the policy scope condition in addition to the body.
-/// The Unspecified entity type does not have a `Name`, so it is excluded
-/// from this iter.
-pub(super) fn policy_entity_type_names(template: &Template) -> impl Iterator<Item = &Name> {
+pub(super) fn policy_entity_type_names(template: &Template) -> impl Iterator<Item = &EntityType> {
     template
         .principal_constraint()
         .as_inner()
@@ -146,10 +139,7 @@ fn text_in_entity_type<'a>(
     loc: Option<&'a Loc>,
     ty: &'a EntityType,
 ) -> impl IntoIterator<Item = TextKind<'a>> {
-    match ty {
-        EntityType::Specified(ty) => text_in_name(loc, ty).collect::<Vec<_>>(),
-        EntityType::Unspecified => vec![],
-    }
+    text_in_name(loc, ty.name()).collect::<Vec<_>>()
 }
 
 fn text_in_name<'a>(loc: Option<&'a Loc>, name: &'a Name) -> impl Iterator<Item = TextKind<'a>> {

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -324,9 +324,9 @@ pub enum AppDecl {
 /// An action declaration
 #[derive(Debug, Clone)]
 pub struct ActionDecl {
-    /// The names this declaration is bindings
-    /// More than one name can be bound if they have the same definition, for convenience
-    pub names: Vec<Node<SmolStr>>,
+    /// The names this declaration is binding.
+    /// More than one name can be bound if they have the same definition, for convenience.
+    pub names: NonEmpty<Node<SmolStr>>,
     /// The parents of this action
     pub parents: Option<NonEmpty<Node<QualName>>>,
     /// The constraining clauses in this declarations
@@ -335,7 +335,7 @@ pub struct ActionDecl {
 
 impl Decl for ActionDecl {
     fn names(&self) -> Vec<Node<SmolStr>> {
-        self.names.clone()
+        self.names.iter().cloned().collect()
     }
 }
 

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -347,15 +347,17 @@ impl Diagnostic for ToJsonSchemaErrors {
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 pub enum ToJsonSchemaError {
     /// Error raised when there are duplicate keys
-    #[error("Duplicate keys: `{key}`")]
+    #[error("duplicate keys: {key}")]
     DuplicateKeys { key: SmolStr, loc1: Loc, loc2: Loc },
     /// Error raised when there are duplicate declarations
-    #[error("Duplicate declarations: `{decl}`")]
+    #[error("duplicate declarations: {decl}")]
     DuplicateDeclarations { decl: SmolStr, loc1: Loc, loc2: Loc },
-    #[error("Duplicate context declaration. Action may have at most one context declaration")]
+    #[error("duplicate context declaration. Action may have at most one context declaration")]
     DuplicateContext { loc1: Loc, loc2: Loc },
-    #[error("Duplicate {kind} decleration. Action may have at most once {kind} declaration")]
-    DuplicatePR { kind: PR, loc1: Loc, loc2: Loc },
+    #[error("duplicate `{kind}` declaration. Action may have at most one {kind} declaration")]
+    DuplicatePrincipalOrResource { kind: PR, loc1: Loc, loc2: Loc },
+    #[error("missing `{kind}` declaration for `{name}`. Actions must define both a `principals` and `resources` field")]
+    NoPrincipalOrResource { kind: PR, name: SmolStr, loc: Loc },
 
     /// Error raised when there are duplicate namespace IDs
     #[error("Duplicate namespace IDs: `{namespace_id}`")]
@@ -392,7 +394,7 @@ impl Diagnostic for ToJsonSchemaError {
         match self {
             ToJsonSchemaError::DuplicateDeclarations { loc1, loc2, .. }
             | ToJsonSchemaError::DuplicateContext { loc1, loc2 }
-            | ToJsonSchemaError::DuplicatePR { loc1, loc2, .. }
+            | ToJsonSchemaError::DuplicatePrincipalOrResource { loc1, loc2, .. }
             | ToJsonSchemaError::DuplicateKeys { loc1, loc2, .. } => Some(Box::new(
                 vec![
                     LabeledSpan::underline(loc1.span),
@@ -408,7 +410,8 @@ impl Diagnostic for ToJsonSchemaError {
             ToJsonSchemaError::UnknownTypeName(node) => Some(Box::new(std::iter::once(
                 LabeledSpan::underline(node.loc.span),
             ))),
-            ToJsonSchemaError::UseReservedNamespace(loc) => {
+            ToJsonSchemaError::UseReservedNamespace(loc)
+            | ToJsonSchemaError::NoPrincipalOrResource { loc, .. } => {
                 Some(Box::new(std::iter::once(LabeledSpan::underline(loc.span))))
             }
         }

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -130,21 +130,17 @@ impl Display for ActionType {
         }
         if let Some(spec) = &self.applies_to {
             match (
-                spec.principal_types
-                    .as_ref()
-                    .map(|refs| non_empty_slice(refs.as_slice())),
-                spec.resource_types
-                    .as_ref()
-                    .map(|refs| non_empty_slice(refs.as_slice())),
+                non_empty_slice(spec.principal_types.as_slice()),
+                non_empty_slice(spec.resource_types.as_slice()),
             ) {
                 // One of the lists is empty
                 // This can only be represented by the empty action
                 // This implies an action group
-                (Some(None), _) | (_, Some(None)) => {
+                (None, _) | (_, None) => {
                     write!(f, "")?;
                 }
-                // Both list are present and non empty
-                (Some(Some(ps)), Some(Some(rs))) => {
+                // Both list are non empty
+                (Some(ps), Some(rs)) => {
                     write!(f, " appliesTo {{")?;
                     write!(f, "\n  principal: ")?;
                     fmt_vec(f, ps)?;
@@ -153,36 +149,9 @@ impl Display for ActionType {
                     write!(f, ",\n  context: {}", &spec.context.0)?;
                     write!(f, "\n}}")?;
                 }
-                // Only principals are present, resource is unspecified
-                (Some(Some(ps)), None) => {
-                    write!(f, " appliesTo {{")?;
-                    write!(f, "\n  principal: ")?;
-                    fmt_vec(f, ps)?;
-                    write!(f, ",\n  context: {}", &spec.context.0)?;
-                    write!(f, "\n}}")?;
-                }
-                // Only resources is present, principal is unspecified
-                (None, Some(Some(rs))) => {
-                    write!(f, " appliesTo {{")?;
-                    write!(f, "\n  resource: ")?;
-                    fmt_vec(f, rs)?;
-                    write!(f, ",\n  context: {}", &spec.context.0)?;
-                    write!(f, "\n}}")?;
-                }
-                // Neither are present, both principal and resource are unspecified
-                (None, None) => {
-                    write!(f, " appliesTo {{")?;
-                    write!(f, "\n  context: {}", &spec.context.0)?;
-                    write!(f, "\n}}")?;
-                }
             }
-        } else {
-            // No `appliesTo` key: both principal and resource must be unspecified entities
-            write!(f, " appliesTo {{")?;
-            // context is an empty record
-            write!(f, "\n  context: {{}}")?;
-            write!(f, "\n}}")?;
         }
+        // No `appliesTo` key: action does not apply to anything
         Ok(())
     }
 }

--- a/cedar-policy-validator/src/human_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/human_schema/grammar.lalrpop
@@ -21,17 +21,17 @@ use cedar_policy_core::parser::{Node, Loc, unescape::to_unescaped_string, cst::R
 use cedar_policy_core::ast::Id;
 use smol_str::SmolStr;
 use smol_str::ToSmolStr;
-use crate::human_schema::ast::{ 
-    Path, 
-    EntityDecl, 
-    Declaration, 
-    Namespace, 
-    Schema as ASchema, 
-    Type as SType, 
-    AttrDecl, 
-    ActionDecl, 
-    PR, 
-    AppDecl, 
+use crate::human_schema::ast::{
+    Path,
+    EntityDecl,
+    Declaration,
+    Namespace,
+    Schema as ASchema,
+    Type as SType,
+    AttrDecl,
+    ActionDecl,
+    PR,
+    AppDecl,
     TypeDecl,
     PrimitiveType,
     QualName,
@@ -127,21 +127,21 @@ TypeDecl: Node<Declaration> = {
 //          | 'context' ':' (Path | RecType) [',' | ',' AppDecls]
 AppDecls: Node<NonEmpty<Node<AppDecl>>> = {
     <l:@L> <pr: PrincipalOrResource> ":" <ets:EntTypes> ","? <r:@R>
-        =>? 
+        =>?
                 NonEmpty::collect(ets.into_iter()).ok_or(ParseError::User {
                     error: Node::with_source_loc(UserError::EmptyList, Loc::new(l..r, Arc::clone(src)))})
-                    .map(|ets| 
+                    .map(|ets|
                         Node::with_source_loc(
                             nonempty![Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys: ets}), Loc::new(l..r, Arc::clone(src)))],
                             Loc::new(l..r, Arc::clone(src)))),
     <l:@L> <pr: PrincipalOrResource> ":" <ets:EntTypes> "," <r:@R> <mut ds: AppDecls>
-        =>? 
+        =>?
                 NonEmpty::collect(ets.into_iter()).ok_or(ParseError::User {
                     error: Node::with_source_loc(UserError::EmptyList, Loc::new(l..r, Arc::clone(src)))})
-                    .map(|ets| 
+                    .map(|ets|
                         {
                             let (mut ds, _) = ds.into_inner();
-                            ds.insert(0, Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys: ets}), Loc::new(l..r, Arc::clone(src)))); 
+                            ds.insert(0, Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys: ets}), Loc::new(l..r, Arc::clone(src))));
                             Node::with_source_loc(ds, Loc::new(l..r, Arc::clone(src)))
                         }),
     <l:@L> CONTEXT ":" <p:Path> ","? <r:@R>
@@ -151,20 +151,20 @@ AppDecls: Node<NonEmpty<Node<AppDecl>>> = {
     <l:@L> CONTEXT ":" <p:Path> "," <r:@R> <mut ds: AppDecls>
         => {
             let (mut ds, _) = ds.into_inner();
-            ds.insert(0, Node::with_source_loc(AppDecl::Context(Either::Left(p)), Loc::new(l..r, Arc::clone(src)))); 
+            ds.insert(0, Node::with_source_loc(AppDecl::Context(Either::Left(p)), Loc::new(l..r, Arc::clone(src))));
             Node::with_source_loc(
                 ds,
                 Loc::new(l..r, Arc::clone(src)))
         },
     <l:@L> CONTEXT ":" "{" <attrs:AttrDecls?> "}" ","? <r:@R>
-        =>  
+        =>
             Node::with_source_loc(
                 nonempty![Node::with_source_loc(AppDecl::Context(Either::Right(attrs.unwrap_or_default())), Loc::new(l..r, Arc::clone(src)))],
                 Loc::new(l..r, Arc::clone(src))),
     <l:@L> CONTEXT ":" "{" <attrs:AttrDecls?> "}" "," <r:@R> <mut ds: AppDecls>
         => {
             let (mut ds, _) = ds.into_inner();
-            ds.insert(0, Node::with_source_loc(AppDecl::Context(Either::Right(attrs.unwrap_or_default())), Loc::new(l..r, Arc::clone(src)))); 
+            ds.insert(0, Node::with_source_loc(AppDecl::Context(Either::Right(attrs.unwrap_or_default())), Loc::new(l..r, Arc::clone(src))));
             Node::with_source_loc(
                 ds,
                 Loc::new(l..r, Arc::clone(src)))
@@ -220,13 +220,13 @@ Ident: Node<Id> = {
         => Node::with_source_loc("context".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> ATTRIBUTES <r:@R>
         => Node::with_source_loc("attributes".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
-    <l:@L> BOOL <r:@R> 
+    <l:@L> BOOL <r:@R>
         => Node::with_source_loc("Bool".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
-    <l:@L> LONG <r:@R> 
+    <l:@L> LONG <r:@R>
         => Node::with_source_loc("Long".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
-    <l:@L> STRING <r:@R> 
+    <l:@L> STRING <r:@R>
         => Node::with_source_loc("String".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
-    <l:@L> TYPE <r:@R> 
+    <l:@L> TYPE <r:@R>
         => Node::with_source_loc("type".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> IN <r:@R>
         =>? Err(ParseError::User {
@@ -280,11 +280,12 @@ Idents: Vec<Node<Id>> = {
 }
 
 // Names := Name {',' Name}
-Names: Vec<Node<SmolStr>> = {
-    <n:Name> => vec![n],
+Names: NonEmpty<Node<SmolStr>> = {
+    <n:Name> => NonEmpty::new(n),
     <mut ns:(<Name> ",")+> <n:Name> => {
-        ns.push(n);
-        ns
+        let mut all = NonEmpty::new(n);
+        all.append(&mut ns);
+        all
     },
 }
 

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -24,6 +24,7 @@ mod demo_tests {
         iter::{empty, once},
     };
 
+    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
     use cool_asserts::assert_matches;
     use smol_str::ToSmolStr;
 
@@ -44,7 +45,13 @@ mod demo_tests {
         let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
         let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
-            ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), ..}), .. } => assert!(resources.is_empty() && principals.is_empty())
+            ActionType {
+                applies_to : Some(ApplySpec {
+                    resource_types : resources,
+                    principal_types : principals, ..
+                }),
+                ..
+            } => assert!(resources.is_empty() && principals.is_empty())
         );
     }
 
@@ -53,19 +60,16 @@ mod demo_tests {
         let src = r#"
         action "Foo" appliesTo { context: {} };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
-        assert_matches!(
-            foo,
-            ActionType {
-                applies_to: Some(ApplySpec {
-                    resource_types: None,
-                    principal_types: None,
-                    ..
-                }),
-                ..
-            }
-        );
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            ),
+        }
     }
 
     #[test]
@@ -74,17 +78,17 @@ mod demo_tests {
         entity a;
         action "Foo" appliesTo { principal: a, context: {}  };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
-        assert_matches!(foo,
-            ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), ..}), .. } =>
-                {
-                    match principals.as_slice() {
-                        [a] if a == &"a".parse().unwrap() => (),
-                        _ => panic!("Bad principals")
-                    }
-                }
-        );
+
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            )
+        }
     }
 
     #[test]
@@ -93,17 +97,16 @@ mod demo_tests {
         entity a;
         action "Foo" appliesTo { resource: a, context: {}  };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
-        assert_matches!(foo,
-            ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, ..}), .. } =>
-                {
-                    match resources.as_slice() {
-                        [a] if a == &"a".parse().unwrap() => (),
-                        _ => panic!("Bad principals")
-                    }
-                }
-        );
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            )
+        }
     }
 
     #[test]
@@ -114,14 +117,16 @@ mod demo_tests {
                 resource : [a]
             };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get(&None).unwrap();
-        let foo = unqual.actions.get("Foo").unwrap();
-        assert_matches!(foo,
-                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, .. }  ), ..} =>
-                    assert_matches!(resources.as_slice(), [a] => assert_eq!(a, &"a".parse().unwrap()))
-            ,
-        );
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            )
+        }
     }
 
     #[test]
@@ -133,17 +138,16 @@ mod demo_tests {
                 resource : [a, b]
             };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get(&None).unwrap();
-        let foo = unqual.actions.get("Foo").unwrap();
-        assert_matches!(foo,
-                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : None, .. }  ), ..} =>
-                    assert_matches!(resources.as_slice(), [a, b] => {
-                        assert_eq!(a, &"a".parse().unwrap());
-                        assert_eq!(b, &"b".parse().unwrap())
-                    })
-            ,
-        );
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            )
+        }
     }
 
     #[test]
@@ -154,14 +158,16 @@ mod demo_tests {
                 principal: [a]
             };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get(&None).unwrap();
-        let foo = unqual.actions.get("Foo").unwrap();
-        assert_matches!(foo,
-                ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), .. }  ), ..} =>
-                    assert_matches!(principals.as_slice(), [a] => assert_eq!(a, &"a".parse().unwrap()))
-            ,
-        );
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            )
+        }
     }
 
     #[test]
@@ -173,17 +179,16 @@ mod demo_tests {
                 principal: [a, b]
             };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
-        let unqual = schema.0.get(&None).unwrap();
-        let foo = unqual.actions.get("Foo").unwrap();
-        assert_matches!(foo,
-                ActionType { applies_to : Some(ApplySpec { resource_types : None, principal_types : Some(principals), .. }  ), ..} =>
-                    assert_matches!(principals.as_slice(), [a,b] => {
-                        assert_eq!(a, &"a".parse().unwrap());
-                        assert_eq!(b, &"b".parse().unwrap());
-                })
-            ,
-        );
+        match SchemaFragment::from_str_natural(src) {
+            Ok(_) => panic!("Should have failed to parse!"),
+            Err(e) => expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                    .exactly_one_underline("\"Foo\"")
+                    .build(),
+            )
+        }
     }
 
     #[test]
@@ -202,13 +207,20 @@ mod demo_tests {
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
-                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), .. }  ), ..} =>
+                ActionType {
+                    applies_to : Some(ApplySpec {
+                        resource_types,
+                        principal_types,
+                        ..
+                    }),
+                    ..
+                } =>
                 {
-                    assert_matches!(principals.as_slice(), [a,b] => {
+                    assert_matches!(principal_types.as_slice(), [a,b] => {
                         assert_eq!(a, &"a".parse().unwrap());
                         assert_eq!(b, &"b".parse().unwrap());
                 });
-                assert_matches!(resources.as_slice(), [c,d] =>  {
+                assert_matches!(resource_types.as_slice(), [c,d] =>  {
                         assert_eq!(c, &"c".parse().unwrap());
                         assert_eq!(d, &"d".parse().unwrap());
 
@@ -234,13 +246,20 @@ mod demo_tests {
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
-                ActionType { applies_to : Some(ApplySpec { resource_types : Some(resources), principal_types : Some(principals), .. }  ), ..} =>
+                ActionType {
+                    applies_to : Some(ApplySpec {
+                        resource_types,
+                        principal_types,
+                        ..
+                    }),
+                    ..
+                } =>
                 {
-                    assert_matches!(principals.as_slice(), [a,b] => {
+                    assert_matches!(principal_types.as_slice(), [a,b] => {
                         assert_eq!(a, &"a".parse().unwrap());
                         assert_eq!(b, &"b".parse().unwrap());
                 });
-                assert_matches!(resources.as_slice(), [c,d] =>  {
+                assert_matches!(resource_types.as_slice(), [c,d] =>  {
                         assert_eq!(c, &"c".parse().unwrap());
                         assert_eq!(d, &"d".parse().unwrap());
 
@@ -274,7 +293,7 @@ mod demo_tests {
                     .any(|err| {
                         matches!(
                             err,
-                            ToJsonSchemaError::DuplicatePR {
+                            ToJsonSchemaError::DuplicatePrincipalOrResource {
                                 kind: PR::Principal,
                                 ..
                             }
@@ -310,7 +329,7 @@ mod demo_tests {
                     .any(|err| {
                         matches!(
                             err,
-                            ToJsonSchemaError::DuplicatePR {
+                            ToJsonSchemaError::DuplicatePrincipalOrResource {
                                 kind: PR::Resource,
                                 ..
                             }
@@ -329,9 +348,7 @@ mod demo_tests {
         let namespace = NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
         let fragment = SchemaFragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
         let as_src = fragment.as_natural_schema().unwrap();
-        let expected = r#"action "foo" appliesTo {
-  context: {}
-};"#;
+        let expected = r#"action "foo";"#;
         assert!(as_src.contains(expected), "src was:\n`{as_src}`");
     }
 
@@ -340,8 +357,11 @@ mod demo_tests {
         assert!(SchemaFragment::from_str_natural(
             r#"
         type empty = {};
+        entity E;
         action "Foo" appliesTo {
             context: empty,
+            principal: [E],
+            resource: [E]
         };
     "#
         )
@@ -350,7 +370,9 @@ mod demo_tests {
             r#"
     type flag = { value: __cedar::Bool };
     action "Foo" appliesTo {
-        context: flag
+        context: flag,
+        principal: [E],
+        resource: [E]
     };
 "#
         )
@@ -359,7 +381,9 @@ mod demo_tests {
             r#"
 namespace Bar { type empty = {}; }
 action "Foo" appliesTo {
-    context: Bar::empty
+    context: Bar::empty,
+    principal: [E],
+    resource: [E]
 };
 "#
         )
@@ -368,7 +392,9 @@ action "Foo" appliesTo {
             r#"
 namespace Bar { type flag = { value: Bool }; }
 namespace Baz {action "Foo" appliesTo {
-    context: Bar::flag
+    context: Bar::flag,
+    principal: [E],
+    resource: [E]
 };}
 "#
         )
@@ -385,8 +411,8 @@ namespace Baz {action "Foo" appliesTo {
           operation: Long,
           request: authcontext
         };
-        action view appliesTo { context: authcontext };
-        action upload appliesTo { context: authcontext };
+        action view appliesTo { context: authcontext, principal: [E], resource: [E] };
+        action upload appliesTo { context: authcontext, principal: [E], resource: [E]};
 "#
         )
         .is_ok());
@@ -408,8 +434,8 @@ namespace Baz {action "Foo" appliesTo {
                 ActionType {
                     attributes: None,
                     applies_to: Some(ApplySpec {
-                        resource_types: Some(vec![]),
-                        principal_types: Some(vec!["a".parse().unwrap()]),
+                        resource_types: vec![],
+                        principal_types: vec!["a".parse().unwrap()],
                         context: AttributesOrContext::default(),
                     }),
                     member_of: None,
@@ -1145,6 +1171,7 @@ mod translator_tests {
         types::{EntityLUB, Type},
         SchemaFragment, SchemaTypeVariant, TypeOfAttribute, ValidatorSchema,
     };
+    use cedar_policy_core::ast as cedar_ast;
 
     #[test]
     fn use_reserved_namespace() {
@@ -1347,9 +1374,9 @@ mod translator_tests {
             schema.try_into().expect("should be a valid schema");
         for (name, et) in validator_schema.entity_types() {
             if name.to_string() == "A::C" || name.to_string() == "X::Y" {
-                assert!(et
-                    .descendants
-                    .contains(&cedar_policy_core::ast::Name::from_normalized_str("A::B").unwrap()));
+                assert!(et.descendants.contains(&cedar_ast::EntityType::from(
+                    cedar_policy_core::ast::Name::from_normalized_str("A::B").unwrap()
+                )));
             } else {
                 assert!(et.descendants.is_empty());
             }
@@ -1413,6 +1440,10 @@ mod translator_tests {
         assert!(validator_schema.is_ok());
     }
 
+    // PANIC SAFETY: testing
+    #[allow(clippy::unwrap_used)]
+    // PANIC SAFETY: testing
+    #[allow(clippy::indexing_slicing)]
     #[test]
     fn type_name_resolution_cross_namespace() {
         let (schema, _) = SchemaFragment::from_str_natural(
@@ -1432,7 +1463,9 @@ mod translator_tests {
         let validator_schema: ValidatorSchema =
             schema.try_into().expect("should be a valid schema");
         let et = validator_schema
-            .get_entity_type(&cedar_policy_core::ast::Name::from_normalized_str("A::B").unwrap())
+            .get_entity_type(&cedar_ast::EntityType::from(
+                cedar_policy_core::ast::Name::from_normalized_str("A::B").unwrap(),
+            ))
             .unwrap();
         let attr = et.attr("foo").unwrap();
         assert!(

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -39,8 +39,8 @@ use super::{
     err::{schema_warnings, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors},
 };
 
-/// Convert a custom schema AST into the JSON representation
-/// This will let you subsequently decode that into the Validator AST for Schemas (`[ValidatorSchema]`)
+/// Convert a schema AST into the JSON representation.
+/// This will let you subsequently decode that into the Validator AST for Schemas (`[ValidatorSchema]`).
 /// On success, this function returns a tuple containing:
 ///     * The SchemaFragment
 ///     * A vector of name collisions, that are essentially warnings
@@ -48,9 +48,9 @@ pub fn custom_schema_to_json_schema(
     schema: Schema,
 ) -> Result<(SchemaFragment, impl Iterator<Item = SchemaWarning>), ToJsonSchemaErrors> {
     // First pass, figure out what each name is bound to
-
     let (qualified_namespaces, unqualified_namespace) =
         split_unqualified_namespace(schema.into_iter().map(|n| n.node));
+    // Create a single iterator for all namespaces
     let all_namespaces = qualified_namespaces
         .chain(unqualified_namespace)
         .collect::<Vec<_>>();
@@ -80,11 +80,16 @@ pub fn custom_type_to_json_type(ty: Node<Type>) -> Result<SchemaType, ToJsonSche
     context.convert_type(ty)
 }
 
+// Split namespaces into two groups: named namespaces and the implicit unqualified namespace
+// The rhs of the tuple will be [`None`] if there are no items in the unqualified namespace.
 fn split_unqualified_namespace(
     namespaces: impl IntoIterator<Item = Namespace>,
 ) -> (impl Iterator<Item = Namespace>, Option<Namespace>) {
+    // First split every namespace into those with explicit names and those without
     let (qualified, unqualified): (Vec<_>, Vec<_>) =
         namespaces.into_iter().partition(|n| n.name.is_some());
+
+    // Now combine all the decls in namespaces without names into one unqualified namespace
     let mut unqualified_decls = vec![];
     for mut unqualified_namespace in unqualified.into_iter() {
         unqualified_decls.append(&mut unqualified_namespace.decls);
@@ -199,13 +204,14 @@ impl<'a> ConversionContext<'a> {
             parents,
             app_decls,
         } = a;
+        let info = (&names.first().node, &names.first().loc);
         // Create the internal type from the 'applies_to' clause and 'member_of'
         let applies_to = app_decls
-            .map(|decls| self.convert_app_decls(decls))
+            .map(|decls| self.convert_app_decls(info, decls))
             .transpose()?
             .unwrap_or_else(|| ApplySpec {
-                resource_types: Some(vec![]),
-                principal_types: Some(vec![]),
+                resource_types: vec![],
+                principal_types: vec![],
                 context: AttributesOrContext::default(),
             });
         let member_of = parents.map(|parents| self.convert_parents(parents));
@@ -233,6 +239,7 @@ impl<'a> ConversionContext<'a> {
     // Convert the applies to decls
     fn convert_app_decls(
         &self,
+        action_info: (&SmolStr, &Loc),
         decls: Node<NonEmpty<Node<AppDecl>>>,
     ) -> Result<ApplySpec, ToJsonSchemaErrors> {
         // Split AppDecl's into context/principal/resource decls
@@ -274,7 +281,7 @@ impl<'a> ConversionContext<'a> {
                     loc,
                 } => match principal_types {
                     Some(existing_tys) => {
-                        return Err(ToJsonSchemaError::DuplicatePR {
+                        return Err(ToJsonSchemaError::DuplicatePrincipalOrResource {
                             kind: PR::Principal,
                             loc1: existing_tys.loc,
                             loc2: loc,
@@ -300,7 +307,7 @@ impl<'a> ConversionContext<'a> {
                     loc,
                 } => match resource_types {
                     Some(existing_tys) => {
-                        return Err(ToJsonSchemaError::DuplicatePR {
+                        return Err(ToJsonSchemaError::DuplicatePrincipalOrResource {
                             kind: PR::Resource,
                             loc1: existing_tys.loc,
                             loc2: loc,
@@ -317,8 +324,20 @@ impl<'a> ConversionContext<'a> {
             }
         }
         Ok(ApplySpec {
-            resource_types: resource_types.map(|tys| tys.node),
-            principal_types: principal_types.map(|tys| tys.node),
+            resource_types: resource_types
+                .map(|node| node.node.into_iter().map(|name| name.into()).collect())
+                .ok_or(ToJsonSchemaError::NoPrincipalOrResource {
+                    kind: PR::Resource,
+                    name: action_info.0.clone(),
+                    loc: action_info.1.clone(),
+                })?,
+            principal_types: principal_types
+                .map(|node| node.node.into_iter().map(|name| name.into()).collect())
+                .ok_or(ToJsonSchemaError::NoPrincipalOrResource {
+                    kind: PR::Principal,
+                    name: action_info.0.clone(),
+                    loc: action_info.1.clone(),
+                })?,
             context: context.map(|c| c.node).unwrap_or_default(),
         })
     }
@@ -334,7 +353,10 @@ impl<'a> ConversionContext<'a> {
             attrs,
         } = e;
         // First build up the defined entity type
-        let member_of_types = member_of_types.into_iter().map(|p| p.into()).collect();
+        let member_of_types = member_of_types
+            .into_iter()
+            .map(|p| Name::from(p).into())
+            .collect();
         let shape = self.convert_attr_decls(attrs)?;
         let etype = EntityType {
             member_of_types,
@@ -453,7 +475,9 @@ impl<'a> ConversionContext<'a> {
         if namespace_to_search.common_types.contains_key(&base) {
             Ok(SchemaType::TypeDef { type_name: name })
         } else if namespace_to_search.entities.contains_key(&base) {
-            Ok(SchemaType::Type(SchemaTypeVariant::Entity { name }))
+            Ok(SchemaType::Type(SchemaTypeVariant::Entity {
+                name: name.into(),
+            }))
         } else if is_unqualified_or_cedar {
             search_cedar_namespace(base, loc)
         } else {
@@ -469,7 +493,7 @@ impl<'a> ConversionContext<'a> {
         loc: Loc,
         name: &Option<Name>,
     ) -> Result<&NamespaceRecord, ToJsonSchemaError> {
-        if &name.as_ref().map_or(SmolStr::default(), |n| n.to_smolstr()) == CEDAR_NAMESPACE {
+        if name.as_ref().map_or(SmolStr::default(), |n| n.to_smolstr()) == CEDAR_NAMESPACE {
             Ok(&self.cedar_namespace)
         } else {
             self.names.get(name).ok_or_else(|| {

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -231,8 +231,8 @@ mod test {
                 action_name.into(),
                 ActionType {
                     applies_to: Some(ApplySpec {
-                        resource_types: None,
-                        principal_types: None,
+                        principal_types: vec!["foo_type".parse().unwrap()],
+                        resource_types: vec!["bar_type".parse().unwrap()],
                         context: AttributesOrContext::default(),
                     }),
                     member_of: None,

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -18,8 +18,8 @@
 
 use cedar_policy_core::{
     ast::{
-        self, ActionConstraint, EntityReference, EntityUID, Name, Policy, PolicyID,
-        PrincipalConstraint, PrincipalOrResourceConstraint, ResourceConstraint, SlotEnv, Template,
+        self, ActionConstraint, EntityReference, EntityUID, Policy, PolicyID, PrincipalConstraint,
+        PrincipalOrResourceConstraint, ResourceConstraint, SlotEnv, Template,
     },
     parser::Loc,
 };
@@ -48,38 +48,23 @@ impl Validator {
             .map(ToString::to_string)
             .collect::<Vec<_>>();
 
-        policy_entity_type_names(template)
-            .filter_map(move |name| {
-                let is_action_entity_type = is_action_entity_type(name);
-                let is_known_entity_type = self.schema.is_known_entity_type(name);
+        policy_entity_type_names(template).filter_map(move |name| {
+            let is_known_entity_type = self.schema.is_known_entity_type(name);
 
-                if !is_action_entity_type && !is_known_entity_type {
-                    let actual_entity_type = name.to_string();
-                    let suggested_entity_type =
-                        fuzzy_search(&actual_entity_type, known_entity_types.as_slice());
-                    Some(ValidationError::unrecognized_entity_type(
-                        name.loc().cloned(),
-                        template.id().clone(),
-                        actual_entity_type,
-                        suggested_entity_type,
-                    ))
-                } else {
-                    None
-                }
-            })
-            .chain(policy_entity_uids(template).filter_map(move |euid| {
-                let entity_type = euid.entity_type();
-                match entity_type {
-                    cedar_policy_core::ast::EntityType::Unspecified => {
-                        Some(ValidationError::unspecified_entity(
-                            euid.loc().cloned(),
-                            template.id().clone(),
-                            euid.eid().clone(),
-                        ))
-                    }
-                    cedar_policy_core::ast::EntityType::Specified(_) => None,
-                }
-            }))
+            if !name.is_action() && !is_known_entity_type {
+                let actual_entity_type = name.to_string();
+                let suggested_entity_type =
+                    fuzzy_search(&actual_entity_type, known_entity_types.as_slice());
+                Some(ValidationError::unrecognized_entity_type(
+                    name.loc().cloned(),
+                    template.id().clone(),
+                    actual_entity_type,
+                    suggested_entity_type,
+                ))
+            } else {
+                None
+            }
+        })
     }
 
     /// Generate `UnrecognizedActionId` error for every entity id with an action
@@ -98,34 +83,21 @@ impl Validator {
             .collect::<Vec<_>>();
         policy_entity_uids(template).filter_map(move |euid| {
             let entity_type = euid.entity_type();
-            match entity_type {
-                ast::EntityType::Unspecified => Some(ValidationError::unspecified_entity(
+            if entity_type.is_action() && !self.schema.is_known_action_id(euid) {
+                Some(ValidationError::unrecognized_action_id(
                     euid.loc().cloned(),
                     template.id().clone(),
-                    euid.eid().clone(),
-                )),
-                ast::EntityType::Specified(name) => {
-                    let is_known_action_entity_id = self.schema.is_known_action_id(euid);
-                    let is_action_entity_type = is_action_entity_type(name);
-
-                    if is_action_entity_type && !is_known_action_entity_id {
-                        Some(ValidationError::unrecognized_action_id(
-                            euid.loc().cloned(),
-                            template.id().clone(),
-                            euid.to_string(),
-                            fuzzy_search(euid.eid().as_ref(), known_action_ids.as_slice()),
-                        ))
-                    } else {
-                        None
-                    }
-                }
+                    euid.to_string(),
+                    fuzzy_search(euid.eid().as_ref(), known_action_ids.as_slice()),
+                ))
+            } else {
+                None
             }
         })
     }
 
-    /// Generate `UnrecognizedEntityType` or `UnspecifiedEntity` error for
-    /// every entity type in the slot environment that is either not in the schema,
-    /// or unspecified.
+    /// Generate `UnrecognizedEntityType` error for
+    /// every entity type in the slot environment that is not in the schema
     pub(crate) fn validate_entity_types_in_slots<'a>(
         &'a self,
         policy_id: &'a PolicyID,
@@ -141,29 +113,18 @@ impl Validator {
 
         slots.values().filter_map(move |euid| {
             let entity_type = euid.entity_type();
-            match entity_type {
-                cedar_policy_core::ast::EntityType::Unspecified => {
-                    Some(ValidationError::unspecified_entity(
-                        None,
-                        policy_id.clone(),
-                        euid.eid().clone(),
-                    ))
-                }
-                cedar_policy_core::ast::EntityType::Specified(name) => {
-                    if !self.schema.is_known_entity_type(name) {
-                        let actual_entity_type = entity_type.to_string();
-                        let suggested_entity_type =
-                            fuzzy_search(&actual_entity_type, known_entity_types.as_slice());
-                        Some(ValidationError::unrecognized_entity_type(
-                            None,
-                            policy_id.clone(),
-                            actual_entity_type,
-                            suggested_entity_type,
-                        ))
-                    } else {
-                        None
-                    }
-                }
+            if !self.schema.is_known_entity_type(entity_type) {
+                let actual_entity_type = entity_type.to_string();
+                let suggested_entity_type =
+                    fuzzy_search(&actual_entity_type, known_entity_types.as_slice());
+                Some(ValidationError::unrecognized_entity_type(
+                    None,
+                    policy_id.clone(),
+                    actual_entity_type,
+                    suggested_entity_type,
+                ))
+            } else {
+                None
             }
         })
     }
@@ -220,18 +181,15 @@ impl Validator {
     fn check_if_none_equal<'a>(
         &'a self,
         specs: &[&'a ValidatorApplySpec],
-        lit_opt: Option<&Name>,
+        lit_opt: Option<&ast::EntityType>,
         select_apply_spec: &impl Fn(
             &'a ValidatorApplySpec,
         ) -> Box<dyn Iterator<Item = &'a ast::EntityType> + 'a>,
     ) -> bool {
         if let Some(lit) = lit_opt {
-            !specs.iter().any(|spec| {
-                select_apply_spec(spec).any(|e| match e {
-                    ast::EntityType::Specified(e) => e == lit,
-                    ast::EntityType::Unspecified => false,
-                })
-            })
+            !specs
+                .iter()
+                .any(|spec| select_apply_spec(spec).any(|e| e == lit))
         } else {
             false
         }
@@ -242,18 +200,15 @@ impl Validator {
     fn check_if_any_contain<'a>(
         &'a self,
         specs: &[&'a ValidatorApplySpec],
-        lit_opt: Option<&Name>,
+        lit_opt: Option<&ast::EntityType>,
         select_apply_spec: &impl Fn(
             &'a ValidatorApplySpec,
         ) -> Box<dyn Iterator<Item = &'a ast::EntityType> + 'a>,
     ) -> bool {
         if let Some(etype) = lit_opt.and_then(|typename| self.schema.get_entity_type(typename)) {
-            specs.iter().any(|spec| {
-                select_apply_spec(spec).any(|p| match p {
-                    ast::EntityType::Specified(p) => etype.descendants.contains(p),
-                    ast::EntityType::Unspecified => false,
-                })
-            })
+            specs
+                .iter()
+                .any(|spec| select_apply_spec(spec).any(|p| etype.descendants.contains(p)))
         } else {
             false
         }
@@ -261,13 +216,12 @@ impl Validator {
 
     /// Check if an expression is an equality comparison between a literal EUID
     /// and a scope variable.  If it is, return the type of the literal EUID.
-    fn get_eq_comparison(scope_constraint: &PrincipalOrResourceConstraint) -> Option<&Name> {
+    fn get_eq_comparison(
+        scope_constraint: &PrincipalOrResourceConstraint,
+    ) -> Option<&ast::EntityType> {
         match scope_constraint {
             PrincipalOrResourceConstraint::Eq(EntityReference::EUID(euid)) => {
-                match euid.entity_type() {
-                    ast::EntityType::Specified(name) => Some(name),
-                    ast::EntityType::Unspecified => None,
-                }
+                Some(euid.entity_type())
             }
             _ => None,
         }
@@ -312,10 +266,10 @@ impl Validator {
         resource_constraint: &ResourceConstraint,
     ) -> impl Iterator<Item = ValidationError> {
         let mut apply_specs = self.get_apply_specs_for_action(action_constraint);
-        let resources_for_scope: HashSet<&Name> = self
+        let resources_for_scope: HashSet<&ast::EntityType> = self
             .get_resources_satisfying_constraint(resource_constraint)
             .collect();
-        let principals_for_scope: HashSet<&Name> = self
+        let principals_for_scope: HashSet<&ast::EntityType> = self
             .get_principals_satisfying_constraint(principal_constraint)
             .collect();
 
@@ -332,31 +286,10 @@ impl Validator {
         ))
         .filter(|_| {
             !apply_specs.any(|spec| {
-                let action_principals = spec
-                    .applicable_principal_types()
-                    .filter_map(|ty| match ty {
-                        ast::EntityType::Specified(name) => Some(name),
-                        ast::EntityType::Unspecified => None,
-                    })
-                    .collect::<HashSet<_>>();
-                let applicable_principal_unspecified = spec
-                    .applicable_principal_types()
-                    .any(|ty| matches!(ty, ast::EntityType::Unspecified));
-                let action_resources = spec
-                    .applicable_resource_types()
-                    .filter_map(|ty| match ty {
-                        ast::EntityType::Specified(name) => Some(name),
-                        ast::EntityType::Unspecified => None,
-                    })
-                    .collect::<HashSet<_>>();
-                let applicable_resource_unspecified = spec
-                    .applicable_resource_types()
-                    .any(|ty| matches!(ty, ast::EntityType::Unspecified));
-
-                let matching_principal = applicable_principal_unspecified
-                    || !principals_for_scope.is_disjoint(&action_principals);
-                let matching_resource = applicable_resource_unspecified
-                    || !resources_for_scope.is_disjoint(&action_resources);
+                let action_principals = spec.applicable_principal_types().collect::<HashSet<_>>();
+                let action_resources = spec.applicable_resource_types().collect::<HashSet<_>>();
+                let matching_principal = !principals_for_scope.is_disjoint(&action_principals);
+                let matching_resource = !resources_for_scope.is_disjoint(&action_resources);
                 matching_principal && matching_resource
             })
         })
@@ -403,7 +336,7 @@ impl Validator {
     pub(crate) fn get_principals_satisfying_constraint<'a>(
         &'a self,
         principal_constraint: &'a PrincipalConstraint,
-    ) -> impl Iterator<Item = &'a Name> + 'a {
+    ) -> impl Iterator<Item = &'a ast::EntityType> + 'a {
         self.get_entity_types_satisfying_constraint(principal_constraint.as_inner())
     }
 
@@ -412,7 +345,7 @@ impl Validator {
     pub(crate) fn get_resources_satisfying_constraint<'a>(
         &'a self,
         resource_constraint: &'a ResourceConstraint,
-    ) -> impl Iterator<Item = &'a Name> + 'a {
+    ) -> impl Iterator<Item = &'a ast::EntityType> + 'a {
         self.get_entity_types_satisfying_constraint(resource_constraint.as_inner())
     }
 
@@ -421,18 +354,14 @@ impl Validator {
     fn get_entity_types_satisfying_constraint<'a>(
         &'a self,
         scope_constraint: &'a PrincipalOrResourceConstraint,
-    ) -> Box<dyn Iterator<Item = &'a Name> + 'a> {
+    ) -> Box<dyn Iterator<Item = &'a ast::EntityType> + 'a> {
         match scope_constraint {
             // <var>
             PrincipalOrResourceConstraint::Any => Box::new(self.schema.known_entity_types()),
             // <var> == <literal euid>
-            PrincipalOrResourceConstraint::Eq(EntityReference::EUID(euid)) => Box::new(
-                match euid.entity_type() {
-                    ast::EntityType::Specified(name) => Some(name),
-                    ast::EntityType::Unspecified => None,
-                }
-                .into_iter(),
-            ),
+            PrincipalOrResourceConstraint::Eq(EntityReference::EUID(euid)) => {
+                Box::new(std::iter::once(euid.entity_type()))
+            }
             // <var> in <literal euid>
             PrincipalOrResourceConstraint::In(EntityReference::EUID(euid)) => {
                 Box::new(self.schema.get_entity_types_in(euid.as_ref()).into_iter())
@@ -483,11 +412,9 @@ mod test {
     use super::*;
     use crate::{
         schema_file_format::{NamespaceDefinition, *},
-        validation_errors::{UnrecognizedEntityType, UnspecifiedEntity},
+        validation_errors::UnrecognizedEntityType,
         ValidationMode, ValidationWarning, Validator,
     };
-
-    use cool_asserts::assert_matches;
 
     #[test]
     fn validate_entity_type_empty_schema() {
@@ -873,7 +800,7 @@ mod test {
         )
         .expect("Expected schema parse.");
         let schema = descriptors.try_into().unwrap();
-        let entity_type: Name = "NS::Foo".parse().expect("Expected entity type parse.");
+        let entity_type: ast::EntityType = "NS::Foo".parse().expect("Expected entity type parse.");
         let policy = Template::new(
             PolicyID::from_string("policy0"),
             None,
@@ -1030,7 +957,6 @@ mod test {
         let principals = validate
             .get_principals_satisfying_constraint(&principal_constraint)
             .cloned()
-            .map(cedar_policy_core::ast::EntityType::Specified)
             .collect::<HashSet<_>>();
         assert_eq!(HashSet::from([euid_foo.components().0]), principals);
     }
@@ -1068,8 +994,8 @@ mod test {
                 action_name.into(),
                 ActionType {
                     applies_to: Some(ApplySpec {
-                        resource_types: Some(vec![resource_type.parse().unwrap()]),
-                        principal_types: Some(vec![principal_type.parse().unwrap()]),
+                        resource_types: vec![resource_type.parse().unwrap()],
+                        principal_types: vec![principal_type.parse().unwrap()],
                         context: AttributesOrContext::default(),
                     }),
                     member_of: Some(vec![]),
@@ -1472,8 +1398,8 @@ mod test {
                     action_name.into(),
                     ActionType {
                         applies_to: Some(ApplySpec {
-                            resource_types: Some(vec![resource_type.parse().unwrap()]),
-                            principal_types: Some(vec![principal_type.parse().unwrap()]),
+                            resource_types: vec![resource_type.parse().unwrap()],
+                            principal_types: vec![principal_type.parse().unwrap()],
                             context: AttributesOrContext::default(),
                         }),
                         member_of: Some(vec![ActionEntityUID {
@@ -1519,145 +1445,6 @@ mod test {
 
         let validator = Validator::new(schema);
         assert_validate_policy_succeeds(&validator, &policy);
-    }
-
-    #[test]
-    fn unspecified_entity_in_scope() {
-        // Note: it's not possible to create an unspecified entity through the parser,
-        // so we have to test using manually-constructed policies.
-        let validate = Validator::new(ValidatorSchema::empty());
-
-        // resource == Unspecified::"foo"
-        let policy = Template::new(
-            PolicyID::from_string("policy0"),
-            None,
-            Annotations::new(),
-            Effect::Permit,
-            PrincipalConstraint::any(),
-            ActionConstraint::any(),
-            ResourceConstraint::is_eq(Arc::new(EntityUID::unspecified_from_eid(Eid::new("foo")))),
-            Expr::val(true),
-        );
-        let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
-        assert_eq!(1, notes.len());
-        assert_matches!(notes.first(),
-            Some(ValidationError::UnspecifiedEntity(UnspecifiedEntity { entity_id, .. })) => {
-                let eid: &str = entity_id.as_ref();
-                assert_eq!("foo", eid);
-            }
-        );
-
-        // principal in Unspecified::"foo"
-        let policy = Template::new(
-            PolicyID::from_string("policy0"),
-            None,
-            Annotations::new(),
-            Effect::Permit,
-            PrincipalConstraint::is_in(Arc::new(EntityUID::unspecified_from_eid(Eid::new("foo")))),
-            ActionConstraint::any(),
-            ResourceConstraint::any(),
-            Expr::val(true),
-        );
-        let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
-        assert_eq!(1, notes.len());
-        assert_matches!(notes.first(),
-            Some(ValidationError::UnspecifiedEntity(UnspecifiedEntity { entity_id, .. })) => {
-                let eid: &str = entity_id.as_ref();
-                assert_eq!("foo", eid);
-            }
-        );
-    }
-
-    #[test]
-    fn unspecified_entity_in_additional_constraints() {
-        let validate = Validator::new(ValidatorSchema::empty());
-
-        // resource == Unspecified::"foo"
-        let policy = Template::new(
-            PolicyID::from_string("policy0"),
-            None,
-            Annotations::new(),
-            Effect::Permit,
-            PrincipalConstraint::any(),
-            ActionConstraint::any(),
-            ResourceConstraint::any(),
-            Expr::is_eq(
-                Expr::var(cedar_policy_core::ast::Var::Resource),
-                Expr::val(EntityUID::unspecified_from_eid(Eid::new("foo"))),
-            ),
-        );
-        let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
-
-        println!("{:?}", notes);
-        assert_eq!(1, notes.len());
-        assert_matches!(notes.first(),
-            Some(ValidationError::UnspecifiedEntity(UnspecifiedEntity { entity_id, .. })) => {
-                let eid: &str = entity_id.as_ref();
-                assert_eq!("foo", eid);
-            }
-        );
-    }
-
-    #[test]
-    fn action_with_unspecified_resource_applies() {
-        let schema = serde_json::from_str::<NamespaceDefinition>(
-            r#"
-        {
-            "entityTypes": {"a": {}},
-            "actions": {
-                "": {
-                    "appliesTo": {
-                        "principalTypes": ["a"],
-                        "resourceTypes": null
-                    }
-                }
-            }
-        }
-        "#,
-        )
-        .unwrap()
-        .try_into()
-        .unwrap();
-        let policy = parse_policy(
-            Some("0".to_string()),
-            r#"permit(principal == a::"", action == Action::"", resource);"#,
-        )
-        .unwrap();
-
-        let validator = Validator::new(schema);
-        let (template, _) = Template::link_static_policy(policy);
-        assert_validate_policy_succeeds(&validator, &template);
-    }
-
-    #[test]
-    fn action_with_unspecified_principal_applies() {
-        let schema = serde_json::from_str::<NamespaceDefinition>(
-            r#"
-        {
-            "entityTypes": {"a": {}},
-            "actions": {
-                "": {
-                    "appliesTo": {
-                        "principalTypes": null,
-                        "resourceTypes": ["a"]
-                    }
-                }
-            }
-        }
-        "#,
-        )
-        .unwrap()
-        .try_into()
-        .unwrap();
-        let policy = parse_policy(
-            Some("0".to_string()),
-            r#"permit(principal, action == Action::"", resource == a::"");"#,
-        )
-        .unwrap();
-
-        let validator = Validator::new(schema);
-        let (template, _) = Template::link_static_policy(policy);
-        assert_validate_policy_succeeds(&validator, &template);
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -47,10 +47,7 @@ pub(crate) use action::ValidatorApplySpec;
 mod entity_type;
 pub use entity_type::ValidatorEntityType;
 mod namespace_def;
-pub(crate) use namespace_def::is_action_entity_type;
 pub use namespace_def::ValidatorNamespaceDef;
-#[cfg(test)]
-pub(crate) use namespace_def::ACTION_ENTITY_TYPE;
 
 // We do not have a formal model for action attributes, so we disable them by default.
 #[derive(Eq, PartialEq, Copy, Clone, Default)]
@@ -116,7 +113,7 @@ impl ValidatorSchemaFragment {
 pub struct ValidatorSchema {
     /// Map from entity type names to the ValidatorEntityType object.
     #[serde_as(as = "Vec<(_, _)>")]
-    entity_types: HashMap<Name, ValidatorEntityType>,
+    entity_types: HashMap<EntityType, ValidatorEntityType>,
 
     /// Map from action id names to the ValidatorActionId object.
     #[serde_as(as = "Vec<(_, _)>")]
@@ -239,7 +236,7 @@ impl ValidatorSchema {
         extensions: Extensions<'_>,
     ) -> Result<ValidatorSchema> {
         let mut type_defs = HashMap::new();
-        let mut entity_type_fragments = HashMap::new();
+        let mut entity_type_fragments: HashMap<EntityType, _> = HashMap::new();
         let mut action_fragments = HashMap::new();
 
         for ns_def in fragments.into_iter().flat_map(|f| f.0.into_iter()) {
@@ -389,8 +386,8 @@ impl ValidatorSchema {
     /// function assumes that all entity types are fully qualified. This is
     /// handled by the `SchemaFragment` constructor.
     fn check_for_undeclared(
-        entity_types: &HashMap<Name, ValidatorEntityType>,
-        undeclared_parent_entities: impl IntoIterator<Item = Name>,
+        entity_types: &HashMap<EntityType, ValidatorEntityType>,
+        undeclared_parent_entities: impl IntoIterator<Item = EntityType>,
         action_ids: &HashMap<EntityUID, ValidatorActionId>,
         undeclared_parent_actions: impl IntoIterator<Item = EntityUID>,
     ) -> Result<()> {
@@ -400,7 +397,7 @@ impl ValidatorSchema {
         // any undeclared entity types which appeared in a `memberOf` list.
         let mut undeclared_e = undeclared_parent_entities
             .into_iter()
-            .collect::<BTreeSet<_>>();
+            .collect::<BTreeSet<EntityType>>();
         // Looking at entity types, we need to check entity references in
         // attribute types. We already know that all elements of the
         // `descendants` list were declared because the list is a result of
@@ -428,24 +425,14 @@ impl ValidatorSchema {
             Self::check_undeclared_in_type(&action.context, entity_types, &mut undeclared_e);
 
             for p_entity in action.applies_to.applicable_principal_types() {
-                match p_entity {
-                    EntityType::Specified(p_entity) => {
-                        if !entity_types.contains_key(p_entity) {
-                            undeclared_e.insert(p_entity.clone());
-                        }
-                    }
-                    EntityType::Unspecified => (),
+                if !entity_types.contains_key(p_entity) {
+                    undeclared_e.insert(p_entity.clone());
                 }
             }
 
             for r_entity in action.applies_to.applicable_resource_types() {
-                match r_entity {
-                    EntityType::Specified(r_entity) => {
-                        if !entity_types.contains_key(r_entity) {
-                            undeclared_e.insert(r_entity.clone());
-                        }
-                    }
-                    EntityType::Unspecified => (),
+                if !entity_types.contains_key(r_entity) {
+                    undeclared_e.insert(r_entity.clone());
                 }
             }
         }
@@ -474,8 +461,8 @@ impl ValidatorSchema {
     // `undeclared_types` set.
     fn check_undeclared_in_type(
         ty: &Type,
-        entity_types: &HashMap<Name, ValidatorEntityType>,
-        undeclared_types: &mut BTreeSet<Name>,
+        entity_types: &HashMap<EntityType, ValidatorEntityType>,
+        undeclared_types: &mut BTreeSet<EntityType>,
     ) {
         match ty {
             Type::EntityOrRecord(EntityRecordKind::Entity(lub)) => {
@@ -510,7 +497,10 @@ impl ValidatorSchema {
     }
 
     /// Lookup the ValidatorEntityType object in the schema with the given name.
-    pub fn get_entity_type<'a>(&'a self, entity_type_id: &Name) -> Option<&'a ValidatorEntityType> {
+    pub fn get_entity_type<'a>(
+        &'a self,
+        entity_type_id: &EntityType,
+    ) -> Option<&'a ValidatorEntityType> {
         self.entity_types.get(entity_type_id)
     }
 
@@ -520,19 +510,13 @@ impl ValidatorSchema {
     }
 
     /// Return true when the entity_type_id corresponds to a valid entity type.
-    pub(crate) fn is_known_entity_type(&self, entity_type: &Name) -> bool {
-        is_action_entity_type(entity_type) || self.entity_types.contains_key(entity_type)
+    pub(crate) fn is_known_entity_type(&self, entity_type: &EntityType) -> bool {
+        entity_type.is_action() || self.entity_types.contains_key(entity_type)
     }
 
-    /// Return true when `euid` has an entity type declared by the schema. We
-    /// treat an Unspecified as "known" because it is always possible to declare
-    /// an action using an unspecified principal/resource type without first
-    /// declaring unspecified as an entity type in the entity types list.
+    /// Return true when `euid` has an entity type declared by the schema.
     pub(crate) fn euid_has_known_entity_type(&self, euid: &EntityUID) -> bool {
-        match euid.entity_type() {
-            EntityType::Specified(ety) => self.is_known_entity_type(ety),
-            EntityType::Unspecified => true,
-        }
+        self.is_known_entity_type(euid.entity_type())
     }
 
     /// An iterator over the action ids in the schema.
@@ -541,12 +525,12 @@ impl ValidatorSchema {
     }
 
     /// An iterator over the entity type names in the schema.
-    pub(crate) fn known_entity_types(&self) -> impl Iterator<Item = &Name> {
+    pub(crate) fn known_entity_types(&self) -> impl Iterator<Item = &EntityType> {
         self.entity_types.keys()
     }
 
     /// An iterator matching the entity Types to their Validator Types
-    pub fn entity_types(&self) -> impl Iterator<Item = (&Name, &ValidatorEntityType)> {
+    pub fn entity_types(&self) -> impl Iterator<Item = (&EntityType, &ValidatorEntityType)> {
         self.entity_types.iter()
     }
 
@@ -555,18 +539,13 @@ impl ValidatorSchema {
     /// includes all entity types that are descendants of the type of `entity`
     /// according  to the schema, and the type of `entity` itself because
     /// `entity in entity` evaluates to `true`.
-    pub(crate) fn get_entity_types_in<'a>(&'a self, entity: &'a EntityUID) -> Vec<&Name> {
-        match entity.entity_type() {
-            EntityType::Specified(ety) => {
-                let mut descendants = self
-                    .get_entity_type(ety)
-                    .map(|v_ety| v_ety.descendants.iter().collect::<Vec<_>>())
-                    .unwrap_or_default();
-                descendants.push(ety);
-                descendants
-            }
-            EntityType::Unspecified => Vec::new(),
-        }
+    pub(crate) fn get_entity_types_in<'a>(&'a self, entity: &'a EntityUID) -> Vec<&EntityType> {
+        let mut descendants = self
+            .get_entity_type(entity.entity_type())
+            .map(|v_ety| v_ety.descendants.iter().collect::<Vec<_>>())
+            .unwrap_or_default();
+        descendants.push(entity.entity_type());
+        descendants
     }
 
     /// Get all entity types in the schema where an `{entity0} in {euids}` can
@@ -575,7 +554,7 @@ impl ValidatorSchema {
     pub(crate) fn get_entity_types_in_set<'a>(
         &'a self,
         euids: impl IntoIterator<Item = &'a EntityUID> + 'a,
-    ) -> impl Iterator<Item = &Name> {
+    ) -> impl Iterator<Item = &EntityType> {
         euids.into_iter().flat_map(|e| self.get_entity_types_in(e))
     }
 
@@ -1229,11 +1208,11 @@ mod test {
             .applies_to;
         assert_eq!(
             apply_spec.applicable_principal_types().collect::<Vec<_>>(),
-            vec![&EntityType::Specified(user_entity_type.clone())]
+            vec![user_entity_type]
         );
         assert_eq!(
             apply_spec.applicable_resource_types().collect::<Vec<_>>(),
-            vec![&EntityType::Specified(photo_entity_type.clone())]
+            vec![photo_entity_type]
         );
     }
 
@@ -1304,7 +1283,7 @@ mod test {
             .try_into()
             .expect("Expected schema to construct without error.");
 
-        let foo_name: Name = "A::B::Foo".parse().expect("Expected entity type name");
+        let foo_name: EntityType = "A::B::Foo".parse().expect("Expected entity type name");
         let foo_type = schema
             .entity_types
             .get(&foo_name)
@@ -1671,13 +1650,13 @@ mod test {
             baz.applies_to
                 .applicable_principal_types()
                 .collect::<HashSet<_>>(),
-            HashSet::from([&EntityType::Specified("Fiz::Buz".parse().unwrap())])
+            HashSet::from([&("Fiz::Buz".parse().unwrap())])
         );
         assert_eq!(
             baz.applies_to
                 .applicable_resource_types()
                 .collect::<HashSet<_>>(),
-            HashSet::from([&EntityType::Specified("Fiz::Baz".parse().unwrap())])
+            HashSet::from([&("Fiz::Baz".parse().unwrap())])
         );
     }
 

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -100,16 +100,10 @@ impl TCNode<EntityUID> for ValidatorActionId {
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct ValidatorApplySpec {
-    /// The principal entity types the action can be applied to. This set may
-    /// be a singleton set containing the unspecified entity type when the
-    /// `principalTypes` list is omitted in the schema. A non-singleton set
-    /// shouldn't contain the unspecified entity type, but (policy) validation
-    /// will give the same success/failure result as when it is the only element
-    /// of the set, perhaps with extra type errors.
+    /// The principal entity types the action can be applied to.
     principal_apply_spec: HashSet<EntityType>,
 
-    /// The resource entity types the action can be applied to. See comments on
-    /// `principal_apply_spec` about the unspecified entity type.
+    /// The resource entity types the action can be applied to.
     resource_apply_spec: HashSet<EntityType>,
 }
 

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -46,21 +46,6 @@ use crate::{fuzzy_match::fuzzy_search, types::OpenTag};
 /// types. All action entities are required to use a single `Action` entity
 /// type. However, the action entity type may be namespaced, so an action entity
 /// may have a fully qualified entity type `My::Namespace::Action`.
-/// This string must be parsable as an unqualified entity type name.
-pub(crate) static ACTION_ENTITY_TYPE: &str = "Action";
-
-#[test]
-fn action_entity_type_parses() {
-    Id::from_normalized_str(ACTION_ENTITY_TYPE).unwrap();
-    Name::parse_unqualified_name(ACTION_ENTITY_TYPE).unwrap();
-}
-
-/// Return true when an entity type is an action entity type. This compares the
-/// base name for the type, so this will return true for any entity type named
-/// `Action` regardless of namespaces.
-pub(crate) fn is_action_entity_type(ty: &Name) -> bool {
-    ty.basename().as_ref() == ACTION_ENTITY_TYPE
-}
 
 /// A single namespace definition from the schema json or human syntax,
 /// processed into a form which is closer to that used by the validator.
@@ -96,7 +81,7 @@ pub struct TypeDefs {
 /// parents and attributes may reference undeclared entity/common types.
 #[derive(Debug)]
 pub struct EntityTypesDef {
-    pub(super) entity_types: HashMap<Name, EntityTypeFragment>,
+    pub(super) entity_types: HashMap<EntityType, EntityTypeFragment>,
 }
 
 /// Defines an EntityType where we have not resolved typedefs occurring in the
@@ -113,7 +98,7 @@ pub struct EntityTypeFragment {
     /// `memberOfTypes` list. These types might be declared in a different
     /// namespace, so we will check if they are declared in any fragment when
     /// constructing a `ValidatorSchema`.
-    pub(super) parents: HashSet<Name>,
+    pub(super) parents: HashSet<EntityType>,
 }
 
 /// Action declarations held in a `ValidatorNamespaceDef`. Entity types
@@ -271,9 +256,12 @@ impl ValidatorNamespaceDef {
         schema_namespace: Option<&Name>,
         extensions: Extensions<'_>,
     ) -> Result<EntityTypesDef> {
-        let mut entity_types = HashMap::with_capacity(schema_files_types.len());
+        let mut entity_types: HashMap<EntityType, _> =
+            HashMap::with_capacity(schema_files_types.len());
         for (id, entity_type) in schema_files_types {
-            let name = Name::from(id.clone()).prefix_namespace_if_unqualified(schema_namespace);
+            let name = cedar_policy_core::ast::EntityType::from(
+                Name::from(id.clone()).prefix_namespace_if_unqualified(schema_namespace),
+            );
             match entity_types.entry(name) {
                 Entry::Vacant(ventry) => {
                     ventry.insert(EntityTypeFragment {
@@ -290,7 +278,7 @@ impl ValidatorNamespaceDef {
                     });
                 }
                 Entry::Occupied(_) => {
-                    return Err(DuplicateEntityTypeError(Name::unqualified_name(id)).into());
+                    return Err(DuplicateEntityTypeError(Name::unqualified_name(id).into()).into());
                 }
             }
         }
@@ -487,7 +475,7 @@ impl ValidatorNamespaceDef {
             // The `name` in an entity type declaration cannot be qualified
             // with a namespace (it always implicitly takes the schema
             // namespace), so we do this comparison directly.
-            .any(|(name, _)| name.to_smolstr() == ACTION_ENTITY_TYPE)
+            .any(|(name, _)| name.to_smolstr() == cedar_policy_core::ast::ACTION_ENTITY_TYPE)
         {
             return Err(ActionEntityTypeDeclaredError {}.into());
         }
@@ -550,25 +538,18 @@ impl ValidatorNamespaceDef {
     }
 
     /// Take an optional list of entity type name strings from an action apply
-    /// spec and parse it into a set of `Name`s for those entity types. If any
-    /// of the entity type names cannot be parsed, then the `Err` case is
-    /// returned, and it will indicate which name did not parse.
+    /// spec and parse it into a set of `Name`s for those entity types.
     fn parse_apply_spec_type_list(
-        types: Option<Vec<Name>>,
+        types: Vec<EntityType>,
         namespace: Option<&Name>,
     ) -> HashSet<EntityType> {
         types
-            .map(|types| {
-                types
-                    .iter()
-                    // Parse each type name string into a `Name`, generating an
-                    // `EntityTypeParseError` when the string is not a valid
-                    // name.
-                    .map(|ty| EntityType::Specified(ty.prefix_namespace_if_unqualified(namespace)))
-                    // Fail if any of the types failed.
-                    .collect::<HashSet<_>>()
-            })
-            .unwrap_or_else(|| HashSet::from([EntityType::Unspecified]))
+            .iter()
+            // Parse each type name string into a `Name`, generating an
+            // `EntityTypeParseError` when the string is not a valid
+            // name.
+            .map(|ty| ty.prefix_namespace_if_unqualified(namespace))
+            .collect::<HashSet<_>>()
     }
 
     /// Take an action identifier as a string and use it to construct an
@@ -585,7 +566,7 @@ impl ValidatorNamespaceDef {
         } else {
             // PANIC SAFETY: The constant ACTION_ENTITY_TYPE is valid entity type.
             #[allow(clippy::expect_used)]
-            let id = Id::from_normalized_str(ACTION_ENTITY_TYPE).expect(
+            let id = Id::from_normalized_str(cedar_policy_core::ast::ACTION_ENTITY_TYPE).expect(
                 "Expected that the constant ACTION_ENTITY_TYPE would be a valid entity type.",
             );
             match namespace {
@@ -593,7 +574,11 @@ impl ValidatorNamespaceDef {
                 None => Name::unqualified_name(id),
             }
         };
-        EntityUID::from_components(namespaced_action_type, Eid::new(action_id.id.clone()), None)
+        EntityUID::from_components(
+            namespaced_action_type.into(),
+            Eid::new(action_id.id.clone()),
+            None,
+        )
     }
 
     /// Implemented to convert a type as written in the schema json format into the

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -540,9 +540,16 @@ fn namespaced_entity_is_wrong_type_when() {
 fn multi_namespace_action_eq() {
     let (schema, _) = SchemaFragment::from_str_natural(
         r#"
-            action "Action" appliesTo { context: {} };
-            namespace NS1 { action "Action" appliesTo { context: {} }; }
-            namespace NS2 { action "Action" appliesTo { context: {} }; }
+            entity E;
+            action "Action" appliesTo { context: {}, principal : [E], resource : [E] };
+            namespace NS1 {
+                entity E;
+                action "Action" appliesTo { context: {}, principal : [E], resource : [E]};
+            }
+            namespace NS2 {
+                entity E;
+                action "Action" appliesTo { context: {}, principal : [E], resource : [E]};
+            }
         "#,
     )
     .unwrap();
@@ -583,11 +590,13 @@ fn multi_namespace_action_eq() {
 fn multi_namespace_action_in() {
     let (schema, _) = SchemaFragment::from_str_natural(
         r#"
+            entity E;
             namespace NS1 { action "Group"; }
             namespace NS2 { action "Group" in [NS1::Action::"Group"]; }
             namespace NS3 {
                 action "Group" in [NS2::Action::"Group"];
-                action "Action" in [Action::"Group"] appliesTo { context: {} };
+                entity E;
+                action "Action" in [Action::"Group"] appliesTo { context: {}, principal: [E], resource: [E] };
             }
             namespace NS4 { action "Group"; }
         "#,

--- a/cedar-policy-validator/src/typecheck/test/policy.rs
+++ b/cedar-policy-validator/src/typecheck/test/policy.rs
@@ -855,7 +855,13 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
                 "Baz": {},
                 "Buz": {}
             },
-            "actions": { "act": {} }
+            "actions": { "act": {
+                "appliesTo" : {
+                    "principalTypes" : ["Foo", "Bar", "Baz", "Buz"],
+                    "resourceTypes" : ["Foo", "Bar", "Baz", "Buz"]
+                }
+            }
+            }
         }"#,
     )
     .expect("Expected valid schema");
@@ -979,6 +985,12 @@ fn record_entity_lub_non_term() {
     let schema: NamespaceDefinition = serde_json::from_value(serde_json::json!(
     {
         "entityTypes": {
+            "E" : {
+                "shape" : {
+                    "type" : "Record",
+                    "attributes" : {}
+                },
+            },
           "U": {
             "shape": {
               "type": "Record",
@@ -998,7 +1010,7 @@ fn record_entity_lub_non_term() {
           "view": {
             "appliesTo": {
               "principalTypes": ["U"],
-              "resourceTypes": null
+              "resourceTypes": ["E"]
             }
           }
         }
@@ -1050,7 +1062,7 @@ fn validate_policy_with_typedef_schema() {
           "act": {
             "appliesTo": {
               "principalTypes": ["Entity"],
-              "resourceTypes": null
+              "resourceTypes": ["Entity"]
             }
           }
         }

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 
 use cedar_policy_core::parser::Loc;
 use cedar_policy_core::{
-    ast::{EntityType, EntityUID, Expr},
+    ast::{EntityUID, Expr},
     parser::parse_policy_template,
 };
 
@@ -143,9 +143,9 @@ where
     f(
         simple_schema_file(),
         RequestEnv::DeclaredAction {
-            principal: &EntityType::Specified("User".parse().unwrap()),
+            principal: &"User".parse().unwrap(),
             action: &EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
-            resource: &EntityType::Specified("Photo".parse().unwrap()),
+            resource: &"Photo".parse().unwrap(),
             context: &Type::record_with_attributes(None, OpenTag::ClosedAttributes),
             principal_slot: None,
             resource_slot: None,
@@ -704,7 +704,9 @@ fn true_false_set() {
 #[test]
 fn qualified_record_attr() {
     let (schema, _) = SchemaFragment::from_str_natural(
-        r#"action A appliesTo { context: {num_of_things?: Long } };"#,
+        r#"
+        entity Foo;
+        action A appliesTo { context: {num_of_things?: Long }, principal : [Foo], resource : [Foo] };"#,
     )
     .unwrap();
     let p = parse_policy_template(

--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -21,11 +21,10 @@
 use cool_asserts::assert_matches;
 use std::{collections::HashSet, sync::Arc};
 
-use cedar_policy_core::ast::{EntityType, EntityUID, Expr, PolicyID, Template};
+use cedar_policy_core::ast::{EntityUID, Expr, PolicyID, Template, ACTION_ENTITY_TYPE};
 
 use crate::typecheck::{TypecheckAnswer, Typechecker};
 use crate::{
-    schema::ACTION_ENTITY_TYPE,
     types::{EffectSet, OpenTag, RequestEnv, Type},
     validation_errors::UnexpectedTypeHelp,
     NamespaceDefinition, ValidationError, ValidationMode, ValidationWarning, ValidatorSchema,
@@ -72,18 +71,14 @@ impl Typechecker<'_> {
         // Using bogus entity type names here for testing. They'll be treated as
         // having empty attribute records, so tests will behave as expected.
         let request_env = RequestEnv::DeclaredAction {
-            principal: &EntityType::Specified(
-                "Principal"
-                    .parse()
-                    .expect("Placeholder type \"Principal\" failed to parse as valid type name."),
-            ),
+            principal: &"Principal"
+                .parse()
+                .expect("Placeholder type \"Principal\" failed to parse as valid type name."),
             action: &EntityUID::with_eid_and_type(ACTION_ENTITY_TYPE, "action")
                 .expect("ACTION_ENTITY_TYPE failed to parse as type name."),
-            resource: &EntityType::Specified(
-                "Resource"
-                    .parse()
-                    .expect("Placeholder type \"Resource\" failed to parse as valid type name."),
-            ),
+            resource: &"Resource"
+                .parse()
+                .expect("Placeholder type \"Resource\" failed to parse as valid type name."),
             context: &Type::record_with_attributes(None, OpenTag::ClosedAttributes),
             principal_slot: None,
             resource_slot: None,

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -40,9 +40,7 @@ use cedar_policy_core::{
 
 use crate::{validation_errors::LubHelp, ValidationMode};
 
-use super::schema::{
-    is_action_entity_type, ValidatorActionId, ValidatorEntityType, ValidatorSchema,
-};
+use super::schema::{ValidatorActionId, ValidatorEntityType, ValidatorSchema};
 
 /// The main type structure.
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
@@ -110,19 +108,14 @@ impl Type {
     /// Construct a type for a literal EUID. This type will be a named entity
     /// type for the type of the EntityUID.
     pub(crate) fn euid_literal(entity: EntityUID, schema: &ValidatorSchema) -> Option<Type> {
-        match entity.entity_type() {
-            EntityType::Unspecified => Some(Type::any_entity_reference()),
-            EntityType::Specified(name) => {
-                if is_action_entity_type(name) {
-                    schema
-                        .get_action_id(&entity)
-                        .and_then(Type::entity_reference_from_action_id)
-                } else {
-                    schema
-                        .get_entity_type(name)
-                        .map(Type::entity_reference_from_entity_type)
-                }
-            }
+        if entity.entity_type().is_action() {
+            schema
+                .get_action_id(&entity)
+                .map(Type::entity_reference_from_action_id)
+        } else {
+            schema
+                .get_entity_type(entity.entity_type())
+                .map(Type::entity_reference_from_entity_type)
         }
     }
 
@@ -168,28 +161,14 @@ impl Type {
         Type::named_entity_reference(validator_entity_type.name.clone())
     }
 
-    pub(crate) fn entity_reference_from_action_id(
-        validator_action_id: &ValidatorActionId,
-    ) -> Option<Type> {
-        match validator_action_id.name.entity_type() {
-            EntityType::Specified(name) => {
-                Some(Type::EntityOrRecord(EntityRecordKind::ActionEntity {
-                    name: name.clone(),
-                    attrs: Attributes::with_attributes(validator_action_id.attribute_types.clone()),
-                }))
-            }
-            EntityType::Unspecified => None,
-        }
+    pub(crate) fn entity_reference_from_action_id(validator_action_id: &ValidatorActionId) -> Type {
+        Type::EntityOrRecord(EntityRecordKind::ActionEntity {
+            name: validator_action_id.name.entity_type().clone(),
+            attrs: Attributes::with_attributes(validator_action_id.attribute_types.clone()),
+        })
     }
 
-    pub(crate) fn possibly_unspecified_entity_reference(ety: EntityType) -> Type {
-        match ety {
-            EntityType::Specified(name) => Type::named_entity_reference(name),
-            EntityType::Unspecified => Type::any_entity_reference(),
-        }
-    }
-
-    pub(crate) fn named_entity_reference(name: Name) -> Type {
+    pub(crate) fn named_entity_reference(name: EntityType) -> Type {
         Type::EntityOrRecord(EntityRecordKind::Entity(EntityLUB::single_entity(name)))
     }
 
@@ -401,22 +380,6 @@ impl Type {
         }
     }
 
-    /// Return true if we know that any value in this type must be a specified
-    /// entity.
-    pub(crate) fn must_be_specified_entity(ty: &Type) -> bool {
-        matches!(
-            ty,
-            // An unspecified entity has type `AnyEntity`, so `AnyEntity` might
-            // not be specified. Other entity types must be specified.
-            Type::EntityOrRecord(
-                EntityRecordKind::Entity(_) | EntityRecordKind::ActionEntity { .. }
-            )
-            // It is vacuously true that any value in the type `Never` is a
-            // specified entity.
-            | Type::Never
-        )
-    }
-
     /// Is this validator type "consistent with" the given Core SchemaType.
     /// Meaning, is there at least some value that could have this SchemaType and
     /// this validator type simultaneously.
@@ -424,7 +387,6 @@ impl Type {
         &self,
         core_type: &cedar_policy_core::entities::SchemaType,
     ) -> bool {
-        use cedar_policy_core::ast::EntityType as CoreEntityType;
         use cedar_policy_core::entities::SchemaType as CoreSchemaType;
         match core_type {
             CoreSchemaType::Bool => matches!(
@@ -506,9 +468,7 @@ impl Type {
                 },
                 _ => false,
             },
-            CoreSchemaType::Entity {
-                ty: CoreEntityType::Specified(concrete_name),
-            } => match self {
+            CoreSchemaType::Entity { ty: concrete_name } => match self {
                 Type::EntityOrRecord(kind) => match kind {
                     EntityRecordKind::Entity(lub) => {
                         lub.lub_elements.iter().any(|n| n == concrete_name)
@@ -516,18 +476,6 @@ impl Type {
                     EntityRecordKind::AnyEntity => true,
                     EntityRecordKind::Record { .. } => false,
                     EntityRecordKind::ActionEntity { name, .. } => concrete_name.eq(name),
-                },
-                _ => false,
-            },
-            CoreSchemaType::Entity {
-                ty: CoreEntityType::Unspecified,
-            } => match self {
-                Type::EntityOrRecord(kind) => match kind {
-                    EntityRecordKind::Entity(_) => false, // Entity(lub) is inconsistent with Unspecified
-                    EntityRecordKind::AnyEntity => true,
-                    EntityRecordKind::Record { .. } | EntityRecordKind::ActionEntity { .. } => {
-                        false
-                    }
                 },
                 _ => false,
             },
@@ -611,19 +559,13 @@ impl Type {
             },
             Type::EntityOrRecord(EntityRecordKind::Entity(lub)) => {
                 match restricted_expr.as_euid() {
-                    Some(euid) => match euid.entity_type() {
-                        EntityType::Specified(name) => Ok(lub.contains(name)),
-                        EntityType::Unspecified => Ok(false), // Unspecified can only have the validator type `AnyEntity`, not any specific lub
-                    },
+                    Some(euid) => Ok(lub.contains(euid.entity_type())),
                     None => Ok(false),
                 }
             }
             Type::EntityOrRecord(EntityRecordKind::ActionEntity { name, .. }) => {
                 match restricted_expr.as_euid() {
-                    Some(euid) if euid.is_action() => match euid.entity_type() {
-                        EntityType::Specified(euid_name) => Ok(euid_name == name),
-                        EntityType::Unspecified => Ok(false), // `euid.is_action()` should never be true for an Unspecified, so this should be unreachable, but it's safe to return Ok(false), because Unspecified can only have the validator type `AnyEntity` anyway
-                    },
+                    Some(euid) if euid.is_action() => Ok(euid.entity_type() == name),
                     _ => Ok(false),
                 }
             }
@@ -789,9 +731,7 @@ impl TryFrom<Type> for cedar_policy_core::entities::SchemaType {
                 "any-entity type is not representable in core::SchemaType: {kind:?}"
             )),
             Type::EntityOrRecord(EntityRecordKind::ActionEntity { name, .. }) => {
-                Ok(CoreSchemaType::Entity {
-                    ty: EntityType::Specified(name),
-                })
+                Ok(CoreSchemaType::Entity { ty: name })
             }
             Type::EntityOrRecord(EntityRecordKind::Record {
                 attrs,
@@ -815,9 +755,7 @@ impl TryFrom<Type> for cedar_policy_core::entities::SchemaType {
                 open_attrs: open_attributes.is_open(),
             }),
             Type::EntityOrRecord(EntityRecordKind::Entity(lub)) => match lub.into_single_entity() {
-                Some(name) => Ok(CoreSchemaType::Entity {
-                    ty: EntityType::Specified(name),
-                }),
+                Some(name) => Ok(CoreSchemaType::Entity { ty: name }),
                 None => Err(
                     "non-singleton LUB type is not representable in core::SchemaType".to_string(),
                 ),
@@ -833,20 +771,20 @@ impl TryFrom<Type> for cedar_policy_core::entities::SchemaType {
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
 pub struct EntityLUB {
     // INVARIANT: Non-empty set.
-    lub_elements: BTreeSet<Name>,
+    lub_elements: BTreeSet<EntityType>,
 }
 
 impl EntityLUB {
     /// Create a least upper bound of a single entity type. This is the same as
     /// just that entity type.
-    pub(crate) fn single_entity(entity_type_name: Name) -> Self {
+    pub(crate) fn single_entity(entity_type_name: EntityType) -> Self {
         Self {
             lub_elements: [entity_type_name].into_iter().collect(),
         }
     }
 
     /// Check if this LUB is a singleton, and if so, return a reference to its entity type
-    pub fn get_single_entity(&self) -> Option<&Name> {
+    pub fn get_single_entity(&self) -> Option<&EntityType> {
         let mut names = self.lub_elements.iter();
         // PANIC SAFETY: Invariant on `lub_elements` guarantees the set is non-empty.
         #[allow(clippy::expect_used)]
@@ -859,7 +797,7 @@ impl EntityLUB {
 
     /// Like `get_single_entity()`, but consumes the EntityLUB and produces an
     /// owned entity type name
-    pub fn into_single_entity(self) -> Option<Name> {
+    pub fn into_single_entity(self) -> Option<EntityType> {
         let mut names = self.lub_elements.into_iter();
         // PANIC SAFETY: Invariant on `lub_elements` guarantees the set is non-empty.
         #[allow(clippy::expect_used)]
@@ -940,18 +878,18 @@ impl EntityLUB {
 
     /// Return true if the given entity type `Name` is in the set of entity
     /// types comprising this LUB.
-    pub(crate) fn contains(&self, ty: &Name) -> bool {
+    pub(crate) fn contains(&self, ty: &EntityType) -> bool {
         self.lub_elements.contains(ty)
     }
 
     /// An iterator over the entity type `Name`s in the set of entity types
     /// comprising this LUB.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = &Name> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &EntityType> {
         self.lub_elements.iter()
     }
 
     // Check if this EntityLUB contains a particular entity type.
-    pub(crate) fn contains_entity_type(&self, ety: &Name) -> bool {
+    pub(crate) fn contains_entity_type(&self, ety: &EntityType) -> bool {
         self.lub_elements.contains(ety)
     }
 }
@@ -1156,7 +1094,7 @@ pub enum EntityRecordKind {
 
     ///We special case action entities. They store their attributes directly rather than
     ///Names
-    ActionEntity { name: Name, attrs: Attributes },
+    ActionEntity { name: EntityType, attrs: Attributes },
 }
 
 impl EntityRecordKind {

--- a/cedar-policy-validator/src/types/request_env.rs
+++ b/cedar-policy-validator/src/types/request_env.rs
@@ -50,7 +50,7 @@ impl<'a> RequestEnv<'a> {
 
     pub fn principal_type(&self) -> Type {
         match self.principal_entity_type() {
-            Some(principal) => Type::possibly_unspecified_entity_reference(principal.clone()),
+            Some(principal) => Type::named_entity_reference(principal.clone()),
             None => Type::any_entity_reference(),
         }
     }
@@ -78,7 +78,7 @@ impl<'a> RequestEnv<'a> {
 
     pub fn resource_type(&self) -> Type {
         match self.resource_entity_type() {
-            Some(resource) => Type::possibly_unspecified_entity_reference(resource.clone()),
+            Some(resource) => Type::named_entity_reference(resource.clone()),
             None => Type::any_entity_reference(),
         }
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The API around `Request::new` has changed to remove the `Option`s 
+  around the entity type arguments.
 - Significantly reworked all public-facing error types to address some issues
   and improve consistency. See issue #745.
 - Finalized the `ffi` module which was preview-released in 3.2.0.
@@ -30,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- Removed unspecified entity type. See [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md).
 - Reduced precision of partial evaluation for `||`, `&&`,  and conditional expressions. `if { foo : <unknown> }.foo then 1 + "hi" else false` now evaluates to `if <unknown> then 1 + "hi" else false`
 - Removed the `error` extension function, which was previously used during partial evaluation.
 - Removed integration testing harness from the `cedar-policy` crate. It is now

--- a/cedar-policy/README.md
+++ b/cedar-policy/README.md
@@ -37,7 +37,7 @@ permit(principal == User::"alice", action == Action::"view", resource == File::"
     let action = r#"Action::"view""#.parse().unwrap();
     let alice = r#"User::"alice""#.parse().unwrap();
     let file = r#"File::"93""#.parse().unwrap();
-    let request = Request::new(Some(alice), Some(action), Some(file), Context::empty(), None).unwrap();
+    let request = Request::new(alice, action, file, Context::empty(), None).unwrap();
 
     let entities = Entities::empty();
     let authorizer = Authorizer::new();
@@ -49,7 +49,7 @@ permit(principal == User::"alice", action == Action::"view", resource == File::"
     let action = r#"Action::"view""#.parse().unwrap();
     let bob = r#"User::"bob""#.parse().unwrap();
     let file = r#"File::"93""#.parse().unwrap();
-    let request = Request::new(Some(bob), Some(action), Some(file), Context::empty(), None).unwrap();
+    let request = Request::new(bob, action, file, Context::empty(), None).unwrap();
 
     let answer = authorizer.is_authorized(&request, &policy, &entities);
 

--- a/cedar-policy/benches/attr_errors.rs
+++ b/cedar-policy/benches/attr_errors.rs
@@ -1,8 +1,12 @@
+// PANIC SAFETY: testing code
+#![allow(clippy::unwrap_used)]
+use cedar_policy::EntityUid;
 use cedar_policy::{Authorizer, Context, Entities, PolicySet, Request, RestrictedExpression};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::str::FromStr;
 
 const LARGE_SIZE: usize = 100_000;
+
 pub fn large_context_record(c: &mut Criterion) {
     let large_context = Context::from_pairs(
         (1..=LARGE_SIZE)
@@ -17,8 +21,23 @@ pub fn large_context_record(c: &mut Criterion) {
     ])
     .unwrap();
 
-    let large_req = Request::new(None, None, None, large_context, None).unwrap();
-    let small_req = Request::new(None, None, None, small_context, None).unwrap();
+    let euid: EntityUid = r#"Placeholder::"entity""#.parse().unwrap();
+    let large_req = Request::new(
+        euid.clone(),
+        euid.clone(),
+        euid.clone(),
+        large_context,
+        None,
+    )
+    .unwrap();
+    let small_req = Request::new(
+        euid.clone(),
+        euid.clone(),
+        euid.clone(),
+        small_context,
+        None,
+    )
+    .unwrap();
     let entities = Entities::empty();
     let auth = Authorizer::new();
 

--- a/cedar-policy/benches/cedar_benchmarks.rs
+++ b/cedar-policy/benches/cedar_benchmarks.rs
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// PANIC SAFETY unit tests
+#![allow(clippy::unwrap_used)]
+// PANIC SAFETY unit tests
+#![allow(clippy::expect_used)]
 
 use std::str::FromStr;
 
@@ -23,8 +27,6 @@ use cedar_policy::{
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
-// PANIC SAFETY unit tests
-#[allow(clippy::unwrap_used)]
 pub fn criterion_benchmark(c: &mut Criterion) {
     let auth = Authorizer::new();
 
@@ -118,9 +120,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     ];
 
     let request_a = Request::new(
-        Some(principal.clone()),
-        Some(action.clone()),
-        Some(resource.clone()),
+        principal.clone(),
+        action.clone(),
+        resource.clone(),
         Context::from_pairs(context.clone()).expect("no duplicate keys in this context"),
         None,
     )
@@ -129,9 +131,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("request_new", |b| {
         b.iter(|| {
             Request::new(
-                Some(black_box(principal.clone())),
-                Some(black_box(action.clone())),
-                Some(black_box(resource.clone())),
+                black_box(principal.clone()),
+                black_box(action.clone()),
+                black_box(resource.clone()),
                 black_box(
                     Context::from_pairs(context.clone())
                         .expect("no duplicate keys in this context"),

--- a/cedar-policy/benches/entity_attr_errors.rs
+++ b/cedar-policy/benches/entity_attr_errors.rs
@@ -1,5 +1,10 @@
+// PANIC SAFETY: testing code
+#![allow(clippy::unwrap_used)]
+// PANIC SAFETY: testing code
+#![allow(clippy::indexing_slicing)]
+
 use cedar_policy::{
-    Authorizer, Context, Entities, Entity, PolicySet, Request, RestrictedExpression,
+    Authorizer, Context, Entities, Entity, EntityUid, PolicySet, Request, RestrictedExpression,
 };
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::iter::once;
@@ -50,7 +55,15 @@ pub fn large_context_record(c: &mut Criterion) {
     let small_entity =
         Entity::new(r#"Foo::"bar""#.parse().unwrap(), small_attr, HashSet::new()).unwrap();
 
-    let req = Request::new(None, None, None, Context::empty(), None).unwrap();
+    let euid: EntityUid = r#"Placeholder::"entity""#.parse().unwrap();
+    let req = Request::new(
+        euid.clone(),
+        euid.clone(),
+        euid.clone(),
+        Context::empty(),
+        None,
+    )
+    .unwrap();
     let large_entities = Entities::from_entities(once(large_entity), None).unwrap();
     let small_entities = Entities::from_entities(once(small_entity), None).unwrap();
     let auth = Authorizer::new();

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -311,11 +311,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionApplication(#[from] validation_errors::InvalidActionApplication),
-    /// An unspecified entity was used in a policy. This should be impossible,
-    /// assuming that the policy was constructed by the parser.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    UnspecifiedEntity(#[from] validation_errors::UnspecifiedEntity),
     /// The typechecker expected to see a subtype of one of the types in
     /// `expected`, but saw `actual`.
     #[error(transparent)]
@@ -378,7 +373,6 @@ impl ValidationError {
             Self::UnrecognizedEntityType(e) => e.policy_id(),
             Self::UnrecognizedActionId(e) => e.policy_id(),
             Self::InvalidActionApplication(e) => e.policy_id(),
-            Self::UnspecifiedEntity(e) => e.policy_id(),
             Self::UnexpectedType(e) => e.policy_id(),
             Self::IncompatibleTypes(e) => e.policy_id(),
             Self::UnsafeAttributeAccess(e) => e.policy_id(),
@@ -407,9 +401,6 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
             }
             cedar_policy_validator::ValidationError::InvalidActionApplication(e) => {
                 Self::InvalidActionApplication(e.into())
-            }
-            cedar_policy_validator::ValidationError::UnspecifiedEntity(e) => {
-                Self::UnspecifiedEntity(e.into())
             }
             cedar_policy_validator::ValidationError::UnexpectedType(e) => {
                 Self::UnexpectedType(e.into())

--- a/cedar-policy/src/api/err/validation_errors.rs
+++ b/cedar-policy/src/api/err/validation_errors.rs
@@ -59,7 +59,6 @@ macro_rules! wrap_core_error {
 wrap_core_error!(UnrecognizedEntityType);
 wrap_core_error!(UnrecognizedActionId);
 wrap_core_error!(InvalidActionApplication);
-wrap_core_error!(UnspecifiedEntity);
 wrap_core_error!(UnexpectedType);
 wrap_core_error!(IncompatibleTypes);
 wrap_core_error!(UnsafeAttributeAccess);

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -244,18 +244,6 @@ permit(principal ==  A :: B
             .expect("failed to roundtrip");
         assert_eq!(reparsed.id().as_ref(), r"b'ob");
     }
-
-    #[test]
-    fn accessing_unspecified_entity_returns_none() {
-        let c = Context::empty();
-        let request = Request::new(None, None, None, c, None).unwrap();
-        let p = request.principal();
-        let a = request.action();
-        let r = request.resource();
-        assert_matches!(p, None);
-        assert_matches!(a, None);
-        assert_matches!(r, None);
-    }
 }
 
 mod scope_constraints_tests {
@@ -659,9 +647,9 @@ mod policy_set_tests {
     fn policyset_remove() {
         let authorizer = Authorizer::new();
         let request = Request::new(
-            Some(EntityUid::from_strs("Test", "test")),
-            Some(EntityUid::from_strs("Action", "a")),
-            Some(EntityUid::from_strs("Resource", "b")),
+            EntityUid::from_strs("Test", "test"),
+            EntityUid::from_strs("Action", "a"),
+            EntityUid::from_strs("Resource", "b"),
             Context::empty(),
             None,
         )
@@ -916,7 +904,7 @@ mod policy_set_tests {
             ast::Expr::unknown(ast::Unknown::new_with_type(
                 "test_entity_type::\"unknown\"",
                 ast::Type::Entity {
-                    ty: ast::EntityType::Specified("test_entity_type".parse().unwrap()),
+                    ty: "test_entity_type".parse().unwrap(),
                 },
             )),
             ast::PolicyID::from_smolstr("static".into()),
@@ -950,9 +938,9 @@ mod policy_set_tests {
 
         let authorizer = Authorizer::new();
         let request = Request::new(
-            Some(EntityUid::from_strs("Test", "test")),
-            Some(EntityUid::from_strs("Action", "a")),
-            Some(EntityUid::from_strs("Resource", "b")),
+            EntityUid::from_strs("Test", "test"),
+            EntityUid::from_strs("Action", "a"),
+            EntityUid::from_strs("Resource", "b"),
             Context::empty(),
             None,
         )
@@ -3702,7 +3690,8 @@ mod error_source_tests {
             "true && ([2, 3, 4] in [4, 5, 6])",
             "ip(3)",
         ];
-        let req = Request::new(None, None, None, Context::empty(), None).unwrap();
+        let euid: EntityUid = r#"Placeholder::"entity""#.parse().unwrap();
+        let req = Request::new(euid.clone(), euid.clone(), euid, Context::empty(), None).unwrap();
         let entities = Entities::empty();
         for src in srcs {
             let expr = Expression::from_str(src).unwrap();
@@ -3719,7 +3708,8 @@ mod error_source_tests {
             "permit ( principal, action, resource ) when { true && ([2, 3, 4] in [4, 5, 6]) };",
             "permit ( principal, action, resource ) when { ip(3) };",
         ];
-        let req = Request::new(None, None, None, Context::empty(), None).unwrap();
+        let euid: EntityUid = r#"Placeholder::"entity""#.parse().unwrap();
+        let req = Request::new(euid.clone(), euid.clone(), euid, Context::empty(), None).unwrap();
         let entities = Entities::empty();
         for src in srcs {
             let pset = PolicySet::from_str(src).unwrap();
@@ -3931,7 +3921,7 @@ mod issue_606 {
 }
 
 mod issue_619 {
-    use crate::{eval_expression, Context, Entities, EvalResult, Policy, Request};
+    use crate::{eval_expression, Context, Entities, EntityUid, EvalResult, Policy, Request};
     use cool_asserts::assert_matches;
 
     /// The first issue reported in issue 619.
@@ -3950,9 +3940,17 @@ mod issue_619 {
     /// Another issue from a comment: Ensure the correct error semantics of these expressions
     #[test]
     fn mult_overflows() {
+        let euid: EntityUid = r#"Placeholder::"entity""#.parse().unwrap();
         let eval = |expr: &str| {
             eval_expression(
-                &Request::new(None, None, None, Context::empty(), None).unwrap(),
+                &Request::new(
+                    euid.clone(),
+                    euid.clone(),
+                    euid.clone(),
+                    Context::empty(),
+                    None,
+                )
+                .unwrap(),
                 &Entities::empty(),
                 &expr.parse().unwrap(),
             )
@@ -4131,7 +4129,8 @@ mod decimal_ip_constructors {
     }
 
     fn evaluate_empty(expr: &Expression) -> Result<EvalResult, EvaluationError> {
-        let r = Request::new(None, None, None, Context::empty(), None).unwrap();
+        let euid: EntityUid = r#"Placeholder::"entity""#.parse().unwrap();
+        let r = Request::new(euid.clone(), euid.clone(), euid, Context::empty(), None).unwrap();
         let e = Entities::empty();
         eval_expression(&r, &e, expr)
     }

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -205,7 +205,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
     );
     let request3 = Request::new(
         principal.clone(),
-        r#"__cedar::"Default""#.parse().unwrap(),
+        r#"Ghost::"ghost""#.parse().unwrap(),
         resource.clone(),
         Context::empty(),
         None,
@@ -221,7 +221,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
 
     // Requesting with a default principal or resource will return Deny (but not fail)
     let request4 = Request::new(
-        r#"__cedar::"Default""#.parse().unwrap(),
+        r#"Ghost::"ghost""#.parse().unwrap(),
         action.clone(),
         resource,
         Context::empty(),
@@ -236,7 +236,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
     let request5 = Request::new(
         principal,
         action,
-        r#"__cedar::"Default""#.parse().unwrap(),
+        r#"Ghost::"ghost""#.parse().unwrap(),
         Context::empty(),
         None,
     )

--- a/cedar-testing/tests/cedar-policy-cli/main.rs
+++ b/cedar-testing/tests/cedar-policy-cli/main.rs
@@ -105,18 +105,12 @@ fn perform_integration_test_from_json(jsonfile: impl AsRef<Path>) {
             .expect("failed to write to tempfile");
 
         let mut entity_args = Vec::new();
-        if let Some(s) = json_request.principal {
-            entity_args.push("--principal".to_string());
-            entity_args.push(value_to_euid_string(s.into()).unwrap());
-        }
-        if let Some(s) = json_request.resource {
-            entity_args.push("--resource".to_string());
-            entity_args.push(value_to_euid_string(s.into()).unwrap());
-        }
-        if let Some(s) = json_request.action {
-            entity_args.push("--action".to_string());
-            entity_args.push(value_to_euid_string(s.into()).unwrap());
-        }
+        entity_args.push("--principal".to_string());
+        entity_args.push(value_to_euid_string(json_request.principal.into()).unwrap());
+        entity_args.push("--resource".to_string());
+        entity_args.push(value_to_euid_string(json_request.resource.into()).unwrap());
+        entity_args.push("--action".to_string());
+        entity_args.push(value_to_euid_string(json_request.action.into()).unwrap());
         if !json_request.validate_request {
             entity_args.push("--request-validation=false".to_string());
         }


### PR DESCRIPTION
## Description of changes
(partially) Implements [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md)
This does not implement the backwards compatibility functions, saving that for a second PR as this one is already large.
## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

