### PR TITLE
more small edits to the JSON FFI

### DIFF
--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -220,6 +220,10 @@ impl EntityUid {
 
     /// Creates `EntityUid` from a JSON value, which should have
     /// either the implicit or explicit `__entity` form.
+    ///
+    /// Examples:
+    /// * `{ "__entity": { "type": "User", "id": "123abc" } }`
+    /// * `{ "type": "User", "id": "123abc" }`
     /// ```
     /// # use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid};
     /// # use std::str::FromStr;

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -915,7 +915,7 @@ mod test {
         );
         let rslice = RecvdSlice {
             policies: PolicySet::Map(HashMap::new()),
-            entities: Entities(entities.into()),
+            entities: entities.into(),
             templates: None,
             template_instantiations: None,
         };

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -17,13 +17,13 @@
 //! This module contains the `is_authorized` entry points that other language
 //! FFIs can call
 #![allow(clippy::module_name_repetitions)]
-use super::utils::{DetailedError, JsonValueWithNoDuplicateKeys, PolicySet, Schema, WithWarnings};
-use crate::{
-    Authorizer, Context, Decision, Entities, EntityId, EntityTypeName, EntityUid, PolicyId,
-    Request, SlotId,
-};
+#[cfg(feature = "partial-eval")]
+use super::utils::JsonValueWithNoDuplicateKeys;
+use super::utils::{Context, DetailedError, Entities, EntityUid, PolicySet, Schema, WithWarnings};
+use crate::{Authorizer, Decision, EntityId, EntityTypeName, PolicyId, Request, SlotId};
+use cedar_policy_validator::human_schema::SchemaWarning;
 use itertools::Itertools;
-use miette::{miette, Diagnostic, WrapErr};
+use miette::{miette, Diagnostic};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, MapPreventDuplicates};
 use std::collections::{HashMap, HashSet};
@@ -42,7 +42,7 @@ thread_local!(
 
 /// Basic interface, using [`AuthorizationCall`] and [`AuthorizationAnswer`] types
 pub fn is_authorized(call: AuthorizationCall) -> AuthorizationAnswer {
-    match call.get_components() {
+    match call.parse() {
         WithWarnings {
             t: Ok((request, policies, entities)),
             warnings,
@@ -66,6 +66,11 @@ pub fn is_authorized(call: AuthorizationCall) -> AuthorizationAnswer {
 
 /// Input is a JSON encoding of [`AuthorizationCall`] and output is a JSON
 /// encoding of [`AuthorizationAnswer`]
+///
+/// # Errors
+///
+/// Will return `Err` if the input JSON cannot be deserialized as an
+/// [`AuthorizationCall`].
 pub fn is_authorized_json(json: serde_json::Value) -> Result<serde_json::Value, serde_json::Error> {
     let ans = is_authorized(serde_json::from_value(json)?);
     serde_json::to_value(ans)
@@ -73,17 +78,22 @@ pub fn is_authorized_json(json: serde_json::Value) -> Result<serde_json::Value, 
 
 /// Input and output are strings containing serialized JSON, in the shapes
 /// expected by [`is_authorized_json()`]
+///
+/// # Errors
+///
+/// Will return `Err` if the input cannot be converted to valid JSON or
+/// deserialized as an [`AuthorizationCall`].
 pub fn is_authorized_json_str(json: &str) -> Result<String, serde_json::Error> {
     let ans = is_authorized(serde_json::from_str(json)?);
     serde_json::to_string(&ans)
 }
 
-/// Basic interface for partial evaluation, using `AuthorizationCall` and
-/// `PartialAuthorizationAnswer` types
+/// Basic interface for partial evaluation, using [`AuthorizationCall`] and
+/// [`PartialAuthorizationAnswer`] types
 #[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 pub fn is_authorized_partial(call: AuthorizationCall) -> PartialAuthorizationAnswer {
-    match call.get_components_partial() {
+    match call.parse_partial() {
         WithWarnings {
             t: Ok((request, policies, entities)),
             warnings,
@@ -115,6 +125,11 @@ pub fn is_authorized_partial(call: AuthorizationCall) -> PartialAuthorizationAns
 
 /// Input is a JSON encoding of [`AuthorizationCall`] and output is a JSON
 /// encoding of [`PartialAuthorizationAnswer`]
+///
+/// # Errors
+///
+/// Will return `Err` if the input JSON cannot be deserialized as an
+/// [`AuthorizationCall`].
 #[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 pub fn is_authorized_partial_json(
@@ -126,6 +141,11 @@ pub fn is_authorized_partial_json(
 
 /// Input and output are strings containing serialized JSON, in the shapes
 /// expected by [`is_authorized_partial_json()`]
+///
+/// # Errors
+///
+/// Will return `Err` if the input cannot be converted to valid JSON or
+/// deserialized as an [`AuthorizationCall`].
 #[doc = include_str!("../../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
 pub fn is_authorized_partial_json_str(json: &str) -> Result<String, serde_json::Error> {
@@ -442,19 +462,13 @@ pub enum PartialAuthorizationAnswer {
 #[serde(rename_all = "camelCase")]
 pub struct AuthorizationCall {
     /// The principal taking action
-    #[cfg_attr(feature = "wasm", tsify(type = "{type: string, id: string}"))]
-    principal: Option<JsonValueWithNoDuplicateKeys>,
+    principal: Option<EntityUid>,
     /// The action the principal is taking
-    #[cfg_attr(feature = "wasm", tsify(type = "{type: string, id: string}"))]
-    action: JsonValueWithNoDuplicateKeys,
+    action: Option<EntityUid>,
     /// The resource being acted on by the principal
-    #[cfg_attr(feature = "wasm", tsify(type = "{type: string, id: string}"))]
-    resource: Option<JsonValueWithNoDuplicateKeys>,
+    resource: Option<EntityUid>,
     /// The context details specific to the request
-    #[serde_as(as = "MapPreventDuplicates<_, _>")]
-    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson>"))]
-    /// The context details specific to the request
-    context: HashMap<String, JsonValueWithNoDuplicateKeys>,
+    context: Context,
     /// Optional schema.
     /// If present, this will inform the parsing: for instance, it will allow
     /// `__entity` and `__extn` escapes to be implicit, and it will error if
@@ -475,143 +489,136 @@ fn constant_true() -> bool {
     true
 }
 
-/// Parses the given JSON into an [`EntityUid`], or if it fails, adds an
-/// appropriate error to `errs` and returns `None`.
-fn parse_entity_uid(
-    entity_uid_json: JsonValueWithNoDuplicateKeys,
-    category: &str,
-    errs: &mut Vec<miette::Report>,
-) -> Option<EntityUid> {
-    match EntityUid::from_json(entity_uid_json.into())
-        .wrap_err_with(|| format!("Failed to parse {category}"))
-    {
-        Ok(euid) => Some(euid),
-        Err(e) => {
-            errs.push(e);
-            None
-        }
-    }
-}
-
-/// Parses the given JSON context into a [`Context`], or if it fails, adds
-/// appropriate error(s) to `errs` and returns an empty context.
-fn parse_context(
-    context_map: HashMap<String, JsonValueWithNoDuplicateKeys>,
-    schema_ref: Option<&crate::Schema>,
-    action_ref: Option<&EntityUid>,
-    errs: &mut Vec<miette::Report>,
-) -> Context {
-    match serde_json::to_value(context_map) {
-        Ok(json) => {
-            match Context::from_json_value(
-                json,
-                match (schema_ref, action_ref) {
-                    (Some(s), Some(a)) => Some((s, a)),
-                    _ => None,
-                },
-            ) {
-                Ok(context) => context,
-                Err(e) => {
-                    errs.push(miette::Report::new(e));
-                    Context::empty()
-                }
-            }
-        }
-        Err(e) => {
-            errs.push(miette!("Failed to parse context: {e}"));
-            Context::empty()
-        }
+fn build_error<T>(
+    errs: Vec<miette::Report>,
+    warnings: Vec<SchemaWarning>,
+) -> WithWarnings<Result<T, Vec<miette::Report>>> {
+    WithWarnings {
+        t: Err(errs),
+        warnings: warnings.into_iter().map(Into::into).collect(),
     }
 }
 
 impl AuthorizationCall {
-    fn get_components(
+    fn parse(
         self,
-    ) -> WithWarnings<Result<(Request, crate::PolicySet, Entities), Vec<miette::Report>>> {
+    ) -> WithWarnings<Result<(Request, crate::PolicySet, crate::Entities), Vec<miette::Report>>>
+    {
         let mut errs = vec![];
         let mut warnings = vec![];
-        let schema = match self.schema.map(Schema::parse).transpose() {
-            Ok(None) => None,
-            Ok(Some((schema, new_warnings))) => {
-                warnings.extend(new_warnings.map(miette::Report::new));
-                Some(schema)
-            }
-            Err(e) => {
-                errs.push(e);
-                None
-            }
-        };
-        let principal = self
+        let maybe_schema = self
+            .schema
+            .map(|schema| {
+                schema.parse().map(|(schema, new_warnings)| {
+                    warnings.extend(new_warnings);
+                    schema
+                })
+            })
+            .transpose()
+            .map_err(|e| errs.push(e));
+        let maybe_principal = self
             .principal
-            .and_then(|p| parse_entity_uid(p, "principal", &mut errs));
-        let action = parse_entity_uid(self.action, "action", &mut errs);
-        let resource = self
+            .map(|uid| uid.parse(Some("principal")))
+            .transpose()
+            .map_err(|e| errs.push(e));
+        let maybe_action = self
+            .action
+            .map(|uid| uid.parse(Some("action")))
+            .transpose()
+            .map_err(|e| errs.push(e));
+        let maybe_resource = self
             .resource
-            .and_then(|r| parse_entity_uid(r, "resource", &mut errs));
-        let context = parse_context(self.context, schema.as_ref(), action.as_ref(), &mut errs);
+            .map(|uid| uid.parse(Some("resource")))
+            .transpose()
+            .map_err(|e| errs.push(e));
 
-        let request = match Request::new(
-            principal,
-            action,
-            resource,
-            context,
-            if self.validate_request {
-                schema.as_ref()
-            } else {
-                None
-            },
-        ) {
-            Ok(req) => Some(req),
+        let (Ok(schema), Ok(principal), Ok(action), Ok(resource)) =
+            (maybe_schema, maybe_principal, maybe_action, maybe_resource)
+        else {
+            // At least one of the `errs.push(e)` statements above must have been reached
+            return build_error(errs, warnings);
+        };
+
+        let context = match self.context.parse(schema.as_ref(), action.as_ref()) {
+            Ok(context) => context,
             Err(e) => {
-                errs.push(miette::Report::new(e));
-                None
-            }
-        };
-        let (policies, entities) = match self.slice.try_into(schema.as_ref()) {
-            Ok((policies, entities)) => (Some(policies), Some(entities)),
-            Err(es) => {
-                errs.extend(es);
-                (None, None)
+                return build_error(vec![e], warnings);
             }
         };
 
-        match (errs.is_empty(), request, policies, entities) {
-            (true, Some(req), Some(policies), Some(entities)) => WithWarnings {
-                t: Ok((req, policies, entities)),
-                warnings,
-            },
-            _ => WithWarnings {
-                t: Err(errs),
-                warnings,
-            },
+        let schema_opt = if self.validate_request {
+            schema.as_ref()
+        } else {
+            None
+        };
+        let request = match Request::new(principal, action, resource, context, schema_opt) {
+            Ok(request) => request,
+            Err(e) => {
+                return build_error(vec![e.into()], warnings);
+            }
+        };
+
+        let (policies, entities) = match self.slice.try_into(schema.as_ref()) {
+            Ok((policies, entities)) => (policies, entities),
+            Err(errs) => {
+                return build_error(errs, warnings);
+            }
+        };
+
+        WithWarnings {
+            t: Ok((request, policies, entities)),
+            warnings: warnings.into_iter().map(Into::into).collect(),
         }
     }
 
     #[cfg(feature = "partial-eval")]
-    fn get_components_partial(
+    /// Similar to [`AuthorizationCall::parse`], except a `None` value for the
+    /// principal, action, or resource indicates _unknown_ instead of _unspecified_.
+    fn parse_partial(
         self,
-    ) -> WithWarnings<Result<(Request, crate::PolicySet, Entities), Vec<miette::Report>>> {
+    ) -> WithWarnings<Result<(Request, crate::PolicySet, crate::Entities), Vec<miette::Report>>>
+    {
         let mut errs = vec![];
         let mut warnings = vec![];
-        let schema = match self.schema.map(Schema::parse).transpose() {
-            Ok(None) => None,
-            Ok(Some((schema, new_warnings))) => {
-                warnings.extend(new_warnings.map(miette::Report::new));
-                Some(schema)
-            }
+        let maybe_schema = self
+            .schema
+            .map(|schema| {
+                schema.parse().map(|(schema, new_warnings)| {
+                    warnings.extend(new_warnings);
+                    schema
+                })
+            })
+            .transpose()
+            .map_err(|e| errs.push(e));
+        let maybe_principal = self
+            .principal
+            .map(|uid| uid.parse(Some("principal")))
+            .transpose()
+            .map_err(|e| errs.push(e));
+        let maybe_action = self
+            .action
+            .map(|uid| uid.parse(Some("action")))
+            .transpose()
+            .map_err(|e| errs.push(e));
+        let maybe_resource = self
+            .resource
+            .map(|uid| uid.parse(Some("resource")))
+            .transpose()
+            .map_err(|e| errs.push(e));
+
+        let (Ok(schema), Ok(principal), Ok(action), Ok(resource)) =
+            (maybe_schema, maybe_principal, maybe_action, maybe_resource)
+        else {
+            // At least one of the `errs.push(e)` statements above must have been reached
+            return build_error(errs, warnings);
+        };
+
+        let context = match self.context.parse(schema.as_ref(), action.as_ref()) {
+            Ok(context) => context,
             Err(e) => {
-                errs.push(e);
-                None
+                return build_error(vec![e], warnings);
             }
         };
-        let principal = self
-            .principal
-            .and_then(|p| parse_entity_uid(p, "principal", &mut errs));
-        let action = parse_entity_uid(self.action, "action", &mut errs);
-        let resource = self
-            .resource
-            .and_then(|r| parse_entity_uid(r, "resource", &mut errs));
-        let context = parse_context(self.context, schema.as_ref(), action.as_ref(), &mut errs);
 
         let mut b = Request::builder();
         if principal.is_some() {
@@ -627,34 +634,26 @@ impl AuthorizationCall {
         let request = if self.validate_request {
             match schema.as_ref() {
                 Some(schema_ref) => match b.schema(schema_ref).build() {
-                    Ok(req) => Some(req),
+                    Ok(req) => req,
                     Err(e) => {
-                        errs.push(miette::Report::new(e));
-                        None
+                        return build_error(vec![e.into()], warnings);
                     }
                 },
-                None => Some(b.build()),
+                None => b.build(),
             }
         } else {
-            Some(b.build())
+            b.build()
         };
         let (policies, entities) = match self.slice.try_into(schema.as_ref()) {
-            Ok((policies, entities)) => (Some(policies), Some(entities)),
-            Err(e) => {
-                errs.extend(e);
-                (None, None)
+            Ok((policies, entities)) => (policies, entities),
+            Err(errs) => {
+                return build_error(errs, warnings);
             }
         };
 
-        match (errs.is_empty(), request, policies, entities) {
-            (true, Some(req), Some(policies), Some(entities)) => WithWarnings {
-                t: Ok((req, policies, entities.partial())),
-                warnings,
-            },
-            _ => WithWarnings {
-                t: Err(errs),
-                warnings,
-            },
+        WithWarnings {
+            t: Ok((request, policies, entities)),
+            warnings: warnings.into_iter().map(Into::into).collect(),
         }
     }
 }
@@ -747,8 +746,7 @@ struct RecvdSlice {
     policies: PolicySet,
     /// JSON object containing the entities data, in "natural JSON" form -- same
     /// format as expected by EntityJsonParser
-    #[cfg_attr(feature = "wasm", tsify(type = "Array<EntityJson>"))]
-    entities: JsonValueWithNoDuplicateKeys,
+    entities: Entities,
 
     /// Optional template policies.
     #[serde_as(as = "Option<MapPreventDuplicates<_, _>>")]
@@ -758,7 +756,7 @@ struct RecvdSlice {
     template_instantiations: Option<Vec<TemplateLink>>,
 }
 
-fn parse_link(v: &Link) -> Result<(SlotId, EntityUid), miette::Report> {
+fn parse_link(v: &Link) -> Result<(SlotId, crate::EntityUid), miette::Report> {
     let slot = match v.slot.as_str() {
         "?principal" => SlotId::principal(),
         "?resource" => SlotId::resource(),
@@ -771,7 +769,7 @@ fn parse_link(v: &Link) -> Result<(SlotId, EntityUid), miette::Report> {
         Ok(eid) => eid,
         Err(err) => match err {},
     };
-    let entity_uid = EntityUid::from_type_name_and_id(type_name, eid);
+    let entity_uid = crate::EntityUid::from_type_name_and_id(type_name, eid);
     Ok((slot, entity_uid))
 }
 
@@ -798,7 +796,7 @@ impl RecvdSlice {
     fn try_into(
         self,
         schema: Option<&crate::Schema>,
-    ) -> Result<(crate::PolicySet, Entities), Vec<miette::Report>> {
+    ) -> Result<(crate::PolicySet, crate::Entities), Vec<miette::Report>> {
         let Self {
             policies,
             entities,
@@ -815,11 +813,11 @@ impl RecvdSlice {
                 crate::PolicySet::new()
             }
         };
-        let entities = match Entities::from_json_value(entities.into(), schema) {
+        let entities = match entities.parse(schema) {
             Ok(entities) => entities,
             Err(e) => {
-                errs.push(miette::Report::new(e));
-                Entities::empty()
+                errs.push(e);
+                crate::Entities::empty()
             }
         };
 
@@ -917,14 +915,14 @@ mod test {
         );
         let rslice = RecvdSlice {
             policies: PolicySet::Map(HashMap::new()),
-            entities: entities.into(),
+            entities: Entities(entities.into()),
             templates: None,
             template_instantiations: None,
         };
         let (policies, entities) = rslice.try_into(None).expect("parse failed");
         assert!(policies.is_empty());
         entities
-            .get(&EntityUid::from_type_name_and_id(
+            .get(&crate::EntityUid::from_type_name_and_id(
                 "user".parse().unwrap(),
                 "alice".parse().unwrap(),
             ))
@@ -932,7 +930,7 @@ mod test {
                 || panic!("Missing user::alice Entity"),
                 |alice| {
                     assert!(entities.is_ancestor_of(
-                        &EntityUid::from_type_name_and_id(
+                        &crate::EntityUid::from_type_name_and_id(
                             "user".parse().unwrap(),
                             "bob".parse().unwrap()
                         ),
@@ -1779,7 +1777,7 @@ mod test {
             }
         }"#;
         assert_matches!(is_authorized_json_str(call), Err(e) => {
-            assert!(e.to_string().contains("found duplicate key"));
+            assert!(e.to_string() == "the key `is_authenticated` occurs two or more times in the same JSON object at line 17 column 13");
         });
     }
 

--- a/cedar-policy/src/ffi/mod.rs
+++ b/cedar-policy/src/ffi/mod.rs
@@ -19,6 +19,6 @@
 mod is_authorized;
 pub use is_authorized::*;
 mod utils;
-pub use utils::{DetailedError, PolicySet, Schema, Severity, SourceLabel, SourceLocation};
+pub use utils::*;
 mod validate;
 pub use validate::*;

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -177,6 +177,13 @@ impl EntityUid {
     }
 }
 
+#[doc(hidden)]
+impl From<serde_json::Value> for EntityUid {
+    fn from(json: serde_json::Value) -> Self {
+        Self(json.into())
+    }
+}
+
 /// Wrapper around a JSON value describing a context. Expects the same format
 /// as [`crate::Context::from_json_value`].
 /// See <https://docs.cedarpolicy.com/auth/entities-syntax.html>
@@ -212,6 +219,13 @@ impl Context {
     }
 }
 
+#[doc(hidden)]
+impl From<serde_json::Value> for Context {
+    fn from(json: serde_json::Value) -> Self {
+        Self(json.into())
+    }
+}
+
 /// Wrapper around a JSON value describing a set of entities. Expects the same
 /// format as [`crate::Entities::from_json_value`].
 /// See <https://docs.cedarpolicy.com/auth/entities-syntax.html>
@@ -220,8 +234,7 @@ impl Context {
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct Entities(
-    #[cfg_attr(feature = "wasm", tsify(type = "Array<EntityJson>"))]
-    pub(super)  JsonValueWithNoDuplicateKeys,
+    #[cfg_attr(feature = "wasm", tsify(type = "Array<EntityJson>"))] JsonValueWithNoDuplicateKeys,
 );
 
 impl Entities {
@@ -236,6 +249,13 @@ impl Entities {
         opt_schema: Option<&crate::Schema>,
     ) -> Result<crate::Entities, miette::Report> {
         crate::Entities::from_json_value(self.0.into(), opt_schema).map_err(Into::into)
+    }
+}
+
+#[doc(hidden)]
+impl From<serde_json::Value> for Entities {
+    fn from(json: serde_json::Value) -> Self {
+        Self(json.into())
     }
 }
 
@@ -413,7 +433,7 @@ mod test {
             serde_json::from_value(schema_json).expect("failed to parse from JSON");
         let _ = schema.parse().expect("failed to convert to schema");
 
-        // Invalid syntax (this is actually a policy)
+        // Invalid syntax (the value is a policy)
         let schema_json = json!({
             "human": "permit(principal == User::\"alice\", action, resource);"
         });

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -372,50 +372,6 @@ mod test {
     use serde_json::json;
 
     #[test]
-    fn test_entity_uid_parser() {
-        // Both {"type": .., "name": ..} and {__entity: ..} are valid
-        let user_alice = EntityUid(
-            json!({
-                 "type": "User",
-                 "id": "alice"
-            })
-            .into(),
-        );
-        let user_bob = EntityUid(
-            json!({
-                 "__entity": {
-                     "type": "User",
-                     "id": "bob"
-                 }
-            })
-            .into(),
-        );
-        user_alice
-            .parse(None)
-            .expect("failed to convert to entity uid");
-        user_bob
-            .parse(None)
-            .expect("failed to convert to entity uid");
-
-        // Invalid syntax
-        let invalid = EntityUid(
-            json!({
-                    "__entity": "User::\"bob\""
-            })
-            .into(),
-        );
-        let err = invalid
-            .parse(None)
-            .expect_err("should have failed to convert to entity uid");
-        expect_err(
-            "",
-            &err,
-            &ExpectedErrorMessageBuilder::error(r#"failed to parse entity uid"#)
-                .help("literal entity references can be made with `{ \"type\": \"SomeType\", \"id\": \"SomeId\" }`")
-                .build());
-    }
-
-    #[test]
     fn test_schema_parser() {
         // Cedar syntax
         let schema_json = json!({

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -77,6 +77,11 @@ pub fn validate(call: ValidationCall) -> ValidationAnswer {
 
 /// Input is a JSON encoding of [`ValidationCall`] and output is a JSON
 /// encoding of [`ValidationAnswer`]
+///
+/// # Errors
+///
+/// Will return `Err` if the input JSON cannot be deserialized as a
+/// [`ValidationCall`].
 pub fn validate_json(json: serde_json::Value) -> Result<serde_json::Value, serde_json::Error> {
     let ans = validate(serde_json::from_value(json)?);
     serde_json::to_value(ans)
@@ -84,6 +89,11 @@ pub fn validate_json(json: serde_json::Value) -> Result<serde_json::Value, serde
 
 /// Input and output are strings containing serialized JSON, in the shapes
 /// expected by [`validate_json()`]
+///
+/// # Errors
+///
+/// Will return `Err` if the input cannot be converted to valid JSON or
+/// deserialized as a [`ValidationCall`].
 pub fn validate_json_str(json: &str) -> Result<String, serde_json::Error> {
     let ans = validate(serde_json::from_str(json)?);
     serde_json::to_string(&ans)

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -5184,7 +5184,7 @@ mod request_validation_tests {
 
     #[test]
     fn invalid_resource_type() {
-        let schema: Schema = schema();
+        let schema = schema();
         let err = Request::new(
             EntityUid::from_strs("Principal", "principal"),
             EntityUid::from_strs("Action", "action"),


### PR DESCRIPTION
## Description of changes

I've ended up making a variety of local edits for #757. This PR includes some of the less interesting ones to reduce the diff of future PRs.

* Added new FFI types `EntityUid`, `Context` and `Entities`, which are just wrappers around a `JsonValueWithNoDuplicateKeys` with a comment about the expected JSON format. I think introducing these new types makes things cleaner, but I'm also sympathetic to the opinion that it adds unneccessary indirection. Lmk what you think.
* Added `# Errors` comments to pacify clippy

I don't expect these changes to break anything downstream.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
