### PR TITLE
Use public `ParseErrors` in the `Parse` variant of `RestrictedExpressionParseError`

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3026,7 +3026,9 @@ impl FromStr for RestrictedExpression {
 
     /// create a `RestrictedExpression` using Cedar syntax
     fn from_str(expression: &str) -> Result<Self, Self::Err> {
-        ast::RestrictedExpr::from_str(expression).map(RestrictedExpression)
+        ast::RestrictedExpr::from_str(expression)
+            .map(RestrictedExpression)
+            .map_err(Into::into)
     }
 }
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -17,9 +17,7 @@
 //! This module defines the publicly exported error types.
 
 use crate::{EntityUid, PolicyId};
-pub use cedar_policy_core::ast::{
-    restricted_expr_errors, RestrictedExpressionError, RestrictedExpressionParseError,
-};
+pub use cedar_policy_core::ast::{restricted_expr_errors, RestrictedExpressionError};
 pub use cedar_policy_core::evaluator::{evaluation_errors, EvaluationError};
 pub use cedar_policy_core::extensions::{
     extension_function_lookup_errors, ExtensionFunctionLookupError,
@@ -865,6 +863,36 @@ pub mod context_json_errors {
         /// Get the [`EntityUid`] of the action which doesn't exist
         pub fn action(&self) -> &EntityUid {
             &self.action
+        }
+    }
+}
+
+/// Error type for parsing a `RestrictedExpression`
+#[derive(Debug, Diagnostic, Error)]
+pub enum RestrictedExpressionParseError {
+    /// Failed to parse the expression
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Parse(#[from] ParseErrors),
+    /// Parsed successfully as an expression, but failed to construct a
+    /// restricted expression, for the reason indicated in the underlying error
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidRestrictedExpression(#[from] RestrictedExpressionError),
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_core::ast::RestrictedExpressionParseError>
+    for RestrictedExpressionParseError
+{
+    fn from(e: cedar_policy_core::ast::RestrictedExpressionParseError) -> Self {
+        match e {
+            cedar_policy_core::ast::RestrictedExpressionParseError::Parse(e) => {
+                Self::Parse(e.into())
+            }
+            cedar_policy_core::ast::RestrictedExpressionParseError::InvalidRestrictedExpression(
+                e,
+            ) => e.into(),
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Previously, we just re-exported Core's `RestrictedExpressionParseError`, so the `Parse` variant contained Core's `ParseErrors`. This PR does the appropriate wrapping so that the `Parse` variant contains the public `ParseErrors` instead.

## Issue #, if available

Mentioned in https://github.com/cedar-policy/cedar/issues/745#issuecomment-2168026032

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

