### PR TITLE
Cherry-pick #966 to 3.2.x

### DIFF
--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -39,4 +39,6 @@ cool_asserts = "2.0"
 
 [build-dependencies]
 cargo-lock = "9.0.0"
-itertools = "0.12.1"
+# Lock `url` (dependencies of cargo-lock) to 2.5.0 until we know if Unicode 3.0 license is ok.
+url = "=2.5.0"
+itertools = "0.13.0"


### PR DESCRIPTION
## Description of changes

#966 

Also updates `itertools` build dependency, matching the dependency version on `main`