### PR TITLE
Replace internal `::new()` with `From`/`Into` for `EntityUid` and `EntityTypeName`

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -87,7 +87,6 @@ impl Entity {
     ) -> Result<Self, EntityAttrEvaluationError> {
         // note that we take a "parents" parameter here; we will compute TC when
         // the `Entities` object is created
-        // INVARIANT(UidOfEntityNotUnspecified): by invariant on `EntityUid`
         Ok(Self(ast::Entity::new(
             uid.into(),
             attrs
@@ -106,7 +105,6 @@ impl Entity {
     pub fn new_no_attrs(uid: EntityUid, parents: HashSet<EntityUid>) -> Self {
         // note that we take a "parents" parameter here; we will compute TC when
         // the `Entities` object is created
-        // INVARIANT(UidOfEntityNotUnspecified): by invariant on `EntityUid`
         Self(ast::Entity::new_with_attr_partial_value(
             uid.into(),
             HashMap::new(),
@@ -125,7 +123,6 @@ impl Entity {
     /// # cool_asserts::assert_matches!(alice.attr("age"), None);
     /// ```
     pub fn with_uid(uid: EntityUid) -> Self {
-        // INVARIANT(UidOfEntityNotUnspecified): by invariant on `EntityUid`
         Self(ast::Entity::with_uid(uid.into()))
     }
 
@@ -140,7 +137,7 @@ impl Entity {
     /// assert_eq!(alice.uid(), euid);
     /// ```
     pub fn uid(&self) -> EntityUid {
-        EntityUid::new(self.0.uid().clone())
+        self.0.uid().clone().into()
     }
 
     /// Get the value for the given attribute, or `None` if not present.
@@ -199,9 +196,9 @@ impl Entity {
             .collect();
 
         (
-            EntityUid::new(uid),
+            uid.into(),
             attrs,
-            ancestors.into_iter().map(EntityUid::new).collect(),
+            ancestors.into_iter().map(Into::into).collect(),
         )
     }
 
@@ -2150,24 +2147,24 @@ impl Template {
             ast::PrincipalOrResourceConstraint::Any => TemplatePrincipalConstraint::Any,
             ast::PrincipalOrResourceConstraint::In(eref) => {
                 TemplatePrincipalConstraint::In(match eref {
-                    ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
+                    ast::EntityReference::EUID(e) => Some(e.as_ref().clone().into()),
                     ast::EntityReference::Slot => None,
                 })
             }
             ast::PrincipalOrResourceConstraint::Eq(eref) => {
                 TemplatePrincipalConstraint::Eq(match eref {
-                    ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
+                    ast::EntityReference::EUID(e) => Some(e.as_ref().clone().into()),
                     ast::EntityReference::Slot => None,
                 })
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                TemplatePrincipalConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
+                TemplatePrincipalConstraint::Is(entity_type.as_ref().clone().into())
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 TemplatePrincipalConstraint::IsIn(
-                    EntityTypeName::new(entity_type.as_ref().clone()),
+                    entity_type.as_ref().clone().into(),
                     match eref {
-                        ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
+                        ast::EntityReference::EUID(e) => Some(e.as_ref().clone().into()),
                         ast::EntityReference::Slot => None,
                     },
                 )
@@ -2180,14 +2177,10 @@ impl Template {
         // Clone the data from Core to be consistent with the other constraints
         match self.ast.action_constraint() {
             ast::ActionConstraint::Any => ActionConstraint::Any,
-            ast::ActionConstraint::In(ids) => ActionConstraint::In(
-                ids.iter()
-                    .map(|id| EntityUid::new(id.as_ref().clone()))
-                    .collect(),
-            ),
-            ast::ActionConstraint::Eq(id) => {
-                ActionConstraint::Eq(EntityUid::new(id.as_ref().clone()))
+            ast::ActionConstraint::In(ids) => {
+                ActionConstraint::In(ids.iter().map(|id| id.as_ref().clone().into()).collect())
             }
+            ast::ActionConstraint::Eq(id) => ActionConstraint::Eq(id.as_ref().clone().into()),
         }
     }
 
@@ -2197,24 +2190,24 @@ impl Template {
             ast::PrincipalOrResourceConstraint::Any => TemplateResourceConstraint::Any,
             ast::PrincipalOrResourceConstraint::In(eref) => {
                 TemplateResourceConstraint::In(match eref {
-                    ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
+                    ast::EntityReference::EUID(e) => Some(e.as_ref().clone().into()),
                     ast::EntityReference::Slot => None,
                 })
             }
             ast::PrincipalOrResourceConstraint::Eq(eref) => {
                 TemplateResourceConstraint::Eq(match eref {
-                    ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
+                    ast::EntityReference::EUID(e) => Some(e.as_ref().clone().into()),
                     ast::EntityReference::Slot => None,
                 })
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                TemplateResourceConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
+                TemplateResourceConstraint::Is(entity_type.as_ref().clone().into())
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 TemplateResourceConstraint::IsIn(
-                    EntityTypeName::new(entity_type.as_ref().clone()),
+                    entity_type.as_ref().clone().into(),
                     match eref {
-                        ast::EntityReference::EUID(e) => Some(EntityUid::new(e.as_ref().clone())),
+                        ast::EntityReference::EUID(e) => Some(e.as_ref().clone().into()),
                         ast::EntityReference::Slot => None,
                     },
                 )
@@ -2407,7 +2400,7 @@ impl Policy {
                 .ast
                 .env()
                 .iter()
-                .map(|(key, value)| ((*key).into(), EntityUid::new(value.clone())))
+                .map(|(key, value)| ((*key).into(), value.clone().into()))
                 .collect();
             Some(wrapped_vals)
         }
@@ -2463,11 +2456,11 @@ impl Policy {
                 PrincipalConstraint::Eq(self.convert_entity_reference(eref, slot_id).clone())
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                PrincipalConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
+                PrincipalConstraint::Is(entity_type.as_ref().clone().into())
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 PrincipalConstraint::IsIn(
-                    EntityTypeName::new(entity_type.as_ref().clone()),
+                    entity_type.as_ref().clone().into(),
                     self.convert_entity_reference(eref, slot_id).clone(),
                 )
             }
@@ -2501,11 +2494,11 @@ impl Policy {
                 ResourceConstraint::Eq(self.convert_entity_reference(eref, slot_id).clone())
             }
             ast::PrincipalOrResourceConstraint::Is(entity_type) => {
-                ResourceConstraint::Is(EntityTypeName::new(entity_type.as_ref().clone()))
+                ResourceConstraint::Is(entity_type.as_ref().clone().into())
             }
             ast::PrincipalOrResourceConstraint::IsIn(entity_type, eref) => {
                 ResourceConstraint::IsIn(
-                    EntityTypeName::new(entity_type.as_ref().clone()),
+                    entity_type.as_ref().clone().into(),
                     self.convert_entity_reference(eref, slot_id).clone(),
                 )
             }
@@ -3492,7 +3485,7 @@ impl From<ast::Value> for EvalResult {
             ast::ValueKind::Lit(ast::Literal::Long(i)) => Self::Long(i),
             ast::ValueKind::Lit(ast::Literal::String(s)) => Self::String(s.to_string()),
             ast::ValueKind::Lit(ast::Literal::EntityUID(e)) => {
-                Self::EntityUid(EntityUid::new(ast::EntityUID::clone(&e)))
+                Self::EntityUid(ast::EntityUID::clone(&e).into())
             }
             ast::ValueKind::Set(set) => Self::Set(Set(set
                 .authoritative

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -271,7 +271,7 @@ impl EntityAttrEvaluationError {
 impl From<ast::EntityAttrEvaluationError> for EntityAttrEvaluationError {
     fn from(err: ast::EntityAttrEvaluationError) -> Self {
         Self {
-            uid: EntityUid::new(err.uid),
+            uid: err.uid.into(),
             attr: err.attr,
             err: err.err,
         }

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -134,12 +134,6 @@ impl EntityTypeName {
     pub fn namespace(&self) -> String {
         self.0.name().namespace()
     }
-
-    /// Construct an [`EntityTypeName`] from the internal type.
-    /// This function is only intended to be used internally.
-    pub(crate) fn new(ty: ast::EntityType) -> Self {
-        Self(ty)
-    }
 }
 
 /// This `FromStr` implementation requires the _normalized_ representation of the
@@ -157,6 +151,20 @@ impl FromStr for EntityTypeName {
 impl std::fmt::Display for EntityTypeName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+#[doc(hidden)]
+impl From<ast::Name> for EntityTypeName {
+    fn from(name: ast::Name) -> Self {
+        Self(name.into())
+    }
+}
+
+#[doc(hidden)]
+impl From<ast::EntityType> for EntityTypeName {
+    fn from(ty: ast::EntityType) -> Self {
+        Self(ty)
     }
 }
 
@@ -215,10 +223,6 @@ impl EntityUid {
 
     /// Creates `EntityUid` from a JSON value, which should have
     /// either the implicit or explicit `__entity` form.
-    ///
-    /// Examples:
-    /// * `{ "__entity": { "type": "User", "id": "123abc" } }`
-    /// * `{ "type": "User", "id": "123abc" }`
     /// ```
     /// # use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid};
     /// # use std::str::FromStr;
@@ -230,9 +234,11 @@ impl EntityUid {
     #[allow(clippy::result_large_err)]
     pub fn from_json(json: serde_json::Value) -> Result<Self, impl miette::Diagnostic> {
         let parsed: cedar_policy_core::entities::EntityUidJson = serde_json::from_value(json)?;
-        Ok::<Self, JsonDeserializationError>(Self::new(
-            parsed.into_euid(|| JsonDeserializationErrorContext::EntityUid)?,
-        ))
+        Ok::<Self, JsonDeserializationError>(
+            parsed
+                .into_euid(|| JsonDeserializationErrorContext::EntityUid)?
+                .into(),
+        )
     }
 
     /// Testing utility for creating `EntityUids` a bit easier
@@ -242,12 +248,6 @@ impl EntityUid {
             EntityTypeName::from_str(typename).unwrap(),
             EntityId::from_str(id).unwrap(),
         )
-    }
-
-    /// Construct an [`EntityUid`] from the internal type.
-    /// This function is only intended to be used internally.
-    pub(crate) fn new(uid: ast::EntityUID) -> Self {
-        Self(uid)
     }
 }
 
@@ -279,7 +279,7 @@ impl FromStr for EntityUid {
     /// If you have separate components of an [`EntityUid`], use [`EntityUid::from_type_name_and_id`]
     fn from_str(uid_str: &str) -> Result<Self, Self::Err> {
         ast::EntityUID::from_normalized_str(uid_str)
-            .map(Self::new)
+            .map(Into::into)
             .map_err(Into::into)
     }
 }
@@ -301,6 +301,13 @@ impl AsRef<ast::EntityUID> for EntityUid {
 impl From<EntityUid> for ast::EntityUID {
     fn from(uid: EntityUid) -> Self {
         uid.0
+    }
+}
+
+#[doc(hidden)]
+impl From<ast::EntityUID> for EntityUid {
+    fn from(uid: ast::EntityUID) -> Self {
+        Self(uid)
     }
 }
 


### PR DESCRIPTION
## Description of changes

I thought this would be more consistent with how we handle other internal/external pairs.

Not breaking, it only removes `pub(crate)` methods.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

