### PR TITLE
implement 745 for LinkingError variant of PolicySetError

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1962,22 +1962,22 @@ impl PolicySet {
         // trying to link a static policy, which we want to error on here.
         let Some(template) = self.templates.get(&template_id) else {
             return Err(if self.policies.contains_key(&template_id) {
-                PolicySetError::ExpectedTemplate(policy_set_errors::ExpectedTemplate::new())
+                policy_set_errors::ExpectedTemplate::new().into()
             } else {
-                PolicySetError::Linking(ast::LinkingError::NoSuchTemplate {
-                    id: template_id.into(),
-                })
+                policy_set_errors::LinkingError {
+                    inner: ast::LinkingError::NoSuchTemplate {
+                        id: template_id.into(),
+                    },
+                }
+                .into()
             });
         };
 
-        let linked_ast = self
-            .ast
-            .link(
-                template_id.into(),
-                new_id.clone().into(),
-                unwrapped_vals.clone(),
-            )
-            .map_err(PolicySetError::Linking)?;
+        let linked_ast = self.ast.link(
+            template_id.into(),
+            new_id.clone().into(),
+            unwrapped_vals.clone(),
+        )?;
 
         // PANIC SAFETY: `lossless.link()` will not fail after `ast.link()` succeeds
         #[allow(clippy::expect_used)]

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -504,7 +504,6 @@ mod scope_constraints_tests {
 /// Tests in this module are adapted from Core's `policy_set.rs` tests
 mod policy_set_tests {
     use super::*;
-    use ast::LinkingError;
     use cool_asserts::assert_matches;
 
     #[test]
@@ -569,7 +568,7 @@ mod policy_set_tests {
 
         assert_matches!(
             r,
-            Err(PolicySetError::Linking(LinkingError::PolicyIdConflict { id })) =>{
+            Err(PolicySetError::Linking(policy_set_errors::LinkingError { inner: ast::LinkingError::PolicyIdConflict { id } })) =>{
                 assert_eq!(id, ast::PolicyID::from_string("id"));
             }
         );
@@ -1334,9 +1333,9 @@ mod policy_set_tests {
                 PolicyId::from_str("policy3").unwrap(),
                 env.clone(),
             ),
-            Err(PolicySetError::Linking(
-                LinkingError::PolicyIdConflict { .. }
-            ))
+            Err(PolicySetError::Linking(policy_set_errors::LinkingError {
+                inner: ast::LinkingError::PolicyIdConflict { .. }
+            }))
         );
 
         //fails for template; link
@@ -1346,9 +1345,9 @@ mod policy_set_tests {
                 PolicyId::from_str("policy0").unwrap(),
                 env.clone(),
             ),
-            Err(PolicySetError::Linking(
-                LinkingError::PolicyIdConflict { .. }
-            ))
+            Err(PolicySetError::Linking(policy_set_errors::LinkingError {
+                inner: ast::LinkingError::PolicyIdConflict { .. }
+            }))
         );
 
         //fails for static; link
@@ -1364,9 +1363,9 @@ mod policy_set_tests {
                 PolicyId::from_str("policy1").unwrap(),
                 env,
             ),
-            Err(PolicySetError::Linking(
-                LinkingError::PolicyIdConflict { .. }
-            ))
+            Err(PolicySetError::Linking(policy_set_errors::LinkingError {
+                inner: ast::LinkingError::PolicyIdConflict { .. }
+            }))
         );
     }
 }
@@ -4556,7 +4555,7 @@ mod policy_set_est_tests {
         let template1 = PolicyId::new("non_existent").into();
         assert_matches!(
             err,
-            PolicySetError::Linking(ast::LinkingError::NoSuchTemplate { id }) if id == template1
+            PolicySetError::Linking(policy_set_errors::LinkingError { inner: ast::LinkingError::NoSuchTemplate { id }}) if id == template1
         );
     }
 
@@ -4631,10 +4630,10 @@ mod policy_set_est_tests {
         let just_principal = vec![SlotId::principal().into()];
         assert_matches!(
             err,
-            PolicySetError::Linking(ast::LinkingError::ArityError {
+            PolicySetError::Linking(policy_set_errors::LinkingError { inner: ast::LinkingError::ArityError {
                 unbound_values,
                 extra_values
-            }) if extra_values.is_empty() && unbound_values == just_principal
+            }}) if extra_values.is_empty() && unbound_values == just_principal
         );
     }
 
@@ -4712,10 +4711,10 @@ mod policy_set_est_tests {
         let just_resource = vec![SlotId::resource().into()];
         assert_matches!(
             err,
-            PolicySetError::Linking(ast::LinkingError::ArityError {
+            PolicySetError::Linking(policy_set_errors::LinkingError { inner: ast::LinkingError::ArityError {
                 unbound_values,
                 extra_values
-            }) if unbound_values.is_empty() && extra_values == just_resource
+            }}) if unbound_values.is_empty() && extra_values == just_resource
         );
     }
 


### PR DESCRIPTION
## Description of changes

Instead of an un-exported enum, `PolicySetError::Linking` gets its own proper error struct (wrapping that enum).

## Issue #, if available

Mentioned in https://github.com/cedar-policy/cedar/issues/745#issuecomment-2168026032

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


