### PR TITLE
fix for a few methods returning an unexported error type

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1684,14 +1684,12 @@ impl PolicySet {
         let mut pset = Self::default();
 
         for PolicyEntry { id, policy } in est.templates {
-            let template = Template::from_est(Some(PolicyId::new(id)), policy)
-                .map_err(|e| policy_set_errors::FromJsonError { inner: e })?;
+            let template = Template::from_est(Some(PolicyId::new(id)), policy)?;
             pset.add_template(template)?;
         }
 
         for PolicyEntry { id, policy } in est.static_policies {
-            let p = Policy::from_est(Some(PolicyId::new(id)), policy)
-                .map_err(|e| policy_set_errors::FromJsonError { inner: e })?;
+            let p = Policy::from_est(Some(PolicyId::new(id)), policy)?;
             pset.add(p)?;
         }
 
@@ -2257,16 +2255,14 @@ impl Template {
     pub fn from_json(
         id: Option<PolicyId>,
         json: serde_json::Value,
-    ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
+    ) -> Result<Self, PolicyFromJsonError> {
         let est: est::Policy = serde_json::from_value(json)
-            .map_err(|e| entities::json::err::JsonDeserializationError::Serde(e.into()))?;
+            .map_err(|e| entities::json::err::JsonDeserializationError::Serde(e.into()))
+            .map_err(cedar_policy_core::est::FromJsonError::from)?;
         Self::from_est(id, est)
     }
 
-    fn from_est(
-        id: Option<PolicyId>,
-        est: est::Policy,
-    ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
+    fn from_est(id: Option<PolicyId>, est: est::Policy) -> Result<Self, PolicyFromJsonError> {
         Ok(Self {
             ast: est.clone().try_into_ast_template(id.map(PolicyId::into))?,
             lossless: LosslessPolicy::Est(est),
@@ -2648,16 +2644,14 @@ impl Policy {
     pub fn from_json(
         id: Option<PolicyId>,
         json: serde_json::Value,
-    ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
+    ) -> Result<Self, PolicyFromJsonError> {
         let est: est::Policy = serde_json::from_value(json)
-            .map_err(|e| entities::json::err::JsonDeserializationError::Serde(e.into()))?;
+            .map_err(|e| entities::json::err::JsonDeserializationError::Serde(e.into()))
+            .map_err(cedar_policy_core::est::FromJsonError::from)?;
         Self::from_est(id, est)
     }
 
-    fn from_est(
-        id: Option<PolicyId>,
-        est: est::Policy,
-    ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
+    fn from_est(id: Option<PolicyId>, est: est::Policy) -> Result<Self, PolicyFromJsonError> {
         Ok(Self {
             ast: est.clone().try_into_ast_policy(id.map(PolicyId::into))?,
             lossless: LosslessPolicy::Est(est),

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -666,15 +666,6 @@ pub mod policy_set_errors {
         }
     }
 
-    /// Error when converting a policy from JSON format
-    #[derive(Debug, Diagnostic, Error)]
-    #[error("Error deserializing a policy/template from JSON: {inner}")]
-    #[diagnostic(transparent)]
-    pub struct FromJsonError {
-        #[from]
-        pub(crate) inner: cedar_policy_core::est::FromJsonError,
-    }
-
     /// Error during JSON ser/de of the policy set (as opposed to individual policies)
     #[derive(Debug, Diagnostic, Error)]
     #[error("Error serializing / deserializing PolicySet to / from JSON: {inner})")]
@@ -729,12 +720,12 @@ pub enum PolicySetError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnlinkLinkNotLink(#[from] policy_set_errors::UnlinkLinkNotLinkError),
-    /// Error when converting from JSON format
+    /// Error when converting a policy/template from JSON format
     #[error(transparent)]
     #[diagnostic(transparent)]
-    FromJson(#[from] policy_set_errors::FromJsonError),
-    /// Error when converting to JSON format
-    #[error("Error serializing a policy to JSON: {0}")]
+    FromJson(#[from] PolicyFromJsonError),
+    /// Error when converting a policy/template to JSON format
+    #[error("Error serializing a policy/template to JSON: {0}")]
     #[diagnostic(transparent)]
     ToJson(#[from] PolicyToJsonError),
     /// Error during JSON ser/de of the policy set (as opposed to individual policies)
@@ -846,6 +837,15 @@ pub mod policy_to_json_errors {
         #[from]
         err: serde_json::Error,
     }
+}
+
+/// Error when converting a policy or template from JSON format
+#[derive(Debug, Diagnostic, Error)]
+#[error("error deserializing a policy/template from JSON: {inner}")]
+#[diagnostic(transparent)]
+pub struct PolicyFromJsonError {
+    #[from]
+    pub(crate) inner: cedar_policy_core::est::FromJsonError,
 }
 
 /// Error type for parsing `Context` from JSON

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3893,9 +3893,9 @@ mod issue_604 {
 }
 
 mod issue_606 {
-    use cedar_policy_core::est::FromJsonError;
-
+    use super::{expect_err, ExpectedErrorMessageBuilder};
     use crate::{PolicyId, Template};
+    use cool_asserts::assert_matches;
 
     #[test]
     fn est_template() {
@@ -3919,11 +3919,15 @@ mod issue_606 {
 
         let tid = PolicyId::new("t0");
         // We should get an error here after trying to construct a template with a slot in the condition
-        let template = Template::from_json(Some(tid), est_json);
-        assert!(matches!(
-            template,
-            Err(FromJsonError::SlotsInConditionClause(_))
-        ));
+        assert_matches!(Template::from_json(Some(tid), est_json.clone()), Err(e) => {
+            expect_err(
+                &est_json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error deserializing a policy/template from JSON: found template slot ?principal in a `when` clause")
+                .help("slots are currently unsupported in `when` clauses")
+                .build(),
+            );
+        });
     }
 }
 


### PR DESCRIPTION
## Description of changes

A few public methods were returning unexported `cedar_policy_core::est::FromJsonError`.  We already had a wrapper of this error for one of the variants of `PolicySetError`.  I promoted that wrapper to the top namespace instead of `policy_set_errors`, and used it in all of the relevant places.

## Issue #, if available

Mentioned in https://github.com/cedar-policy/cedar/issues/745#issuecomment-2168026032

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

