### PR TITLE
use `#[serde(rename_all = "camelCase")]` in more places

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1411,21 +1411,18 @@ impl<T> Expr<T> {
 
 /// AST variables
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Var {
     /// the Principal of the given request
-    #[serde(rename = "principal")]
     Principal,
     /// the Action of the given request
-    #[serde(rename = "action")]
     Action,
     /// the Resource of the given request
-    #[serde(rename = "resource")]
     Resource,
     /// the Context of the given request
-    #[serde(rename = "context")]
     Context,
 }
 

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1765,15 +1765,14 @@ impl<'u> arbitrary::Arbitrary<'u> for PolicyID {
 
 /// the Effect of a policy
 #[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Effect {
     /// this is a Permit policy
-    #[serde(rename = "permit")]
     Permit,
     /// this is a Forbid policy
-    #[serde(rename = "forbid")]
     Forbid,
 }
 

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -162,6 +162,7 @@ impl JsonRecord {
 
 /// Structure expected by the `__entity` escape
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct TypeAndId {
@@ -207,6 +208,7 @@ impl TryFrom<TypeAndId> for EntityUID {
 
 /// Structure expected by the `__extn` escape
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct FnAndArg {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -72,14 +72,13 @@ pub struct Policy {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(tag = "kind", content = "body")]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum Clause {
     /// A `when` clause
-    #[serde(rename = "when")]
     When(Expr),
     /// An `unless` clause
-    #[serde(rename = "unless")]
     Unless(Expr),
 }
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -112,14 +112,13 @@ impl ValidatorSchemaFragment {
 
 #[serde_as]
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ValidatorSchema {
     /// Map from entity type names to the ValidatorEntityType object.
-    #[serde(rename = "entityTypes")]
     #[serde_as(as = "Vec<(_, _)>")]
     entity_types: HashMap<Name, ValidatorEntityType>,
 
     /// Map from action id names to the ValidatorActionId object.
-    #[serde(rename = "actionIds")]
     #[serde_as(as = "Vec<(_, _)>")]
     action_ids: HashMap<EntityUID, ValidatorActionId>,
 }

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -30,12 +30,12 @@ use crate::types::{Attributes, Type};
 /// the struct are the same as the schema entity type structure, but the
 /// `member_of` relation is reversed to instead be `descendants`.
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ValidatorActionId {
     /// The name of the action.
     pub(crate) name: EntityUID,
 
     /// The principals and resources that the action can be applied to.
-    #[serde(rename = "appliesTo")]
     pub(crate) applies_to: ValidatorApplySpec,
 
     /// The set of actions that can be members of this action. When this
@@ -98,6 +98,7 @@ impl TCNode<EntityUID> for ValidatorActionId {
 
 /// The principals and resources that an action can be applied to.
 #[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct ValidatorApplySpec {
     /// The principal entity types the action can be applied to. This set may
     /// be a singleton set containing the unspecified entity type when the
@@ -105,12 +106,10 @@ pub(crate) struct ValidatorApplySpec {
     /// shouldn't contain the unspecified entity type, but (policy) validation
     /// will give the same success/failure result as when it is the only element
     /// of the set, perhaps with extra type errors.
-    #[serde(rename = "principalApplySpec")]
     principal_apply_spec: HashSet<EntityType>,
 
     /// The resource entity types the action can be applied to. See comments on
     /// `principal_apply_spec` about the unspecified entity type.
-    #[serde(rename = "resourceApplySpec")]
     resource_apply_spec: HashSet<EntityType>,
 }
 

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -177,12 +177,12 @@ impl NamespaceDefinition {
 /// can/should be included on entities of each type.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EntityType {
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    #[serde(rename = "memberOfTypes")]
     pub member_of_types: Vec<Name>,
     #[serde(default)]
     #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
@@ -222,6 +222,7 @@ impl Default for AttributesOrContext {
 /// kinds of entities it can be used on.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionType {
@@ -233,11 +234,9 @@ pub struct ActionType {
     pub attributes: Option<HashMap<SmolStr, CedarValueJson>>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "appliesTo")]
     pub applies_to: Option<ApplySpec>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "memberOf")]
     pub member_of: Option<Vec<ActionEntityUID>>,
 }
 
@@ -251,16 +250,15 @@ pub struct ActionType {
 /// applies to.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ApplySpec {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "resourceTypes")]
     pub resource_types: Option<Vec<Name>>,
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[serde(rename = "principalTypes")]
     pub principal_types: Option<Vec<Name>>,
     #[serde(default)]
     #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
@@ -269,6 +267,7 @@ pub struct ApplySpec {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionEntityUID {

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1406,14 +1406,13 @@ impl EntityRecordKind {
 
 /// Contains the type of a record attribute and if the attribute is required.
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AttributeType {
     /// The type of the attribute.
-    #[serde(rename = "attrType")]
     pub attr_type: Type,
 
     /// True when the attribute must be present. False if it is optional, and so
     /// may not be present in a record or entity.
-    #[serde(rename = "isRequired")]
     pub is_required: bool,
 }
 

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -106,12 +106,10 @@ pub mod partial {
     }
 
     #[derive(Debug, Deserialize, PartialEq, Eq)]
+    #[serde(rename_all = "camelCase")]
     pub enum Decision {
-        #[serde(rename = "allow")]
         Allow,
-        #[serde(rename = "deny")]
         Deny,
-        #[serde(rename = "unknown")]
         Unknown,
     }
 


### PR DESCRIPTION
## Description of changes

I think there's only one instance where this is a functional change and not just a refactor, which is for `ValidatorActionId::attribute_types`, but that struct is not part of the official schema JSON format (do we only use the `Serialize`/`Deserialize` for DRT?).  I can revert that one if we'd rather a pure refactor.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

