### PR TITLE
Refactor `maybe_with_parens` to use `write!` instead returning a string

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -325,6 +325,7 @@ mod test {
 
     /// helper function to just do EST data structure --> JSON --> EST data structure.
     /// This roundtrip should be lossless for all policies.
+    #[track_caller]
     fn est_roundtrip(est: Policy) -> Policy {
         let json = serde_json::to_value(est).expect("failed to serialize to JSON");
         serde_json::from_value(json.clone()).unwrap_or_else(|e| {
@@ -337,6 +338,7 @@ mod test {
 
     /// helper function to take EST-->text-->CST-->EST, which directly tests the Display impl for EST.
     /// This roundtrip should be lossless for all policies.
+    #[track_caller]
     fn text_roundtrip(est: &Policy) -> Policy {
         let text = est.to_string();
         let cst = parser::text_to_cst::parse_policy(&text)
@@ -348,6 +350,7 @@ mod test {
 
     /// helper function to take EST-->AST-->EST for inline policies.
     /// This roundtrip is not always lossless, because EST-->AST can be lossy.
+    #[track_caller]
     fn ast_roundtrip(est: Policy) -> Policy {
         let ast = est
             .try_into_ast_policy(None)
@@ -357,6 +360,7 @@ mod test {
 
     /// helper function to take EST-->AST-->EST for templates.
     /// This roundtrip is not always lossless, because EST-->AST can be lossy.
+    #[track_caller]
     fn ast_roundtrip_template(est: Policy) -> Policy {
         let ast = est
             .try_into_ast_template(None)
@@ -366,6 +370,7 @@ mod test {
 
     /// helper function to take EST-->AST-->text-->CST-->EST for inline policies.
     /// This roundtrip is not always lossless, because EST-->AST can be lossy.
+    #[track_caller]
     fn circular_roundtrip(est: Policy) -> Policy {
         let ast = est
             .try_into_ast_policy(None)
@@ -380,6 +385,7 @@ mod test {
 
     /// helper function to take EST-->AST-->text-->CST-->EST for templates.
     /// This roundtrip is not always lossless, because EST-->AST can be lossy.
+    #[track_caller]
     fn circular_roundtrip_template(est: Policy) -> Policy {
         let ast = est
             .try_into_ast_template(None)

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1433,7 +1433,10 @@ impl std::fmt::Display for ExprNoExt {
             ExprNoExt::Var(v) => write!(f, "{v}"),
             ExprNoExt::Slot(id) => write!(f, "{id}"),
             ExprNoExt::Unknown { name } => write!(f, "unknown(\"{}\")", name.escape_debug()),
-            ExprNoExt::Not { arg } => write!(f, "!{}", maybe_with_parens(arg)),
+            ExprNoExt::Not { arg } => {
+                write!(f, "!")?;
+                maybe_with_parens(f, arg)
+            }
             ExprNoExt::Neg { arg } => {
                 // Always add parentheses instead of calling
                 // `maybe_with_parens`.
@@ -1442,104 +1445,91 @@ impl std::fmt::Display for ExprNoExt {
                 // printed form, thus preserving the round-tripping property.
                 write!(f, "-({arg})")
             }
-            ExprNoExt::Eq { left, right } => write!(
-                f,
-                "{} == {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::NotEq { left, right } => write!(
-                f,
-                "{} != {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::In { left, right } => write!(
-                f,
-                "{} in {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::Less { left, right } => write!(
-                f,
-                "{} < {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::LessEq { left, right } => write!(
-                f,
-                "{} <= {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::Greater { left, right } => write!(
-                f,
-                "{} > {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::GreaterEq { left, right } => write!(
-                f,
-                "{} >= {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::And { left, right } => write!(
-                f,
-                "{} && {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::Or { left, right } => write!(
-                f,
-                "{} || {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::Add { left, right } => write!(
-                f,
-                "{} + {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::Sub { left, right } => write!(
-                f,
-                "{} - {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
-            ExprNoExt::Mul { left, right } => write!(
-                f,
-                "{} * {}",
-                maybe_with_parens(left),
-                maybe_with_parens(right)
-            ),
+            ExprNoExt::Eq { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " == ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::NotEq { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " != ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::In { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " in ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::Less { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " < ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::LessEq { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " <= ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::Greater { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " > ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::GreaterEq { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " >= ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::And { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " && ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::Or { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " || ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::Add { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " + ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::Sub { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " - ")?;
+                maybe_with_parens(f, right)
+            }
+            ExprNoExt::Mul { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " * ")?;
+                maybe_with_parens(f, right)
+            }
             ExprNoExt::Contains { left, right } => {
-                write!(f, "{}.contains({right})", maybe_with_parens(left))
+                maybe_with_parens(f, left)?;
+                write!(f, ".contains({right})")
             }
             ExprNoExt::ContainsAll { left, right } => {
-                write!(f, "{}.containsAll({right})", maybe_with_parens(left))
+                maybe_with_parens(f, left)?;
+                write!(f, ".containsAll({right})")
             }
             ExprNoExt::ContainsAny { left, right } => {
-                write!(f, "{}.containsAny({right})", maybe_with_parens(left))
+                maybe_with_parens(f, left)?;
+                write!(f, ".containsAny({right})")
             }
-            ExprNoExt::GetAttr { left, attr } => write!(
-                f,
-                "{}[\"{}\"]",
-                maybe_with_parens(left),
-                attr.escape_debug()
-            ),
-            ExprNoExt::HasAttr { left, attr } => write!(
-                f,
-                "{} has \"{}\"",
-                maybe_with_parens(left),
-                attr.escape_debug()
-            ),
+            ExprNoExt::GetAttr { left, attr } => {
+                maybe_with_parens(f, left)?;
+                write!(f, "[\"{}\"]", attr.escape_debug())
+            }
+            ExprNoExt::HasAttr { left, attr } => {
+                maybe_with_parens(f, left)?;
+                write!(f, " has \"{}\"", attr.escape_debug())
+            }
             ExprNoExt::Like { left, pattern } => {
+                maybe_with_parens(f, left)?;
                 write!(
                     f,
-                    "{} like \"{}\"",
-                    maybe_with_parens(left),
+                    " like \"{}\"",
                     crate::ast::Pattern::from(pattern.clone())
                 )
             }
@@ -1548,9 +1538,13 @@ impl std::fmt::Display for ExprNoExt {
                 entity_type,
                 in_expr,
             } => {
-                write!(f, "{} is {}", maybe_with_parens(left), entity_type)?;
+                maybe_with_parens(f, left)?;
+                write!(f, " is {entity_type}")?;
                 match in_expr {
-                    Some(in_expr) => write!(f, " in {}", maybe_with_parens(in_expr)),
+                    Some(in_expr) => {
+                        write!(f, " in ")?;
+                        maybe_with_parens(f, in_expr)
+                    }
                     None => Ok(()),
                 }
             }
@@ -1558,13 +1552,14 @@ impl std::fmt::Display for ExprNoExt {
                 cond_expr,
                 then_expr,
                 else_expr,
-            } => write!(
-                f,
-                "if {} then {} else {}",
-                maybe_with_parens(cond_expr),
-                maybe_with_parens(then_expr),
-                maybe_with_parens(else_expr)
-            ),
+            } => {
+                write!(f, "if ")?;
+                maybe_with_parens(f, cond_expr)?;
+                write!(f, " then ")?;
+                maybe_with_parens(f, then_expr)?;
+                write!(f, " else ")?;
+                maybe_with_parens(f, else_expr)
+            }
             ExprNoExt::Set(v) => write!(f, "[{}]", v.iter().join(", ")),
             ExprNoExt::Record(m) => write!(
                 f,
@@ -1594,13 +1589,8 @@ impl std::fmt::Display for ExtFuncCall {
         });
         match (style, args.iter().next()) {
             (Some(ast::CallStyle::MethodStyle), Some(receiver)) => {
-                write!(
-                    f,
-                    "{}.{}({})",
-                    maybe_with_parens(receiver),
-                    fn_name,
-                    args.iter().skip(1).join(", ")
-                )
+                maybe_with_parens(f, receiver)?;
+                write!(f, ".{}({})", fn_name, args.iter().skip(1).join(", "))
             }
             (_, _) => {
                 write!(f, "{}({})", fn_name, args.iter().join(", "))
@@ -1614,45 +1604,42 @@ impl std::fmt::Display for ExtFuncCall {
 /// E.g., won't add parens for constants or `principal` etc, but will for things
 /// like `(2 < 5)`.
 /// When in doubt, add the parens.
-fn maybe_with_parens(expr: &Expr) -> String {
+fn maybe_with_parens(f: &mut std::fmt::Formatter<'_>, expr: &Expr) -> std::fmt::Result {
     match expr {
-        Expr::ExprNoExt(ExprNoExt::Value(_)) => expr.to_string(),
-        Expr::ExprNoExt(ExprNoExt::Var(_)) => expr.to_string(),
-        Expr::ExprNoExt(ExprNoExt::Slot(_)) => expr.to_string(),
-        Expr::ExprNoExt(ExprNoExt::Unknown { .. }) => expr.to_string(),
-        Expr::ExprNoExt(ExprNoExt::Not { .. }) => {
-            // we want parens here because things like parse((!x).y)
-            // would be printed into !x.y which has a different meaning
-            format!("({expr})")
-        }
-        Expr::ExprNoExt(ExprNoExt::Neg { .. }) => {
-            // we want parens here because things like parse((-x).y)
-            // would be printed into -x.y which has a different meaning
-            format!("({expr})")
-        }
-        Expr::ExprNoExt(ExprNoExt::Eq { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::NotEq { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::In { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Less { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::LessEq { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Greater { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::GreaterEq { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::And { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Or { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Add { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Sub { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Mul { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Contains { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::HasAttr { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Like { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Is { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::If { .. }) => format!("({expr})"),
-        Expr::ExprNoExt(ExprNoExt::Set(_)) => expr.to_string(),
-        Expr::ExprNoExt(ExprNoExt::Record(_)) => expr.to_string(),
-        Expr::ExtFuncCall { .. } => format!("({expr})"),
+        Expr::ExprNoExt(ExprNoExt::Set(_)) |
+        Expr::ExprNoExt(ExprNoExt::Record(_)) |
+        Expr::ExprNoExt(ExprNoExt::Value(_)) |
+        Expr::ExprNoExt(ExprNoExt::Var(_)) |
+        Expr::ExprNoExt(ExprNoExt::Slot(_)) |
+        Expr::ExprNoExt(ExprNoExt::Unknown { .. }) => write!(f, "{expr}"),
+
+        // we want parens here because things like parse((!x).y)
+        // would be printed into !x.y which has a different meaning
+        Expr::ExprNoExt(ExprNoExt::Not { .. }) |
+        // we want parens here because things like parse((-x).y)
+        // would be printed into -x.y which has a different meaning
+        Expr::ExprNoExt(ExprNoExt::Neg { .. })  |
+        Expr::ExprNoExt(ExprNoExt::Eq { .. }) |
+        Expr::ExprNoExt(ExprNoExt::NotEq { .. }) |
+        Expr::ExprNoExt(ExprNoExt::In { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Less { .. }) |
+        Expr::ExprNoExt(ExprNoExt::LessEq { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Greater { .. }) |
+        Expr::ExprNoExt(ExprNoExt::GreaterEq { .. }) |
+        Expr::ExprNoExt(ExprNoExt::And { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Or { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Add { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Sub { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Mul { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Contains { .. }) |
+        Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) |
+        Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) |
+        Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) |
+        Expr::ExprNoExt(ExprNoExt::HasAttr { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Like { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Is { .. }) |
+        Expr::ExprNoExt(ExprNoExt::If { .. }) |
+        Expr::ExtFuncCall { .. } => write!(f, "({expr})"),
     }
 }
 


### PR DESCRIPTION
Avoids running out of stack space when printing relatively small policies.

## Description of changes

With a debug build, the original implementation would overflow the stack when formatting a  policy like

```
permit ( principal, action, resource) when {
principal
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr.attr
.attr.attr
};
```

with this change we can obviously still run out of stack space, but the debug build does not run out of stack space for policies a little over twice as large

This fixes a failure observed in our nightly testing. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

