### PR TITLE
Bunch more comments and docstrings in cedar-policy-validator

### DIFF
--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,7 +17,7 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![forbid(unsafe_code)]
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
-#![allow(clippy::result_large_err)] // see #878
+#![allow(clippy::result_large_err, clippy::large_enum_variant)] // see #878
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -25,6 +25,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 /// Struct which carries enough information that it can (efficiently) impl Core's `Schema`
+#[derive(Debug)]
 pub struct CoreSchema<'a> {
     /// Contains all the information
     schema: &'a ValidatorSchema,
@@ -37,6 +38,7 @@ pub struct CoreSchema<'a> {
 }
 
 impl<'a> CoreSchema<'a> {
+    /// Create a new `CoreSchema` for the given `ValidatorSchema`
     pub fn new(schema: &'a ValidatorSchema) -> Self {
         Self {
             actions: schema
@@ -261,6 +263,7 @@ impl<'a> ast::RequestSchema for CoreSchema<'a> {
     }
 }
 
+/// Error when the request does not conform to the schema.
 #[derive(Debug, Diagnostic, Error)]
 pub enum RequestValidationError {
     /// Request action is not declared in the schema
@@ -316,6 +319,7 @@ pub enum RequestValidationError {
 
 /// Struct which carries enough information that it can impl Core's
 /// `ContextSchema`.
+#[derive(Debug, Clone, PartialEq)]
 pub struct ContextSchema(
     // INVARIANT: The `Type` stored in this struct must be representable as a
     // `SchemaType` to avoid panicking in `context_type`.

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -41,6 +41,8 @@ pub struct ValidationResult {
 }
 
 impl ValidationResult {
+    /// Create a new `ValidationResult` with these errors and warnings.
+    /// Empty iterators are allowed for either or both arguments.
     pub fn new(
         errors: impl IntoIterator<Item = ValidationError>,
         warnings: impl IntoIterator<Item = ValidationWarning>,
@@ -145,9 +147,12 @@ pub enum ValidationError {
     #[diagnostic(transparent)]
     #[error(transparent)]
     FunctionArgumentValidation(#[from] validation_errors::FunctionArgumentValidation),
+    /// The policy uses an empty set literal in a way that is forbidden
     #[diagnostic(transparent)]
     #[error(transparent)]
     EmptySetForbidden(#[from] validation_errors::EmptySetForbidden),
+    /// The policy passes a non-literal to an extension constructor, which is
+    /// forbidden in strict validation
     #[diagnostic(transparent)]
     #[error(transparent)]
     NonLitExtConstructor(#[from] validation_errors::NonLitExtConstructor),

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -669,7 +669,7 @@ pub enum AttributeAccess {
 impl AttributeAccess {
     /// Construct an `AttributeAccess` access from a `GetAttr` expression `expr.attr`.
     pub(crate) fn from_expr(
-        req_env: &RequestEnv,
+        req_env: &RequestEnv<'_>,
         mut expr: &Expr<Option<Type>>,
         attr: SmolStr,
     ) -> AttributeAccess {

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -634,11 +634,11 @@ impl Diagnostic for NonLitExtConstructor {
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub enum AttributeAccess {
     /// The attribute access is some sequence of attributes accesses eventually
-    /// targeting an EntityLUB.
+    /// targeting an [`EntityLUB`].
     EntityLUB(EntityLUB, Vec<SmolStr>),
     /// The attribute access is some sequence of attributes accesses eventually
-    /// targeting the context variable. The context being accessed is identified
-    /// by the `EntityUID` for the associated action.
+    /// targeting the `context` variable. The context being accessed is identified
+    /// by the [`EntityUID`] for the associated action.
     Context(EntityUID, Vec<SmolStr>),
     /// Other cases where we do not attempt to give more information about the
     /// access. This includes any access on the `AnyEntity` type and on record

--- a/cedar-policy-validator/src/diagnostics/validation_warnings.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_warnings.rs
@@ -31,11 +31,15 @@ use cedar_policy_core::{ast::PolicyID, impl_diagnostic_from_source_loc_field, pa
 use miette::Diagnostic;
 use thiserror::Error;
 
+/// Warning for strings containing mixed scripts
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
 #[error("for policy `{policy_id}`, string `\"{string}\"` contains mixed scripts")]
 pub struct MixedScriptString {
+    /// Source location
     pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
     pub policy_id: PolicyID,
+    /// String containing mixed scripts
     pub string: String,
 }
 
@@ -44,11 +48,15 @@ impl Diagnostic for MixedScriptString {
     impl_diagnostic_warning!();
 }
 
+/// Warning for strings containing BIDI control characters
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
 #[error("for policy `{policy_id}`, string `\"{string}\"` contains BIDI control characters")]
 pub struct BidiCharsInString {
+    /// Source location
     pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
     pub policy_id: PolicyID,
+    /// String containing BIDI control characters
     pub string: String,
 }
 
@@ -57,11 +65,15 @@ impl Diagnostic for BidiCharsInString {
     impl_diagnostic_warning!();
 }
 
+/// Warning for identifiers containing BIDI control characters
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
 #[error("for policy `{policy_id}`, identifier `{id}` contains BIDI control characters")]
 pub struct BidiCharsInIdentifier {
+    /// Source location
     pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
     pub policy_id: PolicyID,
+    /// Identifier containing BIDI control characters
     pub id: String,
 }
 
@@ -70,11 +82,15 @@ impl Diagnostic for BidiCharsInIdentifier {
     impl_diagnostic_warning!();
 }
 
+/// Warning for identifiers containing mixed scripts
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
 #[error("for policy `{policy_id}`, identifier `{id}` contains mixed scripts")]
 pub struct MixedScriptIdentifier {
+    /// Source location
     pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
     pub policy_id: PolicyID,
+    /// Identifier containing mixed scripts
     pub id: String,
 }
 impl Diagnostic for MixedScriptIdentifier {
@@ -82,11 +98,15 @@ impl Diagnostic for MixedScriptIdentifier {
     impl_diagnostic_warning!();
 }
 
+/// Warning for identifiers containing confusable characters
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
 #[error("for policy `{policy_id}`, identifier `{id}` contains characters that fall outside of the General Security Profile for Identifiers")]
 pub struct ConfusableIdentifier {
+    /// Source location
     pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
     pub policy_id: PolicyID,
+    /// Identifier containing confusable characters
     pub id: String,
 }
 
@@ -95,10 +115,13 @@ impl Diagnostic for ConfusableIdentifier {
     impl_diagnostic_warning!();
 }
 
+/// Warning for policies that are impossible (evaluate to `false` for all valid requests)
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
 #[error("for policy `{policy_id}`, policy is impossible: the policy expression evaluates to false for all valid requests")]
 pub struct ImpossiblePolicy {
+    /// Source location
     pub source_loc: Option<Loc>,
+    /// Policy ID where the warning occurred
     pub policy_id: PolicyID,
 }
 

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -20,13 +20,17 @@ use thiserror::Error;
 
 use crate::human_schema;
 
+/// Error creating a schema from human syntax
 #[derive(Debug, Error, Diagnostic)]
 pub enum HumanSchemaError {
+    /// Errors with the schema content
     #[error(transparent)]
     #[diagnostic(transparent)]
     Schema(#[from] SchemaError),
+    /// IO error
     #[error(transparent)]
     IO(#[from] std::io::Error),
+    /// Parse error
     #[error(transparent)]
     #[diagnostic(transparent)]
     Parsing(#[from] HumanSyntaxParseError),
@@ -230,6 +234,7 @@ impl From<transitive_closure::TcError<EntityUID>> for SchemaError {
     }
 }
 
+/// Convenience alias
 pub type Result<T> = std::result::Result<T, SchemaError>;
 
 /// Error subtypes for [`SchemaError`]

--- a/cedar-policy-validator/src/extensions/decimal.rs
+++ b/cedar-policy-validator/src/extensions/decimal.rs
@@ -15,7 +15,7 @@
  */
 //! Note on panic safety
 //! If any of the panics in this file are triggered, that means that this file has become
-//! out-of-date with the decimal extension definition in CedarCore.
+//! out-of-date with the decimal extension definition in Core.
 //! This is tested by the `extension_schema_correctness()` test
 
 use crate::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
@@ -29,7 +29,7 @@ use super::eval_extension_constructor;
 /// Note on safety:
 /// This module depends on the Cedar parser only constructing AST with valid extension calls
 /// If any of the panics in this file are triggered, that means that this file has become
-/// out-of-date with the decimal extension definition in CedarCore.
+/// out-of-date with the decimal extension definition in Core.
 
 // PANIC SAFETY see `Note on safety` above
 #[allow(clippy::panic)]

--- a/cedar-policy-validator/src/extensions/ipaddr.rs
+++ b/cedar-policy-validator/src/extensions/ipaddr.rs
@@ -15,7 +15,7 @@
  */
 //! Note on panic safety
 //! If any of the panics in this file are triggered, that means that this file has become
-//! out-of-date with the decimal extension definition in CedarCore.
+//! out-of-date with the decimal extension definition in Core.
 //! This is tested by the `extension_schema_correctness()` test
 
 use crate::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
@@ -29,7 +29,7 @@ use super::eval_extension_constructor;
 /// Note on safety:
 /// This module depends on the Cedar parser only constructing AST with valid extension calls
 /// If any of the panics in this file are triggered, that means that this file has become
-/// out-of-date with the ipaddr extension definition in CedarCore.
+/// out-of-date with the ipaddr extension definition in Core.
 
 // PANIC SAFETY see `Note on safety` above
 #[allow(clippy::panic)]

--- a/cedar-policy-validator/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-validator/src/extensions/partial_evaluation.rs
@@ -15,7 +15,7 @@
  */
 //! Note on panic safety
 //! If any of the panics in this file are triggered, that means that this file has become
-//! out-of-date with the decimal extension definition in CedarCore.
+//! out-of-date with the decimal extension definition in Core.
 //! This is tested by the `extension_schema_correctness()` test
 
 use crate::extension_schema::{ExtensionFunctionType, ExtensionSchema};
@@ -25,7 +25,7 @@ use cedar_policy_core::extensions::partial_evaluation;
 /// Note on safety:
 /// This module depends on the Cedar parser only constructing AST with valid extension calls
 /// If any of the panics in this file are triggered, that means that this file has become
-/// out-of-date with the decimal extension definition in CedarCore.
+/// out-of-date with the decimal extension definition in Core.
 
 // PANIC SAFETY see `Note on safety` above
 #[allow(clippy::panic)]

--- a/cedar-policy-validator/src/fuzzy_match.rs
+++ b/cedar-policy-validator/src/fuzzy_match.rs
@@ -19,7 +19,7 @@ pub fn fuzzy_search(key: &str, lst: &[impl AsRef<str>]) -> Option<String> {
     if key.is_empty() || lst.is_empty() {
         None
     } else {
-        let t = lst.iter().fold((std::usize::MAX, ""), |acc, word| {
+        let t = lst.iter().fold((usize::MAX, ""), |acc, word| {
             let e = levenshtein_distance(key, word.as_ref());
             if e < acc.0 {
                 (e, word.as_ref())

--- a/cedar-policy-validator/src/human_schema.rs
+++ b/cedar-policy-validator/src/human_schema.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! The Cedar human/natural syntax for schemas
+
 mod ast;
 mod err;
 pub mod fmt;

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -136,7 +136,7 @@ impl PathInternal {
         self.namespace.into_iter().chain(once(self.basename))
     }
 
-    /// Is this referring to a name _in__ the __cedar namespace: ex: __cedar::Bool
+    /// Is this referring to a name _in_ the `__cedar` namespace (ex: `__cedar::Bool`)
     fn is_in_cedar(&self) -> bool {
         // `0` is the position of the most significant namespace
         self.namespace
@@ -150,7 +150,7 @@ impl PathInternal {
         self.namespace.is_empty() && self.basename.as_ref() == CEDAR_NAMESPACE
     }
 
-    /// Is this referring to a name _in__ the __cedar namespace: ex: __cedar::Bool or the unqualified namespace
+    /// Is this referring to a name _in_ the `__cedar` namespace (ex: `__cedar::Bool`) or the unqualified namespace
     fn is_in_unqualified_or_cedar(&self) -> bool {
         self.namespace.is_empty() || self.is_in_cedar()
     }

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -315,7 +315,7 @@ pub struct PRAppDecl {
 /// A declaration of constraints on an action type
 #[derive(Debug, Clone)]
 pub enum AppDecl {
-    /// Constraints on the `principal`` or `resource``
+    /// Constraints on the `principal` or `resource``
     PR(PRAppDecl),
     /// Constraints on the `context`
     Context(Either<Path, Vec<Node<AttrDecl>>>),

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -315,7 +315,7 @@ pub struct PRAppDecl {
 /// A declaration of constraints on an action type
 #[derive(Debug, Clone)]
 pub enum AppDecl {
-    /// Constraints on the `principal` or `resource``
+    /// Constraints on the `principal` or `resource`
     PR(PRAppDecl),
     /// Constraints on the `context`
     Context(Either<Path, Vec<Node<AttrDecl>>>),

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -481,9 +481,11 @@ pub mod schema_warnings {
 // when adding public methods.
 #[derive(Debug, Clone, Error, Diagnostic)]
 pub enum SchemaWarning {
+    /// Warning when a declaration shadows a builtin type
     #[error(transparent)]
     #[diagnostic(transparent)]
     ShadowsBuiltin(#[from] schema_warnings::ShadowsBuiltinWarning),
+    /// Warning when a declaration shadows an entity type
     #[error(transparent)]
     #[diagnostic(transparent)]
     ShadowsEntity(#[from] schema_warnings::ShadowsEntityWarning),

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! `Display` implementations for formatting a schema in human syntax
+
 use std::{collections::HashSet, fmt::Display};
 
 use cedar_policy_core::ast::Name;
@@ -187,8 +189,10 @@ impl Display for ActionType {
     }
 }
 
+/// Error converting a schema to human syntax
 #[derive(Debug, Diagnostic, Error)]
 pub enum ToHumanSchemaSyntaxError {
+    /// Collisions between names prevented the conversion to human syntax
     #[diagnostic(transparent)]
     #[error(transparent)]
     NameCollisions(#[from] NameCollisionsError),
@@ -209,6 +213,7 @@ impl NameCollisionsError {
     }
 }
 
+/// Convert a [`SchemaFragment`] to a string containing human schema syntax
 pub fn json_schema_to_custom_schema_str(
     json_schema: &SchemaFragment,
 ) -> Result<String, ToHumanSchemaSyntaxError> {

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Parser for schemas in human syntax
+
 use std::sync::Arc;
 
 use lalrpop_util::lalrpop_mod;
@@ -27,7 +29,7 @@ use super::{
 };
 
 lalrpop_mod!(
-    #[allow(warnings, unused)]
+    #[allow(warnings, unused, missing_docs, missing_debug_implementations)]
     //PANIC SAFETY: lalrpop uses unwraps, and we are trusting lalrpop to generate correct code
     #[allow(clippy::unwrap_used)]
     //PANIC SAFETY: lalrpop uses slicing, and we are trusting lalrpop to generate correct code
@@ -79,21 +81,27 @@ lazy_static::lazy_static! {
     static ref TYPE_PARSER: grammar::TypeParser = grammar::TypeParser::new();
 }
 
+/// Parse errors for parsing a human-syntax schema
 #[derive(Debug, Diagnostic, Error)]
 pub enum HumanSyntaxParseErrors {
+    /// Parse error for the human syntax
     #[error(transparent)]
     #[diagnostic(transparent)]
     NaturalSyntaxError(#[from] err::ParseErrors),
+    /// Error converting the parsed representation into the internal JSON representation
     #[error(transparent)]
     #[diagnostic(transparent)]
     JsonError(#[from] ToJsonSchemaErrors),
 }
 
+/// Parse a type, in human syntax, into a [`crate::SchemaType`]
 pub fn parse_type(src: &str) -> Result<crate::SchemaType, HumanSyntaxParseErrors> {
     let ty = parse_collect_errors(&*TYPE_PARSER, grammar::TypeParser::parse, src)?;
     Ok(custom_type_to_json_type(ty)?)
 }
 
+/// Parse a schema fragment, in human syntax, into a [`crate::SchemaFragment`],
+/// possibly generating warnings
 pub fn parse_natural_schema_fragment(
     src: &str,
 ) -> Result<(crate::SchemaFragment, impl Iterator<Item = SchemaWarning>), HumanSyntaxParseErrors> {

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -42,9 +42,9 @@ use super::{
 };
 
 /// Convert a schema AST into the JSON representation.
-/// This will let you subsequently decode that into the Validator AST for Schemas (`[ValidatorSchema]`).
+/// This will let you subsequently decode that into the Validator AST for Schemas ([`ValidatorSchema`]).
 /// On success, this function returns a tuple containing:
-///     * The SchemaFragment
+///     * The `SchemaFragment`
 ///     * A vector of name collisions, that are essentially warnings
 pub fn custom_schema_to_json_schema(
     schema: Schema,
@@ -371,7 +371,7 @@ impl<'a> ConversionContext<'a> {
             .map(move |name| (name.node, etype.clone())))
     }
 
-    /// Create a Record Type from a vector of AttrDecl's
+    /// Create a Record Type from a vector of `AttrDecl`s
     fn convert_attr_decls(
         &self,
         attrs: Vec<Node<AttrDecl>>,
@@ -406,7 +406,7 @@ impl<'a> ConversionContext<'a> {
         }))
     }
 
-    /// Convert an attribute type from an AttrDecl
+    /// Convert an attribute type from an `AttrDecl`
     fn convert_attr_decl(
         &self,
         attr: Node<AttrDecl>,

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -42,7 +42,7 @@ use super::{
 };
 
 /// Convert a schema AST into the JSON representation.
-/// This will let you subsequently decode that into the Validator AST for Schemas ([`ValidatorSchema`]).
+/// This will let you subsequently decode that into the Validator AST for Schemas ([`crate::ValidatorSchema`]).
 /// On success, this function returns a tuple containing:
 ///     * The `SchemaFragment`
 ///     * A vector of name collisions, that are essentially warnings

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Convert a schema into the JSON format
+
 use std::collections::HashMap;
 
 use cedar_policy_core::{

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Validator for Cedar policies
 #![forbid(unsafe_code)]
-#![warn(rust_2018_idioms, clippy::pedantic, clippy::nursery)]
+#![warn(rust_2018_idioms)]
 #![deny(
     missing_docs,
     missing_debug_implementations,
@@ -28,7 +28,7 @@
     rustdoc::bare_urls,
     clippy::doc_markdown
 )]
-#![allow(clippy::result_large_err)] // see #878
+#![allow(clippy::result_large_err, clippy::large_enum_variant)] // see #878
 #![cfg_attr(feature = "wasm", allow(non_snake_case))]
 
 use cedar_policy_core::ast::{Policy, PolicySet, Template};

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -16,7 +16,20 @@
 
 //! Validator for Cedar policies
 #![forbid(unsafe_code)]
+#![warn(rust_2018_idioms, clippy::pedantic, clippy::nursery)]
+#![deny(
+    missing_docs,
+    missing_debug_implementations,
+    rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
+    rustdoc::invalid_codeblock_attributes,
+    rustdoc::invalid_html_tags,
+    rustdoc::invalid_rust_codeblocks,
+    rustdoc::bare_urls,
+    clippy::doc_markdown
+)]
 #![allow(clippy::result_large_err)] // see #878
+#![cfg_attr(feature = "wasm", allow(non_snake_case))]
 
 use cedar_policy_core::ast::{Policy, PolicySet, Template};
 use serde::Serialize;
@@ -47,9 +60,13 @@ pub mod types;
 /// Used to select how a policy will be validated.
 #[derive(Default, Eq, PartialEq, Copy, Clone, Debug, Serialize)]
 pub enum ValidationMode {
+    /// Strict mode
     #[default]
     Strict,
+    /// Permissive mode
     Permissive,
+    /// Partial validation, allowing you to use an incomplete schema, but
+    /// providing no formal guarantees
     #[cfg(feature = "partial-validate")]
     Partial,
 }

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -296,7 +296,7 @@ impl Validator {
         .into_iter()
     }
 
-    /// Gather all ApplySpec objects for all actions in the schema. The `applies_to`
+    /// Gather all `ApplySpec` objects for all actions in the schema. The `applies_to`
     /// field is optional in the schema. In the case that it was not supplied, the
     /// `applies_to` field will contain `UnspecifiedEntity`.
     pub(crate) fn get_apply_specs_for_action<'a>(

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -841,7 +841,7 @@ impl<'a> CommonTypeResolver<'a> {
     }
 
     // Resolve common type references
-    fn resolve(&self, extensions: Extensions) -> Result<HashMap<Name, Type>> {
+    fn resolve(&self, extensions: Extensions<'_>) -> Result<HashMap<Name, Type>> {
         let sorted_names = self.topo_sort().map_err(|n| {
             SchemaError::CycleInCommonTypeReferences(CycleInCommonTypeReferencesError(n))
         })?;

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -504,12 +504,12 @@ impl ValidatorSchema {
         }
     }
 
-    /// Lookup the ValidatorActionId object in the schema with the given name.
+    /// Lookup the [`ValidatorActionId`] object in the schema with the given name.
     pub fn get_action_id(&self, action_id: &EntityUID) -> Option<&ValidatorActionId> {
         self.action_ids.get(action_id)
     }
 
-    /// Lookup the ValidatorEntityType object in the schema with the given name.
+    /// Lookup the [`ValidatorEntityType`] object in the schema with the given name.
     pub fn get_entity_type<'a>(
         &'a self,
         entity_type_id: &EntityType,
@@ -517,12 +517,12 @@ impl ValidatorSchema {
         self.entity_types.get(entity_type_id)
     }
 
-    /// Return true when the entity_type_id corresponds to a valid entity type.
+    /// Return true when the `action_id` corresponds to a valid action.
     pub(crate) fn is_known_action_id(&self, action_id: &EntityUID) -> bool {
         self.action_ids.contains_key(action_id)
     }
 
-    /// Return true when the entity_type_id corresponds to a valid entity type.
+    /// Return true when the `entity_type` corresponds to a valid entity type.
     pub(crate) fn is_known_entity_type(&self, entity_type: &EntityType) -> bool {
         entity_type.is_action() || self.entity_types.contains_key(entity_type)
     }
@@ -693,10 +693,14 @@ impl<'a> CommonTypeResolver<'a> {
     }
 
     /// Perform topological sort on the dependency graph
+    ///
     /// Let A -> B denote the RHS of type `A` refers to type `B` (i.e., `A`
     /// depends on `B`)
-    /// topo_sort(A -> B -> C) produces [C, B, A]
+    ///
+    /// `topo_sort(A -> B -> C)` produces [C, B, A]
+    ///
     /// If there is a cycle, a type name involving in this cycle is the error
+    ///
     /// It implements a variant of Kahn's algorithm
     fn topo_sort(&self) -> std::result::Result<Vec<Name>, Name> {
         // The in-degree map

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -181,10 +181,7 @@ pub struct ActionFragment {
     /// `ValidatorSchema`.
     pub(super) parents: HashSet<EntityUID>,
     /// The types for the attributes defined for this actions entity.
-    /// Although these are not literally wrapped in `WithUnresolvedTypeDefs`,
-    /// they are in spirit: they may refer to common types which have not yet
-    /// been resolved/inlined (e.g., because they are not defined in this schema
-    /// fragment).
+    /// Here, common types have been fully resolved/inlined.
     pub(super) attribute_types: Attributes,
     /// The values for the attributes defined for this actions entity, stored
     /// separately so that we can later extract these values to construct the

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -197,7 +197,7 @@ impl<T: 'static> WithUnresolvedTypeDefs<T> {
     }
 
     /// Instantiate any names referencing types with the definition of the type
-    /// from the input HashMap.
+    /// from the input `HashMap`.
     pub fn resolve_type_defs(self, type_defs: &HashMap<Name, Type>) -> Result<T> {
         match self {
             WithUnresolvedTypeDefs::WithUnresolved(f) => f(type_defs),
@@ -602,10 +602,10 @@ impl ValidatorNamespaceDef {
     }
 
     /// Take an action identifier as a string and use it to construct an
-    /// EntityUID for that action. The entity type of the action will always
+    /// [`EntityUID`] for that action. The entity type of the action will always
     /// have the base type `Action`. The type will be qualified with any
     /// namespace provided in the `namespace` argument or with the namespace
-    /// inside the ActionEntityUID if one is present.
+    /// inside the [`ActionEntityUID`] if one is present.
     fn parse_action_id_with_namespace(
         action_id: &ActionEntityUID,
         namespace: Option<&Name>,

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -277,7 +277,7 @@ pub struct ApplySpec {
     pub context: AttributesOrContext,
 }
 
-/// Represents the EntityUID of an action
+/// Represents the [`EntityUID`] of an action
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
@@ -845,14 +845,14 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
 /// flattened for serialization, so, in JSON format, this appears as a regular
 /// type with one extra property `required`.
 ///
-/// Note that we can't add #[serde(deny_unknown_fields)] here because we are
-/// using #[serde(tag = "type")] in ty:SchemaType which is flattened here.
-/// The way serde(flatten) is implemented means it may be possible to access
+/// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
+/// using `#[serde(tag = "type")]` in [`SchemaType`] which is flattened here.
+/// The way `serde(flatten)` is implemented means it may be possible to access
 /// fields incorrectly if a struct contains two structs that are flattened
 /// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
-/// us as we're using flatten only once
+/// us as we're using `flatten` only once
 /// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
-/// unknown fields for TypeOfAttribute should be passed to SchemaType where
+/// unknown fields for [`TypeOfAttribute`] should be passed to [`SchemaType`] where
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -457,7 +457,7 @@ struct SchemaTypeVisitor;
 impl<'de> Visitor<'de> for SchemaTypeVisitor {
     type Value = SchemaType;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("builtin type or reference to type defined in commonTypes")
     }
 

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -277,19 +277,19 @@ pub struct ApplySpec {
     pub context: AttributesOrContext,
 }
 
-/// Represents the [`EntityUID`] of an action
+/// Represents the [`ast::EntityUID`] of an action
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionEntityUID {
-    /// Represents the `Eid` of the action
+    /// Represents the [`ast::Eid`] of the action
     pub id: SmolStr,
 
     /// Represents the type of the action.
     /// `None` is shorthand for `Action`.
-    /// If this is `Some`, the last component of the `Name` should be `Action`.
+    /// If this is `Some`, the last component of the [`Name`] should be `Action`.
     #[serde(rename = "type")]
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -101,8 +101,9 @@ fn is_bidi_char(c: char) -> bool {
     BIDI_CHARS.iter().any(|bidi| bidi == &c)
 }
 
-/// List of BIDI chars to warn on
-/// Source: https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/hidden_unicode_codepoints/static.TEXT_DIRECTION_CODEPOINT_IN_LITERAL.html
+/// List of BIDI chars to warn on.
+/// Source: <`https://doc.rust-lang.org/nightly/nightly-rustc/rustc_lint/hidden_unicode_codepoints/static.TEXT_DIRECTION_CODEPOINT_IN_LITERAL.html`>
+///
 /// We could instead parse the structure of BIDI overrides and make sure it's well balanced.
 /// This is less prone to error, and since it's only a warning can be ignored by a user if need be.
 const BIDI_CHARS: [char; 9] = [

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -363,7 +363,7 @@ impl<'a> Typechecker<'a> {
     /// This method handles the majority of the work. Given an expression,
     /// the type for the request, and the a prior effect context for the
     /// expression, return the result of typechecking the expression, and add
-    /// any errors encountered into the type_errors list. The result of
+    /// any errors encountered into the `type_errors` list. The result of
     /// typechecking contains the type of the expression, any current effect of
     /// the expression, and a flag indicating whether the expression
     /// successfully typechecked.
@@ -2047,8 +2047,8 @@ impl<'a> Typechecker<'a> {
     }
 
     /// Check that an expression has a type that is a subtype of one of the
-    /// given types. If not, generate a type error and return TypecheckFail.
-    /// Return the TypecheckSuccess with the type otherwise.
+    /// given types. If not, generate a type error and return `TypecheckFail`.
+    /// Return `TypecheckSuccess` with the type otherwise.
     fn expect_one_of_types<'b, F>(
         &self,
         request_env: &RequestEnv<'_>,
@@ -2133,8 +2133,8 @@ impl<'a> Typechecker<'a> {
 
     /// Return the least upper bound of all types is the `types` vector. If
     /// there isn't a least upper bound, then a type error is reported and
-    /// TypecheckFail is returned. Note that this function does not preserve the
-    /// effects of the input TypecheckAnswers.
+    /// `TypecheckFail` is returned. Note that this function does not preserve the
+    /// effects of the input [`TypecheckAnswers`].
     fn least_upper_bound_or_error(
         &self,
         expr: &Expr,

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -42,7 +42,7 @@ use super::test_utils::{assert_policy_typecheck_fails, expr_id_placeholder};
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
     schema: SchemaFragment,
-    env: &RequestEnv,
+    env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
 ) {
@@ -64,7 +64,7 @@ fn assert_typechecks_strict(
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_strict_type_error(
     schema: SchemaFragment,
-    env: &RequestEnv,
+    env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
     expected_error: ValidationError,
@@ -87,7 +87,7 @@ fn assert_strict_type_error(
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_types_must_match(
     schema: SchemaFragment,
-    env: &RequestEnv,
+    env: &RequestEnv<'_>,
     e: Expr,
     on_expr: Expr,
     expected_type: Type,
@@ -138,7 +138,7 @@ fn simple_schema_file() -> SchemaFragment {
 
 fn with_simple_schema_and_request<F>(f: F)
 where
-    F: FnOnce(SchemaFragment, RequestEnv),
+    F: FnOnce(SchemaFragment, RequestEnv<'_>),
 {
     f(
         simple_schema_file(),

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -18,7 +18,7 @@ use cedar_policy_core::ast::Expr;
 
 use crate::types::{EffectSet, Type};
 
-/// TypecheckAnswer holds the result of typechecking an expression.
+/// [`TypecheckAnswer`] holds the result of typechecking an expression.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum TypecheckAnswer<'a> {
     /// Typechecking succeeded, and we know the type and a possibly empty effect
@@ -37,12 +37,12 @@ pub(crate) enum TypecheckAnswer<'a> {
         expr_recovery_type: Expr<Option<Type>>,
     },
 
-    /// RecursionLimit Reached
+    /// Recursion limit reached
     RecursionLimit,
 }
 
 impl<'a> TypecheckAnswer<'a> {
-    /// Construct a successful TypecheckAnswer with a type but with an empty
+    /// Construct a successful [`TypecheckAnswer`] with a type but with an empty
     /// effect set.
     pub fn success(expr_type: Expr<Option<Type>>) -> Self {
         Self::TypecheckSuccess {
@@ -51,7 +51,7 @@ impl<'a> TypecheckAnswer<'a> {
         }
     }
 
-    /// Construct a successful TypecheckAnswer with a type and an effect.
+    /// Construct a successful [`TypecheckAnswer`] with a type and an effect.
     pub fn success_with_effect(expr_type: Expr<Option<Type>>, expr_effect: EffectSet<'a>) -> Self {
         Self::TypecheckSuccess {
             expr_type,
@@ -59,14 +59,14 @@ impl<'a> TypecheckAnswer<'a> {
         }
     }
 
-    /// Construct a failing TypecheckAnswer with a type.
+    /// Construct a failing [`TypecheckAnswer`] with a type.
     pub fn fail(expr_type: Expr<Option<Type>>) -> Self {
         Self::TypecheckFail {
             expr_recovery_type: expr_type,
         }
     }
 
-    /// Check if this TypecheckAnswer contains a particular type. It
+    /// Check if this [`TypecheckAnswer`] contains a particular type. It
     /// contains a type if the type annotated AST contains `Some`
     /// of the argument type at its root.
     pub fn contains_type(&self, ty: &Type) -> bool {
@@ -96,7 +96,7 @@ impl<'a> TypecheckAnswer<'a> {
         }
     }
 
-    /// Transform the effect of this TypecheckAnswer without modifying the
+    /// Transform the effect of this [`TypecheckAnswer`] without modifying the
     /// success or type.
     pub fn map_effect<F>(self, f: F) -> Self
     where
@@ -115,9 +115,9 @@ impl<'a> TypecheckAnswer<'a> {
         }
     }
 
-    /// Convert this TypecheckAnswer into an equivalent answer for an expression
-    /// that has failed to typecheck. If this is already TypecheckFail, then no
-    /// change is required, otherwise, a TypecheckFail is constructed containing
+    /// Convert this [`TypecheckAnswer`] into an equivalent answer for an expression
+    /// that has failed to typecheck. If this is already `TypecheckFail`, then no
+    /// change is required, otherwise, a `TypecheckFail` is constructed containing
     /// `Some` of the `expr_type`.
     pub fn into_fail(self) -> Self {
         match self {
@@ -128,8 +128,8 @@ impl<'a> TypecheckAnswer<'a> {
     }
 
     /// Sequence another typechecking operation after this answer. The result of
-    /// the operation will be adjusted to be a TypecheckFail if this is a
-    /// TypecheckFail, otherwise it will be returned unaltered.
+    /// the operation will be adjusted to be a `TypecheckFail` if this is a
+    /// `TypecheckFail`, otherwise it will be returned unaltered.
     pub fn then_typecheck<F>(self, f: F) -> Self
     where
         F: FnOnce(Expr<Option<Type>>, EffectSet<'a>) -> TypecheckAnswer<'a>,
@@ -149,7 +149,7 @@ impl<'a> TypecheckAnswer<'a> {
     /// Sequence another typechecking operation after all of the typechecking
     /// answers in the argument. The result of the operation is adjusted in the
     /// same manner as in `then_typecheck`, but accounts for the all the
-    /// TypecheckAnswers.
+    /// [`TypecheckAnswer`]s.
     pub fn sequence_all_then_typecheck<F>(
         answers: impl IntoIterator<Item = TypecheckAnswer<'a>>,
         f: F,

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -874,24 +874,24 @@ impl EntityLUB {
     }
 
     /// Return true if the set of entity types composing this [`EntityLUB`] is
-    /// disjoint from th entity types composing another LUB.
+    /// disjoint from th entity types composing another [`EntityLUB`].
     pub(crate) fn is_disjoint(&self, other: &EntityLUB) -> bool {
         self.lub_elements.is_disjoint(&other.lub_elements)
     }
 
     /// Return true if the given entity type [`Name`] is in the set of entity
-    /// types comprising this LUB.
+    /// types comprising this [`EntityLUB`].
     pub(crate) fn contains(&self, ty: &EntityType) -> bool {
         self.lub_elements.contains(ty)
     }
 
     /// An iterator over the entity type [`Name`]s in the set of entity types
-    /// comprising this LUB.
+    /// comprising this [`EntityLUB`].
     pub(crate) fn iter(&self) -> impl Iterator<Item = &EntityType> {
         self.lub_elements.iter()
     }
 
-    // Check if this EntityLUB contains a particular entity type.
+    // Check if this [`EntityLUB`] contains a particular entity type.
     pub(crate) fn contains_entity_type(&self, ety: &EntityType) -> bool {
         self.lub_elements.contains(ety)
     }
@@ -1093,7 +1093,7 @@ pub enum EntityRecordKind {
     /// represented using the `AnyEntity` record kind.
     ///
     /// Attributes in this case are not stored inline but must be looked up in
-    /// the schema, based on the elements of the EntityLUB.
+    /// the schema, based on the elements of the [`EntityLUB`].
     Entity(EntityLUB),
 
     /// We special case action entities, which store their attributes directly, like `Record`s do

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -109,7 +109,7 @@ impl Type {
     }
 
     /// Construct a type for a literal EUID. This type will be a named entity
-    /// type for the type of the EntityUID.
+    /// type for the type of the [`EntityUID`].
     pub(crate) fn euid_literal(entity: EntityUID, schema: &ValidatorSchema) -> Option<Type> {
         if entity.entity_type().is_action() {
             schema
@@ -383,8 +383,8 @@ impl Type {
         }
     }
 
-    /// Is this validator type "consistent with" the given Core SchemaType.
-    /// Meaning, is there at least some value that could have this SchemaType and
+    /// Is this validator type "consistent with" the given Core `SchemaType`.
+    /// Meaning, is there at least some value that could have this `SchemaType` and
     /// this validator type simultaneously.
     pub(crate) fn is_consistent_with(
         &self,

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -50,12 +50,14 @@ pub enum Type {
     /// Bottom type. Sub-type of all types.
     Never,
 
-    /// The singleton boolean types: true and false.
+    /// Singleton boolean type true
     True,
+    /// Singleton boolean type false
     False,
 
     /// Primitive types: bool, long, and string.
     Primitive {
+        /// Which primitive type: bool, long, or string
         #[serde(rename = "primitiveType")]
         primitive_type: Primitive,
     },
@@ -71,11 +73,12 @@ pub enum Type {
         element_type: Option<Box<Type>>,
     },
 
-    /// Record and entity types.
+    /// Record and entity types
     EntityOrRecord(EntityRecordKind),
 
-    // Extension types, like "ipaddr".
+    /// Extension types
     ExtensionType {
+        /// Name of the extension type
         name: Name,
     },
 }
@@ -960,6 +963,7 @@ impl EntityLUB {
 /// identifier, a flag indicating weather it is required, and a type.
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
 pub struct Attributes {
+    /// Attributes map
     pub attrs: BTreeMap<SmolStr, AttributeType>,
 }
 
@@ -1111,11 +1115,11 @@ impl IntoIterator for Attributes {
 /// closed.
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone, Serialize)]
 pub enum OpenTag {
-    // The attributes are open. A value of this type may have attributes other
-    // than those listed.
+    /// The attributes are open. A value of this type may have attributes other
+    /// than those listed.
     OpenAttributes,
-    // The attributes are closed. The attributes for a value of this type must
-    // exactly match the attributes listed in the type.
+    /// The attributes are closed. The attributes for a value of this type must
+    /// exactly match the attributes listed in the type.
     ClosedAttributes,
 }
 
@@ -1154,9 +1158,13 @@ pub enum EntityRecordKind {
     /// the schema, based on the elements of the EntityLUB.
     Entity(EntityLUB),
 
-    ///We special case action entities. They store their attributes directly rather than
-    ///Names
-    ActionEntity { name: Name, attrs: Attributes },
+    /// We special case action entities, which store their attributes directly, like `Record`s do
+    ActionEntity {
+        /// Type name of the action entity
+        name: Name,
+        /// Attributes of the action entity
+        attrs: Attributes,
+    },
 }
 
 impl EntityRecordKind {
@@ -1203,6 +1211,8 @@ impl EntityRecordKind {
         }
     }
 
+    /// Get the type of the given attribute in this entity or record, or `None`
+    /// if it doesn't exist (or not known to exist)
     pub(crate) fn get_attr(&self, schema: &ValidatorSchema, attr: &str) -> Option<AttributeType> {
         match self {
             EntityRecordKind::Record { attrs, .. } => attrs.get_attr(attr).cloned(),
@@ -1214,6 +1224,7 @@ impl EntityRecordKind {
         }
     }
 
+    /// Get all the attribute names for this entity or record
     pub fn all_attrs(&self, schema: &ValidatorSchema) -> Vec<SmolStr> {
         // Wish the clone here could be avoided, but `get_attribute_types` returns an owned `Attributes`.
         match self {

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -860,7 +860,7 @@ impl EntityLUB {
         }
     }
 
-    /// Like `get_single_entity()`, but consumes the EntityLUB and produces an
+    /// Like `get_single_entity()`, but consumes the [`EntityLUB`] and produces an
     /// owned entity type name
     pub fn into_single_entity(self) -> Option<Name> {
         let mut names = self.lub_elements.into_iter();
@@ -922,8 +922,8 @@ impl EntityLUB {
         })
     }
 
-    /// Generate the least upper bound of this EntityLUB and another. This
-    /// returns an EntityLUB for the union of the entity types in both argument
+    /// Generate the least upper bound of this [`EntityLUB`] and another. This
+    /// returns an [`EntityLUB`] for the union of the entity types in both argument
     /// LUBs. The attributes of the LUB are not computed.
     pub(crate) fn least_upper_bound(&self, other: &EntityLUB) -> EntityLUB {
         EntityLUB {
@@ -935,19 +935,19 @@ impl EntityLUB {
         }
     }
 
-    /// Return true if the set of entity types composing this EntityLUB is
+    /// Return true if the set of entity types composing this [`EntityLUB`] is
     /// disjoint from th entity types composing another LUB.
     pub(crate) fn is_disjoint(&self, other: &EntityLUB) -> bool {
         self.lub_elements.is_disjoint(&other.lub_elements)
     }
 
-    /// Return true if the given entity type `Name` is in the set of entity
+    /// Return true if the given entity type [`Name`] is in the set of entity
     /// types comprising this LUB.
     pub(crate) fn contains(&self, ty: &Name) -> bool {
         self.lub_elements.contains(ty)
     }
 
-    /// An iterator over the entity type `Name`s in the set of entity types
+    /// An iterator over the entity type [`Name`]s in the set of entity types
     /// comprising this LUB.
     pub(crate) fn iter(&self) -> impl Iterator<Item = &Name> {
         self.lub_elements.iter()
@@ -1135,7 +1135,7 @@ impl OpenTag {
 /// Represents whether a type is an entity type, record type, or could be either
 ///
 /// The subtyping lattice for these types is that
-/// Entity <: AnyEntity. Record does not subtype anything.
+/// `Entity` <: `AnyEntity`. `Record` does not subtype anything.
 #[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
 pub enum EntityRecordKind {
     /// A record type, with these attributes
@@ -1428,7 +1428,7 @@ pub struct AttributeType {
 }
 
 impl AttributeType {
-    /// Construct an AttributeType with some type that may be required or
+    /// Construct an [`AttributeType`] with some type that may be required or
     /// optional as specified by the `is_required` parameter.
     pub fn new(attr_type: Type, is_required: bool) -> Self {
         Self {
@@ -1437,7 +1437,7 @@ impl AttributeType {
         }
     }
 
-    /// Construct an AttributeType for an attribute that must be present given
+    /// Construct an [`AttributeType`] for an attribute that must be present given
     /// the type of the attribute.
     pub fn required_attribute(attr_type: Type) -> Self {
         Self::new(attr_type, true)

--- a/cedar-policy-validator/src/types/effect.rs
+++ b/cedar-policy-validator/src/types/effect.rs
@@ -24,25 +24,30 @@ use cedar_policy_core::ast::{Expr, ExprShapeOnly};
 pub struct EffectSet<'a>(HashSet<Effect<'a>>);
 
 impl<'a> EffectSet<'a> {
+    /// An empty effect set
     pub fn new() -> Self {
         EffectSet(HashSet::new())
     }
 
+    /// An effect set with a single [`Effect`]
     pub fn singleton(e: Effect<'a>) -> Self {
         let mut set = Self::new();
         set.0.insert(e);
         set
     }
 
+    /// Construct the union of `self` and `other`
     pub fn union(&self, other: &Self) -> Self {
         EffectSet(self.0.union(&other.0).cloned().collect())
     }
 
+    /// Construct the intersection of `self` and `other`
     pub fn intersect(&self, other: &Self) -> Self {
         EffectSet(self.0.intersection(&other.0).cloned().collect())
     }
 
-    pub fn contains(&self, e: &Effect) -> bool {
+    /// Does this effect set contain the given [`Effect`]
+    pub fn contains(&self, e: &Effect<'_>) -> bool {
         self.0.contains(e)
     }
 }
@@ -51,11 +56,15 @@ impl<'a> EffectSet<'a> {
 /// known to exist for that expression.
 #[derive(Hash, Eq, PartialEq, Debug, Clone)]
 pub struct Effect<'a> {
+    /// For this expression
     on_expr: ExprShapeOnly<'a>,
+    /// This attribute is known to exist on that expression
     attribute: &'a str,
 }
 
 impl<'a> Effect<'a> {
+    /// Construct a new [`Effect`] stating that the attribute `attribute` is
+    /// known to exist for the expression `on_expr`
     pub fn new(on_expr: &'a Expr, attribute: &'a str) -> Self {
         Self {
             on_expr: ExprShapeOnly::new(on_expr),

--- a/cedar-policy-validator/src/types/request_env.rs
+++ b/cedar-policy-validator/src/types/request_env.rs
@@ -20,18 +20,26 @@ use crate::ValidatorSchema;
 
 use super::Type;
 
+/// Represents a request type environment. In principle, this contains full
+/// types for the four variables (principal, action, resource, context).
 #[derive(Clone, Debug, PartialEq)]
 pub enum RequestEnv<'a> {
     /// Contains the four variables bound in the type environment. These together
     /// represent the full type of (principal, action, resource, context)
     /// authorization request.
     DeclaredAction {
+        /// Principal type
         principal: &'a EntityType,
+        /// Action
         action: &'a EntityUID,
+        /// Resource type
         resource: &'a EntityType,
+        /// Context type
         context: &'a Type,
 
+        /// Binding for the ?principal slot, if any
         principal_slot: Option<EntityType>,
+        /// Binding for the ?resource slot, if any
         resource_slot: Option<EntityType>,
     },
     /// Only in partial schema validation, the action might not have been
@@ -41,6 +49,8 @@ pub enum RequestEnv<'a> {
 }
 
 impl<'a> RequestEnv<'a> {
+    /// The principal type for this request environment, as an [`EntityType`].
+    /// `None` indicates we don't know (only possible in partial schema validation).
     pub fn principal_entity_type(&self) -> Option<&'a EntityType> {
         match self {
             RequestEnv::UndeclaredAction => None,
@@ -48,6 +58,7 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// [`Type`] of the `principal` for this request environment
     pub fn principal_type(&self) -> Type {
         match self.principal_entity_type() {
             Some(principal) => Type::possibly_unspecified_entity_reference(principal.clone()),
@@ -55,6 +66,8 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// The action for this request environment, as an [`EntityUID`].
+    /// `None` indicates we don't know (only possible in partial schema validation).
     pub fn action_entity_uid(&self) -> Option<&'a EntityUID> {
         match self {
             RequestEnv::UndeclaredAction => None,
@@ -62,6 +75,7 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// [`Type`] of the `action` for this request environment
     pub fn action_type(&self, schema: &ValidatorSchema) -> Option<Type> {
         match self.action_entity_uid() {
             Some(action) => Type::euid_literal(action.clone(), schema),
@@ -69,6 +83,8 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// The resource type for this request environment, as an [`EntityType`].
+    /// `None` indicates we don't know (only possible in partial schema validation).
     pub fn resource_entity_type(&self) -> Option<&'a EntityType> {
         match self {
             RequestEnv::UndeclaredAction => None,
@@ -76,6 +92,7 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// [`Type`] of the `resource` for this request environment
     pub fn resource_type(&self) -> Type {
         match self.resource_entity_type() {
             Some(resource) => Type::possibly_unspecified_entity_reference(resource.clone()),
@@ -83,6 +100,7 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// [`Type`] of the `context` for this request environment
     pub fn context_type(&self) -> Type {
         match self {
             RequestEnv::UndeclaredAction => Type::any_record(),
@@ -90,6 +108,9 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// Type of the ?principal slot for this request environment, as an [`EntityType`].
+    /// `None` may indicate we don't know (in partial schema validation) or that
+    /// this slot doesn't exist.
     pub fn principal_slot(&self) -> &Option<EntityType> {
         match self {
             RequestEnv::UndeclaredAction => &None,
@@ -97,6 +118,9 @@ impl<'a> RequestEnv<'a> {
         }
     }
 
+    /// Type of the ?resource slot for this request environment, as an [`EntityType`].
+    /// `None` may indicate we don't know (in partial schema validation) or that
+    /// this slot doesn't exist.
     pub fn resource_slot(&self) -> &Option<EntityType> {
         match self {
             RequestEnv::UndeclaredAction => &None,


### PR DESCRIPTION
## Description of changes

Add more comments and docstrings through `cedar-policy-validator`.

Brings `cedar-policy-validator` to the same warning/clippy settings we use for `cedar-policy`.

Many of these changes are unremarkable, but careful review is requested for some of the invariants/assumptions newly documented in `namespace_def.rs`.

No functional changes.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

