### PR TITLE
Tweak `extract_scope` error case to remove dead match case

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -45,7 +45,6 @@ use crate::ast::{
 };
 use crate::est::extract_single_argument;
 use itertools::Either;
-use nonempty::NonEmpty;
 use smol_str::SmolStr;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashSet};
@@ -278,15 +277,18 @@ impl cst::Policy {
             )
             .into())
         };
-        let maybe_extra_vars = if let Some(vars) = NonEmpty::collect(vars) {
+
+        let maybe_extra_vars = if let Some(errs) = ParseErrors::from_iter(
             // Add each of the extra constraints to the error list
-            Err(ParseErrors::new_from_nonempty(vars.map(|extra_var| {
+            vars.map(|extra_var| {
                 extra_var
                     .try_as_inner()
                     .map(|def| extra_var.to_ast_err(ToASTErrorKind::ExtraScopeElement(def.clone())))
                     .unwrap_or_else(|e| e)
                     .into()
-            })))
+            }),
+        ) {
+            Err(errs)
         } else {
             Ok(())
         };

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -707,10 +707,10 @@ impl ParseErrors {
 
     /// Construct a new `ParseErrors` with at least one element
     pub(crate) fn new(first: ParseError, rest: impl IntoIterator<Item = ParseError>) -> Self {
-        let mut nv = NonEmpty::singleton(first);
-        let mut v = rest.into_iter().collect::<Vec<_>>();
-        nv.append(&mut v);
-        Self(nv)
+        Self(NonEmpty {
+            head: first,
+            tail: rest.into_iter().collect::<Vec<_>>(),
+        })
     }
 
     /// Construct a new `ParseErrors` from another `NonEmpty` type
@@ -719,8 +719,7 @@ impl ParseErrors {
     }
 
     pub(crate) fn from_iter(i: impl IntoIterator<Item = ParseError>) -> Option<Self> {
-        let v = i.into_iter().collect::<Vec<_>>();
-        Some(Self(NonEmpty::from_vec(v)?))
+        NonEmpty::collect(i).map(Self::new_from_nonempty)
     }
 
     /// Flatten a `Vec<ParseErrors>` into a single `ParseErrors`, returning


### PR DESCRIPTION
## Description of changes

Noticed the `None => Ok(()),` branch was unreachable, but we can tweak the code to remove it. Also tweak the implementation of some `ParserError` functions to use similar functionality built in to  `NonEmpty`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

