### PR TITLE
Add checks for error source

### DIFF
--- a/cedar-policy-cli/sample-data/sandbox_c/README.md
+++ b/cedar-policy-cli/sample-data/sandbox_c/README.md
@@ -44,8 +44,8 @@ This looks like a regular policy, but it has `?principal` instead of a concrete 
 Let's link this template to give `alice` access:
 ```
 cargo run link \
-	--policies-file policies.cedar \
-	--template-linked-file ./linked \
+	--policies policies.cedar \
+	--template-linked ./linked \
 	--template-id "AccessVacation" \
 	--new-id "AliceAccess" \
 	--arguments '{ "?principal" : "User::\"alice\"" }'
@@ -70,8 +70,8 @@ And we should now get `ALLOW`.
 Let's also give `bob` access:
 ```
 cargo run link \
-	--policies-file policies.cedar \
-	--template-linked-file ./linked \
+	--policies policies.cedar \
+	--template-linked ./linked \
 	--template-id "AccessVacation" \
 	--new-id "BobAccess" \
 	--arguments '{ "?principal" : "User::\"bob\"" }'

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -961,11 +961,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in uid field of <unknown entity>, expected a literal entity reference, but got `"test_entity_type::\"Alice\""`"#,
-            ).help(
-                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ).build());
+            expect_err(
+                &json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in uid field of <unknown entity>, expected a literal entity reference, but got `"test_entity_type::\"Alice\""`"#)
+                    .help(r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#)
+                    .build()
+            );
         });
     }
 
@@ -995,11 +998,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                "error during entity deserialization: in uid field of <unknown entity>, the `__expr` escape is no longer supported",
-            ).help(
-                "to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly",
-            ).build());
+            expect_err(
+                &json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in uid field of <unknown entity>, the `__expr` escape is no longer supported"#)
+                    .help(r#"to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"#)
+                    .build()
+            );
         });
     }
 
@@ -1029,11 +1035,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in attribute `pancakes` on `test_entity_type::"Alice"`, the `__expr` escape is no longer supported"#,
-            ).help(
-                "to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly",
-            ).build());
+            expect_err(
+                &json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in attribute `pancakes` on `test_entity_type::"Alice"`, the `__expr` escape is no longer supported"#)
+                    .help(r#"to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"#)
+                    .build()
+            );
         });
     }
 
@@ -1061,11 +1070,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in parents field of `test_entity_type::"Alice"`, the `__expr` escape is no longer supported"#,
-            ).help(
-                "to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly",
-            ).build());
+            expect_err(
+                &json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in parents field of `test_entity_type::"Alice"`, the `__expr` escape is no longer supported"#)
+                    .help(r#"to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"#)
+                    .build()
+            );
         });
     }
 
@@ -1093,11 +1105,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in parents field of `test_entity_type::"Alice"`, expected a literal entity reference, but got `"test_entity_type::\"bob\""`"#,
-            ).help(
-                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ).build());
+            expect_err(
+                &json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in parents field of `test_entity_type::"Alice"`, expected a literal entity reference, but got `"test_entity_type::\"bob\""`"#)
+                    .help(r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#)
+                    .build()
+            );
         });
     }
 
@@ -1752,11 +1767,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_value(json.clone()), Err(e) => {
-            expect_err(&json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: action `XYZ::Action::"view"` has a non-action parent `User::"alice"`"#,
-            ).help(
-                "parents of actions need to have type `Action` themselves, perhaps namespaced",
-            ).build());
+            expect_err(
+                &json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"action `XYZ::Action::"view"` has a non-action parent `User::"alice"`"#)
+                    .help(r#"parents of actions need to have type `Action` themselves, perhaps namespaced"#)
+                    .build()
+            );
         });
     }
 
@@ -1805,9 +1823,14 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_str(json), Err(e) => {
-            expect_err(json, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: the key `bar` occurs two or more times in the same JSON object at line 11 column 25"# // TODO: put the line-column information in `Diagnostic::labels()` instead of printing it in the error message
-            ).build());
+            // TODO: put the line-column information in `Diagnostic::labels()` instead of printing it in the error message
+            expect_err(
+                json,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"the key `bar` occurs two or more times in the same JSON object at line 11 column 25"#)
+                    .build()
+            );
         });
     }
 }
@@ -2283,9 +2306,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: value was expected to have type long, but actually has type string: `"3"`"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"in attribute `numDirectReports` on `Employee::"12UA45"`, type mismatch: value was expected to have type long, but actually has type string: `"3"`"#)
+                    .build()
+            );
         });
     }
 
@@ -2326,11 +2353,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#,
-            ).help(
-                r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in attribute `manager` on `Employee::"12UA45"`, expected a literal entity reference, but got `"34FB87"`"#)
+                    .help(r#"literal entity references can be made with `{ "type": "SomeType", "id": "SomeId" }`"#)
+                    .build()
+            );
         });
     }
 
@@ -2368,9 +2398,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: value was expected to have type (set of `HR`), but actually has type record with attributes: {"id" => (optional) string, "type" => (optional) string}: `{"id": "aaaaa", "type": "HR"}`"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in attribute `hr_contacts` on `Employee::"12UA45"`, type mismatch: value was expected to have type (set of `HR`), but actually has type record with attributes: {"id" => (optional) string, "type" => (optional) string}: `{"id": "aaaaa", "type": "HR"}`"#)
+                    .build()
+            );
         });
     }
 
@@ -2411,9 +2445,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: in attribute `manager` on `Employee::"12UA45"`, type mismatch: value was expected to have type `Employee`, but actually has type `HR`: `HR::"34FB87"`"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"in attribute `manager` on `Employee::"12UA45"`, type mismatch: value was expected to have type `Employee`, but actually has type `HR`: `HR::"34FB87"`"#)
+                    .build()
+            );
         });
     }
 
@@ -2455,9 +2493,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"in attribute `home_ip` on `Employee::"12UA45"`, type mismatch: value was expected to have type ipaddr, but actually has type decimal: `decimal("3.33")`"#)
+                    .build()
+            );
         });
     }
 
@@ -2497,9 +2539,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in attribute `json_blob` on `Employee::"12UA45"`, expected the record to have an attribute `inner2`, but it does not"#)
+                    .build()
+            );
         });
     }
 
@@ -2540,9 +2586,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error_starts_with(
-                r#"entity does not conform to the schema: in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: value was expected to have type record with attributes: "#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error_starts_with("entity does not conform to the schema")
+                    .source(r#"in attribute `json_blob` on `Employee::"12UA45"`, type mismatch: value was expected to have type record with attributes: "#)
+                    .build()
+            );
         });
 
         let entitiesjson = json!(
@@ -2615,9 +2665,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: in attribute `json_blob` on `Employee::"12UA45"`, record attribute `inner4` should not exist according to the schema"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"in attribute `json_blob` on `Employee::"12UA45"`, record attribute `inner4` should not exist according to the schema"#)
+                    .build()
+            );
         });
     }
 
@@ -2657,9 +2711,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: expected entity `Employee::"12UA45"` to have attribute `numDirectReports`, but it does not"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"expected entity `Employee::"12UA45"` to have attribute `numDirectReports`, but it does not"#)
+                    .build()
+            );
         });
     }
 
@@ -2701,9 +2759,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: attribute `wat` on `Employee::"12UA45"` should not exist according to the schema"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"attribute `wat` on `Employee::"12UA45"` should not exist according to the schema"#)
+                    .build()
+            );
         });
     }
 
@@ -2746,9 +2808,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: `Employee::"12UA45"` is not allowed to have an ancestor of type `Employee` according to the schema"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"`Employee::"12UA45"` is not allowed to have an ancestor of type `Employee` according to the schema"#)
+                    .build()
+            );
         });
     }
 
@@ -2770,9 +2836,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: entity `CEO::"abcdef"` has type `CEO` which is not declared in the schema"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"entity `CEO::"abcdef"` has type `CEO` which is not declared in the schema"#)
+                    .build()
+            );
         });
     }
 
@@ -2794,9 +2864,13 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: found action entity `Action::"update"`, but it was not declared as an action in the schema"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"found action entity `Action::"update"`, but it was not declared as an action in the schema"#)
+                    .build()
+            );
         });
     }
 
@@ -2855,11 +2929,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
-            ).help(
-                r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"definition of action `Action::"view"` does not match its schema declaration"#)
+                    .help(r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#)
+                    .build()
+            );
         });
     }
 
@@ -2885,11 +2962,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
-            ).help(
-                r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"definition of action `Action::"view"` does not match its schema declaration"#)
+                    .help(r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#)
+                    .build()
+            );
         });
     }
 
@@ -2913,11 +2993,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
-            ).help(
-                r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"definition of action `Action::"view"` does not match its schema declaration"#)
+                    .help(r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#)
+                    .build()
+            );
         });
     }
 
@@ -2944,11 +3027,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: definition of action `Action::"view"` does not match its schema declaration"#,
-            ).help(
-                r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"definition of action `Action::"view"` does not match its schema declaration"#)
+                    .help(r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#)
+                    .build()
+            );
         });
     }
 
@@ -2972,11 +3058,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
-            ).help(
-                r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"definition of action `Action::"view"` does not match its schema declaration"#)
+                    .help(r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#)
+                    .build()
+            );
         });
     }
 
@@ -3003,11 +3092,14 @@ mod schema_based_parsing_tests {
             TCComputation::ComputeNow,
         );
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: definition of action `Action::"view"` does not match its schema declaration"#,
-            ).help(
-                r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#,
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"definition of action `Action::"view"` does not match its schema declaration"#)
+                    .help(r#"to use the schema's definition of `Action::"view"`, simply omit it from the entities input data"#)
+                    .build()
+            );
         });
     }
 
@@ -3138,9 +3230,13 @@ mod schema_based_parsing_tests {
         );
 
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"entity does not conform to the schema: in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: value was expected to have type `XYZCorp::Employee`, but actually has type `Employee`: `Employee::"34FB87"`"#
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                    .source(r#"in attribute `manager` on `XYZCorp::Employee::"12UA45"`, type mismatch: value was expected to have type `XYZCorp::Employee`, but actually has type `Employee`: `Employee::"34FB87"`"#)
+                    .build()
+            );
         });
 
         let entitiesjson = json!(
@@ -3158,11 +3254,14 @@ mod schema_based_parsing_tests {
         );
 
         assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
-            expect_err(&entitiesjson, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                r#"error during entity deserialization: entity `Employee::"12UA45"` has type `Employee` which is not declared in the schema"#,
-            ).help(
-                "did you mean `XYZCorp::Employee`?",
-            ).build());
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"entity `Employee::"12UA45"` has type `Employee` which is not declared in the schema"#)
+                    .help(r#"did you mean `XYZCorp::Employee`?"#)
+                    .build()
+            );
         });
     }
 }

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1823,7 +1823,7 @@ mod json_parsing_tests {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         assert_matches!(eparser.from_json_str(json), Err(e) => {
-            // TODO: put the line-column information in `Diagnostic::labels()` instead of printing it in the error message
+            // TODO(#599): put the line-column information in `Diagnostic::labels()` instead of printing it in the error message
             expect_err(
                 json,
                 &miette::Report::new(e),

--- a/cedar-policy-core/src/entities/err.rs
+++ b/cedar-policy-core/src/entities/err.rs
@@ -23,11 +23,11 @@ use thiserror::Error;
 #[derive(Debug, Diagnostic, Error)]
 pub enum EntitiesError {
     /// Error occurring in serialization of entities
-    #[error("error during entity serialization: {0}")]
+    #[error("error during entity serialization")]
     #[diagnostic(transparent)]
     Serialization(#[from] crate::entities::json::err::JsonSerializationError),
     /// Error occurring in deserialization of entities
-    #[error("error during entity deserialization: {0}")]
+    #[error("error during entity deserialization")]
     #[diagnostic(transparent)]
     Deserialization(#[from] crate::entities::json::err::JsonDeserializationError),
     /// Error constructing the Entities collection as there is a duplicate Entity UID
@@ -36,11 +36,11 @@ pub enum EntitiesError {
     Duplicate(Duplicate),
     /// Errors occurring while computing or enforcing transitive closure on the
     /// entity hierarchy.
-    #[error("transitive closure computation/enforcement error: {0}")]
+    #[error("transitive closure computation/enforcement error")]
     #[diagnostic(transparent)]
     TransitiveClosureError(#[from] TransitiveClosureError),
     /// Error because an entity doesn't conform to the schema
-    #[error("entity does not conform to the schema: {0}")]
+    #[error("entity does not conform to the schema")]
     #[diagnostic(transparent)]
     InvalidEntity(#[from] crate::entities::conformance::err::EntitySchemaConformanceError),
 }

--- a/cedar-policy-core/src/entities/json/context.rs
+++ b/cedar-policy-core/src/entities/json/context.rs
@@ -108,7 +108,7 @@ pub enum ContextJsonDeserializationError {
     ///
     /// (Note: as of this writing, `JsonDeserializationError` actually contains
     /// many variants that aren't possible here)
-    #[error("while parsing context, {0}")]
+    #[error(transparent)]
     #[diagnostic(transparent)]
     JsonDeserialization(#[from] JsonDeserializationError),
     /// Error constructing the `Context` itself

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -72,7 +72,7 @@ pub enum JsonDeserializationError {
     #[diagnostic(transparent)]
     ExpectedExtnValue(ExpectedExtnValue),
     /// Errors creating the request context from JSON
-    #[error("while parsing context, {0}")]
+    #[error(transparent)]
     #[diagnostic(transparent)]
     ContextCreation(#[from] ContextCreationError),
     /// Parents of actions should be actions, but this action has a non-action parent

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -31,7 +31,7 @@ pub enum FromJsonError {
     #[diagnostic(transparent)]
     JsonDeserializationError(#[from] JsonDeserializationError),
     /// Tried to convert an EST representing a template to an AST representing a static policy
-    #[error("tried to convert JSON representing a template to a static policy: {0}")]
+    #[error("tried to convert JSON representing a template to a static policy")]
     #[diagnostic(transparent)]
     TemplateToPolicy(#[from] ast::UnexpectedSlotError),
     /// Slot name was not valid for the position it was used in. (Currently, principal slots must

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -121,9 +121,8 @@ impl<'a> ExpectedErrorMessageBuilder<'a> {
         }
     }
 
-    /// Add expected underlined text. The error message will be expected to have
-    /// exactly one miette label, and the underlined portion should be `snippet`.
-    /// The label text is expected to match `label`.
+    /// Add expected contents of `source()`, or expected prefix of `source()` if
+    /// this builder was originally constructed with `error_starts_with()`
     pub fn source(self, msg: &'a str) -> Self {
         Self {
             source: Some(msg),

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -261,7 +261,7 @@ pub mod schema_errors {
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
-    #[error("transitive closure computation/enforcement error on action hierarchy: {0}")]
+    #[error("transitive closure computation/enforcement error on action hierarchy")]
     #[diagnostic(transparent)]
     pub struct ActionTransitiveClosureError(
         #[from] pub(crate) Box<transitive_closure::TcError<EntityUID>>,
@@ -273,7 +273,7 @@ pub mod schema_errors {
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
-    #[error("transitive closure computation/enforcement error on entity type hierarchy: {0}")]
+    #[error("transitive closure computation/enforcement error on entity type hierarchy")]
     #[diagnostic(transparent)]
     pub struct EntityTypeTransitiveClosureError(
         #[from] pub(crate) Box<transitive_closure::TcError<Name>>,
@@ -445,7 +445,7 @@ pub mod schema_errors {
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, Diagnostic, Error)]
-    #[error("unsupported feature used in schema: {0}")]
+    #[error("unsupported feature used in schema")]
     #[diagnostic(transparent)]
     pub struct UnsupportedFeatureError(#[from] pub(crate) UnsupportedFeature);
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1382,16 +1382,13 @@ mod test {
             Extensions::all_available(),
         );
         match schema {
-            Err(SchemaError::UnsupportedFeature(UnsupportedFeatureError(
-                UnsupportedFeature::ActionAttributes(actions),
-            ))) => {
-                assert_eq!(
-                    actions.into_iter().collect::<HashSet<_>>(),
-                    HashSet::from([
-                        "view_photo".to_string(),
-                        "edit_photo".to_string(),
-                        "delete_photo".to_string(),
-                    ])
+            Err(e) => {
+                expect_err(
+                    "",
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error("unsupported feature used in schema")
+                        .source(r#"action declared with attributes: [delete_photo, edit_photo, view_photo]"#)
+                        .build()
                 )
             }
             _ => panic!("Did not see expected error."),

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -499,7 +499,7 @@ impl ValidatorNamespaceDef {
                 }
             }
             if !actions_with_attributes.is_empty() {
-                actions_with_attributes.sort(); // for deterministic error messages
+                actions_with_attributes.sort(); // TODO(#833): sort required for deterministic error messages
                 return Err(
                     UnsupportedFeatureError(UnsupportedFeature::ActionAttributes(
                         actions_with_attributes,

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -499,6 +499,7 @@ impl ValidatorNamespaceDef {
                 }
             }
             if !actions_with_attributes.is_empty() {
+                actions_with_attributes.sort(); // for deterministic error messages
                 return Err(
                     UnsupportedFeatureError(UnsupportedFeature::ActionAttributes(
                         actions_with_attributes,

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -275,7 +275,7 @@ impl From<ast::ContextCreationError> for ContextCreationError {
     fn from(e: ast::ContextCreationError) -> Self {
         match e {
             ast::ContextCreationError::NotARecord(nre) => Self::NotARecord(nre),
-            ast::ContextCreationError::Evaluation(e) => Self::Evaluation(e.into()),
+            ast::ContextCreationError::Evaluation(e) => Self::Evaluation(e),
             ast::ContextCreationError::ExpressionConstruction(ece) => {
                 Self::ExpressionConstruction(ece)
             }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -668,7 +668,7 @@ pub mod policy_set_errors {
 
     /// Error when converting a policy from JSON format
     #[derive(Debug, Diagnostic, Error)]
-    #[error("Error deserializing a policy/template from JSON: {inner}")]
+    #[error("error deserializing a policy/template from JSON")]
     #[diagnostic(transparent)]
     pub struct FromJsonError {
         #[from]
@@ -677,7 +677,7 @@ pub mod policy_set_errors {
 
     /// Error during JSON ser/de of the policy set (as opposed to individual policies)
     #[derive(Debug, Diagnostic, Error)]
-    #[error("Error serializing / deserializing PolicySet to / from JSON: {inner})")]
+    #[error("error serializing/deserializing policy set to/from JSON")]
     pub struct JsonPolicySetError {
         #[from]
         pub(crate) inner: serde_json::Error,
@@ -694,7 +694,7 @@ pub enum PolicySetError {
     #[diagnostic(transparent)]
     AlreadyDefined(#[from] policy_set_errors::AlreadyDefined),
     /// Error when linking a template
-    #[error("unable to link template: {0}")]
+    #[error("unable to link template")]
     #[diagnostic(transparent)]
     Linking(#[from] ast::LinkingError),
     /// Expected a static policy, but a template-linked policy was provided
@@ -734,7 +734,7 @@ pub enum PolicySetError {
     #[diagnostic(transparent)]
     FromJson(#[from] policy_set_errors::FromJsonError),
     /// Error when converting to JSON format
-    #[error("Error serializing a policy to JSON: {0}")]
+    #[error("error serializing a policy to JSON")]
     #[diagnostic(transparent)]
     ToJson(#[from] PolicyToJsonError),
     /// Error during JSON ser/de of the policy set (as opposed to individual policies)

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -169,7 +169,7 @@ permit(principal ==  A :: B
         let result = EntityTypeName::from_str(src);
 
         assert_matches!(result, Err(_));
-        let error = result.err().unwrap();
+        let error = result.unwrap_err();
         expect_err(
             src,
             &Report::new(error),
@@ -3310,7 +3310,7 @@ mod schema_based_parsing_tests {
                 "parents": []
             }
         ]);
-        let r = Entities::from_json_value(json.clone(), None).err().unwrap();
+        let r = Entities::from_json_value(json.clone(), None).unwrap_err();
         match r {
             EntitiesError::Duplicate(euid) => {
                 expect_err(
@@ -4628,7 +4628,7 @@ mod policy_set_est_tests {
             }
         ]});
 
-        let err = PolicySet::from_json_value(value).err().unwrap();
+        let err = PolicySet::from_json_value(value).unwrap_err();
         expect_err(
             "",
             &Report::new(err),
@@ -4705,7 +4705,7 @@ mod policy_set_est_tests {
             }
         ]});
 
-        let err = PolicySet::from_json_value(value).err().unwrap();
+        let err = PolicySet::from_json_value(value).unwrap_err();
         expect_err(
             "",
             &Report::new(err),
@@ -4754,7 +4754,7 @@ mod policy_set_est_tests {
             }
         ]});
 
-        let err = PolicySet::from_json_value(value).err().unwrap();
+        let err = PolicySet::from_json_value(value).unwrap_err();
         expect_err(
             "",
             &Report::new(err),
@@ -4834,7 +4834,7 @@ mod policy_set_est_tests {
             }
         ]});
 
-        let err = PolicySet::from_json_value(value).err().unwrap();
+        let err = PolicySet::from_json_value(value).unwrap_err();
         expect_err(
             "",
             &Report::new(err),


### PR DESCRIPTION
## Description of changes

The more interesting error message change promised in #996. 

While messing with the FFI, I noticed that some error messages were displaying with redundant information, e.g.:
<img width="731" alt="Screenshot 2024-06-17 at 11 09 06 AM" src="https://github.com/cedar-policy/cedar/assets/3478866/44fb694c-0014-4bcb-a667-8a55ca15827e">

The reason for this is that given a definition like:
```rust
    #[error("unable to link template: {inner}")]
    pub struct LinkingError {
        #[from]
        #[diagnostic(transparent)]
        pub(crate) inner: ast::LinkingError,
    }
```

The `ast::LinkingError` error is automatically set as the "source" field for the error. So there's no need to include `: {inner}` in the error message text. This PR fixes the error message above (along with several other errors using this pattern) and updates the error testing infrastructure to check the "source" field in addition to help text and underlines.

**Bonus:** the best error message I found that used this pattern was:
<img width="808" alt="Screenshot 2024-06-17 at 1 58 55 PM" src="https://github.com/cedar-policy/cedar/assets/3478866/ce458249-afd8-4231-99a2-b790349c6017">

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

