### PR TITLE
introduce `RawName` wrapper type

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -59,9 +59,9 @@ impl EntityType {
         self.0.loc()
     }
 
-    /// Calls [`Name::prefix_namespace_if_unqualified`] on the underlying [`Name`]
-    pub fn prefix_namespace_if_unqualified(&self, namespace: Option<&Name>) -> Self {
-        Self(self.0.prefix_namespace_if_unqualified(namespace))
+    /// Calls [`Name::qualify_with`] on the underlying [`Name`]
+    pub fn qualify_with(&self, namespace: Option<&Name>) -> Self {
+        Self(self.0.qualify_with(namespace))
     }
 
     /// Wraps [`Name::from_normalized_str`]

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -150,13 +150,23 @@ impl Name {
         self.path.iter().join("::")
     }
 
-    /// Prefix the name with a optional namespace
-    /// When the name is not an `Id`, it doesn't make sense to prefix any
-    /// namespace and hence this method returns a copy of `self`
-    /// When the name is an `Id`, prefix it with the optional namespace
-    /// e.g., prefix `A::B`` with `Some(C)` or `None` produces `A::B`
-    /// prefix `A` with `Some(B::C)` yields `B::C::A`
-    pub fn prefix_namespace_if_unqualified(&self, namespace: Option<&Name>) -> Name {
+    /// Qualify the name with a namespace
+    ///
+    /// When the name already has an explicit namespace, it doesn't make sense
+    /// to prefix any namespace, and hence this method returns a copy of `self`.
+    ///
+    /// If `namespace` is `None`, that represents the empty namespace, so no
+    /// prefixing will be done.
+    ///
+    /// When the name does not already have an explicit namespace, and
+    /// `namespace` is `Some`, prefix it with the namespace.
+    ///
+    /// Examples:
+    /// `A::B`.qualify_with(Some(C)) is just A::B
+    /// `A`.qualify_with(Some(C)) is C::A
+    /// `A`.qualify_with(Some(B::C)) is B::C::A
+    /// `A`.qualify_with(None) is A
+    pub fn qualify_with(&self, namespace: Option<&Name>) -> Name {
         if self.is_unqualified() {
             // Ideally, we want to implement `IntoIterator` for `Name`
             match namespace {
@@ -379,34 +389,41 @@ mod test {
     }
 
     #[test]
-    fn prefix_namespace() {
+    fn qualify_with() {
         assert_eq!(
             "foo::bar::baz",
             Name::from_normalized_str("baz")
                 .unwrap()
-                .prefix_namespace_if_unqualified(Some(&"foo::bar".parse().unwrap()))
+                .qualify_with(Some(&"foo::bar".parse().unwrap()))
                 .to_smolstr()
         );
         assert_eq!(
             "C::D",
             Name::from_normalized_str("C::D")
                 .unwrap()
-                .prefix_namespace_if_unqualified(Some(&"A::B".parse().unwrap()))
+                .qualify_with(Some(&"A::B".parse().unwrap()))
                 .to_smolstr()
         );
         assert_eq!(
             "A::B::C::D",
             Name::from_normalized_str("D")
                 .unwrap()
-                .prefix_namespace_if_unqualified(Some(&"A::B::C".parse().unwrap()))
+                .qualify_with(Some(&"A::B::C".parse().unwrap()))
                 .to_smolstr()
         );
         assert_eq!(
             "B::C::D",
             Name::from_normalized_str("B::C::D")
                 .unwrap()
-                .prefix_namespace_if_unqualified(Some(&"A".parse().unwrap()))
+                .qualify_with(Some(&"A".parse().unwrap()))
                 .to_smolstr()
         );
+        assert_eq!(
+            "A",
+            Name::from_normalized_str("A")
+                .unwrap()
+                .qualify_with(None)
+                .to_smolstr()
+        )
     }
 }

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -18,7 +18,6 @@
 
 use std::{collections::HashSet, fmt::Display};
 
-use cedar_policy_core::ast::Name;
 use itertools::Itertools;
 use miette::Diagnostic;
 use nonempty::NonEmpty;
@@ -26,10 +25,11 @@ use smol_str::{SmolStr, ToSmolStr};
 use thiserror::Error;
 
 use crate::{
-    ActionType, EntityType, NamespaceDefinition, SchemaFragment, SchemaType, SchemaTypeVariant,
+    ActionType, EntityType, NamespaceDefinition, RawName, SchemaFragment, SchemaType,
+    SchemaTypeVariant,
 };
 
-impl Display for SchemaFragment {
+impl<N: Display> Display for SchemaFragment<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (ns, def) in &self.0 {
             match ns {
@@ -41,7 +41,7 @@ impl Display for SchemaFragment {
     }
 }
 
-impl Display for NamespaceDefinition {
+impl<N: Display> Display for NamespaceDefinition<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (n, ty) in &self.common_types {
             writeln!(f, "type {n} = {ty};")?
@@ -56,7 +56,7 @@ impl Display for NamespaceDefinition {
     }
 }
 
-impl Display for SchemaType {
+impl<N: Display> Display for SchemaType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SchemaType::Type(ty) => match ty {
@@ -103,7 +103,7 @@ fn fmt_vec<T: Display>(f: &mut std::fmt::Formatter<'_>, ets: NonEmpty<T>) -> std
     write!(f, "[{contents}]")
 }
 
-impl Display for EntityType {
+impl<N: Display> Display for EntityType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(non_empty) = non_empty_slice(&self.member_of_types) {
             write!(f, " in ")?;
@@ -120,7 +120,7 @@ impl Display for EntityType {
     }
 }
 
-impl Display for ActionType {
+impl<N: Display> Display for ActionType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(parents) = self
             .member_of
@@ -183,8 +183,8 @@ impl NameCollisionsError {
 }
 
 /// Convert a [`SchemaFragment`] to a string containing human schema syntax
-pub fn json_schema_to_custom_schema_str(
-    json_schema: &SchemaFragment,
+pub fn json_schema_to_custom_schema_str<N: Display>(
+    json_schema: &SchemaFragment<N>,
 ) -> Result<String, ToHumanSchemaSyntaxError> {
     let mut name_collisions: Vec<SmolStr> = Vec::new();
     for (name, ns) in json_schema.0.iter().filter(|(name, _)| !name.is_none()) {
@@ -192,8 +192,8 @@ pub fn json_schema_to_custom_schema_str(
             .entity_types
             .keys()
             .map(|ty_name| {
-                Name::unqualified_name(ty_name.clone())
-                    .prefix_namespace_if_unqualified(name.as_ref())
+                RawName::new(ty_name.clone())
+                    .qualify_with(name.as_ref())
                     .to_smolstr()
             })
             .collect();
@@ -201,8 +201,8 @@ pub fn json_schema_to_custom_schema_str(
             .common_types
             .keys()
             .map(|ty_name| {
-                Name::unqualified_name(ty_name.clone())
-                    .prefix_namespace_if_unqualified(name.as_ref())
+                RawName::new(ty_name.clone())
+                    .qualify_with(name.as_ref())
                     .to_smolstr()
             })
             .collect();

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -95,7 +95,7 @@ pub enum HumanSyntaxParseErrors {
 }
 
 /// Parse a type, in human syntax, into a [`crate::SchemaType`]
-pub fn parse_type(src: &str) -> Result<crate::SchemaType, HumanSyntaxParseErrors> {
+pub fn parse_type(src: &str) -> Result<crate::SchemaType<crate::RawName>, HumanSyntaxParseErrors> {
     let ty = parse_collect_errors(&*TYPE_PARSER, grammar::TypeParser::parse, src)?;
     Ok(custom_type_to_json_type(ty)?)
 }
@@ -104,7 +104,13 @@ pub fn parse_type(src: &str) -> Result<crate::SchemaType, HumanSyntaxParseErrors
 /// possibly generating warnings
 pub fn parse_natural_schema_fragment(
     src: &str,
-) -> Result<(crate::SchemaFragment, impl Iterator<Item = SchemaWarning>), HumanSyntaxParseErrors> {
+) -> Result<
+    (
+        crate::SchemaFragment<crate::RawName>,
+        impl Iterator<Item = SchemaWarning>,
+    ),
+    HumanSyntaxParseErrors,
+> {
     let ast: Schema = parse_collect_errors(&*SCHEMA_PARSER, grammar::SchemaParser::parse, src)?;
     let tuple = custom_schema_to_json_schema(ast)?;
     Ok(tuple)

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -29,7 +29,7 @@ use std::collections::hash_map::Entry;
 
 use crate::{
     human_schema::ast::Path, ActionEntityUID, ActionType, ApplySpec, AttributesOrContext,
-    EntityType, NamespaceDefinition, SchemaFragment, SchemaType, SchemaTypeVariant,
+    EntityType, NamespaceDefinition, RawName, SchemaFragment, SchemaType, SchemaTypeVariant,
     TypeOfAttribute,
 };
 
@@ -48,7 +48,7 @@ use super::{
 ///     * A vector of name collisions, that are essentially warnings
 pub fn custom_schema_to_json_schema(
     schema: Schema,
-) -> Result<(SchemaFragment, impl Iterator<Item = SchemaWarning>), ToJsonSchemaErrors> {
+) -> Result<(SchemaFragment<RawName>, impl Iterator<Item = SchemaWarning>), ToJsonSchemaErrors> {
     // First pass, figure out what each name is bound to
     let (qualified_namespaces, unqualified_namespace) =
         split_unqualified_namespace(schema.into_iter().map(|n| n.node));
@@ -70,7 +70,7 @@ pub fn custom_schema_to_json_schema(
 
 /// Convert a custom type AST into the JSON representation of the type.
 /// Conversion is done in an empty context.
-pub fn custom_type_to_json_type(ty: Node<Type>) -> Result<SchemaType, ToJsonSchemaErrors> {
+pub fn custom_type_to_json_type(ty: Node<Type>) -> Result<SchemaType<RawName>, ToJsonSchemaErrors> {
     let names = HashMap::from([(None, NamespaceRecord::default())]);
     let context = ConversionContext::new(
         &names,
@@ -112,14 +112,15 @@ fn split_unqualified_namespace(
 fn convert_namespace(
     names: &HashMap<Option<Name>, NamespaceRecord>,
     namespace: Namespace,
-) -> Result<(Option<Name>, NamespaceDefinition), ToJsonSchemaErrors> {
+) -> Result<(Option<Name>, NamespaceDefinition<RawName>), ToJsonSchemaErrors> {
     let r = ConversionContext::new(names, &namespace);
     let def = r.convert_namespace(namespace)?;
     Ok((r.current_namespace_name, def))
 }
 
 /// The "context" for converting a piece of schema syntax into the JSON representation
-/// It's primary purpose is implementing the procedure for looking up a type name
+///
+/// Its primary purpose is implementing the procedure for looking up a type name
 /// and resolving it to a type.
 struct ConversionContext<'a> {
     names: &'a HashMap<Option<Name>, NamespaceRecord>,
@@ -133,19 +134,18 @@ impl<'a> ConversionContext<'a> {
         names: &'a HashMap<Option<Name>, NamespaceRecord>,
         current_namespace: &Namespace,
     ) -> Self {
-        let current_namespace_name = current_namespace
-            .name
-            .as_ref()
-            .map(|path| path.clone().node.into());
         Self {
             names,
-            current_namespace_name,
+            current_namespace_name: current_namespace.name(),
             cedar_namespace: NamespaceRecord::default(), // The `__cedar` namespace is empty (besides primitives)
         }
     }
 
     /// Convert a cst namespace
-    fn convert_namespace(&self, n: Namespace) -> Result<NamespaceDefinition, ToJsonSchemaErrors> {
+    fn convert_namespace(
+        &self,
+        n: Namespace,
+    ) -> Result<NamespaceDefinition<RawName>, ToJsonSchemaErrors> {
         // Ensure we aren't using a reserved namespace
         match n.name.as_ref() {
             Some(name) if name.node.is_cedar() || name.node.is_in_cedar() => {
@@ -190,7 +190,10 @@ impl<'a> ConversionContext<'a> {
     }
 
     /// Converts common type decls
-    fn convert_common_types(&self, decl: TypeDecl) -> Result<(Id, SchemaType), ToJsonSchemaErrors> {
+    fn convert_common_types(
+        &self,
+        decl: TypeDecl,
+    ) -> Result<(Id, SchemaType<RawName>), ToJsonSchemaErrors> {
         let TypeDecl { name, def } = decl;
         let ty = self.convert_type(def)?;
         Ok((name.node, ty))
@@ -200,7 +203,7 @@ impl<'a> ConversionContext<'a> {
     fn convert_action_decl(
         &self,
         a: ActionDecl,
-    ) -> Result<impl Iterator<Item = (SmolStr, ActionType)>, ToJsonSchemaErrors> {
+    ) -> Result<impl Iterator<Item = (SmolStr, ActionType<RawName>)>, ToJsonSchemaErrors> {
         let ActionDecl {
             names,
             parents,
@@ -226,11 +229,11 @@ impl<'a> ConversionContext<'a> {
         Ok(names.into_iter().map(move |name| (name.node, ty.clone())))
     }
 
-    fn convert_parents(&self, parents: NonEmpty<Node<QualName>>) -> Vec<ActionEntityUID> {
+    fn convert_parents(&self, parents: NonEmpty<Node<QualName>>) -> Vec<ActionEntityUID<RawName>> {
         parents.into_iter().map(Self::convert_qual_name).collect()
     }
 
-    fn convert_qual_name(qn: Node<QualName>) -> ActionEntityUID {
+    fn convert_qual_name(qn: Node<QualName>) -> ActionEntityUID<RawName> {
         let qn = qn.node;
         ActionEntityUID {
             id: qn.eid,
@@ -243,12 +246,12 @@ impl<'a> ConversionContext<'a> {
         &self,
         action_info: (&SmolStr, &Loc),
         decls: Node<NonEmpty<Node<AppDecl>>>,
-    ) -> Result<ApplySpec, ToJsonSchemaErrors> {
+    ) -> Result<ApplySpec<RawName>, ToJsonSchemaErrors> {
         // Split AppDecl's into context/principal/resource decls
         let (decls, _) = decls.into_inner();
-        let mut principal_types: Option<Node<Vec<Name>>> = None;
-        let mut resource_types: Option<Node<Vec<Name>>> = None;
-        let mut context: Option<Node<AttributesOrContext>> = None;
+        let mut principal_types: Option<Node<Vec<RawName>>> = None;
+        let mut resource_types: Option<Node<Vec<RawName>>> = None;
+        let mut context: Option<Node<AttributesOrContext<RawName>>> = None;
 
         for decl in decls {
             match decl {
@@ -348,7 +351,7 @@ impl<'a> ConversionContext<'a> {
     fn convert_entity_decl(
         &self,
         e: EntityDecl,
-    ) -> Result<impl Iterator<Item = (Id, EntityType)>, ToJsonSchemaErrors> {
+    ) -> Result<impl Iterator<Item = (Id, EntityType<RawName>)>, ToJsonSchemaErrors> {
         let EntityDecl {
             names,
             member_of_types,
@@ -357,7 +360,7 @@ impl<'a> ConversionContext<'a> {
         // First build up the defined entity type
         let member_of_types = member_of_types
             .into_iter()
-            .map(|p| Name::from(p).into())
+            .map(|p| RawName::from(p).into())
             .collect();
         let shape = self.convert_attr_decls(attrs)?;
         let etype = EntityType {
@@ -375,7 +378,7 @@ impl<'a> ConversionContext<'a> {
     fn convert_attr_decls(
         &self,
         attrs: Vec<Node<AttrDecl>>,
-    ) -> Result<AttributesOrContext, ToJsonSchemaErrors> {
+    ) -> Result<AttributesOrContext<RawName>, ToJsonSchemaErrors> {
         Ok(AttributesOrContext(SchemaType::Type(
             SchemaTypeVariant::Record {
                 attributes: collect_all_errors(
@@ -391,7 +394,7 @@ impl<'a> ConversionContext<'a> {
     fn convert_context_decl(
         &self,
         decl: Either<Path, Vec<Node<AttrDecl>>>,
-    ) -> Result<AttributesOrContext, ToJsonSchemaErrors> {
+    ) -> Result<AttributesOrContext<RawName>, ToJsonSchemaErrors> {
         Ok(AttributesOrContext(match decl {
             Either::Left(p) => SchemaType::TypeDef {
                 type_name: p.into(),
@@ -410,7 +413,7 @@ impl<'a> ConversionContext<'a> {
     fn convert_attr_decl(
         &self,
         attr: Node<AttrDecl>,
-    ) -> Result<(SmolStr, TypeOfAttribute), ToJsonSchemaErrors> {
+    ) -> Result<(SmolStr, TypeOfAttribute<RawName>), ToJsonSchemaErrors> {
         let AttrDecl { name, required, ty } = attr.node;
         Ok((
             name.node,
@@ -422,7 +425,7 @@ impl<'a> ConversionContext<'a> {
     }
 
     /// Convert a type recursively
-    fn convert_type(&self, ty: Node<Type>) -> Result<SchemaType, ToJsonSchemaErrors> {
+    fn convert_type(&self, ty: Node<Type>) -> Result<SchemaType<RawName>, ToJsonSchemaErrors> {
         match ty.node {
             Type::Set(t) => Ok(SchemaType::Type(SchemaTypeVariant::Set {
                 element: Box::new(self.convert_type(*t)?),
@@ -446,9 +449,9 @@ impl<'a> ConversionContext<'a> {
 
     /// Dereference a type name to get it's type
     /// This follows the procedure from RFC 24.
-    fn dereference_name(&self, p: Path) -> Result<SchemaType, ToJsonSchemaError> {
+    fn dereference_name(&self, p: Path) -> Result<SchemaType<RawName>, ToJsonSchemaError> {
         // First determine what namespace we are searching
-        let name: Name = p.clone().into();
+        let name: RawName = p.clone().into();
         let is_unqualified_or_cedar = p.is_in_unqualified_or_cedar();
         let loc = p.loc().clone();
         let (prefix, base) = p.split_last();
@@ -539,7 +542,7 @@ where
 }
 
 /// Search the cedar namespace, the things that live here are cedar builtins, unless overridden within a context.
-fn search_cedar_namespace(name: Id, loc: Loc) -> Result<SchemaType, ToJsonSchemaError> {
+fn search_cedar_namespace(name: Id, loc: Loc) -> Result<SchemaType<RawName>, ToJsonSchemaError> {
     match name.as_ref() {
         "Long" => Ok(SchemaType::Type(SchemaTypeVariant::Long)),
         "String" => Ok(SchemaType::Type(SchemaTypeVariant::String)),
@@ -564,7 +567,6 @@ struct NamespaceRecord {
 impl NamespaceRecord {
     fn new(namespace: &Namespace) -> Result<(Option<Name>, Self), ToJsonSchemaErrors> {
         let (entities, actions, types) = partition_decls(&namespace.decls);
-        let name = namespace.name.as_ref().map(|n| n.node.clone().into());
 
         let entities = collect_decls(
             entities
@@ -592,7 +594,7 @@ impl NamespaceRecord {
             loc: namespace.name.as_ref().map(|n| n.loc.clone()),
         };
 
-        Ok((name, record))
+        Ok((namespace.name(), record))
     }
 }
 

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -21,7 +21,6 @@
     missing_docs,
     missing_debug_implementations,
     rustdoc::broken_intra_doc_links,
-    rustdoc::private_intra_doc_links,
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_html_tags,
     rustdoc::invalid_rust_codeblocks,

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -311,7 +311,7 @@ mod test {
     #[test]
     fn top_level_validate_with_links() -> Result<()> {
         let mut set = PolicySet::new();
-        let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment>(
+        let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment<RawName>>(
             r#"
             {
                 "some_namespace": {
@@ -458,7 +458,7 @@ mod test {
 
     #[test]
     fn validate_finds_warning_and_error() {
-        let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment>(
+        let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment<RawName>>(
             r#"
             {
                 "": {

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -21,6 +21,7 @@
     missing_docs,
     missing_debug_implementations,
     rustdoc::broken_intra_doc_links,
+    rustdoc::private_intra_doc_links,
     rustdoc::invalid_codeblock_attributes,
     rustdoc::invalid_html_tags,
     rustdoc::invalid_rust_codeblocks,

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -296,9 +296,7 @@ impl Validator {
         .into_iter()
     }
 
-    /// Gather all `ApplySpec` objects for all actions in the schema. The `applies_to`
-    /// field is optional in the schema. In the case that it was not supplied, the
-    /// `applies_to` field will contain `UnspecifiedEntity`.
+    /// Gather all `ApplySpec` objects for all actions in the schema.
     pub(crate) fn get_apply_specs_for_action<'a>(
         &'a self,
         action_constraint: &'a ActionConstraint,
@@ -413,7 +411,7 @@ mod test {
     use crate::{
         schema_file_format::{NamespaceDefinition, *},
         validation_errors::UnrecognizedEntityType,
-        ValidationMode, ValidationWarning, Validator,
+        RawName, ValidationMode, ValidationWarning, Validator,
     };
 
     #[test]
@@ -436,7 +434,7 @@ mod test {
 
     #[test]
     fn validate_equals_instead_of_in() {
-        let schema_file: NamespaceDefinition = serde_json::from_value(serde_json::json!(
+        let schema_file: NamespaceDefinition<RawName> = serde_json::from_value(serde_json::json!(
             {
                 "entityTypes": {
                     "user": {
@@ -726,7 +724,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_action_id_in_schema() {
-        let descriptors: SchemaFragment = serde_json::from_str(
+        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -758,7 +756,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_invalid_action() {
-        let descriptors: SchemaFragment = serde_json::from_str(
+        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -789,7 +787,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_entity_type_in_schema() {
-        let descriptors: SchemaFragment = serde_json::from_str(
+        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -824,7 +822,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_invalid_entity_type() {
-        let descriptors: SchemaFragment = serde_json::from_str(
+        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -1449,7 +1447,7 @@ mod test {
 
     #[test]
     fn unspecified_principal_resource_with_scope_conditions() {
-        let schema = serde_json::from_str::<NamespaceDefinition>(
+        let schema = serde_json::from_str::<NamespaceDefinition<RawName>>(
             r#"
         {
             "entityTypes": {"a": {}},
@@ -1482,11 +1480,11 @@ mod partial_schema {
         parser::parse_policy,
     };
 
-    use crate::{NamespaceDefinition, Validator};
+    use crate::{NamespaceDefinition, RawName, Validator};
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_validates_with_empty_schema(policy: StaticPolicy) {
-        let schema = serde_json::from_str::<NamespaceDefinition>(
+        let schema = serde_json::from_str::<NamespaceDefinition<RawName>>(
             r#"
         {
             "entityTypes": { },

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -49,7 +49,7 @@ pub use entity_type::ValidatorEntityType;
 mod namespace_def;
 pub use namespace_def::ValidatorNamespaceDef;
 mod raw_name;
-pub(crate) use raw_name::RawName;
+pub use raw_name::RawName;
 
 /// Configurable validator behaviors regarding actions
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -48,6 +48,8 @@ mod entity_type;
 pub use entity_type::ValidatorEntityType;
 mod namespace_def;
 pub use namespace_def::ValidatorNamespaceDef;
+mod raw_name;
+pub(crate) use raw_name::RawName;
 
 /// Configurable validator behaviors regarding actions
 #[derive(Debug, Eq, PartialEq, Copy, Clone, Default)]
@@ -68,7 +70,7 @@ pub enum ActionBehavior {
 #[derive(Debug)]
 pub struct ValidatorSchemaFragment(Vec<ValidatorNamespaceDef>);
 
-impl TryInto<ValidatorSchemaFragment> for SchemaFragment {
+impl TryInto<ValidatorSchemaFragment> for SchemaFragment<RawName> {
     type Error = SchemaError;
 
     fn try_into(self) -> Result<ValidatorSchemaFragment> {
@@ -88,7 +90,7 @@ impl ValidatorSchemaFragment {
 
     /// Construct a [`ValidatorSchemaFragment`] from a [`SchemaFragment`]
     pub fn from_schema_fragment(
-        fragment: SchemaFragment,
+        fragment: SchemaFragment<RawName>,
         action_behavior: ActionBehavior,
         extensions: Extensions<'_>,
     ) -> Result<Self> {
@@ -136,16 +138,16 @@ impl std::str::FromStr for ValidatorSchema {
     type Err = SchemaError;
 
     fn from_str(s: &str) -> Result<Self> {
-        serde_json::from_str::<SchemaFragment>(s)
+        serde_json::from_str::<SchemaFragment<RawName>>(s)
             .map_err(|e| JsonDeserializationError::new(e, Some(s)))?
             .try_into()
     }
 }
 
-impl TryFrom<NamespaceDefinition> for ValidatorSchema {
+impl TryFrom<NamespaceDefinition<RawName>> for ValidatorSchema {
     type Error = SchemaError;
 
-    fn try_from(nsd: NamespaceDefinition) -> Result<ValidatorSchema> {
+    fn try_from(nsd: NamespaceDefinition<RawName>) -> Result<ValidatorSchema> {
         ValidatorSchema::from_schema_fragments(
             [ValidatorSchemaFragment::from_namespaces([nsd.try_into()?])],
             Extensions::all_available(),
@@ -153,10 +155,10 @@ impl TryFrom<NamespaceDefinition> for ValidatorSchema {
     }
 }
 
-impl TryFrom<SchemaFragment> for ValidatorSchema {
+impl TryFrom<SchemaFragment<RawName>> for ValidatorSchema {
     type Error = SchemaError;
 
-    fn try_from(frag: SchemaFragment) -> Result<ValidatorSchema> {
+    fn try_from(frag: SchemaFragment<RawName>) -> Result<ValidatorSchema> {
         ValidatorSchema::from_schema_fragments([frag.try_into()?], Extensions::all_available())
     }
 }
@@ -175,7 +177,7 @@ impl ValidatorSchema {
     /// shape.
     pub fn from_json_value(json: serde_json::Value, extensions: Extensions<'_>) -> Result<Self> {
         Self::from_schema_frag(
-            SchemaFragment::from_json_value(json)?,
+            SchemaFragment::<RawName>::from_json_value(json)?,
             ActionBehavior::default(),
             extensions,
         )
@@ -185,7 +187,7 @@ impl ValidatorSchema {
     /// appropriate shape.
     pub fn from_json_str(json: &str, extensions: Extensions<'_>) -> Result<Self> {
         Self::from_schema_frag(
-            SchemaFragment::from_json_str(json)?,
+            SchemaFragment::<RawName>::from_json_str(json)?,
             ActionBehavior::default(),
             extensions,
         )
@@ -195,7 +197,7 @@ impl ValidatorSchema {
     /// in the appropriate shape.
     pub fn from_file(file: impl std::io::Read, extensions: Extensions<'_>) -> Result<Self> {
         Self::from_schema_frag(
-            SchemaFragment::from_file(file)?,
+            SchemaFragment::<RawName>::from_file(file)?,
             ActionBehavior::default(),
             extensions,
         )
@@ -229,7 +231,7 @@ impl ValidatorSchema {
 
     /// Helper function to construct a [`ValidatorSchema`] from a single [`SchemaFragment`].
     pub(crate) fn from_schema_frag(
-        schema_file: SchemaFragment,
+        schema_file: SchemaFragment<RawName>,
         action_behavior: ActionBehavior,
         extensions: Extensions<'_>,
     ) -> Result<ValidatorSchema> {
@@ -437,13 +439,13 @@ impl ValidatorSchema {
         for action in action_ids.values() {
             Self::check_undeclared_in_type(&action.context, entity_types, &mut undeclared_e);
 
-            for p_entity in action.applies_to.applicable_principal_types() {
+            for p_entity in action.applies_to_principals() {
                 if !entity_types.contains_key(p_entity) {
                     undeclared_e.insert(p_entity.clone());
                 }
             }
 
-            for r_entity in action.applies_to.applicable_resource_types() {
+            for r_entity in action.applies_to_resources() {
                 if !entity_types.contains_key(r_entity) {
                     undeclared_e.insert(r_entity.clone());
                 }
@@ -593,7 +595,7 @@ impl ValidatorSchema {
     }
 
     /// Get the `Type` of context expected for the given `action`.
-    /// This always reutrns a closed record type.
+    /// This always returns a closed record type.
     ///
     /// Returns `None` if the action is not in the schema.
     pub fn context_type(&self, action: &EntityUID) -> Option<Type> {
@@ -647,10 +649,11 @@ impl ValidatorSchema {
 /// Used to write a schema implicitly overriding the default handling of action
 /// groups.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
-pub(crate) struct NamespaceDefinitionWithActionAttributes(pub(crate) NamespaceDefinition);
+pub(crate) struct NamespaceDefinitionWithActionAttributes<N>(pub(crate) NamespaceDefinition<N>);
 
-impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes {
+impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes<RawName> {
     type Error = SchemaError;
 
     fn try_into(self) -> Result<ValidatorSchema> {
@@ -668,25 +671,29 @@ impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes {
     }
 }
 
-/// A common type reference resolver
+/// A common type reference resolver.
+/// This resolver is designed to operate on fully-qualified references.
+/// It facilitates inlining the definitions of common types.
 #[derive(Debug)]
 struct CommonTypeResolver<'a> {
     /// Common type declarations to resolve
-    type_defs: &'a HashMap<Name, SchemaType>,
-    /// The dependency graph among common type names
-    /// The graph contains a vertex for each `Name` and `graph.get(u)` gives the set of vertices `v` for which `(u,v)` is a directed edge in the graph
-    /// A common type name is prefixed with the namespace id where it's declared
+    type_defs: &'a HashMap<Name, SchemaType<Name>>,
+    /// The dependency graph among common type names.
+    /// The graph contains a vertex for each `Name` and `graph.get(u)` gives the set of vertices `v` for which `(u,v)` is a directed edge in the graph.
+    /// A common type name is prefixed with the namespace id where it's declared.
     graph: HashMap<Name, HashSet<Name>>,
 }
 
 impl<'a> CommonTypeResolver<'a> {
-    /// Construct a the resolver
-    fn new(type_defs: &'a HashMap<Name, SchemaType>) -> Self {
+    /// Construct the resolver.
+    /// Note that this requires that all common-type references are already
+    /// fully qualified, because it uses [`Name`] and not [`RawName`].
+    fn new(type_defs: &'a HashMap<Name, SchemaType<Name>>) -> Self {
         let mut graph = HashMap::new();
         for (name, ty) in type_defs {
             graph.insert(
                 name.clone(),
-                HashSet::from_iter(ty.common_type_references()),
+                HashSet::from_iter(ty.common_type_references().cloned()),
             );
         }
         Self { type_defs, graph }
@@ -726,7 +733,7 @@ impl<'a> CommonTypeResolver<'a> {
         let mut work_set: HashSet<&Name> = HashSet::new();
         let mut res: Vec<Name> = Vec::new();
 
-        // Find all type names with zero in coming edges
+        // Find all type names with zero incoming edges
         for (name, degree) in indegrees.iter() {
             let name = *name;
             if *degree == 0 {
@@ -784,9 +791,9 @@ impl<'a> CommonTypeResolver<'a> {
 
     // Substitute common type references in `ty` according to `resolve_table`
     fn resolve_type(
-        resolve_table: &HashMap<&Name, SchemaType>,
-        ty: SchemaType,
-    ) -> Result<SchemaType> {
+        resolve_table: &HashMap<&Name, SchemaType<Name>>,
+        ty: SchemaType<Name>,
+    ) -> Result<SchemaType<Name>> {
         match ty {
             SchemaType::TypeDef { type_name } => resolve_table
                 .get(&type_name)
@@ -823,7 +830,8 @@ impl<'a> CommonTypeResolver<'a> {
         }
     }
 
-    // Resolve common type references
+    // Resolve common type references, returning a map from (fully-qualified)
+    // [`Name`] of a common type to its [`Type`] definition
     fn resolve(&self, extensions: Extensions<'_>) -> Result<HashMap<Name, Type>> {
         let sorted_names = self.topo_sort().map_err(|n| {
             SchemaError::CycleInCommonTypeReferences(CycleInCommonTypeReferencesError(n))
@@ -833,13 +841,6 @@ impl<'a> CommonTypeResolver<'a> {
         let mut tys = HashMap::new();
 
         for name in sorted_names.iter() {
-            let ns: Option<Name> = if name.is_unqualified() {
-                None
-            } else {
-                // PANIC SAFETY: The namespace of qualified names should be a valid name
-                #[allow(clippy::unwrap_used)]
-                Some(name.namespace().parse().unwrap())
-            };
             // PANIC SAFETY: `name.basename()` should be an existing common type id
             #[allow(clippy::unwrap_used)]
             let ty = self.type_defs.get(name).unwrap();
@@ -848,7 +849,6 @@ impl<'a> CommonTypeResolver<'a> {
             tys.insert(
                 name.clone(),
                 ValidatorNamespaceDef::try_schema_type_into_validator_type(
-                    ns.as_ref(),
                     substituted_ty,
                     extensions,
                 )?
@@ -906,7 +906,8 @@ mod test {
                 }
             }
         });
-        let schema_file: NamespaceDefinition = serde_json::from_value(src).expect("Parse Error");
+        let schema_file: NamespaceDefinition<RawName> =
+            serde_json::from_value(src).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert!(schema.is_ok());
     }
@@ -1009,7 +1010,7 @@ mod test {
                 }
             }
         });
-        let schema_file: NamespaceDefinition =
+        let schema_file: NamespaceDefinition<RawName> =
             serde_json::from_value(src.clone()).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(schema, Err(e) => {
@@ -1034,7 +1035,8 @@ mod test {
             },
             "actions": {}
         }});
-        let schema_file: SchemaFragment = serde_json::from_value(src.clone()).expect("Parse Error");
+        let schema_file: SchemaFragment<RawName> =
+            serde_json::from_value(src.clone()).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(schema, Err(e) => {
             expect_err(
@@ -1060,7 +1062,8 @@ mod test {
                 }
             }
         }});
-        let schema_file: SchemaFragment = serde_json::from_value(src.clone()).expect("Parse Error");
+        let schema_file: SchemaFragment<RawName> =
+            serde_json::from_value(src.clone()).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(schema, Err(e) => {
             expect_err(
@@ -1098,7 +1101,7 @@ mod test {
                 }
             }
         });
-        let schema_file: NamespaceDefinition =
+        let schema_file: NamespaceDefinition<RawName> =
             serde_json::from_value(src.clone()).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(schema, Err(e) => {
@@ -1124,7 +1127,8 @@ mod test {
                 }
             }
         });
-        let schema_file: NamespaceDefinition = serde_json::from_value(src).expect("Parse Error");
+        let schema_file: NamespaceDefinition<RawName> =
+            serde_json::from_value(src).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(
             schema,
@@ -1156,7 +1160,8 @@ mod test {
                 }
             }
         });
-        let schema_file: NamespaceDefinition = serde_json::from_value(src).expect("Parse Error");
+        let schema_file: NamespaceDefinition<RawName> =
+            serde_json::from_value(src).expect("Parse Error");
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(
             schema,
@@ -1183,7 +1188,7 @@ mod test {
             }
         } }
         "#;
-        let schema_file: SchemaFragment = serde_json::from_str(src).expect("Parse Error");
+        let schema_file: SchemaFragment<RawName> = serde_json::from_str(src).expect("Parse Error");
         let schema: ValidatorSchema = schema_file
             .try_into()
             .expect("Namespaced schema failed to convert.");
@@ -1217,18 +1222,13 @@ mod test {
         );
         assert_eq!(schema.action_ids.len(), 1, "Expected exactly 1 action.");
 
-        let apply_spec = &schema
-            .action_ids
-            .values()
-            .next()
-            .expect("Expected Action")
-            .applies_to;
+        let action = &schema.action_ids.values().next().expect("Expected Action");
         assert_eq!(
-            apply_spec.applicable_principal_types().collect::<Vec<_>>(),
+            action.applies_to_principals().collect::<Vec<_>>(),
             vec![user_entity_type]
         );
         assert_eq!(
-            apply_spec.applicable_resource_types().collect::<Vec<_>>(),
+            action.applies_to_resources().collect::<Vec<_>>(),
             vec![photo_entity_type]
         );
     }
@@ -1241,8 +1241,10 @@ mod test {
             "actions": {}
         }
         "#;
-        let schema_file: std::result::Result<NamespaceDefinition, _> = serde_json::from_str(src);
-        assert!(schema_file.is_err());
+        assert_matches!(
+            serde_json::from_str::<NamespaceDefinition<RawName>>(src),
+            Err(_)
+        );
     }
 
     #[test]
@@ -1261,7 +1263,7 @@ mod test {
             },
             "actions": {}
           }});
-        let schema_json: SchemaFragment =
+        let schema_json: SchemaFragment<RawName> =
             serde_json::from_value(src.clone()).expect("Expected valid schema");
 
         let schema: Result<ValidatorSchema> = schema_json.try_into();
@@ -1277,7 +1279,7 @@ mod test {
 
     #[test]
     fn entity_attribute_entity_type_with_declared_namespace() {
-        let schema_json: SchemaFragment = serde_json::from_str(
+        let schema_json: SchemaFragment<RawName> = serde_json::from_str(
             r#"
             {"A::B": {
                 "entityTypes": {
@@ -1316,7 +1318,7 @@ mod test {
 
     #[test]
     fn cannot_declare_action_type_when_prohibited() {
-        let schema_json: NamespaceDefinition = serde_json::from_str(
+        let schema_json: NamespaceDefinition<RawName> = serde_json::from_str(
             r#"
             {
                 "entityTypes": { "Action": {} },
@@ -1335,7 +1337,7 @@ mod test {
 
     #[test]
     fn can_declare_other_type_when_action_type_prohibited() {
-        let schema_json: NamespaceDefinition = serde_json::from_str(
+        let schema_json: NamespaceDefinition<RawName> = serde_json::from_str(
             r#"
             {
                 "entityTypes": { "Foo": { } },
@@ -1350,7 +1352,7 @@ mod test {
 
     #[test]
     fn cannot_declare_action_in_group_when_prohibited() {
-        let schema_json: SchemaFragment = serde_json::from_str(
+        let schema_json: SchemaFragment<RawName> = serde_json::from_str(
             r#"
             {"": {
                 "entityTypes": {},
@@ -1393,7 +1395,7 @@ mod test {
     #[test]
     fn test_entity_type_no_namespace() {
         let src = json!({"type": "Entity", "name": "Foo"});
-        let schema_ty: SchemaType = serde_json::from_value(src).expect("Parse Error");
+        let schema_ty: SchemaType<RawName> = serde_json::from_value(src).expect("Parse Error");
         assert_eq!(
             schema_ty,
             SchemaType::Type(SchemaTypeVariant::Entity {
@@ -1401,8 +1403,7 @@ mod test {
             })
         );
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
-            Some(&Name::parse_unqualified_name("NS").expect("Expected namespace.")),
-            schema_ty,
+            schema_ty.qualify_type_references(Some(&Name::parse_unqualified_name("NS").unwrap())),
             Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
@@ -1414,7 +1415,7 @@ mod test {
     #[test]
     fn test_entity_type_namespace() {
         let src = json!({"type": "Entity", "name": "NS::Foo"});
-        let schema_ty: SchemaType = serde_json::from_value(src).expect("Parse Error");
+        let schema_ty: SchemaType<RawName> = serde_json::from_value(src).expect("Parse Error");
         assert_eq!(
             schema_ty,
             SchemaType::Type(SchemaTypeVariant::Entity {
@@ -1422,8 +1423,7 @@ mod test {
             })
         );
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
-            Some(&Name::parse_unqualified_name("NS").expect("Expected namespace.")),
-            schema_ty,
+            schema_ty.qualify_type_references(Some(&Name::parse_unqualified_name("NS").unwrap())),
             Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
@@ -1435,14 +1435,13 @@ mod test {
     #[test]
     fn test_entity_type_namespace_parse_error() {
         let src = json!({"type": "Entity", "name": "::Foo"});
-        let schema_ty: std::result::Result<SchemaType, _> = serde_json::from_value(src);
-        assert!(schema_ty.is_err());
+        assert_matches!(serde_json::from_value::<SchemaType<RawName>>(src), Err(_));
     }
 
     #[test]
     fn schema_type_record_is_validator_type_record() {
         let src = json!({"type": "Record", "attributes": {}});
-        let schema_ty: SchemaType = serde_json::from_value(src).expect("Parse Error");
+        let schema_ty: SchemaType<RawName> = serde_json::from_value(src).expect("Parse Error");
         assert_eq!(
             schema_ty,
             SchemaType::Type(SchemaTypeVariant::Record {
@@ -1451,8 +1450,7 @@ mod test {
             }),
         );
         let ty: Type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
-            None,
-            schema_ty,
+            schema_ty.qualify_type_references(None),
             Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
@@ -1463,7 +1461,7 @@ mod test {
 
     #[test]
     fn get_namespaces() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "Foo::Bar::Baz": {
                 "entityTypes": {},
                 "actions": {}
@@ -1504,7 +1502,7 @@ mod test {
 
     #[test]
     fn same_action_different_namespace() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "Foo::Bar": {
                 "entityTypes": {},
                 "actions": {
@@ -1540,7 +1538,7 @@ mod test {
 
     #[test]
     fn same_type_different_namespace() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "Foo::Bar": {
                 "entityTypes": {"Baz" : {}},
                 "actions": { }
@@ -1570,7 +1568,7 @@ mod test {
 
     #[test]
     fn member_of_different_namespace() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "Bar": {
                 "entityTypes": {
                     "Baz": {
@@ -1598,7 +1596,7 @@ mod test {
 
     #[test]
     fn attribute_different_namespace() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "Bar": {
                 "entityTypes": {
                     "Baz": {
@@ -1634,7 +1632,7 @@ mod test {
 
     #[test]
     fn applies_to_different_namespace() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "Foo::Bar": {
                 "entityTypes": { },
                 "actions": {
@@ -1676,7 +1674,7 @@ mod test {
 
     #[test]
     fn simple_defined_type() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "": {
                 "commonTypes": {
                     "MyLong": {"type": "Long"}
@@ -1704,7 +1702,7 @@ mod test {
 
     #[test]
     fn defined_record_as_attrs() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "": {
                 "commonTypes": {
                     "MyRecord": {
@@ -1730,7 +1728,7 @@ mod test {
 
     #[test]
     fn cross_namespace_type() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "A": {
                 "commonTypes": {
                     "MyLong": {"type": "Long"}
@@ -1762,36 +1760,38 @@ mod test {
 
     #[test]
     fn cross_fragment_type() {
-        let fragment1: ValidatorSchemaFragment = serde_json::from_value::<SchemaFragment>(json!({
-            "A": {
-                "commonTypes": {
-                    "MyLong": {"type": "Long"}
-                },
-                "entityTypes": { },
-                "actions": {}
-            }
-        }))
-        .unwrap()
-        .try_into()
-        .unwrap();
-        let fragment2: ValidatorSchemaFragment = serde_json::from_value::<SchemaFragment>(json!({
-            "A": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "a": {"type": "MyLong"}
+        let fragment1: ValidatorSchemaFragment =
+            serde_json::from_value::<SchemaFragment<RawName>>(json!({
+                "A": {
+                    "commonTypes": {
+                        "MyLong": {"type": "Long"}
+                    },
+                    "entityTypes": { },
+                    "actions": {}
+                }
+            }))
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let fragment2: ValidatorSchemaFragment =
+            serde_json::from_value::<SchemaFragment<RawName>>(json!({
+                "A": {
+                    "entityTypes": {
+                        "User": {
+                            "shape": {
+                                "type": "Record",
+                                "attributes": {
+                                    "a": {"type": "MyLong"}
+                                }
                             }
                         }
-                    }
-                },
-                "actions": {}
-            }
-        }))
-        .unwrap()
-        .try_into()
-        .unwrap();
+                    },
+                    "actions": {}
+                }
+            }))
+            .unwrap()
+            .try_into()
+            .unwrap();
         let schema = ValidatorSchema::from_schema_fragments(
             [fragment1, fragment2],
             Extensions::all_available(),
@@ -1806,46 +1806,47 @@ mod test {
 
     #[test]
     fn cross_fragment_duplicate_type() {
-        let fragment1: ValidatorSchemaFragment = serde_json::from_value::<SchemaFragment>(json!({
-            "A": {
-                "commonTypes": {
-                    "MyLong": {"type": "Long"}
-                },
-                "entityTypes": {},
-                "actions": {}
-            }
-        }))
-        .unwrap()
-        .try_into()
-        .unwrap();
-        let fragment2: ValidatorSchemaFragment = serde_json::from_value::<SchemaFragment>(json!({
-            "A": {
-                "commonTypes": {
-                    "MyLong": {"type": "Long"}
-                },
-                "entityTypes": {},
-                "actions": {}
-            }
-        }))
-        .unwrap()
-        .try_into()
-        .unwrap();
+        let fragment1: ValidatorSchemaFragment =
+            serde_json::from_value::<SchemaFragment<RawName>>(json!({
+                "A": {
+                    "commonTypes": {
+                        "MyLong": {"type": "Long"}
+                    },
+                    "entityTypes": {},
+                    "actions": {}
+                }
+            }))
+            .unwrap()
+            .try_into()
+            .unwrap();
+        let fragment2: ValidatorSchemaFragment =
+            serde_json::from_value::<SchemaFragment<RawName>>(json!({
+                "A": {
+                    "commonTypes": {
+                        "MyLong": {"type": "Long"}
+                    },
+                    "entityTypes": {},
+                    "actions": {}
+                }
+            }))
+            .unwrap()
+            .try_into()
+            .unwrap();
 
         let schema = ValidatorSchema::from_schema_fragments(
             [fragment1, fragment2],
             Extensions::all_available(),
         );
 
-        match schema {
-            Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError(s)))
-                if s == "A::MyLong".parse().unwrap() => {}
-            _ => panic!("should have errored because schema fragments have duplicate types"),
-        };
+        // should error because schema fragments have duplicate types
+        assert_matches!(schema, Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError(s))) => {
+            assert_eq!(s, "A::MyLong".parse().unwrap());
+        });
     }
 
     #[test]
     fn undeclared_type_in_attr() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "": {
                 "commonTypes": { },
                 "entityTypes": {
@@ -1862,18 +1863,15 @@ mod test {
             }
         }))
         .unwrap();
-        match TryInto::<ValidatorSchema>::try_into(fragment) {
-            Err(SchemaError::UndeclaredCommonTypes(_)) => (),
-            s => panic!(
-                "Expected Err(SchemaError::UndeclaredCommonType), got {:?}",
-                s
-            ),
-        }
+        assert_matches!(
+            TryInto::<ValidatorSchema>::try_into(fragment),
+            Err(SchemaError::UndeclaredCommonTypes(_))
+        );
     }
 
     #[test]
     fn undeclared_type_in_type_def() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "": {
                 "commonTypes": {
                     "a": { "type": "b" }
@@ -1883,18 +1881,15 @@ mod test {
             }
         }))
         .unwrap();
-        match TryInto::<ValidatorSchema>::try_into(fragment) {
-            Err(SchemaError::UndeclaredCommonTypes(_)) => (),
-            s => panic!(
-                "Expected Err(SchemaError::UndeclaredCommonType), got {:?}",
-                s
-            ),
-        }
+        assert_matches!(
+            TryInto::<ValidatorSchema>::try_into(fragment),
+            Err(SchemaError::UndeclaredCommonTypes(_))
+        );
     }
 
     #[test]
     fn shape_not_record() {
-        let fragment: SchemaFragment = serde_json::from_value(json!({
+        let fragment: SchemaFragment<RawName> = serde_json::from_value(json!({
             "": {
                 "commonTypes": {
                     "MyLong": { "type": "Long" }
@@ -1908,13 +1903,10 @@ mod test {
             }
         }))
         .unwrap();
-        match TryInto::<ValidatorSchema>::try_into(fragment) {
-            Err(SchemaError::ContextOrShapeNotRecord(_)) => (),
-            s => panic!(
-                "Expected Err(SchemaError::ContextOrShapeNotRecord), got {:?}",
-                s
-            ),
-        }
+        assert_matches!(
+            TryInto::<ValidatorSchema>::try_into(fragment),
+            Err(SchemaError::ContextOrShapeNotRecord(_))
+        );
     }
 
     /// This test checks for regressions on (adapted versions of) the examples
@@ -1941,9 +1933,10 @@ mod test {
                 "actions": {}
             }
         });
-        let fragment = serde_json::from_value::<SchemaFragment>(bad1); // should this fail in the future?
-                                                                       // The future has come?
-        assert!(fragment.is_err());
+        assert_matches!(
+            serde_json::from_value::<SchemaFragment<RawName>>(bad1),
+            Err(_)
+        );
 
         // non-normalized schema namespace
         let bad2 = json!({
@@ -1956,9 +1949,10 @@ mod test {
                 "actions": {}
             }
         });
-        let fragment = serde_json::from_value::<SchemaFragment>(bad2); // should this fail in the future?
-                                                                       // The future has come?
-        assert!(fragment.is_err());
+        assert_matches!(
+            serde_json::from_value::<SchemaFragment<RawName>>(bad2),
+            Err(_)
+        );
     }
 
     #[test]
@@ -1971,7 +1965,8 @@ mod test {
             }
         });
 
-        let schema_file: NamespaceDefinition = serde_json::from_value(src).expect("Parse Error");
+        let schema_file: NamespaceDefinition<RawName> =
+            serde_json::from_value(src).expect("Parse Error");
         let schema: ValidatorSchema = schema_file.try_into().expect("Schema Error");
         let actions = schema.action_entities().expect("Entity Construct Error");
 
@@ -1999,7 +1994,8 @@ mod test {
             }
         });
 
-        let schema_file: NamespaceDefinition = serde_json::from_value(src).expect("Parse Error");
+        let schema_file: NamespaceDefinition<RawName> =
+            serde_json::from_value(src).expect("Parse Error");
         let schema: ValidatorSchema = schema_file.try_into().expect("Schema Error");
         let actions = schema.action_entities().expect("Entity Construct Error");
 
@@ -2046,7 +2042,7 @@ mod test {
             }
         });
 
-        let schema_file: NamespaceDefinitionWithActionAttributes =
+        let schema_file: NamespaceDefinitionWithActionAttributes<RawName> =
             serde_json::from_value(src).expect("Parse Error");
         let schema: ValidatorSchema = schema_file.try_into().expect("Schema Error");
         let actions = schema.action_entities().expect("Entity Construct Error");
@@ -2089,7 +2085,7 @@ mod test {
             },
         });
         let schema_fragment =
-            serde_json::from_value::<SchemaFragment>(src).expect("Failed to parse schema");
+            serde_json::from_value::<SchemaFragment<RawName>>(src).expect("Failed to parse schema");
         let schema: ValidatorSchema = schema_fragment.try_into().expect("Schema should construct");
         let view_photo = schema
             .action_entities_iter()
@@ -2126,7 +2122,7 @@ mod test {
             },
         });
         let schema_fragment =
-            serde_json::from_value::<SchemaFragment>(src).expect("Failed to parse schema");
+            serde_json::from_value::<SchemaFragment<RawName>>(src).expect("Failed to parse schema");
         let schema: std::result::Result<ValidatorSchema, _> = schema_fragment.try_into();
         schema.expect_err("Schema should fail to construct as the normalization rules treat any qualification as starting from the root");
     }
@@ -2150,7 +2146,7 @@ mod test {
             }
         });
         let schema_fragment =
-            serde_json::from_value::<SchemaFragment>(src).expect("Failed to parse schema");
+            serde_json::from_value::<SchemaFragment<RawName>>(src).expect("Failed to parse schema");
         let schema: ValidatorSchema = schema_fragment.try_into().unwrap();
         let view_photo = schema
             .action_entities_iter()
@@ -2558,10 +2554,11 @@ mod test_resolver {
     use cool_asserts::assert_matches;
 
     use super::CommonTypeResolver;
-    use crate::{err::SchemaError, types::Type, SchemaFragment, ValidatorSchemaFragment};
+    use crate::{err::SchemaError, types::Type, RawName, SchemaFragment, ValidatorSchemaFragment};
 
-    fn resolve(schema: SchemaFragment) -> Result<HashMap<Name, Type>, SchemaError> {
-        let schema: ValidatorSchemaFragment = schema.try_into().unwrap();
+    fn resolve(schema_json: serde_json::Value) -> Result<HashMap<Name, Type>, SchemaError> {
+        let sfrag: SchemaFragment<RawName> = serde_json::from_value(schema_json).unwrap();
+        let schema: ValidatorSchemaFragment = sfrag.try_into().unwrap();
         let mut type_defs = HashMap::new();
         for def in schema.0 {
             type_defs.extend(def.type_defs.type_defs.into_iter());
@@ -2572,7 +2569,7 @@ mod test_resolver {
 
     #[test]
     fn test_simple() {
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2587,8 +2584,7 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema).unwrap();
         assert_eq!(
             res,
@@ -2598,7 +2594,7 @@ mod test_resolver {
             ])
         );
 
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2616,8 +2612,7 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema).unwrap();
         assert_eq!(
             res,
@@ -2631,7 +2626,7 @@ mod test_resolver {
 
     #[test]
     fn test_set() {
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2649,8 +2644,7 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema).unwrap();
         assert_eq!(
             res,
@@ -2663,7 +2657,7 @@ mod test_resolver {
 
     #[test]
     fn test_record() {
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2683,8 +2677,7 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema).unwrap();
         assert_eq!(
             res,
@@ -2703,7 +2696,7 @@ mod test_resolver {
 
     #[test]
     fn test_names() {
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "A": {
                     "entityTypes": {},
@@ -2724,8 +2717,7 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema).unwrap();
         assert_eq!(
             res,
@@ -2739,7 +2731,7 @@ mod test_resolver {
     #[test]
     fn test_cycles() {
         // self reference
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2751,13 +2743,12 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
 
         // 2 node loop
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2772,13 +2763,12 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
 
         // 3 node loop
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "": {
                     "entityTypes": {},
@@ -2796,13 +2786,12 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
 
         // cross-namespace 2 node loop
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "A": {
                     "entityTypes": {},
@@ -2823,13 +2812,12 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
 
         // cross-namespace 3 node loop
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "A": {
                     "entityTypes": {},
@@ -2859,13 +2847,12 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
 
         // cross-namespace 3 node loop
-        let schema = serde_json::from_value::<SchemaFragment>(serde_json::json!(
+        let schema = serde_json::json!(
             {
                 "A": {
                     "entityTypes": {},
@@ -2889,8 +2876,7 @@ mod test_resolver {
                     }
                 }
             }
-        ))
-        .unwrap();
+        );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
     }

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -51,7 +51,7 @@ use crate::{fuzzy_match::fuzzy_search, types::OpenTag};
 /// In this representation, there may still be references to undeclared
 /// entity/common types, because any entity/common type may be declared in a
 /// different fragment that will only be known about when building the complete
-/// [`ValidatorSchema`].
+/// [`crate::ValidatorSchema`].
 ///
 /// In this representation, entity/common type names are fully
 /// qualified/disambiguated. This means that implicit namespace prepending no

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -37,26 +37,21 @@ use crate::{
     err::{schema_errors::*, Result, SchemaError},
     schema_file_format,
     types::{AttributeType, Attributes, Type},
-    ActionBehavior, ActionEntityUID, ActionType, NamespaceDefinition, SchemaType,
+    ActionBehavior, ActionEntityUID, ActionType, NamespaceDefinition, RawName, SchemaType,
     SchemaTypeVariant, TypeOfAttribute, PRIMITIVE_TYPES,
 };
 use crate::{fuzzy_match::fuzzy_search, types::OpenTag};
 
-/// The current schema format specification does not include multiple action entity
-/// types. All action entities are required to use a single `Action` entity
-/// type. However, the action entity type may be namespaced, so an action entity
-/// may have a fully qualified entity type `My::Namespace::Action`.
-
 /// A single namespace definition from the schema json or human syntax,
 /// processed into a form which is closer to that used by the validator.
-///
 /// The processing includes detection of some errors, for example, parse errors
 /// in entity/common type names or entity/common types which are declared
 /// multiple times.
 ///
-/// This does not detect references to undeclared entity/common types because
-/// any entity/common type may be declared in a different fragment that will
-/// only be known about when building the complete `ValidatorSchema`.
+/// In this representation, there may still be references to undeclared
+/// entity/common types, because any entity/common type may be declared in a
+/// different fragment that will only be known about when building the complete
+/// [`ValidatorSchema`].
 ///
 /// In this representation, entity/common type names are fully
 /// qualified/disambiguated. This means that implicit namespace prepending no
@@ -66,8 +61,8 @@ use crate::{fuzzy_match::fuzzy_search, types::OpenTag};
 /// as a key in the `type_defs` / `entity_types` maps).
 #[derive(Debug)]
 pub struct ValidatorNamespaceDef {
-    /// The name of the namespace this is a definition of, or `None` if this is
-    /// a definition for the empty namespace.
+    /// The (fully-qualified) name of the namespace this is a definition of, or
+    /// `None` if this is a definition for the empty namespace.
     ///
     /// This is informational only; it does not change the semantics of any
     /// definition in `type_defs`, `entity_types`, or `actions`. All
@@ -85,26 +80,25 @@ pub struct ValidatorNamespaceDef {
     pub(super) actions: ActionsDef,
 }
 
-/// Holds a map from (fully qualified) `Name`s of common type definitions to
-/// their corresponding `SchemaType`. The common type `Name`s (keys in the map)
-/// are fully qualified, and inside the `SchemaType`s (values in the map), all
-/// entity/common type references are also fully qualified.
+/// Holds a map from (fully qualified) [`Name`]s of common type definitions to
+/// their corresponding [`SchemaType`]. The common type [`Name`]s (keys in the
+/// map) are fully qualified, and inside the [`SchemaType`]s (values in the
+/// map), all entity/common type references are also fully qualified.
 #[derive(Debug)]
 pub struct TypeDefs {
-    pub(super) type_defs: HashMap<Name, SchemaType>,
+    pub(super) type_defs: HashMap<Name, SchemaType<Name>>,
 }
 
-/// Holds a map from (fully qualified) `Name`s of entity type definitions to
-/// their corresponding `EntityTypeFragment`. The entity type `Name`s (keys in
-/// the map) are fully qualified, and inside the `EntityTypeFragment`s (values
+/// Holds a map from (fully qualified) [`EntityType`]s (names of entity types) to
+/// their corresponding [`EntityTypeFragment`]. The [`EntityType`] keys in
+/// the map are fully qualified, and inside the [`EntityTypeFragment`]s (values
 /// in the map), all entity/common type references are also fully qualified.
 ///
-/// However, inside the `EntityTypeFragment`s, entity type parents and
+/// However, inside the [`EntityTypeFragment`]s, entity type parents and
 /// attributes may reference undeclared (but fully qualified) entity/common
-/// types.
+/// types (that will be declared in a different schema fragment).
 ///
-/// All entity type `Name` keys in this map are declared in this schema
-/// fragment.
+/// All [`EntityType`] keys in this map are declared in this schema fragment.
 #[derive(Debug)]
 pub struct EntityTypesDef {
     pub(super) entity_types: HashMap<EntityType, EntityTypeFragment>,
@@ -127,18 +121,24 @@ pub struct EntityTypeFragment {
     /// These are fully qualified entity types, but may be entity types declared
     /// in a different namespace or schema fragment.
     /// We will check for undeclared parent types when combining fragments into
-    /// a `ValidatorSchema`.
+    /// a [`crate::ValidatorSchema`].
     pub(super) parents: HashSet<EntityType>,
 }
 
-/// Holds a map from (fully qualified) `EntityUID`s of action definitions
-/// to their corresponding `ActionFragment`. The action `EntityUID`s (keys in the map)
-/// are fully qualified, and inside the `ActionFragment`s (values in the map),
-/// all entity/common type references (including references to other actions)
-/// are also fully qualified.
+/// Holds a map from (fully qualified) [`EntityUID`]s of action definitions
+/// to their corresponding [`ActionFragment`]. The action [`EntityUID`]s (keys
+/// in the map) are fully qualified, and inside the [`ActionFragment`]s (values
+/// in the map), all entity/common type references (including references to
+/// other actions) are also fully qualified.
 ///
-/// However, the `ActionFragment`s may reference undeclared (but fully
-/// qualified) entity/common types and actions.
+/// However, the [`ActionFragment`]s may reference undeclared (but fully
+/// qualified) entity/common types and actions (that will be declared in a
+/// different schema fragment).
+///
+/// The current schema format specification does not include multiple action entity
+/// types. All action entities are required to use a single `Action` entity
+/// type. However, the action entity type may be namespaced, so an action entity
+/// may have a fully qualified entity type `My::Namespace::Action`.
 #[derive(Debug)]
 pub struct ActionsDef {
     pub(super) actions: HashMap<EntityUID, ActionFragment>,
@@ -148,8 +148,9 @@ pub struct ActionsDef {
 ///
 /// In this representation, references to common types may not yet have been
 /// fully resolved/inlined. But, all entity/common type references (including
-/// references to other actions) are fully qualified. This `ActionFragment` may
-/// reference undeclared (but fully qualified) entity/common types and actions.
+/// references to other actions) are fully qulaified. This [`ActionFragment`]
+/// may also reference undeclared entity/common types and actions (that will be
+/// declared in a different schema fragment).
 #[derive(Debug)]
 pub struct ActionFragment {
     /// The type of the context record for this action. The type is wrapped in
@@ -163,7 +164,7 @@ pub struct ActionFragment {
     /// These are fully qualified `EntityUID`s, but may be actions declared in a
     /// different namespace or schema fragment, and thus not declared yet.
     /// We will check for undeclared parents when combining fragments into a
-    /// `ValidatorSchema`.
+    /// [`crate::ValidatorSchema`].
     pub(super) parents: HashSet<EntityUID>,
     /// The types for the attributes defined for this actions entity.
     /// Here, common types have been fully resolved/inlined.
@@ -223,7 +224,7 @@ impl<T: std::fmt::Debug> std::fmt::Debug for WithUnresolvedTypeDefs<T> {
     }
 }
 
-impl TryInto<ValidatorNamespaceDef> for NamespaceDefinition {
+impl TryInto<ValidatorNamespaceDef> for NamespaceDefinition<RawName> {
     type Error = SchemaError;
 
     fn try_into(self) -> Result<ValidatorNamespaceDef> {
@@ -240,7 +241,7 @@ impl ValidatorNamespaceDef {
     /// Construct a new `ValidatorNamespaceDef` from the underlying `NamespaceDefinition`
     pub fn from_namespace_definition(
         namespace: Option<Name>,
-        namespace_def: NamespaceDefinition,
+        namespace_def: NamespaceDefinition<RawName>,
         action_behavior: ActionBehavior,
         extensions: Extensions<'_>,
     ) -> Result<ValidatorNamespaceDef> {
@@ -269,7 +270,7 @@ impl ValidatorNamespaceDef {
     }
 
     fn build_type_defs(
-        schema_file_type_def: HashMap<Id, SchemaType>,
+        schema_file_type_def: HashMap<Id, SchemaType<RawName>>,
         schema_namespace: Option<&Name>,
     ) -> Result<TypeDefs> {
         let mut type_defs = HashMap::with_capacity(schema_file_type_def.len());
@@ -279,16 +280,14 @@ impl ValidatorNamespaceDef {
                     CommonTypeNameConflictError(id),
                 ));
             }
-            let name = Name::from(id.clone()).prefix_namespace_if_unqualified(schema_namespace);
+            let name = RawName::new(id).qualify_with(schema_namespace);
             match type_defs.entry(name) {
                 Entry::Vacant(ventry) => {
-                    ventry.insert(
-                        schema_ty.prefix_common_type_references_with_namespace(schema_namespace),
-                    );
+                    ventry.insert(schema_ty.qualify_type_references(schema_namespace));
                 }
-                Entry::Occupied(_) => {
+                Entry::Occupied(oentry) => {
                     return Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError(
-                        Name::unqualified_name(id),
+                        oentry.key().clone(),
                     )));
                 }
             }
@@ -300,28 +299,30 @@ impl ValidatorNamespaceDef {
     // used internally by the validator. This is mostly accomplished by directly
     // copying data between fields.
     fn build_entity_types(
-        schema_files_types: HashMap<Id, schema_file_format::EntityType>,
+        schema_files_types: HashMap<Id, schema_file_format::EntityType<RawName>>,
         schema_namespace: Option<&Name>,
         extensions: Extensions<'_>,
     ) -> Result<EntityTypesDef> {
         let mut entity_types: HashMap<EntityType, _> =
             HashMap::with_capacity(schema_files_types.len());
         for (id, entity_type) in schema_files_types {
-            let name = cedar_policy_core::ast::EntityType::from(
-                Name::from(id.clone()).prefix_namespace_if_unqualified(schema_namespace),
+            let ety = cedar_policy_core::ast::EntityType::from(
+                RawName::new(id.clone()).qualify_with(schema_namespace),
             );
-            match entity_types.entry(name) {
+            match entity_types.entry(ety) {
                 Entry::Vacant(ventry) => {
                     ventry.insert(EntityTypeFragment {
                         attributes: Self::try_schema_type_into_validator_type(
-                            schema_namespace,
-                            entity_type.shape.into_inner(),
+                            entity_type
+                                .shape
+                                .into_inner()
+                                .qualify_type_references(schema_namespace),
                             extensions,
                         )?,
                         parents: entity_type
                             .member_of_types
                             .into_iter()
-                            .map(|ty| ty.prefix_namespace_if_unqualified(schema_namespace))
+                            .map(|raw_name| raw_name.qualify_with(schema_namespace).into())
                             .collect(),
                     });
                 }
@@ -439,14 +440,14 @@ impl ValidatorNamespaceDef {
     // internally by the validator. This is mostly accomplished by directly
     // copying data between fields.
     fn build_action_ids(
-        schema_file_actions: HashMap<SmolStr, ActionType>,
+        schema_file_actions: HashMap<SmolStr, ActionType<RawName>>,
         schema_namespace: Option<&Name>,
         extensions: Extensions<'_>,
     ) -> Result<ActionsDef> {
         let mut actions = HashMap::with_capacity(schema_file_actions.len());
         for (action_id_str, action_type) in schema_file_actions {
             let action_id = Self::parse_action_id_with_namespace(
-                &ActionEntityUID::default_type(action_id_str.clone()),
+                ActionEntityUID::default_type(action_id_str.clone()),
                 schema_namespace,
             );
             match actions.entry(action_id) {
@@ -471,15 +472,16 @@ impl ValidatorNamespaceDef {
                     );
 
                     let context = Self::try_schema_type_into_validator_type(
-                        schema_namespace,
-                        context.into_inner(),
+                        context
+                            .into_inner()
+                            .qualify_type_references(schema_namespace),
                         extensions,
                     )?;
 
                     let parents = action_type
                         .member_of
                         .unwrap_or_default()
-                        .iter()
+                        .into_iter()
                         .map(|parent| {
                             Self::parse_action_id_with_namespace(parent, schema_namespace)
                         })
@@ -513,8 +515,8 @@ impl ValidatorNamespaceDef {
     // should not be used in groups and should not have attributes, then this
     // function will return `Err` if it sees any action groups or attributes
     // declared in the schema.
-    fn check_action_behavior(
-        schema_file: &NamespaceDefinition,
+    fn check_action_behavior<N>(
+        schema_file: &NamespaceDefinition<N>,
         action_behavior: ActionBehavior,
     ) -> Result<()> {
         if schema_file
@@ -549,12 +551,11 @@ impl ValidatorNamespaceDef {
     }
 
     /// Given the attributes for an entity type or action context as written in
-    /// a schema file, convert the types of the attributes into the `Type` data
-    /// structure used by the typechecker, and return the result as a map from
-    /// attribute name to type.
+    /// a schema file (but with fully-qualified names), convert the types of the
+    /// attributes into the [`Type`] data structure used by the typechecker, and
+    /// return the result as an [`Attributes`] structure.
     fn parse_record_attributes(
-        schema_namespace: Option<&Name>,
-        attrs: impl IntoIterator<Item = (SmolStr, TypeOfAttribute)>,
+        attrs: impl IntoIterator<Item = (SmolStr, TypeOfAttribute<Name>)>,
         extensions: Extensions<'_>,
     ) -> Result<WithUnresolvedTypeDefs<Attributes>> {
         let attrs_with_type_defs = attrs
@@ -563,11 +564,7 @@ impl ValidatorNamespaceDef {
                 Ok((
                     attr,
                     (
-                        Self::try_schema_type_into_validator_type(
-                            schema_namespace,
-                            ty.ty,
-                            extensions,
-                        )?,
+                        Self::try_schema_type_into_validator_type(ty.ty, extensions)?,
                         ty.required,
                     ),
                 ))
@@ -586,18 +583,15 @@ impl ValidatorNamespaceDef {
         }))
     }
 
-    /// Take an optional list of entity type name strings from an action apply
-    /// spec and parse it into a set of `Name`s for those entity types.
+    /// Take a list of raw entity type names from an action apply spec and parse it
+    /// into a set of [`EntityType`]s for those entity types.
     fn parse_apply_spec_type_list(
-        types: Vec<EntityType>,
+        types: Vec<RawName>,
         namespace: Option<&Name>,
     ) -> HashSet<EntityType> {
         types
-            .iter()
-            // Parse each type name string into a `Name`, generating an
-            // `EntityTypeParseError` when the string is not a valid
-            // name.
-            .map(|ty| ty.prefix_namespace_if_unqualified(namespace))
+            .into_iter()
+            .map(|ty| ty.qualify_with(namespace).into())
             .collect::<HashSet<_>>()
     }
 
@@ -607,47 +601,43 @@ impl ValidatorNamespaceDef {
     /// namespace provided in the `namespace` argument or with the namespace
     /// inside the [`ActionEntityUID`] if one is present.
     fn parse_action_id_with_namespace(
-        action_id: &ActionEntityUID,
+        action_id: ActionEntityUID<RawName>,
         namespace: Option<&Name>,
     ) -> EntityUID {
-        let namespaced_action_type = if let Some(action_ty) = &action_id.ty {
-            action_ty.prefix_namespace_if_unqualified(namespace)
-        } else {
-            // PANIC SAFETY: The constant ACTION_ENTITY_TYPE is valid entity type.
-            #[allow(clippy::expect_used)]
-            let id = Id::from_normalized_str(cedar_policy_core::ast::ACTION_ENTITY_TYPE).expect(
-                "Expected that the constant ACTION_ENTITY_TYPE would be a valid entity type.",
-            );
-            match namespace {
-                Some(namespace) => Name::type_in_namespace(id, namespace.clone(), None),
-                None => Name::unqualified_name(id),
+        let action_ty = match action_id.ty {
+            Some(ty) => ty.clone(),
+            None => {
+                // PANIC SAFETY: The constant ACTION_ENTITY_TYPE is valid entity type.
+                #[allow(clippy::expect_used)]
+                RawName::new(Id::from_normalized_str(cedar_policy_core::ast::ACTION_ENTITY_TYPE).expect(
+                    "Expected that the constant ACTION_ENTITY_TYPE would be a valid entity type.",
+                ))
             }
         };
         EntityUID::from_components(
-            namespaced_action_type.into(),
-            Eid::new(action_id.id.clone()),
+            action_ty.qualify_with(namespace).into(),
+            Eid::new(action_id.id),
             None,
         )
     }
 
-    /// Implemented to convert a type as written in the schema json format into the
-    /// `Type` type used by the validator. Conversion can fail if an entity or
-    /// record attribute name is invalid. It will also fail for some types that can
-    /// be written in the schema, but are not yet implemented in the typechecking
-    /// logic.
+    /// Implemented to convert a type as written in the schema json format (but with
+    /// fully-qualified names) into the [`Type`] type used by the validator.
+    ///
+    /// Conversion can fail if an entity or record attribute name is invalid. It
+    /// will also fail for some types that can be written in the schema, but are
+    /// not yet implemented in the typechecking logic.
     pub(crate) fn try_schema_type_into_validator_type(
-        default_namespace: Option<&Name>,
-        schema_ty: SchemaType,
+        schema_ty: SchemaType<Name>,
         extensions: Extensions<'_>,
     ) -> Result<WithUnresolvedTypeDefs<Type>> {
         match schema_ty {
             SchemaType::Type(SchemaTypeVariant::String) => Ok(Type::primitive_string().into()),
             SchemaType::Type(SchemaTypeVariant::Long) => Ok(Type::primitive_long().into()),
             SchemaType::Type(SchemaTypeVariant::Boolean) => Ok(Type::primitive_boolean().into()),
-            SchemaType::Type(SchemaTypeVariant::Set { element }) => Ok(
-                Self::try_schema_type_into_validator_type(default_namespace, *element, extensions)?
-                    .map(Type::set),
-            ),
+            SchemaType::Type(SchemaTypeVariant::Set { element }) => {
+                Ok(Self::try_schema_type_into_validator_type(*element, extensions)?.map(Type::set))
+            }
             SchemaType::Type(SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes,
@@ -656,25 +646,21 @@ impl ValidatorNamespaceDef {
                     Err(UnsupportedFeatureError(UnsupportedFeature::OpenRecordsAndEntities).into())
                 } else {
                     Ok(
-                        Self::parse_record_attributes(default_namespace, attributes, extensions)?
-                            .map(move |attrs| {
-                                Type::record_with_attributes(
-                                    attrs,
-                                    if additional_attributes {
-                                        OpenTag::OpenAttributes
-                                    } else {
-                                        OpenTag::ClosedAttributes
-                                    },
-                                )
-                            }),
+                        Self::parse_record_attributes(attributes, extensions)?.map(move |attrs| {
+                            Type::record_with_attributes(
+                                attrs,
+                                if additional_attributes {
+                                    OpenTag::OpenAttributes
+                                } else {
+                                    OpenTag::ClosedAttributes
+                                },
+                            )
+                        }),
                     )
                 }
             }
             SchemaType::Type(SchemaTypeVariant::Entity { name }) => {
-                Ok(Type::named_entity_reference(
-                    name.prefix_namespace_if_unqualified(default_namespace),
-                )
-                .into())
+                Ok(Type::named_entity_reference(name.into()).into())
             }
             SchemaType::Type(SchemaTypeVariant::Extension { name }) => {
                 let extension_type_name = Name::unqualified_name(name);
@@ -696,16 +682,12 @@ impl ValidatorNamespaceDef {
                     ))
                 }
             }
-            SchemaType::TypeDef { type_name } => {
-                let defined_type_name =
-                    type_name.prefix_namespace_if_unqualified(default_namespace);
-                Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
-                    typ_defs
-                        .get(&defined_type_name)
-                        .cloned()
-                        .ok_or(UndeclaredCommonTypesError(defined_type_name).into())
-                }))
-            }
+            SchemaType::TypeDef { type_name } => Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
+                typ_defs
+                    .get(&type_name)
+                    .cloned()
+                    .ok_or(UndeclaredCommonTypesError(type_name).into())
+            })),
         }
     }
 

--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -1,0 +1,93 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cedar_policy_core::ast::{Id, Name};
+use cedar_policy_core::parser::Loc;
+use serde::{Deserialize, Serialize};
+
+/// A newtype which indicates that the contained `Name` may not yet be
+/// fully-qualified.
+///
+/// You can convert it to a fully-qualified `Name` using `.qualify_with()`.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct RawName(Name);
+
+impl RawName {
+    /// Create a new `RawName` from the given `Id`
+    pub fn new(id: Id) -> Self {
+        Self(Name::unqualified_name(id))
+    }
+
+    /// Create a new `RawName` from a basename, namespace components as `Id`s, and optional source location
+    pub fn from_components(
+        basename: Id,
+        namespace: impl IntoIterator<Item = Id>,
+        loc: Option<Loc>,
+    ) -> Self {
+        Self(Name::new(basename, namespace, loc))
+    }
+
+    /// Create a new `RawName` by parsing the provided string, which should contain
+    /// an unqualified `Name` (no explicit namespaces)
+    pub fn parse_unqualified_name(
+        s: &str,
+    ) -> Result<Self, cedar_policy_core::parser::err::ParseErrors> {
+        Name::parse_unqualified_name(s).map(RawName)
+    }
+
+    /// Create a new `RawName` by parsing the provided string, which should contain
+    /// a `Name` in normalized form.
+    ///
+    /// (See the [`cedar_policy_core::FromNormalizedStr`] trait.)
+    pub fn from_normalized_str(
+        s: &str,
+    ) -> Result<Self, cedar_policy_core::parser::err::ParseErrors> {
+        use cedar_policy_core::FromNormalizedStr;
+        Name::from_normalized_str(s).map(RawName)
+    }
+
+    /// Is this `RawName` unqualified, that is, written without any _explicit_
+    /// namespaces.
+    /// (This method returning `true` does not imply that the `RawName` will
+    /// _eventually resolve_ to an unqualified name.)
+    pub fn is_unqualified(&self) -> bool {
+        self.0.is_unqualified()
+    }
+
+    /// Convert this `RawName` to a `Name` by adding the given `ns` as its
+    /// prefix, or by no-op if `ns` is `None`.
+    ///
+    /// Note that if the `RawName` already had a non-empty explicit namespace,
+    /// no additional prefixing will be done, even if `ns` is `Some`.
+    pub fn qualify_with(self, ns: Option<&Name>) -> Name {
+        self.0.prefix_namespace_if_unqualified(ns)
+    }
+}
+
+impl std::fmt::Display for RawName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::str::FromStr for RawName {
+    type Err = <Name as std::str::FromStr>::Err;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Name::from_str(s).map(RawName)
+    }
+}

--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -75,7 +75,7 @@ impl RawName {
     /// Note that if the `RawName` already had a non-empty explicit namespace,
     /// no additional prefixing will be done, even if `ns` is `Some`.
     pub fn qualify_with(self, ns: Option<&Name>) -> Name {
-        self.0.prefix_namespace_if_unqualified(ns)
+        self.0.qualify_with(ns)
     }
 }
 

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -318,7 +318,7 @@ pub struct ApplySpec<N> {
     pub context: AttributesOrContext<N>,
 }
 
-/// Represents the [`ast::EntityUID`] of an action
+/// Represents the [`cedar_policy_core::ast::EntityUID`] of an action
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(deny_unknown_fields)]
@@ -326,7 +326,7 @@ pub struct ApplySpec<N> {
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct ActionEntityUID<N> {
-    /// Represents the [`ast::Eid`] of the action
+    /// Represents the [`cedar_policy_core::ast::Eid`] of the action
     pub id: SmolStr,
 
     /// Represents the type of the action.
@@ -339,7 +339,7 @@ pub struct ActionEntityUID<N> {
 }
 
 impl<N> ActionEntityUID<N> {
-    /// Given an `id`, get the `ActionEntityUID` representing `Action::<id>`.
+    /// Given an `id`, get the [`ActionEntityUID`] representing `Action::<id>`.
     pub fn default_type(id: SmolStr) -> Self {
         Self { id, ty: None }
     }
@@ -356,8 +356,8 @@ impl<N: std::fmt::Display> std::fmt::Display for ActionEntityUID<N> {
     }
 }
 
-/// A restricted version of the `Type` enum containing only the types which are
-/// exposed to users.
+/// A restricted version of the [`crate::types::Type`] enum containing only the types
+/// which are exposed to users.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
 /// this [`SchemaType`], including recursively.
@@ -403,9 +403,9 @@ impl<N> SchemaType<N> {
     }
 
     /// Is this [`SchemaType`] an extension type, or does it contain one
-    /// (recursively)? Returns `None` if this is a [`TypeDef`] because we can't
+    /// (recursively)? Returns `None` if this is a `TypeDef` because we can't
     /// easily properly check the type of a typedef, accounting for namespaces,
-    /// without first converting to a [`Type`].
+    /// without first converting to a [`crate::types::Type`].
     pub fn is_extension(&self) -> Option<bool> {
         match self {
             Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -15,7 +15,7 @@
  */
 
 use cedar_policy_core::{
-    ast::{self, Id, Name},
+    ast::{Id, Name},
     entities::CedarValueJson,
     FromNormalizedStr,
 };
@@ -26,43 +26,55 @@ use serde::{
 };
 use serde_with::serde_as;
 use smol_str::{SmolStr, ToSmolStr};
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt::Display,
+    marker::PhantomData,
+};
 
 use crate::{
     err::{schema_errors::*, Result},
     human_schema::{
         self, fmt::ToHumanSchemaSyntaxError, parser::parse_natural_schema_fragment, SchemaWarning,
     },
-    HumanSchemaError, HumanSyntaxParseError,
+    HumanSchemaError, HumanSyntaxParseError, RawName,
 };
 
-#[cfg(feature = "wasm")]
-extern crate tsify;
-
-/// A `SchemaFragment` is split into multiple namespace definitions, and is just
+/// A [`SchemaFragment`] is split into multiple namespace definitions, and is just
 /// a map from namespace name to namespace definition (i.e., definitions of
 /// common types, entity types, and actions in that namespace).
 /// The namespace name is implicitly applied to all definitions in the
-/// corresponding `NamespaceDefinition`.
+/// corresponding [`NamespaceDefinition`].
 /// See [`NamespaceDefinition`].
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// attributes/parents fields in this [`SchemaFragment`], including
+/// recursively. (It doesn't affect the type of common and entity type names
+/// _that are being declared here_, which is always an [`Id`] and unambiguously
+/// refers to the [`Name`] with the appropriate implicit namespace prepended.)
+/// For example:
+/// - `N` = [`RawName`]: This is the schema JSON format exposed to users
+/// - `N` = [`Name`]: a [`SchemaFragment`] in which all names have been
+///     resolved into fully-qualified [`Name`]s
 #[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct SchemaFragment(
+pub struct SchemaFragment<N>(
     #[serde(deserialize_with = "deserialize_schema_fragment")]
     #[cfg_attr(feature = "wasm", tsify(type = "Record<string, NamespaceDefinition>"))]
-    pub HashMap<Option<Name>, NamespaceDefinition>,
+    pub HashMap<Option<Name>, NamespaceDefinition<N>>,
 );
 
 /// Custom deserializer to ensure that the empty namespace is mapped to `None`
-fn deserialize_schema_fragment<'de, D>(
+fn deserialize_schema_fragment<'de, D, N: Deserialize<'de> + From<RawName>>(
     deserializer: D,
-) -> std::result::Result<HashMap<Option<Name>, NamespaceDefinition>, D::Error>
+) -> std::result::Result<HashMap<Option<Name>, NamespaceDefinition<N>>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let raw: HashMap<SmolStr, NamespaceDefinition> =
+    let raw: HashMap<SmolStr, NamespaceDefinition<N>> =
         serde_with::rust::maps_duplicate_key_is_error::deserialize(deserializer)?;
     Ok(HashMap::from_iter(
         raw.into_iter()
@@ -76,11 +88,12 @@ where
                 };
                 Ok((key, value))
             })
-            .collect::<std::result::Result<Vec<(Option<Name>, NamespaceDefinition)>, D::Error>>()?,
+            .collect::<std::result::Result<Vec<(Option<Name>, NamespaceDefinition<N>)>, D::Error>>(
+            )?,
     ))
 }
 
-impl Serialize for SchemaFragment {
+impl<N: Serialize> Serialize for SchemaFragment<N> {
     /// Custom serializer to ensure that `None` is mapped to the empty namespace
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -98,8 +111,8 @@ impl Serialize for SchemaFragment {
     }
 }
 
-impl SchemaFragment {
-    /// Cretae a [`SchemaFragment`] from a string containing JSON (which should
+impl SchemaFragment<RawName> {
+    /// Create a [`SchemaFragment`] from a string containing JSON (which should
     /// be an object of the appropriate shape).
     pub fn from_json_str(json: &str) -> Result<Self> {
         serde_json::from_str(json).map_err(|e| JsonDeserializationError::new(e, Some(json)).into())
@@ -131,7 +144,9 @@ impl SchemaFragment {
         file.read_to_string(&mut src)?;
         Self::from_str_natural(&src)
     }
+}
 
+impl<N: Display> SchemaFragment<N> {
     /// Pretty print this [`SchemaFragment`]
     pub fn as_natural_schema(&self) -> std::result::Result<String, ToHumanSchemaSyntaxError> {
         let src = human_schema::fmt::json_schema_to_custom_schema_str(self)?;
@@ -141,28 +156,37 @@ impl SchemaFragment {
 
 /// A single namespace definition from a SchemaFragment.
 /// This is composed of common types, entity types, and action definitions.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// attributes/parents fields in this [`NamespaceDefinition`], including
+/// recursively. (It doesn't affect the type of common and entity type names
+/// _that are being declared here_, which is always an `Id` and unambiguously
+/// refers to the `Name` with the implicit current/active namespace prepended.)
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde_as]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+#[serde(bound(serialize = "N: Serialize"))]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct NamespaceDefinition {
+pub struct NamespaceDefinition<N> {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    pub common_types: HashMap<Id, SchemaType>,
+    pub common_types: HashMap<Id, SchemaType<N>>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    pub entity_types: HashMap<Id, EntityType>,
+    pub entity_types: HashMap<Id, EntityType<N>>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    pub actions: HashMap<SmolStr, ActionType>,
+    pub actions: HashMap<SmolStr, ActionType<N>>,
 }
 
-impl NamespaceDefinition {
+impl<N> NamespaceDefinition<N> {
     pub fn new(
-        entity_types: impl IntoIterator<Item = (Id, EntityType)>,
-        actions: impl IntoIterator<Item = (SmolStr, ActionType)>,
+        entity_types: impl IntoIterator<Item = (Id, EntityType<N>)>,
+        actions: impl IntoIterator<Item = (SmolStr, ActionType<N>)>,
     ) -> Self {
         Self {
             common_types: HashMap::new(),
@@ -176,38 +200,48 @@ impl NamespaceDefinition {
 /// Entity types describe the relationships in the entity store, including what
 /// entities can be members of groups of what types, and what attributes
 /// can/should be included on entities of each type.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`EntityType`], including recursively.
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct EntityType {
+pub struct EntityType<N> {
     /// Entities of this [`EntityType`] are allowed to be members of entities of
     /// these types.
     #[serde(default)]
     #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub member_of_types: Vec<cedar_policy_core::ast::EntityType>,
+    pub member_of_types: Vec<N>,
     /// Description of the attributes for entities of this [`EntityType`].
     #[serde(default)]
     #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
-    pub shape: AttributesOrContext,
+    pub shape: AttributesOrContext<N>,
 }
 
 /// Declaration of entity attributes, or of an action context.
 /// These share a JSON format.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`AttributesOrContext`], including recursively.
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct AttributesOrContext(
+pub struct AttributesOrContext<N>(
     // We use the usual `SchemaType` deserialization, but it will ultimately
     // need to be a `Record` or type def which resolves to a `Record`.
-    pub SchemaType,
+    pub SchemaType<N>,
 );
 
-impl AttributesOrContext {
+impl<N> AttributesOrContext<N> {
     /// Convert the `AttributesOrContext` into its `SchemaType`.
-    pub fn into_inner(self) -> SchemaType {
+    pub fn into_inner(self) -> SchemaType<N> {
         self.0
     }
 
@@ -217,7 +251,7 @@ impl AttributesOrContext {
     }
 }
 
-impl Default for AttributesOrContext {
+impl<N> Default for AttributesOrContext<N> {
     fn default() -> Self {
         Self(SchemaType::Type(SchemaTypeVariant::Record {
             attributes: BTreeMap::new(),
@@ -229,14 +263,19 @@ impl Default for AttributesOrContext {
 /// An [`ActionType`] describes a specific action entity.
 /// It also describes what principals/resources/contexts are valid for the
 /// action.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`ActionType`], including recursively.
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct ActionType {
+pub struct ActionType<N> {
     /// This maps attribute names to
-    /// `cedar_policy_core::entities::json::value::CedarValueJson` which is the
+    /// `cedar_policy_core::entities::CedarValueJson` which is the
     /// canonical representation of a cedar value as JSON.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -244,46 +283,49 @@ pub struct ActionType {
     /// Describes what principals/resources/contexts are valid for this action.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub applies_to: Option<ApplySpec>,
+    pub applies_to: Option<ApplySpec<N>>,
     /// Which actions are parents of this action.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_of: Option<Vec<ActionEntityUID>>,
+    pub member_of: Option<Vec<ActionEntityUID<N>>>,
 }
 
 /// The apply spec specifies what principals and resources an action can be used
 /// with.  This specification can either be done through containing to entity
-/// types. The fields of this record are optional so that they can be omitted to
-/// declare that the apply spec for the principal or resource is undefined,
-/// meaning that the action can be applied to any principal or resource. This is
-/// different than providing an empty list because the empty list is interpreted
-/// as specifying that there are no principals or resources that an action
-/// applies to.
+/// types.
+/// An empty list is interpreted as specifying that there are no principals or
+/// resources that an action applies to.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`ApplySpec`], including recursively.
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct ApplySpec {
+pub struct ApplySpec<N> {
     /// Resource types that are valid for the action
     #[serde(default)]
-    pub resource_types: Vec<ast::EntityType>,
+    pub resource_types: Vec<N>,
     /// Principal types that are valid for the action
     #[serde(default)]
-    pub principal_types: Vec<ast::EntityType>,
+    pub principal_types: Vec<N>,
     /// Context type that this action expects
     #[serde(default)]
     #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
-    pub context: AttributesOrContext,
+    pub context: AttributesOrContext<N>,
 }
 
 /// Represents the [`ast::EntityUID`] of an action
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(deny_unknown_fields)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct ActionEntityUID {
+pub struct ActionEntityUID<N> {
     /// Represents the [`ast::Eid`] of the action
     pub id: SmolStr,
 
@@ -293,17 +335,17 @@ pub struct ActionEntityUID {
     #[serde(rename = "type")]
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub ty: Option<Name>,
+    pub ty: Option<N>,
 }
 
-impl ActionEntityUID {
+impl<N> ActionEntityUID<N> {
     /// Given an `id`, get the `ActionEntityUID` representing `Action::<id>`.
     pub fn default_type(id: SmolStr) -> Self {
         Self { id, ty: None }
     }
 }
 
-impl std::fmt::Display for ActionEntityUID {
+impl<N: std::fmt::Display> std::fmt::Display for ActionEntityUID<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(ty) = &self.ty {
             write!(f, "{}::", ty)?
@@ -316,6 +358,10 @@ impl std::fmt::Display for ActionEntityUID {
 
 /// A restricted version of the `Type` enum containing only the types which are
 /// exposed to users.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`SchemaType`], including recursively.
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 // This enum is `untagged` with these variants as a workaround to a serde
 // limitation. It is not possible to have the known variants on one enum, and
@@ -324,20 +370,23 @@ impl std::fmt::Display for ActionEntityUID {
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum SchemaType {
+pub enum SchemaType<N> {
     /// One of the standard types exposed to users
-    Type(SchemaTypeVariant),
+    Type(SchemaTypeVariant<N>),
     /// A common type ("typedef")
     TypeDef {
-        /// Name of the common type
+        /// Name of the common type.
+        /// For the important case of `N` = [`RawName`], this is the schema JSON
+        /// format, and the `RawName` is exactly how it appears in the schema;
+        /// may not yet be fully qualified
         #[serde(rename = "type")]
-        type_name: Name,
+        type_name: N,
     },
 }
 
-impl SchemaType {
+impl<N> SchemaType<N> {
     /// Return an iterator of common type references ocurred in the type
-    pub(crate) fn common_type_references(&self) -> Box<dyn Iterator<Item = Name>> {
+    pub(crate) fn common_type_references(&self) -> Box<dyn Iterator<Item = &N> + '_> {
         match self {
             SchemaType::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
                 .iter()
@@ -348,56 +397,78 @@ impl SchemaType {
             SchemaType::Type(SchemaTypeVariant::Set { element }) => {
                 element.common_type_references()
             }
-            SchemaType::TypeDef { type_name } => Box::new(std::iter::once(type_name.clone())),
+            SchemaType::TypeDef { type_name } => Box::new(std::iter::once(type_name)),
             _ => Box::new(std::iter::empty()),
         }
     }
 
-    /// Prefix unqualified common type references with the namespace they are in
-    pub(crate) fn prefix_common_type_references_with_namespace(
-        self,
-        ns: Option<&Name>,
-    ) -> SchemaType {
+    /// Is this [`SchemaType`] an extension type, or does it contain one
+    /// (recursively)? Returns `None` if this is a [`TypeDef`] because we can't
+    /// easily properly check the type of a typedef, accounting for namespaces,
+    /// without first converting to a [`Type`].
+    pub fn is_extension(&self) -> Option<bool> {
+        match self {
+            Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
+            Self::Type(SchemaTypeVariant::Set { element }) => element.is_extension(),
+            Self::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
+                .values()
+                .try_fold(false, |a, e| match e.ty.is_extension() {
+                    Some(true) => Some(true),
+                    Some(false) => Some(a),
+                    None => None,
+                }),
+            Self::Type(_) => Some(false),
+            Self::TypeDef { .. } => None,
+        }
+    }
+
+    /// Is this [`SchemaType`] an empty record? This function is used by the `Display`
+    /// implementation to avoid printing unnecessary entity/action data.
+    pub fn is_empty_record(&self) -> bool {
         match self {
             Self::Type(SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes,
-            }) => Self::Type(SchemaTypeVariant::Record {
-                attributes: BTreeMap::from_iter(attributes.into_iter().map(
-                    |(attr, TypeOfAttribute { ty, required })| {
-                        (
-                            attr,
-                            TypeOfAttribute {
-                                ty: ty.prefix_common_type_references_with_namespace(ns),
-                                required,
-                            },
-                        )
-                    },
-                )),
-                additional_attributes,
-            }),
-            Self::Type(SchemaTypeVariant::Set { element }) => Self::Type(SchemaTypeVariant::Set {
-                element: Box::new(element.prefix_common_type_references_with_namespace(ns)),
-            }),
-            Self::TypeDef { type_name } => Self::TypeDef {
-                type_name: type_name.prefix_namespace_if_unqualified(ns),
-            },
-            _ => self,
+            }) => *additional_attributes == partial_schema_default() && attributes.is_empty(),
+            _ => false,
         }
     }
 }
 
-impl<'de> Deserialize<'de> for SchemaType {
+impl SchemaType<RawName> {
+    /// Prefix unqualified entity and common type references with the namespace they are in
+    pub(crate) fn qualify_type_references(self, ns: Option<&Name>) -> SchemaType<Name> {
+        match self {
+            Self::Type(stv) => SchemaType::Type(stv.qualify_type_references(ns)),
+            Self::TypeDef { type_name } => SchemaType::TypeDef {
+                type_name: type_name.qualify_with(ns),
+            },
+        }
+    }
+
+    fn into_n<N: From<RawName>>(self) -> SchemaType<N> {
+        match self {
+            Self::Type(stv) => SchemaType::Type(stv.into_n()),
+            Self::TypeDef { type_name } => SchemaType::TypeDef {
+                type_name: type_name.into(),
+            },
+        }
+    }
+}
+
+impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for SchemaType<N> {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(SchemaTypeVisitor)
+        deserializer.deserialize_any(SchemaTypeVisitor {
+            _phantom: PhantomData,
+        })
     }
 }
 
 /// The fields for a `SchemaTypes`. Used for implementing deserialization.
-#[derive(Hash, Eq, PartialEq, Deserialize)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 #[serde(field_identifier, rename_all = "camelCase")]
 enum TypeFields {
     Type,
@@ -447,13 +518,15 @@ impl TypeFields {
 #[derive(Deserialize)]
 struct AttributesTypeMap(
     #[serde(with = "serde_with::rust::maps_duplicate_key_is_error")]
-    BTreeMap<SmolStr, TypeOfAttribute>,
+    BTreeMap<SmolStr, TypeOfAttribute<RawName>>,
 );
 
-struct SchemaTypeVisitor;
+struct SchemaTypeVisitor<N> {
+    _phantom: PhantomData<N>,
+}
 
-impl<'de> Visitor<'de> for SchemaTypeVisitor {
-    type Value = SchemaType;
+impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for SchemaTypeVisitor<N> {
+    type Value = SchemaType<N>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("builtin type or reference to type defined in commonTypes")
@@ -471,7 +544,7 @@ impl<'de> Visitor<'de> for SchemaTypeVisitor {
         // field so not exist at all, so that the schema author can delete the
         // field without wasting time fixing errors in the value.
         let mut type_name: Option<std::result::Result<SmolStr, M::Error>> = None;
-        let mut element: Option<std::result::Result<SchemaType, M::Error>> = None;
+        let mut element: Option<std::result::Result<SchemaType<N>, M::Error>> = None;
         let mut attributes: Option<std::result::Result<AttributesTypeMap, M::Error>> = None;
         let mut additional_attributes: Option<std::result::Result<bool, M::Error>> = None;
         let mut name: Option<std::result::Result<SmolStr, M::Error>> = None;
@@ -523,28 +596,28 @@ impl<'de> Visitor<'de> for SchemaTypeVisitor {
 // PANIC SAFETY `Set`, `Record`, `Entity`, and `Extension` are valid `Name`s
 #[allow(clippy::expect_used)]
 pub(crate) mod static_names {
-    use cedar_policy_core::ast::Name;
+    use crate::RawName;
 
     lazy_static::lazy_static! {
-        pub(crate) static ref SET_NAME : Name = Name::parse_unqualified_name("Set").expect("valid identifier");
-        pub(crate) static ref RECORD_NAME : Name = Name::parse_unqualified_name("Record").expect("valid identifier");
-        pub(crate) static ref ENTITY_NAME : Name = Name::parse_unqualified_name("Entity").expect("valid identifier");
-        pub(crate) static ref EXTENSION_NAME : Name = Name::parse_unqualified_name("Extension").expect("valid identifier");
+        pub(crate) static ref SET_NAME : RawName = RawName::parse_unqualified_name("Set").expect("valid identifier");
+        pub(crate) static ref RECORD_NAME : RawName = RawName::parse_unqualified_name("Record").expect("valid identifier");
+        pub(crate) static ref ENTITY_NAME : RawName = RawName::parse_unqualified_name("Entity").expect("valid identifier");
+        pub(crate) static ref EXTENSION_NAME : RawName = RawName::parse_unqualified_name("Extension").expect("valid identifier");
     }
 }
 
-impl SchemaTypeVisitor {
+impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
     /// Construct a schema type given the name of the type and its fields.
     /// Fields which were not present are `None`. It is an error for a field
     /// which is not used for a particular type to be `Some` when building that
     /// type.
-    fn build_schema_type<'de, M>(
+    fn build_schema_type<M>(
         type_name: Option<std::result::Result<SmolStr, M::Error>>,
-        element: Option<std::result::Result<SchemaType, M::Error>>,
+        element: Option<std::result::Result<SchemaType<N>, M::Error>>,
         attributes: Option<std::result::Result<AttributesTypeMap, M::Error>>,
         additional_attributes: Option<std::result::Result<bool, M::Error>>,
         name: Option<std::result::Result<SmolStr, M::Error>>,
-    ) -> std::result::Result<SchemaType, M::Error>
+    ) -> std::result::Result<SchemaType<N>, M::Error>
     where
         M: MapAccess<'de>,
     {
@@ -597,8 +670,9 @@ impl SchemaTypeVisitor {
                     }
                     "Set" => {
                         if remaining_fields.is_empty() {
+                            // must be referring to a common type named `Set`
                             Ok(SchemaType::TypeDef {
-                                type_name: SET_NAME.clone(),
+                                type_name: N::from(SET_NAME.clone()),
                             })
                         } else {
                             error_if_fields(
@@ -607,16 +681,20 @@ impl SchemaTypeVisitor {
                             )?;
 
                             Ok(SchemaType::Type(SchemaTypeVariant::Set {
-                                // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them, ensuring `element` exists
-                                #[allow(clippy::unwrap_used)]
-                                element: Box::new(element.unwrap()?),
+                                element: {
+                                    // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them, ensuring `element` exists
+                                    #[allow(clippy::unwrap_used)]
+                                    let element: SchemaType<N> = element.unwrap()?;
+                                    Box::new(element)
+                                },
                             }))
                         }
                     }
                     "Record" => {
                         if remaining_fields.is_empty() {
+                            // must be referring to a common type named `Record`
                             Ok(SchemaType::TypeDef {
-                                type_name: RECORD_NAME.clone(),
+                                type_name: N::from(RECORD_NAME.clone()),
                             })
                         } else {
                             error_if_fields(
@@ -631,7 +709,19 @@ impl SchemaTypeVisitor {
                                 let additional_attributes =
                                     additional_attributes.unwrap_or(Ok(partial_schema_default()));
                                 Ok(SchemaType::Type(SchemaTypeVariant::Record {
-                                    attributes: attributes?.0,
+                                    attributes: attributes?
+                                        .0
+                                        .into_iter()
+                                        .map(|(k, TypeOfAttribute { ty, required })| {
+                                            (
+                                                k,
+                                                TypeOfAttribute {
+                                                    ty: ty.into_n(),
+                                                    required,
+                                                },
+                                            )
+                                        })
+                                        .collect(),
                                     additional_attributes: additional_attributes?,
                                 }))
                             } else {
@@ -641,8 +731,9 @@ impl SchemaTypeVisitor {
                     }
                     "Entity" => {
                         if remaining_fields.is_empty() {
+                            // must be referring to a common type named `Entity`
                             Ok(SchemaType::TypeDef {
-                                type_name: ENTITY_NAME.clone(),
+                                type_name: N::from(ENTITY_NAME.clone()),
                             })
                         } else {
                             error_if_fields(
@@ -653,7 +744,7 @@ impl SchemaTypeVisitor {
                             #[allow(clippy::unwrap_used)]
                             let name = name.unwrap()?;
                             Ok(SchemaType::Type(SchemaTypeVariant::Entity {
-                                name: cedar_policy_core::ast::Name::from_normalized_str(&name)
+                                name: RawName::from_normalized_str(&name)
                                     .map_err(|err| {
                                         serde::de::Error::custom(format!(
                                             "invalid entity type `{name}`: {err}"
@@ -666,7 +757,7 @@ impl SchemaTypeVisitor {
                     "Extension" => {
                         if remaining_fields.is_empty() {
                             Ok(SchemaType::TypeDef {
-                                type_name: EXTENSION_NAME.clone(),
+                                type_name: N::from(EXTENSION_NAME.clone()),
                             })
                         } else {
                             error_if_fields(
@@ -689,12 +780,13 @@ impl SchemaTypeVisitor {
                     type_name => {
                         error_if_any_fields()?;
                         Ok(SchemaType::TypeDef {
-                            type_name: cedar_policy_core::ast::Name::from_normalized_str(type_name)
-                                .map_err(|err| {
+                            type_name: N::from(RawName::from_normalized_str(type_name).map_err(
+                                |err| {
                                     serde::de::Error::custom(format!(
                                         "invalid common type `{type_name}`: {err}"
                                     ))
-                                })?,
+                                },
+                            )?),
                         })
                     }
                 }
@@ -704,19 +796,24 @@ impl SchemaTypeVisitor {
     }
 }
 
-impl From<SchemaTypeVariant> for SchemaType {
-    fn from(variant: SchemaTypeVariant) -> Self {
+impl<N> From<SchemaTypeVariant<N>> for SchemaType<N> {
+    fn from(variant: SchemaTypeVariant<N>) -> Self {
         Self::Type(variant)
     }
 }
 
-/// The variants of `SchemaType` that are exposed to users, i.e., legal to write
+/// The variants of [`SchemaType`] that are exposed to users, i.e., legal to write
 /// in schemas. Does not include common types, which are handled separately.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`SchemaTypeVariant`], including recursively.
+/// See notes on [`SchemaFragment`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "type")]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum SchemaTypeVariant {
+pub enum SchemaTypeVariant<N> {
     /// String
     String,
     /// Long
@@ -726,12 +823,12 @@ pub enum SchemaTypeVariant {
     /// Set
     Set {
         /// Element type
-        element: Box<SchemaType>,
+        element: Box<SchemaType<N>>,
     },
     /// Record
     Record {
         /// Attribute names and types for the record
-        attributes: BTreeMap<SmolStr, TypeOfAttribute>,
+        attributes: BTreeMap<SmolStr, TypeOfAttribute<N>>,
         /// Whether "additional attributes" are possible on this record
         #[serde(rename = "additionalAttributes")]
         #[serde(skip_serializing_if = "is_partial_schema_default")]
@@ -739,14 +836,75 @@ pub enum SchemaTypeVariant {
     },
     /// Entity
     Entity {
-        /// Name of the entity type
-        name: ast::EntityType,
+        /// Name of the entity type.
+        /// For the important case of `N` = `RawName`, this is the schema JSON
+        /// format, and the `RawName` is exactly how it appears in the schema;
+        /// may not yet be fully qualified
+        name: N,
     },
     /// Extension types
     Extension {
         /// Name of the extension type
         name: Id,
     },
+}
+
+impl SchemaTypeVariant<RawName> {
+    /// Prefix unqualified entity and common type references with the namespace they are in
+    pub(crate) fn qualify_type_references(self, ns: Option<&Name>) -> SchemaTypeVariant<Name> {
+        match self {
+            Self::Boolean => SchemaTypeVariant::Boolean,
+            Self::Long => SchemaTypeVariant::Long,
+            Self::String => SchemaTypeVariant::String,
+            Self::Entity { name } => SchemaTypeVariant::Entity {
+                name: name.qualify_with(ns),
+            },
+            Self::Record {
+                attributes,
+                additional_attributes,
+            } => SchemaTypeVariant::Record {
+                attributes: BTreeMap::from_iter(attributes.into_iter().map(
+                    |(attr, TypeOfAttribute { ty, required })| {
+                        (
+                            attr,
+                            TypeOfAttribute {
+                                ty: ty.qualify_type_references(ns),
+                                required,
+                            },
+                        )
+                    },
+                )),
+                additional_attributes,
+            },
+            Self::Set { element } => SchemaTypeVariant::Set {
+                element: Box::new(element.qualify_type_references(ns)),
+            },
+            Self::Extension { name } => SchemaTypeVariant::Extension { name },
+        }
+    }
+
+    fn into_n<N: From<RawName>>(self) -> SchemaTypeVariant<N> {
+        match self {
+            Self::Boolean => SchemaTypeVariant::Boolean,
+            Self::Long => SchemaTypeVariant::Long,
+            Self::String => SchemaTypeVariant::String,
+            Self::Entity { name } => SchemaTypeVariant::Entity { name: name.into() },
+            Self::Record {
+                attributes,
+                additional_attributes,
+            } => SchemaTypeVariant::Record {
+                attributes: attributes
+                    .into_iter()
+                    .map(|(k, v)| (k, v.into_n()))
+                    .collect(),
+                additional_attributes,
+            },
+            Self::Set { element } => SchemaTypeVariant::Set {
+                element: Box::new(element.into_n()),
+            },
+            Self::Extension { name } => SchemaTypeVariant::Extension { name },
+        }
+    }
 }
 
 // Only used for serialization
@@ -757,45 +915,11 @@ fn is_partial_schema_default(b: &bool) -> bool {
 // We forbid declaring a custom typedef with the same name as a builtin type.
 pub(crate) static PRIMITIVE_TYPES: &[&str] = &["String", "Long", "Boolean"];
 
-impl SchemaType {
-    /// Is this `SchemaType` an extension type, or does it contain one
-    /// (recursively)? Returns `None` if this is a `TypeDef` because we can't
-    /// easily properly check the type of a typedef, accounting for namespaces,
-    /// without first converting to a `Type`.
-    pub fn is_extension(&self) -> Option<bool> {
-        match self {
-            Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
-            Self::Type(SchemaTypeVariant::Set { element }) => element.is_extension(),
-            Self::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
-                .values()
-                .try_fold(false, |a, e| match e.ty.is_extension() {
-                    Some(true) => Some(true),
-                    Some(false) => Some(a),
-                    None => None,
-                }),
-            Self::Type(_) => Some(false),
-            Self::TypeDef { .. } => None,
-        }
-    }
-
-    /// Is this `SchemaType` an empty record? This function is used by the `Display`
-    /// implementation to avoid printing unnecessary entity/action data.
-    pub fn is_empty_record(&self) -> bool {
-        match self {
-            Self::Type(SchemaTypeVariant::Record {
-                attributes,
-                additional_attributes,
-            }) => *additional_attributes == partial_schema_default() && attributes.is_empty(),
-            _ => false,
-        }
-    }
-}
-
 #[cfg(feature = "arbitrary")]
 // PANIC SAFETY property testing code
 #[allow(clippy::panic)]
-impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType> {
+impl<'a> arbitrary::Arbitrary<'a> for SchemaType<RawName> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType<RawName>> {
         use std::collections::BTreeSet;
 
         Ok(SchemaType::Type(match u.int_in_range::<u8>(1..=8)? {
@@ -818,10 +942,9 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
                     additional_attributes: u.arbitrary()?,
                 }
             }
-            6 => {
-                let name: Name = u.arbitrary()?;
-                SchemaTypeVariant::Entity { name: name.into() }
-            }
+            6 => SchemaTypeVariant::Entity {
+                name: u.arbitrary()?,
+            },
             7 => SchemaTypeVariant::Extension {
                 // PANIC SAFETY: `ipaddr` is a valid `Id`
                 #[allow(clippy::unwrap_used)]
@@ -845,6 +968,10 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
 /// flattened for serialization, so, in JSON format, this appears as a regular
 /// type with one extra property `required`.
 ///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`TypeOfAttribute`], including recursively.
+/// See notes on [`SchemaFragment`].
+///
 /// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
 /// using `#[serde(tag = "type")]` in [`SchemaType`] which is flattened here.
 /// The way `serde(flatten)` is implemented means it may be possible to access
@@ -855,15 +982,41 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType {
 /// unknown fields for [`TypeOfAttribute`] should be passed to [`SchemaType`] where
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct TypeOfAttribute {
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+pub struct TypeOfAttribute<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]
-    pub ty: SchemaType,
+    pub ty: SchemaType<N>,
     /// Whether the attribute is required
     #[serde(default = "record_attribute_required_default")]
     #[serde(skip_serializing_if = "is_record_attribute_required_default")]
     pub required: bool,
+}
+
+impl TypeOfAttribute<RawName> {
+    fn into_n<N: From<RawName>>(self) -> TypeOfAttribute<N> {
+        TypeOfAttribute {
+            ty: self.ty.into_n(),
+            required: self.required,
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for TypeOfAttribute<RawName> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            ty: u.arbitrary()?,
+            required: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and(
+            <SchemaType<RawName> as arbitrary::Arbitrary>::size_hint(depth),
+            <bool as arbitrary::Arbitrary>::size_hint(depth),
+        )
+    }
 }
 
 // Only used for serialization
@@ -901,7 +1054,7 @@ mod test {
             "memberOfTypes" : ["UserGroup"]
         }
         "#;
-        let et = serde_json::from_str::<EntityType>(user).expect("Parse Error");
+        let et = serde_json::from_str::<EntityType<RawName>>(user).expect("Parse Error");
         assert_eq!(et.member_of_types, vec!["UserGroup".parse().unwrap()]);
         assert_eq!(
             et.shape.into_inner(),
@@ -917,7 +1070,7 @@ mod test {
         let src = r#"
               { }
         "#;
-        let et = serde_json::from_str::<EntityType>(src).expect("Parse Error");
+        let et = serde_json::from_str::<EntityType<RawName>>(src).expect("Parse Error");
         assert_eq!(et.member_of_types.len(), 0);
         assert_eq!(
             et.shape.into_inner(),
@@ -939,7 +1092,7 @@ mod test {
                 "memberOf": [{"id": "readWrite"}]
               }
         "#;
-        let at: ActionType = serde_json::from_str(src).expect("Parse Error");
+        let at: ActionType<RawName> = serde_json::from_str(src).expect("Parse Error");
         let spec = ApplySpec {
             resource_types: vec!["Album".parse().unwrap()],
             principal_types: vec!["User".parse().unwrap()],
@@ -960,7 +1113,7 @@ mod test {
         let src = r#"
               { }
         "#;
-        let at: ActionType = serde_json::from_str(src).expect("Parse Error");
+        let at: ActionType<RawName> = serde_json::from_str(src).expect("Parse Error");
         assert_eq!(at.applies_to, None);
         assert!(at.member_of.is_none());
     }
@@ -1018,7 +1171,8 @@ mod test {
               }
             }
           });
-        let schema_file: NamespaceDefinition = serde_json::from_value(src).expect("Parse Error");
+        let schema_file: NamespaceDefinition<RawName> =
+            serde_json::from_value(src).expect("Parse Error");
 
         assert_eq!(schema_file.entity_types.len(), 5);
         assert_eq!(schema_file.actions.len(), 6);
@@ -1033,7 +1187,7 @@ mod test {
                 "actions": {}
             }
         }"#;
-        let schema: SchemaFragment = serde_json::from_str(src).expect("Parse Error");
+        let schema: SchemaFragment<RawName> = serde_json::from_str(src).expect("Parse Error");
         let (namespace, _descriptor) = schema.0.into_iter().next().unwrap();
         assert_eq!(namespace, Some("foo::foo::bar::baz".parse().unwrap()));
     }
@@ -1059,7 +1213,7 @@ mod test {
             },
             "actions": {}
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
+        let schema: NamespaceDefinition<RawName> = serde_json::from_value(src).unwrap();
         println!("{:#?}", schema);
     }
 
@@ -1083,7 +1237,7 @@ mod test {
             },
             "actions": {}
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
+        let schema: NamespaceDefinition<RawName> = serde_json::from_value(src).unwrap();
         println!("{:#?}", schema);
     }
 
@@ -1108,7 +1262,7 @@ mod test {
             },
             "actions": {}
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
+        let schema: NamespaceDefinition<RawName> = serde_json::from_value(src).unwrap();
         println!("{:#?}", schema);
     }
 
@@ -1133,7 +1287,7 @@ mod test {
             },
             "actions": {}
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
+        let schema: NamespaceDefinition<RawName> = serde_json::from_value(src).unwrap();
         println!("{:#?}", schema);
     }
 
@@ -1180,7 +1334,7 @@ mod test {
             },
             "actions": {}
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
+        let schema: NamespaceDefinition<RawName> = serde_json::from_value(src).unwrap();
         println!("{:#?}", schema);
     }
 
@@ -1206,7 +1360,7 @@ mod test {
             },
             "actions": {}
         });
-        let schema: NamespaceDefinition = serde_json::from_value(src).unwrap();
+        let schema: NamespaceDefinition<RawName> = serde_json::from_value(src).unwrap();
         println!("{:#?}", schema);
     }
 }
@@ -1217,7 +1371,8 @@ mod strengthened_types {
     use cool_asserts::assert_matches;
 
     use crate::{
-        ActionEntityUID, ApplySpec, EntityType, NamespaceDefinition, SchemaFragment, SchemaType,
+        ActionEntityUID, ApplySpec, EntityType, NamespaceDefinition, RawName, SchemaFragment,
+        SchemaType,
     };
 
     /// Assert that `result` is an `Err`, and the error message matches `msg`
@@ -1235,7 +1390,7 @@ mod strengthened_types {
             "actions": {}
            }
         });
-        let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
+        let schema: Result<SchemaFragment<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid namespace `\n`: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1245,7 +1400,7 @@ mod strengthened_types {
             "actions": {}
            }
         });
-        let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
+        let schema: Result<SchemaFragment<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid namespace `1`: unexpected token `1`");
 
         let src = serde_json::json!(
@@ -1255,7 +1410,7 @@ mod strengthened_types {
             "actions": {}
            }
         });
-        let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
+        let schema: Result<SchemaFragment<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid namespace `*1`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -1265,7 +1420,7 @@ mod strengthened_types {
             "actions": {}
            }
         });
-        let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
+        let schema: Result<SchemaFragment<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid namespace `::`: unexpected token `::`");
 
         let src = serde_json::json!(
@@ -1275,7 +1430,7 @@ mod strengthened_types {
             "actions": {}
            }
         });
-        let schema: Result<SchemaFragment, _> = serde_json::from_value(src);
+        let schema: Result<SchemaFragment<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid namespace `A::`: unexpected end of input");
     }
 
@@ -1291,7 +1446,7 @@ mod strengthened_types {
                 }
             }
         });
-        let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
+        let schema: Result<NamespaceDefinition<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid id ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1304,7 +1459,7 @@ mod strengthened_types {
                 }
             }
         });
-        let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
+        let schema: Result<NamespaceDefinition<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid id `~`: invalid token");
 
         let src = serde_json::json!(
@@ -1317,7 +1472,7 @@ mod strengthened_types {
                 }
             }
         });
-        let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
+        let schema: Result<NamespaceDefinition<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid id `A::B`: unexpected token `::`");
     }
 
@@ -1330,7 +1485,7 @@ mod strengthened_types {
             },
             "actions": {}
         });
-        let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
+        let schema: Result<NamespaceDefinition<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid id ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1340,7 +1495,7 @@ mod strengthened_types {
             },
             "actions": {}
         });
-        let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
+        let schema: Result<NamespaceDefinition<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid id `*`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -1350,7 +1505,7 @@ mod strengthened_types {
             },
             "actions": {}
         });
-        let schema: Result<NamespaceDefinition, _> = serde_json::from_value(src);
+        let schema: Result<NamespaceDefinition<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid id `A::B`: unexpected token `::`");
     }
 
@@ -1360,28 +1515,28 @@ mod strengthened_types {
         {
            "memberOfTypes": [""]
         });
-        let schema: Result<EntityType, _> = serde_json::from_value(src);
+        let schema: Result<EntityType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["*"]
         });
-        let schema: Result<EntityType, _> = serde_json::from_value(src);
+        let schema: Result<EntityType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["A::"]
         });
-        let schema: Result<EntityType, _> = serde_json::from_value(src);
+        let schema: Result<EntityType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `A::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "memberOfTypes": ["::A"]
         });
-        let schema: Result<EntityType, _> = serde_json::from_value(src);
+        let schema: Result<EntityType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `::A`: unexpected token `::`");
     }
 
@@ -1391,28 +1546,28 @@ mod strengthened_types {
         {
            "resourceTypes": [""]
         });
-        let schema: Result<ApplySpec, _> = serde_json::from_value(src);
+        let schema: Result<ApplySpec<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["*"]
         });
-        let schema: Result<ApplySpec, _> = serde_json::from_value(src);
+        let schema: Result<ApplySpec<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["A::"]
         });
-        let schema: Result<ApplySpec, _> = serde_json::from_value(src);
+        let schema: Result<ApplySpec<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `A::`: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "resourceTypes": ["::A"]
         });
-        let schema: Result<ApplySpec, _> = serde_json::from_value(src);
+        let schema: Result<ApplySpec<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `::A`: unexpected token `::`");
     }
 
@@ -1423,7 +1578,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": ""
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1431,7 +1586,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": "*"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -1439,7 +1594,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": "::A"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type `::A`: unexpected token `::`");
 
         let src = serde_json::json!(
@@ -1447,7 +1602,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": "A::"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type `A::`: unexpected end of input");
     }
 
@@ -1458,7 +1613,7 @@ mod strengthened_types {
            "id": "action",
             "type": ""
         });
-        let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
+        let schema: Result<ActionEntityUID<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1466,7 +1621,7 @@ mod strengthened_types {
            "id": "action",
             "type": "*"
         });
-        let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
+        let schema: Result<ActionEntityUID<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `*`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -1474,7 +1629,7 @@ mod strengthened_types {
            "id": "action",
             "type": "Action::"
         });
-        let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
+        let schema: Result<ActionEntityUID<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `Action::`: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1482,7 +1637,7 @@ mod strengthened_types {
            "id": "action",
             "type": "::Action"
         });
-        let schema: Result<ActionEntityUID, _> = serde_json::from_value(src);
+        let schema: Result<ActionEntityUID<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid name `::Action`: unexpected token `::`");
     }
 
@@ -1492,28 +1647,28 @@ mod strengthened_types {
         {
            "type": ""
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "type": "*"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "type": "::A"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type `::A`: unexpected token `::`");
 
         let src = serde_json::json!(
         {
            "type": "A::"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type `A::`: unexpected end of input");
     }
 
@@ -1524,7 +1679,7 @@ mod strengthened_types {
            "type": "Extension",
            "name": ""
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid extension type ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -1532,7 +1687,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "*"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid extension type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -1540,7 +1695,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "__cedar::decimal"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(
             schema,
             "invalid extension type `__cedar::decimal`: unexpected token `::`",
@@ -1551,7 +1706,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "__cedar::"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(
             schema,
             "invalid extension type `__cedar::`: unexpected token `::`",
@@ -1562,7 +1717,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "::__cedar"
         });
-        let schema: Result<SchemaType, _> = serde_json::from_value(src);
+        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(
             schema,
             "invalid extension type `::__cedar`: unexpected token `::`",
@@ -1576,9 +1731,9 @@ mod test_json_roundtrip {
     use super::*;
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
-    fn roundtrip(schema: SchemaFragment) {
+    fn roundtrip(schema: SchemaFragment<RawName>) {
         let json = serde_json::to_value(schema.clone()).unwrap();
-        let new_schema: SchemaFragment = serde_json::from_value(json).unwrap();
+        let new_schema: SchemaFragment<RawName> = serde_json::from_value(json).unwrap();
         assert_eq!(schema, new_schema);
     }
 
@@ -1718,7 +1873,7 @@ mod test_duplicates_error {
               "actions": {}
             }
         }"#;
-        serde_json::from_str::<SchemaFragment>(src).unwrap();
+        serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
     }
 
     #[test]
@@ -1733,7 +1888,7 @@ mod test_duplicates_error {
               "actions": {}
             }
         }"#;
-        serde_json::from_str::<SchemaFragment>(src).unwrap();
+        serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
     }
 
     #[test]
@@ -1748,7 +1903,7 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<SchemaFragment>(src).unwrap();
+        serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
     }
 
     #[test]
@@ -1764,7 +1919,7 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<SchemaFragment>(src).unwrap();
+        serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
     }
 
     #[test]
@@ -1786,6 +1941,6 @@ mod test_duplicates_error {
               "actions": { }
             }
         }"#;
-        serde_json::from_str::<SchemaFragment>(src).unwrap();
+        serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
     }
 }

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -28,7 +28,7 @@ use crate::{
     diagnostics::ValidationError, types::Type, validation_errors::AttributeAccess,
     validation_errors::LubContext, validation_errors::LubHelp,
     validation_errors::UnexpectedTypeHelp, AttributesOrContext, EntityType, NamespaceDefinition,
-    SchemaFragment, ValidationMode,
+    RawName, SchemaFragment, ValidationMode,
 };
 
 use super::test_utils::{
@@ -374,7 +374,7 @@ fn eq_typechecks() {
 
 #[test]
 fn entity_eq_is_false() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {
@@ -422,7 +422,7 @@ fn entity_eq_is_false() {
 
 #[test]
 fn set_eq_is_not_false() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {
@@ -475,7 +475,7 @@ fn set_eq_is_not_false() {
 
 #[test]
 fn eq_typecheck_action_literals_false() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {},
@@ -504,7 +504,7 @@ fn eq_typecheck_action_literals_false() {
 
 #[test]
 fn eq_typecheck_entity_literals_false() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {
@@ -849,7 +849,7 @@ fn contains_typecheck_fails() {
 
 #[test]
 fn contains_typecheck_literals_false() {
-    let schema: NamespaceDefinition = serde_json::from_value(json!(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_value(json!(
     {
         "entityTypes": {},
         "actions": {
@@ -910,7 +910,7 @@ fn contains_all_typecheck_fails() {
 
 #[test]
 fn contains_all_typecheck_literals_false() {
-    let schema: NamespaceDefinition = serde_json::from_value(json!(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_value(json!(
     {
         "entityTypes": {},
         "actions": {
@@ -1177,7 +1177,7 @@ fn add_sub_typecheck_fails() {
 
 #[test]
 fn is_typecheck_fails() {
-    let schema: NamespaceDefinition =
+    let schema: NamespaceDefinition<RawName> =
         serde_json::from_value(json!({ "entityTypes": { "User": {}, }, "actions": {} })).unwrap();
     assert_typecheck_fails(
         schema,
@@ -1195,7 +1195,7 @@ fn is_typecheck_fails() {
 
 #[test]
 fn is_typechecks() {
-    let schema: SchemaFragment = serde_json::from_value(json!({
+    let schema: SchemaFragment<RawName> = serde_json::from_value(json!({
             "": { "entityTypes": { "User": {}, "Photo": {} }, "actions": {} },
             "N::S": { "entityTypes": { "User": {} }, "actions": {} }
     }))

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -36,10 +36,10 @@ use crate::{
     diagnostics::ValidationError,
     types::{EntityLUB, Type},
     validation_errors::AttributeAccess,
-    SchemaError, SchemaFragment, ValidationWarning, ValidatorSchema,
+    RawName, SchemaError, SchemaFragment, ValidationWarning, ValidatorSchema,
 };
 
-fn namespaced_entity_type_schema() -> SchemaFragment {
+fn namespaced_entity_type_schema() -> SchemaFragment<RawName> {
     serde_json::from_str(
         r#"
             { "N::S": {
@@ -186,7 +186,7 @@ fn namespaced_entity_wrong_namespace() {
 
 #[test]
 fn namespaced_entity_type_in_attribute() {
-    let schema: SchemaFragment = serde_json::from_str(
+    let schema: SchemaFragment<RawName> = serde_json::from_str(
         r#"{ "N::S":
             {
                 "entityTypes": {
@@ -234,7 +234,7 @@ fn namespaced_entity_type_in_attribute() {
 
 #[test]
 fn namespaced_entity_type_member_of() {
-    let schema: SchemaFragment = serde_json::from_value(serde_json::json!(
+    let schema: SchemaFragment<RawName> = serde_json::from_value(serde_json::json!(
     {"N::S": {
         "entityTypes": {
             "Foo": {
@@ -265,7 +265,7 @@ fn namespaced_entity_type_member_of() {
 
 #[test]
 fn namespaced_entity_type_applies_to() {
-    let schema: SchemaFragment = serde_json::from_value(serde_json::json!(
+    let schema: SchemaFragment<RawName> = serde_json::from_value(serde_json::json!(
     {"N::S": {
         "entityTypes": {
             "Foo": { },
@@ -291,7 +291,7 @@ fn namespaced_entity_type_applies_to() {
 
 #[test]
 fn multiple_namespaces_literals() {
-    let authorization_model: SchemaFragment = serde_json::from_value(json!(
+    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
         {
             "A": {
                 "entityTypes": {"Foo": {}},
@@ -329,7 +329,7 @@ fn multiple_namespaces_literals() {
 
 #[test]
 fn multiple_namespaces_attributes() {
-    let authorization_model: SchemaFragment = serde_json::from_value(json!(
+    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -377,7 +377,7 @@ fn multiple_namespaces_attributes() {
 
 #[test]
 fn multiple_namespaces_member_of() {
-    let authorization_model: SchemaFragment = serde_json::from_value(json!(
+    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -414,7 +414,7 @@ fn multiple_namespaces_member_of() {
 
 #[test]
 fn multiple_namespaces_applies_to() {
-    let authorization_model: SchemaFragment = serde_json::from_value(json!(
+    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
         {
             "A": {
                 "entityTypes": {

--- a/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
@@ -26,15 +26,15 @@ use smol_str::SmolStr;
 
 use crate::{
     diagnostics::ValidationError, types::EntityLUB, validation_errors::AttributeAccess,
-    NamespaceDefinition, NamespaceDefinitionWithActionAttributes, ValidationWarning,
+    NamespaceDefinition, NamespaceDefinitionWithActionAttributes, RawName, ValidationWarning,
 };
 
 use super::test_utils::{
     assert_policy_typecheck_fails, assert_policy_typecheck_warns, assert_policy_typechecks,
 };
 
-fn schema_with_optionals() -> NamespaceDefinition {
-    serde_json::from_str::<NamespaceDefinition>(
+fn schema_with_optionals() -> NamespaceDefinition<RawName> {
+    serde_json::from_str::<NamespaceDefinition<RawName>>(
         r#"
 {
     "entityTypes": {
@@ -539,7 +539,7 @@ fn in_list_no_effect() {
 
 #[test]
 fn record_optional_attrs() {
-    let schema = serde_json::from_str::<NamespaceDefinition>(
+    let schema = serde_json::from_str::<NamespaceDefinition<RawName>>(
         r#"
 {
     "entityTypes": {
@@ -621,7 +621,7 @@ fn record_optional_attrs() {
 
 #[test]
 fn action_attrs_passing() {
-    let schema = serde_json::from_str::<NamespaceDefinitionWithActionAttributes>(
+    let schema = serde_json::from_str::<NamespaceDefinitionWithActionAttributes<RawName>>(
         r#"
         {
             "entityTypes": {
@@ -719,7 +719,7 @@ fn action_attrs_passing() {
 
 #[test]
 fn action_attrs_failing() {
-    let schema = serde_json::from_str::<NamespaceDefinitionWithActionAttributes>(
+    let schema = serde_json::from_str::<NamespaceDefinitionWithActionAttributes<RawName>>(
         r#"
         {
             "entityTypes": {

--- a/cedar-policy-validator/src/typecheck/test/partial.rs
+++ b/cedar-policy-validator/src/typecheck/test/partial.rs
@@ -27,7 +27,8 @@ use crate::typecheck::Typechecker;
 use crate::types::{EntityLUB, Type};
 use crate::validation_errors::{AttributeAccess, UnexpectedTypeHelp};
 use crate::{
-    NamespaceDefinition, ValidationError, ValidationMode, ValidationWarning, ValidatorSchema,
+    NamespaceDefinition, RawName, ValidationError, ValidationMode, ValidationWarning,
+    ValidatorSchema,
 };
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
@@ -499,7 +500,7 @@ mod fails_empty_schema {
     }
 }
 
-fn partial_schema_file() -> NamespaceDefinition {
+fn partial_schema_file() -> NamespaceDefinition<RawName> {
     serde_json::from_value(serde_json::json!(
         {
             "entityTypes": {

--- a/cedar-policy-validator/src/typecheck/test/policy.rs
+++ b/cedar-policy-validator/src/typecheck/test/policy.rs
@@ -37,10 +37,10 @@ use crate::{
     typecheck::{PolicyCheck, Typechecker},
     types::{EntityLUB, Type},
     validation_errors::{AttributeAccess, LubContext, LubHelp},
-    NamespaceDefinition, ValidationMode, ValidationWarning,
+    NamespaceDefinition, RawName, ValidationMode, ValidationWarning,
 };
 
-fn simple_schema_file() -> NamespaceDefinition {
+fn simple_schema_file() -> NamespaceDefinition<RawName> {
     serde_json::from_value(serde_json::json!(
         {
             "entityTypes": {
@@ -793,7 +793,7 @@ fn entity_record_lub_is_none() {
 
 #[test]
 fn optional_attr_fail() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
         {
             "entityTypes": {
@@ -846,7 +846,7 @@ fn optional_attr_fail() {
 
 #[test]
 fn type_error_is_not_reported_for_every_cross_product_element() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
         {
             "entityTypes": {
@@ -885,7 +885,7 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
 
 #[test]
 fn action_groups() {
-    let schema: NamespaceDefinition = serde_json::from_str(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
         {
             "entityTypes": { "Entity": {} },
@@ -982,7 +982,7 @@ fn action_groups() {
 // Example demonstrating Non-terminating LUB computation
 #[test]
 fn record_entity_lub_non_term() {
-    let schema: NamespaceDefinition = serde_json::from_value(serde_json::json!(
+    let schema: NamespaceDefinition<RawName> = serde_json::from_value(serde_json::json!(
     {
         "entityTypes": {
             "E" : {
@@ -1041,7 +1041,7 @@ fn record_entity_lub_non_term() {
 
 #[test]
 fn validate_policy_with_typedef_schema() {
-    let namespace_def: NamespaceDefinition = serde_json::from_value(serde_json::json!(
+    let namespace_def: NamespaceDefinition<RawName> = serde_json::from_value(serde_json::json!(
     {
         "commonTypes": {
             "SharedAttrs": {

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -34,14 +34,14 @@ use crate::{
     types::{AttributeType, EffectSet, OpenTag, RequestEnv, Type},
     validation_errors::LubContext,
     validation_errors::LubHelp,
-    SchemaFragment, ValidationError, ValidationMode,
+    RawName, SchemaFragment, ValidationError, ValidationMode,
 };
 
 use super::test_utils::{assert_policy_typecheck_fails, expr_id_placeholder};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
-    schema: SchemaFragment,
+    schema: SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
@@ -63,7 +63,7 @@ fn assert_typechecks_strict(
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_strict_type_error(
-    schema: SchemaFragment,
+    schema: SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
@@ -86,7 +86,7 @@ fn assert_strict_type_error(
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_types_must_match(
-    schema: SchemaFragment,
+    schema: SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     on_expr: Expr,
@@ -110,7 +110,7 @@ fn assert_types_must_match(
     )
 }
 
-fn simple_schema_file() -> SchemaFragment {
+fn simple_schema_file() -> SchemaFragment<RawName> {
     serde_json::from_value(json!(
     { "": {
       "entityTypes": {
@@ -138,7 +138,7 @@ fn simple_schema_file() -> SchemaFragment {
 
 fn with_simple_schema_and_request<F>(f: F)
 where
-    F: FnOnce(SchemaFragment, RequestEnv<'_>),
+    F: FnOnce(SchemaFragment<RawName>, RequestEnv<'_>),
 {
     f(
         simple_schema_file(),

--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -27,7 +27,8 @@ use crate::typecheck::{TypecheckAnswer, Typechecker};
 use crate::{
     types::{EffectSet, OpenTag, RequestEnv, Type},
     validation_errors::UnexpectedTypeHelp,
-    NamespaceDefinition, ValidationError, ValidationMode, ValidationWarning, ValidatorSchema,
+    NamespaceDefinition, RawName, ValidationError, ValidationMode, ValidationWarning,
+    ValidatorSchema,
 };
 
 // Placeholder policy id for use when typechecking an expression directly.
@@ -335,7 +336,7 @@ pub(crate) fn assert_typecheck_fails_for_mode(
     });
 }
 
-pub(crate) fn empty_schema_file() -> NamespaceDefinition {
+pub(crate) fn empty_schema_file() -> NamespaceDefinition<RawName> {
     NamespaceDefinition::new([], [])
 }
 

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use cedar_policy_core::ast::{EntityUID, Expr, ExprBuilder, PolicyID};
 
 use super::test_utils::{empty_schema_file, expr_id_placeholder};
-use crate::{typecheck::Typechecker, types::Type, SchemaFragment, ValidationMode};
+use crate::{typecheck::Typechecker, types::Type, RawName, SchemaFragment, ValidationMode};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_expr_has_annotated_ast(e: &Expr, annotated: &Expr<Option<Type>>) {
@@ -137,7 +137,7 @@ fn expr_typechecks_with_correct_annotation() {
         .unwrap(),
     );
 
-    let schema = serde_json::from_value::<SchemaFragment>(
+    let schema = serde_json::from_value::<SchemaFragment<RawName>>(
         json!({"": { "entityTypes": { "Foo": {} }, "actions": {} }}),
     )
     .unwrap()

--- a/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
@@ -16,7 +16,8 @@
 
 // GRCOV_STOP_COVERAGE
 
-use crate::NamespaceDefinition;
+use crate::{NamespaceDefinition, RawName};
+use cool_asserts::assert_matches;
 
 fn schema_with_unspecified() -> &'static str {
     r#"
@@ -54,5 +55,8 @@ fn schema_with_unspecified() -> &'static str {
 
 #[test]
 fn unspecified_does_not_parse() {
-    assert!(serde_json::from_str::<NamespaceDefinition>(schema_with_unspecified()).is_err());
+    assert_matches!(
+        serde_json::from_str::<NamespaceDefinition<RawName>>(schema_with_unspecified()),
+        Err(_)
+    );
 }

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -2118,8 +2118,7 @@ mod test {
         let parsed_schema_type = parse_type(&type_str)
             .expect("String representation should have parsed into a schema type");
         let type_from_schema_type = ValidatorNamespaceDef::try_schema_type_into_validator_type(
-            None,
-            parsed_schema_type,
+            parsed_schema_type.qualify_type_references(None),
             Extensions::all_available(),
         )
         .expect("Schema type should have converted to type.")

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1184,7 +1184,7 @@ impl Validator {
 #[derive(Debug)]
 pub struct SchemaFragment {
     value: cedar_policy_validator::ValidatorSchemaFragment,
-    lossless: cedar_policy_validator::SchemaFragment,
+    lossless: cedar_policy_validator::SchemaFragment<cedar_policy_validator::RawName>,
 }
 
 impl SchemaFragment {


### PR DESCRIPTION
## Description of changes

Introduces the `RawName` wrapper type, to make explicit in the type system the difference between may-not-yet-be-fully-qualified `Name` (we now call this `RawName`) and guaranteed-to-be-fully-qualified `Name` (which is just `Name`).

This PR also starts to separate out the operations of (1) adding explicit namespaces to type references, and (2) inlining common type definitions. These two operations are currently conflated / performed simultaneously, and this PR begins to separate them for clarity.

Also cleans up a few comments, including a couple places where comments weren't updated to reflect #983. 

This is a non-functional-change refactor in preparation for #579. But I thought this change was worth separating into its own PR, to review it separately and keep diff sizes down.

## Issue #, if available

Towards #579 (but this is a non-functional-change refactor that does not resolve the issue yet)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
