### PR TITLE
additional public utilities following cedar#1016

### DIFF
--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -33,6 +33,20 @@ impl RawName {
         Self(Name::unqualified_name(id))
     }
 
+    /// Create a new `RawName` from the given `Name`.
+    ///
+    /// Note that if `name` includes explicit namespaces, the result will be a
+    /// `RawName` that also includes those explicit namespaces, as if that
+    /// fully-qualified name appeared directly in the (JSON or human) schema
+    /// format.
+    /// If `name` does not include explicit namespaces, the result will be a
+    /// `RawName` that also does not include explicit namespaces, which may or
+    /// may not translate back to the original input `name`, due to
+    /// namespace-qualification rules.
+    pub fn from_name(name: Name) -> Self {
+        Self(name)
+    }
+
     /// Create a new `RawName` from a basename, namespace components as `Id`s, and optional source location
     pub fn from_components(
         basename: Id,


### PR DESCRIPTION
## Description of changes

Adds some additional public utilities to code introduced in #1016.  These utilities are for the convenience of DRT primarily.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

