### PR TITLE
Context `merge` function

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1157,7 +1157,7 @@ pub enum ExpressionConstructionError {
     /// The same key occurred two or more times
     #[error(transparent)]
     #[diagnostic(transparent)]
-    DuplicateKeyInRecordLiteral(#[from] expression_construction_errors::DuplicateKeyError),
+    DuplicateKey(#[from] expression_construction_errors::DuplicateKeyError),
 }
 
 /// Error subtypes for [`ExpressionConstructionError`]
@@ -1187,7 +1187,7 @@ pub mod expression_construction_errors {
         }
 
         /// Make a new error with an updated `context` field
-        pub fn set_context(self, context: &'static str) -> Self {
+        pub(crate) fn with_context(self, context: &'static str) -> Self {
             Self { context, ..self }
         }
     }

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -274,12 +274,9 @@ impl Context {
         // INVARIANT(ContextRecord): via invariant on `Self::from_expr`
         match RestrictedExpr::record(pairs) {
             Ok(record) => Self::from_expr(record.as_borrowed(), extensions),
-            Err(ExpressionConstructionError::DuplicateKeyInRecordLiteral(err)) => {
-                Err(ExpressionConstructionError::DuplicateKeyInRecordLiteral(
-                    err.set_context("in context"),
-                )
-                .into())
-            }
+            Err(ExpressionConstructionError::DuplicateKey(err)) => Err(
+                ExpressionConstructionError::DuplicateKey(err.with_context("in context")).into(),
+            ),
         }
     }
 

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -27,8 +27,8 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use super::{
-    BorrowedRestrictedExpr, EntityUID, Expr, ExprKind, PartialValue, PartialValueSerializedAsExpr,
-    RecordConstructionError, RestrictedExpr, Unknown, Value, ValueKind, Var,
+    BorrowedRestrictedExpr, EntityUID, Expr, ExprKind, ExpressionConstructionError, PartialValue,
+    PartialValueSerializedAsExpr, RestrictedExpr, Unknown, Value, ValueKind, Var,
 };
 
 /// Represents the request tuple <P, A, R, C> (see the Cedar design doc).
@@ -267,10 +267,12 @@ impl Context {
         // INVARIANT(ContextRecord): via invariant on `Self::from_expr`
         match RestrictedExpr::record(pairs) {
             Ok(record) => Self::from_expr(record.as_borrowed(), extensions),
-            Err(RecordConstructionError::DuplicateKeyInRecordLiteral(err)) => Err(
-                RecordConstructionError::DuplicateKeyInRecordLiteral(err.set_context("in context"))
-                    .into(),
-            ),
+            Err(ExpressionConstructionError::DuplicateKeyInRecordLiteral(err)) => {
+                Err(ExpressionConstructionError::DuplicateKeyInRecordLiteral(
+                    err.set_context("in context"),
+                )
+                .into())
+            }
         }
     }
 
@@ -382,7 +384,7 @@ pub enum ContextCreationError {
     /// Only returned by `Context::from_pairs()` and `Context::merge()`
     #[error(transparent)]
     #[diagnostic(transparent)]
-    RecordConstruction(#[from] RecordConstructionError),
+    ExpressionConstruction(#[from] ExpressionConstructionError),
 }
 
 impl ContextCreationError {

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -15,7 +15,7 @@
  */
 
 use super::{
-    EntityUID, Expr, ExprKind, ExpressionConstructionError, Literal, Name, PartialValue, Unknown,
+    EntityUID, Expr, ExprKind, Literal, Name, PartialValue, RecordConstructionError, Unknown,
     Value, ValueKind,
 };
 use crate::entities::json::err::JsonSerializationError;
@@ -120,7 +120,7 @@ impl RestrictedExpr {
     /// Throws an error if any key occurs two or more times.
     pub fn record(
         pairs: impl IntoIterator<Item = (SmolStr, RestrictedExpr)>,
-    ) -> Result<Self, ExpressionConstructionError> {
+    ) -> Result<Self, RecordConstructionError> {
         // Record expressions are valid restricted-exprs if their elements are;
         // and we know the elements are because we require `RestrictedExpr`s in
         // the parameter
@@ -702,7 +702,8 @@ mod test {
             ]),
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "foo".into()
+                    key: "foo".into(),
+                    context: "in record literal",
                 }
                 .into()
             )
@@ -716,7 +717,8 @@ mod test {
             ]),
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "foo".into()
+                    key: "foo".into(),
+                    context: "in record literal",
                 }
                 .into()
             )
@@ -730,7 +732,8 @@ mod test {
             ]),
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "foo".into()
+                    key: "foo".into(),
+                    context: "in record literal",
                 }
                 .into()
             )
@@ -747,7 +750,8 @@ mod test {
             ]),
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "foo".into()
+                    key: "foo".into(),
+                    context: "in record literal",
                 }
                 .into()
             )
@@ -759,9 +763,10 @@ mod test {
             RestrictedExpr::from_str(str),
             Err(RestrictedExpressionParseError::Parse(
                 ParseErrors::singleton(ParseError::ToAST(ToASTError::new(
-                    ToASTErrorKind::ExpressionConstructionError(
+                    ToASTErrorKind::RecordConstructionError(
                         expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                            key: "foo".into()
+                            key: "foo".into(),
+                            context: "in record literal",
                         }
                         .into()
                     ),

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -426,6 +426,7 @@ impl PartialResponse {
                         });
                     }
                     None => {
+                        // INVARIANT(ContextRecord): `val` is a record since `.get_as_record()` was Ok
                         context = Some(Context::from_partial_value_unchecked(val.clone().into()));
                     }
                 }
@@ -446,6 +447,10 @@ impl PartialResponse {
                 let eval = RestrictedEvaluator::new(&extns);
                 let partial_value =
                     eval.partial_interpret(BorrowedRestrictedExpr::new_unchecked(&expr))?;
+                // INVARIANT(ContextRecord): `expr` is a record because it was previously
+                // a valid context. `partial_value` is also a record since
+                // `RestrictedEvaluator::partial_interpret` always returns a record
+                // given a record as input.
                 context = Some(Context::from_partial_value_unchecked(partial_value));
             }
         }

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -449,7 +449,7 @@ impl PartialResponse {
                 // INVARIANT(ContextRecord): `expr` is a record because it was previously
                 // a valid context. `partial_value` is also a record since
                 // `RestrictedEvaluator::partial_interpret` always returns a record
-                // given a record as input.
+                // (or an error) given a record as input.
                 context = Some(Context::from_partial_value_unchecked(partial_value));
             }
         }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -80,10 +80,10 @@ pub enum JsonDeserializationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     MissingImpliedConstructor(MissingImpliedConstructor),
-    /// The same key appears two or more times in a single record literal
+    /// The same key appears two or more times in a single record
     #[error(transparent)]
     #[diagnostic(transparent)]
-    DuplicateKeyInRecordLiteral(DuplicateKeyInRecordLiteral),
+    DuplicateKey(DuplicateKey),
     /// Error when evaluating an entity attribute
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -204,11 +204,11 @@ impl JsonDeserializationError {
         })
     }
 
-    pub(crate) fn duplicate_key_in_record_literal(
+    pub(crate) fn duplicate_key(
         ctx: JsonDeserializationErrorContext,
         key: impl Into<SmolStr>,
     ) -> Self {
-        Self::DuplicateKeyInRecordLiteral(DuplicateKeyInRecordLiteral {
+        Self::DuplicateKey(DuplicateKey {
             ctx: Box::new(ctx),
             key: key.into(),
         })
@@ -348,9 +348,9 @@ pub struct UnexpectedRecordAttr {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-#[error("{}, duplicate key `{}` in record literal", .ctx, .key)]
-/// Error type for recordc literals having duplicate keys
-pub struct DuplicateKeyInRecordLiteral {
+#[error("{}, duplicate key `{}` in record", .ctx, .key)]
+/// Error type for records having duplicate keys
+pub struct DuplicateKey {
     /// Context of this error
     ctx: Box<JsonDeserializationErrorContext>,
     /// The key that appeared two or more times

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -248,9 +248,9 @@ impl CedarValueJson {
                     .collect::<Result<Vec<_>, JsonDeserializationError>>()?,
             )
             .map_err(|e| match e {
-                ExpressionConstructionError::DuplicateKeyInRecordLiteral(
+                ExpressionConstructionError::DuplicateKey(
                     expression_construction_errors::DuplicateKeyError { key, .. },
-                ) => JsonDeserializationError::duplicate_key_in_record_literal(ctx(), key),
+                ) => JsonDeserializationError::duplicate_key(ctx(), key),
             })?),
             Self::EntityEscape { __entity: entity } => Ok(RestrictedExpr::val(
                 EntityUID::try_from(entity.clone()).map_err(|errs| {
@@ -561,9 +561,9 @@ impl<'e> ValueParser<'e> {
                     // duplicate keys; they're both maps), but we can still throw
                     // the error properly in the case that it somehow happens
                     RestrictedExpr::record(rexpr_pairs).map_err(|e| match e {
-                        ExpressionConstructionError::DuplicateKeyInRecordLiteral(
+                        ExpressionConstructionError::DuplicateKey(
                             expression_construction_errors::DuplicateKeyError { key, .. },
-                        ) => JsonDeserializationError::duplicate_key_in_record_literal(ctx2(), key),
+                        ) => JsonDeserializationError::duplicate_key(ctx2(), key),
                     })
                 }
                 val => {

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -19,8 +19,8 @@ use super::{
     SchemaType,
 };
 use crate::ast::{
-    expression_construction_errors, BorrowedRestrictedExpr, Eid, EntityUID, ExprKind,
-    ExpressionConstructionError, Literal, Name, RestrictedExpr, Unknown, Value, ValueKind,
+    expression_construction_errors, BorrowedRestrictedExpr, Eid, EntityUID, ExprKind, Literal,
+    Name, RecordConstructionError, RestrictedExpr, Unknown, Value, ValueKind,
 };
 use crate::entities::{
     conformance::err::EntitySchemaConformanceError,
@@ -248,8 +248,10 @@ impl CedarValueJson {
                     .collect::<Result<Vec<_>, JsonDeserializationError>>()?,
             )
             .map_err(|e| match e {
-                ExpressionConstructionError::DuplicateKeyInRecordLiteral(
-                    expression_construction_errors::DuplicateKeyInRecordLiteralError { key },
+                RecordConstructionError::DuplicateKeyInRecordLiteral(
+                    expression_construction_errors::DuplicateKeyInRecordLiteralError {
+                        key, ..
+                    },
                 ) => JsonDeserializationError::duplicate_key_in_record_literal(ctx(), key),
             })?),
             Self::EntityEscape { __entity: entity } => Ok(RestrictedExpr::val(
@@ -561,9 +563,10 @@ impl<'e> ValueParser<'e> {
                     // duplicate keys; they're both maps), but we can still throw
                     // the error properly in the case that it somehow happens
                     RestrictedExpr::record(rexpr_pairs).map_err(|e| match e {
-                        ExpressionConstructionError::DuplicateKeyInRecordLiteral(
+                        RecordConstructionError::DuplicateKeyInRecordLiteral(
                             expression_construction_errors::DuplicateKeyInRecordLiteralError {
                                 key,
+                                ..
                             },
                         ) => JsonDeserializationError::duplicate_key_in_record_literal(ctx2(), key),
                     })

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -19,8 +19,8 @@ use super::{
     SchemaType,
 };
 use crate::ast::{
-    expression_construction_errors, BorrowedRestrictedExpr, Eid, EntityUID, ExprKind, Literal,
-    Name, RecordConstructionError, RestrictedExpr, Unknown, Value, ValueKind,
+    expression_construction_errors, BorrowedRestrictedExpr, Eid, EntityUID, ExprKind,
+    ExpressionConstructionError, Literal, Name, RestrictedExpr, Unknown, Value, ValueKind,
 };
 use crate::entities::{
     conformance::err::EntitySchemaConformanceError,
@@ -248,10 +248,8 @@ impl CedarValueJson {
                     .collect::<Result<Vec<_>, JsonDeserializationError>>()?,
             )
             .map_err(|e| match e {
-                RecordConstructionError::DuplicateKeyInRecordLiteral(
-                    expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                        key, ..
-                    },
+                ExpressionConstructionError::DuplicateKeyInRecordLiteral(
+                    expression_construction_errors::DuplicateKeyError { key, .. },
                 ) => JsonDeserializationError::duplicate_key_in_record_literal(ctx(), key),
             })?),
             Self::EntityEscape { __entity: entity } => Ok(RestrictedExpr::val(
@@ -563,11 +561,8 @@ impl<'e> ValueParser<'e> {
                     // duplicate keys; they're both maps), but we can still throw
                     // the error properly in the case that it somehow happens
                     RestrictedExpr::record(rexpr_pairs).map_err(|e| match e {
-                        RecordConstructionError::DuplicateKeyInRecordLiteral(
-                            expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                                key,
-                                ..
-                            },
+                        ExpressionConstructionError::DuplicateKeyInRecordLiteral(
+                            expression_construction_errors::DuplicateKeyError { key, .. },
                         ) => JsonDeserializationError::duplicate_key_in_record_literal(ctx2(), key),
                     })
                 }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1919,7 +1919,8 @@ pub mod test {
             ]),
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "foo".into()
+                    key: "foo".into(),
+                    context: "in record literal",
                 }
                 .into()
             )
@@ -5526,7 +5527,8 @@ pub mod test {
             e,
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "a".into()
+                    key: "a".into(),
+                    context: "in record literal",
                 }
                 .into()
             )
@@ -5540,7 +5542,8 @@ pub mod test {
             e,
             Err(
                 expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "a".into()
+                    key: "a".into(),
+                    context: "in record literal",
                 }
                 .into()
             )

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1917,13 +1917,11 @@ pub mod test {
                 ("bar".into(), Expr::val(4)),
                 ("foo".into(), Expr::val("hi")),
             ]),
-            Err(
-                expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "foo".into(),
-                    context: "in record literal",
-                }
-                .into()
-            )
+            Err(expression_construction_errors::DuplicateKeyError {
+                key: "foo".into(),
+                context: "in record literal",
+            }
+            .into())
         );
         // entity_with_attrs.address.street
         assert_eq!(
@@ -5525,13 +5523,11 @@ pub mod test {
         ]);
         assert_eq!(
             e,
-            Err(
-                expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "a".into(),
-                    context: "in record literal",
-                }
-                .into()
-            )
+            Err(expression_construction_errors::DuplicateKeyError {
+                key: "a".into(),
+                context: "in record literal",
+            }
+            .into())
         );
 
         let e = Expr::record([
@@ -5540,13 +5536,11 @@ pub mod test {
         ]);
         assert_eq!(
             e,
-            Err(
-                expression_construction_errors::DuplicateKeyInRecordLiteralError {
-                    key: "a".into(),
-                    context: "in record literal",
-                }
-                .into()
-            )
+            Err(expression_construction_errors::DuplicateKeyError {
+                key: "a".into(),
+                context: "in record literal",
+            }
+            .into())
         );
 
         let e = Expr::record([

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -279,10 +279,10 @@ pub enum ToASTErrorKind {
     /// Returned when a policy uses the remainder/modulo operator (`%`), which is not supported
     #[error("remainder/modulo is not supported")]
     UnsupportedModulo,
-    /// Any `ExpressionConstructionError` can also happen while converting CST to AST
+    /// Any `RecordConstructionError` can also happen while converting CST to AST
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ExpressionConstructionError(#[from] ast::ExpressionConstructionError),
+    RecordConstructionError(#[from] ast::RecordConstructionError),
     /// Returned when a policy contains an integer literal that is out of range
     #[error("integer literal `{0}` is too large")]
     #[diagnostic(help("maximum allowed integer literal is `{}`", ast::InputInteger::MAX))]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -279,10 +279,10 @@ pub enum ToASTErrorKind {
     /// Returned when a policy uses the remainder/modulo operator (`%`), which is not supported
     #[error("remainder/modulo is not supported")]
     UnsupportedModulo,
-    /// Any `RecordConstructionError` can also happen while converting CST to AST
+    /// Any `ExpressionConstructionError` can also happen while converting CST to AST
     #[error(transparent)]
     #[diagnostic(transparent)]
-    RecordConstructionError(#[from] ast::RecordConstructionError),
+    ExpressionConstructionError(#[from] ast::ExpressionConstructionError),
     /// Returned when a policy contains an integer literal that is out of range
     #[error("integer literal `{0}` is too large")]
     #[diagnostic(help("maximum allowed integer literal is `{}`", ast::InputInteger::MAX))]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   resolving #549)
 - Added methods for reading and writing individual `Entity`s as JSON
   (resolving #807)
+- `Context::values` to get a `HashMap` of the contents of a `Context` and
+  `Context::merge` to combine `Context`s (returning an error on duplicate keys)
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,7 +17,8 @@ Cedar Language Version: 4.0
 - Added methods for reading and writing individual `Entity`s as JSON
   (resolving #807)
 - `Context::into_iter` to get the contents of a `Context` and `Context::merge`
-   to combine `Context`s (returning an error on duplicate keys)
+  to combine `Context`s, returning an error on duplicate keys (#1027,
+  resolving #1013)
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,8 +16,8 @@ Cedar Language Version: 4.0
   resolving #549)
 - Added methods for reading and writing individual `Entity`s as JSON
   (resolving #807)
-- `Context::values` to get a `HashMap` of the contents of a `Context` and
-  `Context::merge` to combine `Context`s (returning an error on duplicate keys)
+- `Context::into_iter` to get the contents of a `Context` and `Context::merge`
+   to combine `Context`s (returning an error on duplicate keys)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3385,9 +3385,14 @@ impl Context {
             .ok_or_else(|| ContextJsonError::missing_action(action.clone()))
     }
 
-    /// Combine two [`Context`]s, returning an error if they contain overlapping keys
-    pub fn merge(self, context: Self) -> Result<Self, ContextCreationError> {
-        Self::from_pairs(self.into_iter().chain(context))
+    /// Merge this [`Context`] with another context (or iterator over
+    /// `(String, RestrictedExpression)` pairs), returning an error if the two
+    /// contain overlapping keys
+    pub fn merge(
+        self,
+        other_context: impl IntoIterator<Item = (String, RestrictedExpression)>,
+    ) -> Result<Self, ContextCreationError> {
+        Self::from_pairs(self.into_iter().chain(other_context))
     }
 }
 
@@ -3413,6 +3418,8 @@ mod context {
                             RestrictedExpression(ast::RestrictedExpr::from(val))
                         }
                         ast::PartialValue::Residual(exp) => {
+                            // `exp` is guaranteed to be a valid `RestrictedExpr`
+                            // since it was originally stored in a `Context`
                             RestrictedExpression(ast::RestrictedExpr::new_unchecked(exp))
                         }
                     },

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2813,7 +2813,7 @@ impl Expression {
     /// Error if any key appears two or more times in `fields`.
     pub fn new_record(
         fields: impl IntoIterator<Item = (String, Self)>,
-    ) -> Result<Self, RecordConstructionError> {
+    ) -> Result<Self, ExpressionConstructionError> {
         Ok(Self(ast::Expr::record(
             fields.into_iter().map(|(k, v)| (SmolStr::from(k), v.0)),
         )?))
@@ -2910,7 +2910,7 @@ impl RestrictedExpression {
     /// Error if any key appears two or more times in `fields`.
     pub fn new_record(
         fields: impl IntoIterator<Item = (String, Self)>,
-    ) -> Result<Self, RecordConstructionError> {
+    ) -> Result<Self, ExpressionConstructionError> {
         Ok(Self(ast::RestrictedExpr::record(
             fields.into_iter().map(|(k, v)| (SmolStr::from(k), v.0)),
         )?))

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -182,9 +182,9 @@ impl Entity {
                 (
                     k.to_string(),
                     match v {
-                        ast::PartialValue::Value(val) => RestrictedExpression(
-                            ast::RestrictedExpr::from(val),
-                        ),
+                        ast::PartialValue::Value(val) => {
+                            RestrictedExpression(ast::RestrictedExpr::from(val))
+                        }
                         ast::PartialValue::Residual(exp) => {
                             RestrictedExpression(ast::RestrictedExpr::new_unchecked(exp))
                         }
@@ -3393,7 +3393,7 @@ impl Context {
 
 /// Utilities for implementing `IntoIterator` for `Context`
 mod context {
-    use super::{RestrictedExpression, ast};
+    use super::{ast, RestrictedExpression};
 
     /// `IntoIter` iterator for `Context`
     #[derive(Debug)]
@@ -3409,9 +3409,9 @@ mod context {
                 (
                     k.to_string(),
                     match v {
-                        ast::PartialValue::Value(val) => RestrictedExpression(
-                            ast::RestrictedExpr::from(val),
-                        ),
+                        ast::PartialValue::Value(val) => {
+                            RestrictedExpression(ast::RestrictedExpr::from(val))
+                        }
                         ast::PartialValue::Residual(exp) => {
                             RestrictedExpression(ast::RestrictedExpr::new_unchecked(exp))
                         }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -183,7 +183,7 @@ impl Entity {
                     k.to_string(),
                     match v {
                         ast::PartialValue::Value(val) => RestrictedExpression(
-                            ast::RestrictedExpr::new_unchecked(ast::Expr::from(val)),
+                            ast::RestrictedExpr::from(val),
                         ),
                         ast::PartialValue::Residual(exp) => {
                             RestrictedExpression(ast::RestrictedExpr::new_unchecked(exp))
@@ -3410,7 +3410,7 @@ mod context {
                     k.to_string(),
                     match v {
                         ast::PartialValue::Value(val) => RestrictedExpression(
-                            ast::RestrictedExpr::new_unchecked(ast::Expr::from(val)),
+                            ast::RestrictedExpr::from(val),
                         ),
                         ast::PartialValue::Residual(exp) => {
                             RestrictedExpression(ast::RestrictedExpr::new_unchecked(exp))

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -18,7 +18,7 @@
 
 use crate::{EntityUid, PolicyId};
 pub use cedar_policy_core::ast::{
-    expression_construction_errors, restricted_expr_errors, ExpressionConstructionError,
+    expression_construction_errors, restricted_expr_errors, RecordConstructionError,
     RestrictedExpressionError,
 };
 pub use cedar_policy_core::evaluator::{evaluation_errors, EvaluationError};
@@ -293,7 +293,7 @@ pub enum ContextCreationError {
     /// Only returned by `Context::from_pairs()`
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ExpressionConstruction(#[from] ExpressionConstructionError),
+    RecordConstruction(#[from] RecordConstructionError),
 }
 
 #[doc(hidden)]
@@ -302,9 +302,7 @@ impl From<ast::ContextCreationError> for ContextCreationError {
         match e {
             ast::ContextCreationError::NotARecord(nre) => Self::NotARecord(nre),
             ast::ContextCreationError::Evaluation(e) => Self::Evaluation(e),
-            ast::ContextCreationError::ExpressionConstruction(ece) => {
-                Self::ExpressionConstruction(ece)
-            }
+            ast::ContextCreationError::RecordConstruction(ece) => Self::RecordConstruction(ece),
         }
     }
 }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -18,7 +18,7 @@
 
 use crate::{EntityUid, PolicyId};
 pub use cedar_policy_core::ast::{
-    expression_construction_errors, restricted_expr_errors, RecordConstructionError,
+    expression_construction_errors, restricted_expr_errors, ExpressionConstructionError,
     RestrictedExpressionError,
 };
 pub use cedar_policy_core::evaluator::{evaluation_errors, EvaluationError};
@@ -293,7 +293,7 @@ pub enum ContextCreationError {
     /// Only returned by `Context::from_pairs()`
     #[error(transparent)]
     #[diagnostic(transparent)]
-    RecordConstruction(#[from] RecordConstructionError),
+    ExpressionConstruction(#[from] ExpressionConstructionError),
 }
 
 #[doc(hidden)]
@@ -302,7 +302,9 @@ impl From<ast::ContextCreationError> for ContextCreationError {
         match e {
             ast::ContextCreationError::NotARecord(nre) => Self::NotARecord(nre),
             ast::ContextCreationError::Evaluation(e) => Self::Evaluation(e),
-            ast::ContextCreationError::RecordConstruction(ece) => Self::RecordConstruction(ece),
+            ast::ContextCreationError::ExpressionConstruction(ece) => {
+                Self::ExpressionConstruction(ece)
+            }
         }
     }
 }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -42,12 +42,12 @@ pub mod entities_errors {
 /// Errors related to serializing/deserializing entities or contexts to/from JSON
 pub mod entities_json_errors {
     pub use cedar_policy_core::entities::json::err::{
-        ActionParentIsNotAction, DuplicateKeyInRecordLiteral, ExpectedExtnValue,
-        ExpectedLiteralEntityRef, ExtensionFunctionLookup, ExtnCall0Arguments,
-        ExtnCall2OrMoreArguments, HeterogeneousSet, JsonDeserializationError, JsonError,
-        JsonSerializationError, MissingImpliedConstructor, MissingRequiredRecordAttr, ParseEscape,
-        ReservedKey, Residual, TypeMismatch, TypeMismatchError, UnexpectedRecordAttr,
-        UnexpectedRestrictedExprKind, UnknownInImplicitConstructorArg,
+        ActionParentIsNotAction, DuplicateKey, ExpectedExtnValue, ExpectedLiteralEntityRef,
+        ExtensionFunctionLookup, ExtnCall0Arguments, ExtnCall2OrMoreArguments, HeterogeneousSet,
+        JsonDeserializationError, JsonError, JsonSerializationError, MissingImpliedConstructor,
+        MissingRequiredRecordAttr, ParseEscape, ReservedKey, Residual, TypeMismatch,
+        TypeMismatchError, UnexpectedRecordAttr, UnexpectedRestrictedExprKind,
+        UnknownInImplicitConstructorArg,
     };
 }
 

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -5379,8 +5379,7 @@ mod context_tests {
         let context = context_pt_1
             .merge(context_pt_2)
             .expect("context merge should have succeeded");
-        let values = context.values();
-        assert_eq!(values.len(), 3);
+        let values = context.into_iter();
         for (k, v) in values {
             match k.as_ref() {
                 "key1" => {

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -5226,7 +5226,8 @@ mod request_validation_tests {
     }
 }
 
-mod context_creation_tests {
+mod context_tests {
+    use cool_asserts::assert_matches;
     use serde_json::json;
 
     use super::*;
@@ -5363,7 +5364,65 @@ mod context_creation_tests {
         expect_err(
             "",
             &Report::new(err),
-            &ExpectedErrorMessageBuilder::error("duplicate key `key1` in record literal").build(),
+            &ExpectedErrorMessageBuilder::error("duplicate key `key1` in context").build(),
+        );
+    }
+
+    #[test]
+    fn merge_contexts() {
+        let context_pt_1 = Context::from_json_value(json!({"key1": "foo", "key2": true}), None)
+            .expect("context creation should have succeeded");
+        let pairs = vec![(String::from("key3"), RestrictedExpression::new_long(42))];
+        let context_pt_2 =
+            Context::from_pairs(pairs).expect("context creation should have succeeded");
+
+        let context = context_pt_1
+            .merge(context_pt_2)
+            .expect("context merge should have succeeded");
+        let values = context.values();
+        assert_eq!(values.len(), 3);
+        for (k, v) in values {
+            match k.as_ref() {
+                "key1" => {
+                    assert_matches!(
+                        v.into_inner().expr_kind(),
+                        ast::ExprKind::Lit(ast::Literal::String(s)) => {
+                            assert_eq!(s.as_str(), "foo");
+                        }
+                    );
+                }
+                "key2" => {
+                    assert_matches!(
+                        v.into_inner().expr_kind(),
+                        ast::ExprKind::Lit(ast::Literal::Bool(true)),
+                    );
+                }
+                "key3" => {
+                    assert_matches!(
+                        v.into_inner().expr_kind(),
+                        ast::ExprKind::Lit(ast::Literal::Long(42)),
+                    );
+                }
+                _ => {
+                    panic!("unexpected key `{k}`");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn merge_contexts_duplicate_keys() {
+        let context_pt_1 = Context::from_json_value(json!({"key1": "foo", "key2": true}), None)
+            .expect("context creation should have succeeded");
+        let pairs = vec![(String::from("key2"), RestrictedExpression::new_long(42))];
+        let context_pt_2 =
+            Context::from_pairs(pairs).expect("context creation should have succeeded");
+
+        let err = context_pt_1.merge(context_pt_2).unwrap_err();
+        expect_err(
+            "",
+            &Report::new(err),
+            &ExpectedErrorMessageBuilder::error("duplicate key `key2` in context").build(),
         );
     }
 }


### PR DESCRIPTION
## Description of changes

Adds two new methods to the public API:
* `Context::merge` as suggested in #1013 
* `Context::values` which gets the key/value pairs out of the context. This function seemed like the most natural way to implement `merge`, and could be useful in general.

Makes a breaking error API change (because I can't help myself):
* Renamed `DuplicateKeyInRecordLiteralError` to `DuplicateKeyError` and added a "context" field to allow more precise error messages. The reason for this change is just that I didn't like the error message "duplicate key _ in a record literal" for the `Context` functions.

## Issue #, if available

Resolves #1013

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
