### PR TITLE
Follow-up PR to #1026

### DIFF
--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -459,7 +459,7 @@ mod test {
         pset.add_static(parser::parse_policy(Some("2".to_string()), src2).unwrap())
             .unwrap();
 
-        let mut r = a.is_authorized_core(q.clone(), &pset, &es);
+        let r = a.is_authorized_core(q.clone(), &pset, &es);
         let map = [("test".into(), Value::from(false))].into_iter().collect();
         let r2: Response = r.reauthorize(&map, &a, &es).unwrap().into();
         assert_eq!(r2.decision, Decision::Allow);
@@ -571,7 +571,7 @@ mod test {
         pset.add_static(parser::parse_policy(Some("2".into()), src2).unwrap())
             .unwrap();
 
-        let mut r = a.is_authorized_core(q.clone(), &pset, &es);
+        let r = a.is_authorized_core(q.clone(), &pset, &es);
         let map = [("a".into(), Value::from(false))].into_iter().collect();
         let r2: Response = r.reauthorize(&map, &a, &es).unwrap().into();
         assert_eq!(r2.decision, Decision::Deny);

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -828,8 +828,7 @@ mod test {
         let entities = Entities::new();
 
         let authorizer = Authorizer::new();
-        let partial_response =
-            authorizer.is_authorized_core(partial_request, &policies, &entities);
+        let partial_response = authorizer.is_authorized_core(partial_request, &policies, &entities);
 
         let response_with_concrete_resource = partial_response
             .reauthorize(

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -317,15 +317,14 @@ impl PartialResponse {
 
     /// Attempt to re-authorize this response given a mapping from unknowns to values
     pub fn reauthorize(
-        &mut self,
+        &self,
         mapping: &HashMap<SmolStr, Value>,
         auth: &Authorizer,
         es: &Entities,
     ) -> Result<Self, ReauthorizationError> {
         let policyset = self.all_policies(mapping)?;
         let new_request = self.concretize_request(mapping)?;
-        self.request = Arc::new(new_request);
-        Ok(auth.is_authorized_core(self.request.as_ref().clone(), &policyset, es))
+        Ok(auth.is_authorized_core(new_request, &policyset, es))
     }
 
     fn all_policies(&self, mapping: &HashMap<SmolStr, Value>) -> Result<PolicySet, PolicySetError> {
@@ -829,10 +828,10 @@ mod test {
         let entities = Entities::new();
 
         let authorizer = Authorizer::new();
-        let mut partial_response =
+        let partial_response =
             authorizer.is_authorized_core(partial_request, &policies, &entities);
 
-        let mut response_with_concrete_resource = partial_response
+        let response_with_concrete_resource = partial_response
             .reauthorize(
                 &HashMap::from_iter(std::iter::once((
                     "resource".into(),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -906,7 +906,7 @@ impl PartialResponse {
 
     /// Attempt to re-authorize this response given a mapping from unknowns to values
     pub fn reauthorize(
-        &mut self,
+        &self,
         mapping: HashMap<SmolStr, RestrictedExpression>,
         auth: &Authorizer,
         es: &Entities,


### PR DESCRIPTION
## Description of changes

It just occurred to me that we don't need mutable references as in #1026. My mistake. This PR fixes it. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

