### PR TITLE
Implementing backwards compatible JSON parsing

### DIFF
--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -38,7 +38,7 @@ default = ["ipaddr", "decimal"]
 # when enabling a feature, make sure that the Core feature is also enabled
 ipaddr = ["cedar-policy-core/ipaddr"]
 decimal = ["cedar-policy-core/decimal"]
-deprecated_unspecified = []
+rfc55_backwards_compatible = []
 
 # Enables `Arbitrary` implementations for several types in this crate
 arbitrary = ["dep:arbitrary", "cedar-policy-core/arbitrary"]

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -38,6 +38,7 @@ default = ["ipaddr", "decimal"]
 # when enabling a feature, make sure that the Core feature is also enabled
 ipaddr = ["cedar-policy-core/ipaddr"]
 decimal = ["cedar-policy-core/decimal"]
+deprecated_unspecified = []
 
 # Enables `Arbitrary` implementations for several types in this crate
 arbitrary = ["dep:arbitrary", "cedar-policy-core/arbitrary"]

--- a/cedar-policy-validator/src/compat.rs
+++ b/cedar-policy-validator/src/compat.rs
@@ -1,0 +1,2 @@
+/// Backwards compatible parsing of the old schema file format
+pub mod schema_file_format;

--- a/cedar-policy-validator/src/compat/schema_file_format.rs
+++ b/cedar-policy-validator/src/compat/schema_file_format.rs
@@ -19,36 +19,20 @@ use cedar_policy_core::{
     entities::CedarValueJson,
     FromNormalizedStr,
 };
-use serde::{
-    de::{MapAccess, Visitor},
-    ser::SerializeMap,
-    Deserialize, Deserializer, Serialize, Serializer,
-};
+use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use serde_with::serde_as;
 use smol_str::{SmolStr, ToSmolStr};
-use std::{
-    collections::{BTreeMap, HashMap, HashSet},
-    fmt::Display,
-    marker::PhantomData,
-};
+use std::{collections::HashMap, fmt::Display};
 
 use crate::{
     err::{schema_errors::*, Result},
-    human_schema::{
-        self, fmt::ToHumanSchemaSyntaxError, parser::parse_natural_schema_fragment, SchemaWarning,
-    },
-    HumanSchemaError, HumanSyntaxParseError, RawName,
+    human_schema::fmt::ToHumanSchemaSyntaxError,
+    schema_file_format::DEFAULT_CEDAR_TYPE,
+    RawName,
 };
-use std::str::FromStr;
 
-lazy_static::lazy_static! {
-    /// The stand in for the "unspecified" entity type removed by RFC 55
-    pub static ref DEFAULT_CEDAR_TYPE : Name = {
-        // PANIC SAFETY: unwrapping a constant
-        #[allow(clippy::unwrap_used)]
-        Name::from_str("__cedar::default").unwrap()
-    };
-}
+use crate::schema_file_format as current;
+
 /// A [`SchemaFragment`] is split into multiple namespace definitions, and is just
 /// a map from namespace name to namespace definition (i.e., definitions of
 /// common types, entity types, and actions in that namespace).
@@ -75,6 +59,30 @@ pub struct SchemaFragment<N>(
     #[cfg_attr(feature = "wasm", tsify(type = "Record<string, NamespaceDefinition>"))]
     pub HashMap<Option<Name>, NamespaceDefinition<N>>,
 );
+
+impl From<SchemaFragment<Name>> for current::SchemaFragment<Name> {
+    fn from(value: SchemaFragment<Name>) -> Self {
+        Self(
+            value
+                .0
+                .into_iter()
+                .map(|(name, namespace)| (name, namespace.into()))
+                .collect(),
+        )
+    }
+}
+
+impl From<SchemaFragment<RawName>> for current::SchemaFragment<RawName> {
+    fn from(value: SchemaFragment<RawName>) -> Self {
+        Self(
+            value
+                .0
+                .into_iter()
+                .map(|(name, namespace)| (name, namespace.into()))
+                .collect(),
+        )
+    }
+}
 
 /// Custom deserializer to ensure that the empty namespace is mapped to `None`
 fn deserialize_schema_fragment<'de, D, N: Deserialize<'de> + From<RawName>>(
@@ -137,29 +145,14 @@ impl SchemaFragment<RawName> {
     pub fn from_file(file: impl std::io::Read) -> Result<Self> {
         serde_json::from_reader(file).map_err(|e| JsonDeserializationError::new(e, None).into())
     }
-
-    /// Parse the schema (in natural schema syntax) from a string
-    pub fn from_str_natural(
-        src: &str,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        parse_natural_schema_fragment(src).map_err(|e| HumanSyntaxParseError::new(e, src).into())
-    }
-
-    /// Parse the schema (in natural schema syntax) from a reader
-    pub fn from_file_natural(
-        mut file: impl std::io::Read,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let mut src = String::new();
-        file.read_to_string(&mut src)?;
-        Self::from_str_natural(&src)
-    }
 }
 
 impl<N: Display> SchemaFragment<N> {
     /// Pretty print this [`SchemaFragment`]
     pub fn as_natural_schema(&self) -> std::result::Result<String, ToHumanSchemaSyntaxError> {
-        let src = human_schema::fmt::json_schema_to_custom_schema_str(self)?;
-        Ok(src)
+        todo!()
+        // let src = human_schema::fmt::json_schema_to_custom_schema_str(self)?;
+        // Ok(src)
     }
 }
 
@@ -185,11 +178,55 @@ pub struct NamespaceDefinition<N> {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    pub common_types: HashMap<Id, SchemaType<N>>,
+    pub common_types: HashMap<Id, current::SchemaType<N>>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     pub entity_types: HashMap<Id, EntityType<N>>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     pub actions: HashMap<SmolStr, ActionType<N>>,
+}
+
+impl From<NamespaceDefinition<Name>> for current::NamespaceDefinition<Name> {
+    fn from(value: NamespaceDefinition<Name>) -> Self {
+        Self {
+            common_types: value
+                .common_types
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            entity_types: value
+                .entity_types
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            actions: value
+                .actions
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
+}
+
+impl From<NamespaceDefinition<RawName>> for current::NamespaceDefinition<RawName> {
+    fn from(value: NamespaceDefinition<RawName>) -> Self {
+        Self {
+            common_types: value
+                .common_types
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            entity_types: value
+                .entity_types
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+            actions: value
+                .actions
+                .into_iter()
+                .map(|(k, v)| (k, v.into()))
+                .collect(),
+        }
+    }
 }
 
 impl<N> NamespaceDefinition<N> {
@@ -250,8 +287,26 @@ pub struct EntityType<N> {
     pub member_of_types: Vec<N>,
     /// Description of the attributes for entities of this [`EntityType`].
     #[serde(default)]
-    #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
-    pub shape: AttributesOrContext<N>,
+    #[serde(skip_serializing_if = "current::AttributesOrContext::is_empty_record")]
+    pub shape: current::AttributesOrContext<N>,
+}
+
+impl From<EntityType<Name>> for current::EntityType<Name> {
+    fn from(value: EntityType<Name>) -> Self {
+        Self {
+            member_of_types: value.member_of_types,
+            shape: value.shape.into(),
+        }
+    }
+}
+
+impl From<EntityType<RawName>> for current::EntityType<RawName> {
+    fn from(value: EntityType<RawName>) -> Self {
+        Self {
+            member_of_types: value.member_of_types,
+            shape: value.shape.into(),
+        }
+    }
 }
 
 impl EntityType<RawName> {
@@ -265,51 +320,6 @@ impl EntityType<RawName> {
                 .collect(),
             shape: self.shape.qualify_type_references(ns),
         }
-    }
-}
-
-/// Declaration of entity attributes, or of an action context.
-/// These share a JSON format.
-///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`AttributesOrContext`], including recursively.
-/// See notes on [`SchemaFragment`].
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[serde(transparent)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct AttributesOrContext<N>(
-    // We use the usual `SchemaType` deserialization, but it will ultimately
-    // need to be a `Record` or type def which resolves to a `Record`.
-    pub SchemaType<N>,
-);
-
-impl<N> AttributesOrContext<N> {
-    /// Convert the `AttributesOrContext` into its `SchemaType`.
-    pub fn into_inner(self) -> SchemaType<N> {
-        self.0
-    }
-
-    /// Is this `AttributesOrContext` an empty record?
-    pub fn is_empty_record(&self) -> bool {
-        self.0.is_empty_record()
-    }
-}
-
-impl<N> Default for AttributesOrContext<N> {
-    fn default() -> Self {
-        Self(SchemaType::Type(SchemaTypeVariant::Record {
-            attributes: BTreeMap::new(),
-            additional_attributes: partial_schema_default(),
-        }))
-    }
-}
-
-impl AttributesOrContext<RawName> {
-    /// Prefix unqualified entity and common type references with the namespace they are in
-    pub fn qualify_type_references(self, ns: Option<&Name>) -> AttributesOrContext<Name> {
-        AttributesOrContext(self.0.qualify_type_references(ns))
     }
 }
 
@@ -340,20 +350,56 @@ pub struct ActionType<N> {
     /// Which actions are parents of this action.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub member_of: Option<Vec<ActionEntityUID<N>>>,
+    pub member_of: Option<Vec<current::ActionEntityUID<N>>>,
+}
+
+impl From<ActionType<Name>> for current::ActionType<Name> {
+    fn from(value: ActionType<Name>) -> Self {
+        Self {
+            attributes: value.attributes.map(|v| v.into_iter().collect()),
+            applies_to: value
+                .applies_to
+                .map(|v| Some(v.into()))
+                .unwrap_or_else(|| Some(unspecified_applies_to::<Name>().into())),
+            member_of: value
+                .member_of
+                .map(|v| v.into_iter().map(Into::into).collect()),
+        }
+    }
+}
+
+fn unspecified_applies_to<T>() -> ApplySpec<T> {
+    ApplySpec {
+        principal_types: None,
+        resource_types: None,
+        context: current::AttributesOrContext::default(),
+    }
+}
+
+impl From<ActionType<RawName>> for current::ActionType<RawName> {
+    fn from(value: ActionType<RawName>) -> Self {
+        Self {
+            attributes: value.attributes.map(|v| v.into_iter().collect()),
+            applies_to: value
+                .applies_to
+                .map(|v| Some(v.into()))
+                .unwrap_or_else(|| Some(unspecified_applies_to::<RawName>().into())),
+            member_of: value
+                .member_of
+                .map(|v| v.into_iter().map(Into::into).collect()),
+        }
+    }
 }
 
 impl ActionType<RawName> {
-    /// Prefix unqualified entity and common type references with the namespace they are in
+    /// Qualify type references with the namespace they are in
     pub fn qualify_type_references(self, ns: Option<&Name>) -> ActionType<Name> {
         ActionType {
             attributes: self.attributes,
-            applies_to: self
-                .applies_to
-                .map(|applyspec| applyspec.qualify_type_references(ns)),
+            applies_to: self.applies_to.map(|v| v.qualify_type_references(ns)),
             member_of: self.member_of.map(|v| {
                 v.into_iter()
-                    .map(|aeuid| aeuid.qualify_type_references(ns))
+                    .map(|v| v.qualify_type_references(ns))
                     .collect()
             }),
         }
@@ -378,760 +424,57 @@ impl ActionType<RawName> {
 pub struct ApplySpec<N> {
     /// Resource types that are valid for the action
     #[serde(default)]
-    pub resource_types: Vec<N>,
+    pub resource_types: Option<Vec<N>>,
     /// Principal types that are valid for the action
     #[serde(default)]
-    pub principal_types: Vec<N>,
+    pub principal_types: Option<Vec<N>>,
     /// Context type that this action expects
     #[serde(default)]
-    #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
-    pub context: AttributesOrContext<N>,
+    #[serde(skip_serializing_if = "current::AttributesOrContext::is_empty_record")]
+    pub context: current::AttributesOrContext<N>,
+}
+
+impl From<ApplySpec<Name>> for current::ApplySpec<Name> {
+    fn from(value: ApplySpec<Name>) -> Self {
+        Self {
+            resource_types: value
+                .resource_types
+                .unwrap_or_else(|| vec![DEFAULT_CEDAR_TYPE.clone()]),
+            principal_types: value
+                .principal_types
+                .unwrap_or_else(|| vec![DEFAULT_CEDAR_TYPE.clone()]),
+            context: value.context,
+        }
+    }
+}
+
+impl From<ApplySpec<RawName>> for current::ApplySpec<RawName> {
+    fn from(value: ApplySpec<RawName>) -> Self {
+        Self {
+            resource_types: value
+                .resource_types
+                .unwrap_or_else(|| vec![RawName::from_name(DEFAULT_CEDAR_TYPE.clone())]),
+            principal_types: value
+                .principal_types
+                .unwrap_or_else(|| vec![RawName::from_name(DEFAULT_CEDAR_TYPE.clone())]),
+            context: value.context,
+        }
+    }
 }
 
 impl ApplySpec<RawName> {
-    /// Prefix unqualified entity and common type references with the namespace they are in
+    /// Qualify type references with the namespace they are in
     pub fn qualify_type_references(self, ns: Option<&Name>) -> ApplySpec<Name> {
         ApplySpec {
             resource_types: self
                 .resource_types
-                .into_iter()
-                .map(|rname| rname.qualify_with(ns))
-                .collect(),
+                .map(|v| v.into_iter().map(|rname| rname.qualify_with(ns)).collect()),
             principal_types: self
                 .principal_types
-                .into_iter()
-                .map(|rname| rname.qualify_with(ns))
-                .collect(),
+                .map(|v| v.into_iter().map(|rname| rname.qualify_with(ns)).collect()),
             context: self.context.qualify_type_references(ns),
         }
     }
-}
-
-/// Represents the [`cedar_policy_core::ast::EntityUID`] of an action
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[serde(deny_unknown_fields)]
-#[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct ActionEntityUID<N> {
-    /// Represents the [`cedar_policy_core::ast::Eid`] of the action
-    pub id: SmolStr,
-
-    /// Represents the type of the action.
-    /// `None` is shorthand for `Action`.
-    /// If this is `Some`, the last component of the [`Name`] should be `Action`.
-    #[serde(rename = "type")]
-    #[serde(default)]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub ty: Option<N>,
-}
-
-impl<N> ActionEntityUID<N> {
-    /// Given an `id`, get the [`ActionEntityUID`] representing `Action::<id>`.
-    pub fn default_type(id: SmolStr) -> Self {
-        Self { id, ty: None }
-    }
-}
-
-impl<N: std::fmt::Display> std::fmt::Display for ActionEntityUID<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if let Some(ty) = &self.ty {
-            write!(f, "{}::", ty)?
-        } else {
-            write!(f, "Action::")?
-        }
-        write!(f, "\"{}\"", self.id.escape_debug())
-    }
-}
-
-impl ActionEntityUID<RawName> {
-    /// Prefix unqualified entity and common type references with the namespace they are in
-    pub fn qualify_type_references(self, ns: Option<&Name>) -> ActionEntityUID<Name> {
-        ActionEntityUID {
-            id: self.id,
-            ty: self.ty.map(|rname| rname.qualify_with(ns)),
-        }
-    }
-}
-
-/// A restricted version of the [`crate::types::Type`] enum containing only the types
-/// which are exposed to users.
-///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`SchemaType`], including recursively.
-/// See notes on [`SchemaFragment`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-// This enum is `untagged` with these variants as a workaround to a serde
-// limitation. It is not possible to have the known variants on one enum, and
-// then, have catch-all variant for any unrecognized tag in the same enum that
-// captures the name of the unrecognized tag.
-#[serde(untagged)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum SchemaType<N> {
-    /// One of the standard types exposed to users
-    Type(SchemaTypeVariant<N>),
-    /// A common type ("typedef")
-    TypeDef {
-        /// Name of the common type.
-        /// For the important case of `N` = [`RawName`], this is the schema JSON
-        /// format, and the `RawName` is exactly how it appears in the schema;
-        /// may not yet be fully qualified
-        #[serde(rename = "type")]
-        type_name: N,
-    },
-}
-
-impl<N> SchemaType<N> {
-    /// Return an iterator of common type references ocurred in the type
-    pub(crate) fn common_type_references(&self) -> Box<dyn Iterator<Item = &N> + '_> {
-        match self {
-            SchemaType::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
-                .iter()
-                .map(|(_, ty)| ty.ty.common_type_references())
-                .fold(Box::new(std::iter::empty()), |it, tys| {
-                    Box::new(it.chain(tys))
-                }),
-            SchemaType::Type(SchemaTypeVariant::Set { element }) => {
-                element.common_type_references()
-            }
-            SchemaType::TypeDef { type_name } => Box::new(std::iter::once(type_name)),
-            _ => Box::new(std::iter::empty()),
-        }
-    }
-
-    /// Is this [`SchemaType`] an extension type, or does it contain one
-    /// (recursively)? Returns `None` if this is a `TypeDef` because we can't
-    /// easily properly check the type of a typedef, accounting for namespaces,
-    /// without first converting to a [`crate::types::Type`].
-    pub fn is_extension(&self) -> Option<bool> {
-        match self {
-            Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
-            Self::Type(SchemaTypeVariant::Set { element }) => element.is_extension(),
-            Self::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
-                .values()
-                .try_fold(false, |a, e| match e.ty.is_extension() {
-                    Some(true) => Some(true),
-                    Some(false) => Some(a),
-                    None => None,
-                }),
-            Self::Type(_) => Some(false),
-            Self::TypeDef { .. } => None,
-        }
-    }
-
-    /// Is this [`SchemaType`] an empty record? This function is used by the `Display`
-    /// implementation to avoid printing unnecessary entity/action data.
-    pub fn is_empty_record(&self) -> bool {
-        match self {
-            Self::Type(SchemaTypeVariant::Record {
-                attributes,
-                additional_attributes,
-            }) => *additional_attributes == partial_schema_default() && attributes.is_empty(),
-            _ => false,
-        }
-    }
-}
-
-impl SchemaType<RawName> {
-    /// Prefix unqualified entity and common type references with the namespace they are in
-    pub fn qualify_type_references(self, ns: Option<&Name>) -> SchemaType<Name> {
-        match self {
-            Self::Type(stv) => SchemaType::Type(stv.qualify_type_references(ns)),
-            Self::TypeDef { type_name } => SchemaType::TypeDef {
-                type_name: type_name.qualify_with(ns),
-            },
-        }
-    }
-
-    fn into_n<N: From<RawName>>(self) -> SchemaType<N> {
-        match self {
-            Self::Type(stv) => SchemaType::Type(stv.into_n()),
-            Self::TypeDef { type_name } => SchemaType::TypeDef {
-                type_name: type_name.into(),
-            },
-        }
-    }
-}
-
-impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for SchemaType<N> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_any(SchemaTypeVisitor {
-            _phantom: PhantomData,
-        })
-    }
-}
-
-/// The fields for a `SchemaTypes`. Used for implementing deserialization.
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
-#[serde(field_identifier, rename_all = "camelCase")]
-enum TypeFields {
-    Type,
-    Element,
-    Attributes,
-    AdditionalAttributes,
-    Name,
-}
-
-// This macro is used to avoid duplicating the fields names when calling
-// `serde::de::Error::unknown_field`. It wants an `&'static [&'static str]`, and
-// AFAIK, the elements of the static slice must be literals.
-macro_rules! type_field_name {
-    (Type) => {
-        "type"
-    };
-    (Element) => {
-        "element"
-    };
-    (Attributes) => {
-        "attributes"
-    };
-    (AdditionalAttributes) => {
-        "additionalAttributes"
-    };
-    (Name) => {
-        "name"
-    };
-}
-
-impl TypeFields {
-    fn as_str(&self) -> &'static str {
-        match self {
-            TypeFields::Type => type_field_name!(Type),
-            TypeFields::Element => type_field_name!(Element),
-            TypeFields::Attributes => type_field_name!(Attributes),
-            TypeFields::AdditionalAttributes => type_field_name!(AdditionalAttributes),
-            TypeFields::Name => type_field_name!(Name),
-        }
-    }
-}
-
-/// Used during deserialization to deserialize the attributes type map while
-/// reporting an error if there are any duplicate keys in the map. I could not
-/// find a way to do the `serde_with` conversion inline without introducing this
-/// struct.
-#[derive(Deserialize)]
-struct AttributesTypeMap(
-    #[serde(with = "serde_with::rust::maps_duplicate_key_is_error")]
-    BTreeMap<SmolStr, TypeOfAttribute<RawName>>,
-);
-
-struct SchemaTypeVisitor<N> {
-    _phantom: PhantomData<N>,
-}
-
-impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for SchemaTypeVisitor<N> {
-    type Value = SchemaType<N>;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("builtin type or reference to type defined in commonTypes")
-    }
-
-    fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
-    where
-        M: MapAccess<'de>,
-    {
-        use TypeFields::*;
-
-        // We keep field values wrapped in a `Result` initially so that we do
-        // not report errors due the contents of a field when the field is not
-        // expected for a particular type variant. We instead report that the
-        // field so not exist at all, so that the schema author can delete the
-        // field without wasting time fixing errors in the value.
-        let mut type_name: Option<std::result::Result<SmolStr, M::Error>> = None;
-        let mut element: Option<std::result::Result<SchemaType<N>, M::Error>> = None;
-        let mut attributes: Option<std::result::Result<AttributesTypeMap, M::Error>> = None;
-        let mut additional_attributes: Option<std::result::Result<bool, M::Error>> = None;
-        let mut name: Option<std::result::Result<SmolStr, M::Error>> = None;
-
-        // Gather all the fields in the object. Any fields that are not one of
-        // the possible fields for some schema type will have been reported by
-        // serde already.
-        while let Some(key) = map.next_key()? {
-            match key {
-                Type => {
-                    if type_name.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Type.as_str()));
-                    }
-                    type_name = Some(map.next_value());
-                }
-                Element => {
-                    if element.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Element.as_str()));
-                    }
-                    element = Some(map.next_value());
-                }
-                Attributes => {
-                    if attributes.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Attributes.as_str()));
-                    }
-                    attributes = Some(map.next_value());
-                }
-                AdditionalAttributes => {
-                    if additional_attributes.is_some() {
-                        return Err(serde::de::Error::duplicate_field(
-                            AdditionalAttributes.as_str(),
-                        ));
-                    }
-                    additional_attributes = Some(map.next_value());
-                }
-                Name => {
-                    if name.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Name.as_str()));
-                    }
-                    name = Some(map.next_value());
-                }
-            }
-        }
-
-        Self::build_schema_type::<M>(type_name, element, attributes, additional_attributes, name)
-    }
-}
-
-// PANIC SAFETY `Set`, `Record`, `Entity`, and `Extension` are valid `Name`s
-#[allow(clippy::expect_used)]
-pub(crate) mod static_names {
-    use crate::RawName;
-
-    lazy_static::lazy_static! {
-        pub(crate) static ref SET_NAME : RawName = RawName::parse_unqualified_name("Set").expect("valid identifier");
-        pub(crate) static ref RECORD_NAME : RawName = RawName::parse_unqualified_name("Record").expect("valid identifier");
-        pub(crate) static ref ENTITY_NAME : RawName = RawName::parse_unqualified_name("Entity").expect("valid identifier");
-        pub(crate) static ref EXTENSION_NAME : RawName = RawName::parse_unqualified_name("Extension").expect("valid identifier");
-    }
-}
-
-impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
-    /// Construct a schema type given the name of the type and its fields.
-    /// Fields which were not present are `None`. It is an error for a field
-    /// which is not used for a particular type to be `Some` when building that
-    /// type.
-    fn build_schema_type<M>(
-        type_name: Option<std::result::Result<SmolStr, M::Error>>,
-        element: Option<std::result::Result<SchemaType<N>, M::Error>>,
-        attributes: Option<std::result::Result<AttributesTypeMap, M::Error>>,
-        additional_attributes: Option<std::result::Result<bool, M::Error>>,
-        name: Option<std::result::Result<SmolStr, M::Error>>,
-    ) -> std::result::Result<SchemaType<N>, M::Error>
-    where
-        M: MapAccess<'de>,
-    {
-        use static_names::*;
-        use TypeFields::*;
-        // Fields that remain to be parsed
-        let mut remaining_fields = [
-            (Type, type_name.is_some()),
-            (Element, element.is_some()),
-            (Attributes, attributes.is_some()),
-            (AdditionalAttributes, additional_attributes.is_some()),
-            (Name, name.is_some()),
-        ]
-        .into_iter()
-        .filter(|(_, present)| *present)
-        .map(|(field, _)| field)
-        .collect::<HashSet<_>>();
-
-        match type_name.transpose()?.as_ref() {
-            Some(s) => {
-                // We've concluded that type exists
-                remaining_fields.remove(&Type);
-                // Used to generate the appropriate serde error if a field is present
-                // when it is not expected.
-                let error_if_fields = |fs: &[TypeFields],
-                                       expected: &'static [&'static str]|
-                 -> std::result::Result<(), M::Error> {
-                    for f in fs {
-                        if remaining_fields.contains(f) {
-                            return Err(serde::de::Error::unknown_field(f.as_str(), expected));
-                        }
-                    }
-                    Ok(())
-                };
-                let error_if_any_fields = || -> std::result::Result<(), M::Error> {
-                    error_if_fields(&[Element, Attributes, AdditionalAttributes, Name], &[])
-                };
-                match s.as_str() {
-                    "String" => {
-                        error_if_any_fields()?;
-                        Ok(SchemaType::Type(SchemaTypeVariant::String))
-                    }
-                    "Long" => {
-                        error_if_any_fields()?;
-                        Ok(SchemaType::Type(SchemaTypeVariant::Long))
-                    }
-                    "Boolean" => {
-                        error_if_any_fields()?;
-                        Ok(SchemaType::Type(SchemaTypeVariant::Boolean))
-                    }
-                    "Set" => {
-                        if remaining_fields.is_empty() {
-                            // must be referring to a common type named `Set`
-                            Ok(SchemaType::TypeDef {
-                                type_name: N::from(SET_NAME.clone()),
-                            })
-                        } else {
-                            error_if_fields(
-                                &[Attributes, AdditionalAttributes, Name],
-                                &[type_field_name!(Element)],
-                            )?;
-
-                            Ok(SchemaType::Type(SchemaTypeVariant::Set {
-                                element: {
-                                    // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them, ensuring `element` exists
-                                    #[allow(clippy::unwrap_used)]
-                                    let element: SchemaType<N> = element.unwrap()?;
-                                    Box::new(element)
-                                },
-                            }))
-                        }
-                    }
-                    "Record" => {
-                        if remaining_fields.is_empty() {
-                            // must be referring to a common type named `Record`
-                            Ok(SchemaType::TypeDef {
-                                type_name: N::from(RECORD_NAME.clone()),
-                            })
-                        } else {
-                            error_if_fields(
-                                &[Element, Name],
-                                &[
-                                    type_field_name!(Attributes),
-                                    type_field_name!(AdditionalAttributes),
-                                ],
-                            )?;
-
-                            if let Some(attributes) = attributes {
-                                let additional_attributes =
-                                    additional_attributes.unwrap_or(Ok(partial_schema_default()));
-                                Ok(SchemaType::Type(SchemaTypeVariant::Record {
-                                    attributes: attributes?
-                                        .0
-                                        .into_iter()
-                                        .map(|(k, TypeOfAttribute { ty, required })| {
-                                            (
-                                                k,
-                                                TypeOfAttribute {
-                                                    ty: ty.into_n(),
-                                                    required,
-                                                },
-                                            )
-                                        })
-                                        .collect(),
-                                    additional_attributes: additional_attributes?,
-                                }))
-                            } else {
-                                Err(serde::de::Error::missing_field(Attributes.as_str()))
-                            }
-                        }
-                    }
-                    "Entity" => {
-                        if remaining_fields.is_empty() {
-                            // must be referring to a common type named `Entity`
-                            Ok(SchemaType::TypeDef {
-                                type_name: N::from(ENTITY_NAME.clone()),
-                            })
-                        } else {
-                            error_if_fields(
-                                &[Element, Attributes, AdditionalAttributes],
-                                &[type_field_name!(Name)],
-                            )?;
-                            // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
-                            #[allow(clippy::unwrap_used)]
-                            let name = name.unwrap()?;
-                            Ok(SchemaType::Type(SchemaTypeVariant::Entity {
-                                name: RawName::from_normalized_str(&name)
-                                    .map_err(|err| {
-                                        serde::de::Error::custom(format!(
-                                            "invalid entity type `{name}`: {err}"
-                                        ))
-                                    })?
-                                    .into(),
-                            }))
-                        }
-                    }
-                    "Extension" => {
-                        if remaining_fields.is_empty() {
-                            Ok(SchemaType::TypeDef {
-                                type_name: N::from(EXTENSION_NAME.clone()),
-                            })
-                        } else {
-                            error_if_fields(
-                                &[Element, Attributes, AdditionalAttributes],
-                                &[type_field_name!(Name)],
-                            )?;
-
-                            // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
-                            #[allow(clippy::unwrap_used)]
-                            let name = name.unwrap()?;
-                            Ok(SchemaType::Type(SchemaTypeVariant::Extension {
-                                name: Id::from_normalized_str(&name).map_err(|err| {
-                                    serde::de::Error::custom(format!(
-                                        "invalid extension type `{name}`: {err}"
-                                    ))
-                                })?,
-                            }))
-                        }
-                    }
-                    type_name => {
-                        error_if_any_fields()?;
-                        Ok(SchemaType::TypeDef {
-                            type_name: N::from(RawName::from_normalized_str(type_name).map_err(
-                                |err| {
-                                    serde::de::Error::custom(format!(
-                                        "invalid common type `{type_name}`: {err}"
-                                    ))
-                                },
-                            )?),
-                        })
-                    }
-                }
-            }
-            None => Err(serde::de::Error::missing_field(Type.as_str())),
-        }
-    }
-}
-
-impl<N> From<SchemaTypeVariant<N>> for SchemaType<N> {
-    fn from(variant: SchemaTypeVariant<N>) -> Self {
-        Self::Type(variant)
-    }
-}
-
-/// The variants of [`SchemaType`] that are exposed to users, i.e., legal to write
-/// in schemas. Does not include common types, which are handled separately.
-///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`SchemaTypeVariant`], including recursively.
-/// See notes on [`SchemaFragment`].
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(tag = "type")]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum SchemaTypeVariant<N> {
-    /// String
-    String,
-    /// Long
-    Long,
-    /// Boolean
-    Boolean,
-    /// Set
-    Set {
-        /// Element type
-        element: Box<SchemaType<N>>,
-    },
-    /// Record
-    Record {
-        /// Attribute names and types for the record
-        attributes: BTreeMap<SmolStr, TypeOfAttribute<N>>,
-        /// Whether "additional attributes" are possible on this record
-        #[serde(rename = "additionalAttributes")]
-        #[serde(skip_serializing_if = "is_partial_schema_default")]
-        additional_attributes: bool,
-    },
-    /// Entity
-    Entity {
-        /// Name of the entity type.
-        /// For the important case of `N` = `RawName`, this is the schema JSON
-        /// format, and the `RawName` is exactly how it appears in the schema;
-        /// may not yet be fully qualified
-        name: N,
-    },
-    /// Extension types
-    Extension {
-        /// Name of the extension type
-        name: Id,
-    },
-}
-
-impl SchemaTypeVariant<RawName> {
-    /// Prefix unqualified entity and common type references with the namespace they are in
-    pub fn qualify_type_references(self, ns: Option<&Name>) -> SchemaTypeVariant<Name> {
-        match self {
-            Self::Boolean => SchemaTypeVariant::Boolean,
-            Self::Long => SchemaTypeVariant::Long,
-            Self::String => SchemaTypeVariant::String,
-            Self::Entity { name } => SchemaTypeVariant::Entity {
-                name: name.qualify_with(ns),
-            },
-            Self::Record {
-                attributes,
-                additional_attributes,
-            } => SchemaTypeVariant::Record {
-                attributes: BTreeMap::from_iter(attributes.into_iter().map(
-                    |(attr, TypeOfAttribute { ty, required })| {
-                        (
-                            attr,
-                            TypeOfAttribute {
-                                ty: ty.qualify_type_references(ns),
-                                required,
-                            },
-                        )
-                    },
-                )),
-                additional_attributes,
-            },
-            Self::Set { element } => SchemaTypeVariant::Set {
-                element: Box::new(element.qualify_type_references(ns)),
-            },
-            Self::Extension { name } => SchemaTypeVariant::Extension { name },
-        }
-    }
-
-    fn into_n<N: From<RawName>>(self) -> SchemaTypeVariant<N> {
-        match self {
-            Self::Boolean => SchemaTypeVariant::Boolean,
-            Self::Long => SchemaTypeVariant::Long,
-            Self::String => SchemaTypeVariant::String,
-            Self::Entity { name } => SchemaTypeVariant::Entity { name: name.into() },
-            Self::Record {
-                attributes,
-                additional_attributes,
-            } => SchemaTypeVariant::Record {
-                attributes: attributes
-                    .into_iter()
-                    .map(|(k, v)| (k, v.into_n()))
-                    .collect(),
-                additional_attributes,
-            },
-            Self::Set { element } => SchemaTypeVariant::Set {
-                element: Box::new(element.into_n()),
-            },
-            Self::Extension { name } => SchemaTypeVariant::Extension { name },
-        }
-    }
-}
-
-// Only used for serialization
-fn is_partial_schema_default(b: &bool) -> bool {
-    *b == partial_schema_default()
-}
-
-// We forbid declaring a custom typedef with the same name as a builtin type.
-pub(crate) static PRIMITIVE_TYPES: &[&str] = &["String", "Long", "Boolean"];
-
-#[cfg(feature = "arbitrary")]
-// PANIC SAFETY property testing code
-#[allow(clippy::panic)]
-impl<'a> arbitrary::Arbitrary<'a> for SchemaType<RawName> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType<RawName>> {
-        use std::collections::BTreeSet;
-
-        Ok(SchemaType::Type(match u.int_in_range::<u8>(1..=8)? {
-            1 => SchemaTypeVariant::String,
-            2 => SchemaTypeVariant::Long,
-            3 => SchemaTypeVariant::Boolean,
-            4 => SchemaTypeVariant::Set {
-                element: Box::new(u.arbitrary()?),
-            },
-            5 => {
-                let attributes = {
-                    let attr_names: BTreeSet<String> = u.arbitrary()?;
-                    attr_names
-                        .into_iter()
-                        .map(|attr_name| Ok((attr_name.into(), u.arbitrary()?)))
-                        .collect::<arbitrary::Result<_>>()?
-                };
-                SchemaTypeVariant::Record {
-                    attributes,
-                    additional_attributes: u.arbitrary()?,
-                }
-            }
-            6 => SchemaTypeVariant::Entity {
-                name: u.arbitrary()?,
-            },
-            7 => SchemaTypeVariant::Extension {
-                // PANIC SAFETY: `ipaddr` is a valid `Id`
-                #[allow(clippy::unwrap_used)]
-                name: "ipaddr".parse().unwrap(),
-            },
-            8 => SchemaTypeVariant::Extension {
-                // PANIC SAFETY: `decimal` is a valid `Id`
-                #[allow(clippy::unwrap_used)]
-                name: "decimal".parse().unwrap(),
-            },
-            n => panic!("bad index: {n}"),
-        }))
-    }
-    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (1, None) // Unfortunately, we probably can't be more precise than this
-    }
-}
-
-/// Used to describe the type of a record or entity attribute. It contains a the
-/// type of the attribute and whether the attribute is required. The type is
-/// flattened for serialization, so, in JSON format, this appears as a regular
-/// type with one extra property `required`.
-///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`TypeOfAttribute`], including recursively.
-/// See notes on [`SchemaFragment`].
-///
-/// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
-/// using `#[serde(tag = "type")]` in [`SchemaType`] which is flattened here.
-/// The way `serde(flatten)` is implemented means it may be possible to access
-/// fields incorrectly if a struct contains two structs that are flattened
-/// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
-/// us as we're using `flatten` only once
-/// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
-/// unknown fields for [`TypeOfAttribute`] should be passed to [`SchemaType`] where
-/// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-pub struct TypeOfAttribute<N> {
-    /// Underlying type of the attribute
-    #[serde(flatten)]
-    pub ty: SchemaType<N>,
-    /// Whether the attribute is required
-    #[serde(default = "record_attribute_required_default")]
-    #[serde(skip_serializing_if = "is_record_attribute_required_default")]
-    pub required: bool,
-}
-
-impl TypeOfAttribute<RawName> {
-    fn into_n<N: From<RawName>>(self) -> TypeOfAttribute<N> {
-        TypeOfAttribute {
-            ty: self.ty.into_n(),
-            required: self.required,
-        }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for TypeOfAttribute<RawName> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            ty: u.arbitrary()?,
-            required: u.arbitrary()?,
-        })
-    }
-
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        arbitrary::size_hint::and(
-            <SchemaType<RawName> as arbitrary::Arbitrary>::size_hint(depth),
-            <bool as arbitrary::Arbitrary>::size_hint(depth),
-        )
-    }
-}
-
-// Only used for serialization
-fn is_record_attribute_required_default(b: &bool) -> bool {
-    *b == record_attribute_required_default()
-}
-
-/// By default schema properties which enable parts of partial schema validation
-/// should be `false`.  Defines the default value for `additionalAttributes`.
-fn partial_schema_default() -> bool {
-    false
-}
-
-/// Defines the default value for `required` on record and entity attributes.
-fn record_attribute_required_default() -> bool {
-    true
 }
 
 #[cfg(test)]
@@ -1145,6 +488,8 @@ mod test {
     use cool_asserts::assert_matches;
 
     use crate::ValidatorSchema;
+    use current::{AttributesOrContext, SchemaType, SchemaTypeVariant};
+    use std::collections::BTreeMap;
 
     use super::*;
 
@@ -1195,14 +540,14 @@ mod test {
         "#;
         let at: ActionType<RawName> = serde_json::from_str(src).expect("Parse Error");
         let spec = ApplySpec {
-            resource_types: vec!["Album".parse().unwrap()],
-            principal_types: vec!["User".parse().unwrap()],
+            resource_types: Some(vec!["Album".parse().unwrap()]),
+            principal_types: Some(vec!["User".parse().unwrap()]),
             context: AttributesOrContext::default(),
         };
         assert_eq!(at.applies_to, Some(spec));
         assert_eq!(
             at.member_of,
-            Some(vec![ActionEntityUID {
+            Some(vec![current::ActionEntityUID {
                 ty: None,
                 id: "readWrite".into()
             }])
@@ -1848,6 +1193,8 @@ mod strengthened_types {
 #[cfg(test)]
 mod test_json_roundtrip {
     use super::*;
+    use current::{AttributesOrContext, SchemaType, SchemaTypeVariant};
+    use std::collections::BTreeMap;
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn roundtrip(schema: SchemaFragment<RawName>) {
@@ -1903,8 +1250,8 @@ mod test_json_roundtrip {
                     ActionType {
                         attributes: None,
                         applies_to: Some(ApplySpec {
-                            resource_types: vec!["a".parse().unwrap()],
-                            principal_types: vec!["a".parse().unwrap()],
+                            resource_types: Some(vec!["a".parse().unwrap()]),
+                            principal_types: Some(vec!["a".parse().unwrap()]),
                             context: AttributesOrContext(SchemaType::Type(
                                 SchemaTypeVariant::Record {
                                     attributes: BTreeMap::new(),
@@ -1952,8 +1299,8 @@ mod test_json_roundtrip {
                         ActionType {
                             attributes: None,
                             applies_to: Some(ApplySpec {
-                                resource_types: vec!["foo::a".parse().unwrap()],
-                                principal_types: vec!["foo::a".parse().unwrap()],
+                                resource_types: Some(vec!["foo::a".parse().unwrap()]),
+                                principal_types: Some(vec!["foo::a".parse().unwrap()]),
                                 context: AttributesOrContext(SchemaType::Type(
                                     SchemaTypeVariant::Record {
                                         attributes: BTreeMap::new(),
@@ -2061,5 +1408,67 @@ mod test_duplicates_error {
             }
         }"#;
         serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
+    }
+}
+
+#[cfg(test)]
+mod back_compat {
+    use super::*;
+    #[test]
+    fn test_parse() {
+        let src = r#"{
+            "Foo": {
+              "entityTypes" : {},
+              "actions": {
+                "Bar": {
+                    "appliesTo": {
+                    }
+                },
+                "Baz": {
+                    "appliesTo": {
+                        "resourceTypes": ["a", "b"]
+                    }
+                },
+                "Another": {
+                    "appliesTo": {
+                        "principalTypes": ["a", "b"]
+                    }
+                }
+              }
+            }
+        }"#;
+        let schema = serde_json::from_str::<SchemaFragment<RawName>>(src).unwrap();
+        let c: current::SchemaFragment<RawName> = schema.into();
+        let namespace = c.0.get(&Some("Foo".parse().unwrap())).unwrap();
+        let action = namespace.actions.get("Bar").unwrap();
+        let applies_to = action.applies_to.as_ref().unwrap();
+        assert_eq!(applies_to.principal_types.len(), 1);
+        assert!(applies_to
+            .principal_types
+            .contains(&RawName::from_name(DEFAULT_CEDAR_TYPE.clone())));
+        assert_eq!(applies_to.resource_types.len(), 1);
+        assert!(applies_to
+            .resource_types
+            .contains(&RawName::from_name(DEFAULT_CEDAR_TYPE.clone())));
+
+        let action = namespace.actions.get("Another").unwrap();
+        let applies_to = action.applies_to.as_ref().unwrap();
+        assert_eq!(applies_to.principal_types.len(), 2);
+        assert!(applies_to.principal_types.contains(&"a".parse().unwrap()));
+        assert!(applies_to.principal_types.contains(&"b".parse().unwrap()));
+        assert_eq!(applies_to.resource_types.len(), 1);
+        assert!(applies_to
+            .resource_types
+            .contains(&RawName::from_name(DEFAULT_CEDAR_TYPE.clone())));
+
+        let action = namespace.actions.get("Baz").unwrap();
+        let applies_to = action.applies_to.as_ref().unwrap();
+        assert_eq!(applies_to.resource_types.len(), 2);
+        assert!(applies_to.resource_types.contains(&"a".parse().unwrap()));
+        assert!(applies_to.resource_types.contains(&"b".parse().unwrap()));
+        assert_eq!(applies_to.principal_types.len(), 1);
+        assert!(applies_to
+            .principal_types
+            .contains(&RawName::from_name(DEFAULT_CEDAR_TYPE.clone())));
     }
 }

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -56,7 +56,7 @@ pub mod human_schema;
 pub mod typecheck;
 use typecheck::Typechecker;
 /// Compatibility functions
-#[cfg(feature = "deprecated_unspecified")]
+#[cfg(feature = "rfc55_backwards_compatible")]
 pub mod compat;
 pub mod types;
 

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -55,6 +55,9 @@ pub use str_checks::confusable_string_checks;
 pub mod human_schema;
 pub mod typecheck;
 use typecheck::Typechecker;
+/// Compatibility functions
+#[cfg(feature = "deprecated_unspecified")]
+pub mod compat;
 pub mod types;
 
 /// Used to select how a policy will be validated.

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -37,6 +37,7 @@ use crate::{
     err::schema_errors::*,
     err::*,
     human_schema::SchemaWarning,
+    schema_file_format::DEFAULT_CEDAR_TYPE,
     types::{Attributes, EntityRecordKind, OpenTag, Type},
     SchemaFragment, SchemaType, SchemaTypeVariant, TypeOfAttribute,
 };
@@ -441,13 +442,13 @@ impl ValidatorSchema {
             Self::check_undeclared_in_type(&action.context, entity_types, &mut undeclared_e);
 
             for p_entity in action.applies_to_principals() {
-                if !entity_types.contains_key(p_entity) {
+                if !entity_types.contains_key(p_entity) && p_entity.name() != &*DEFAULT_CEDAR_TYPE {
                     undeclared_e.insert(p_entity.clone());
                 }
             }
 
             for r_entity in action.applies_to_resources() {
-                if !entity_types.contains_key(r_entity) {
+                if !entity_types.contains_key(r_entity) && r_entity.name() != &*DEFAULT_CEDAR_TYPE {
                     undeclared_e.insert(r_entity.clone());
                 }
             }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -46,7 +46,7 @@ lazy_static::lazy_static! {
     pub static ref DEFAULT_CEDAR_TYPE : Name = {
         // PANIC SAFETY: unwrapping a constant
         #[allow(clippy::unwrap_used)]
-        Name::from_str("__cedar::default").unwrap()
+        Name::from_str("__cedar::Default").unwrap()
     };
 }
 /// A [`SchemaFragment`] is split into multiple namespace definitions, and is just

--- a/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
@@ -16,8 +16,11 @@
 
 // GRCOV_STOP_COVERAGE
 
-use crate::{NamespaceDefinition, RawName};
 use cool_asserts::assert_matches;
+
+use crate::{NamespaceDefinition, RawName};
+
+use super::test_utils;
 
 fn schema_with_unspecified() -> &'static str {
     r#"
@@ -59,4 +62,132 @@ fn unspecified_does_not_parse() {
         serde_json::from_str::<NamespaceDefinition<RawName>>(schema_with_unspecified()),
         Err(_)
     );
+}
+
+#[cfg(feature = "deprecated_unspecified")]
+mod backwards_compat_tests {
+    use crate::{
+        compat, schema_file_format, schema_file_format::DEFAULT_CEDAR_TYPE,
+        typecheck::AttributeAccess, types::EntityLUB, RawName, ValidationError,
+    };
+    use cedar_policy_core::{
+        ast::{Expr, PolicyID, StaticPolicy, Var},
+        parser::parse_policy,
+    };
+
+    use super::*;
+
+    fn parsed_schema_with_unspecified() -> schema_file_format::NamespaceDefinition<RawName> {
+        let temp: compat::schema_file_format::NamespaceDefinition<RawName> =
+            serde_json::from_str(schema_with_unspecified()).unwrap();
+        temp.into()
+    }
+
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
+    fn assert_policy_typechecks(p: StaticPolicy) {
+        test_utils::assert_policy_typechecks(parsed_schema_with_unspecified(), p);
+    }
+
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
+    fn assert_policy_typecheck_fails(p: StaticPolicy, expected_type_errors: Vec<ValidationError>) {
+        test_utils::assert_policy_typecheck_fails(
+            parsed_schema_with_unspecified(),
+            p,
+            expected_type_errors,
+        );
+    }
+
+    fn default_access() -> AttributeAccess {
+        AttributeAccess::EntityLUB(
+            EntityLUB::single_entity(DEFAULT_CEDAR_TYPE.clone().into()),
+            vec!["name".into()],
+        )
+    }
+
+    #[test]
+    fn spec_principal_unspec_resource() {
+        let policy = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action == Action::"act1", resource) when { principal.name == "foo" };"#,
+    )
+    .expect("Policy should parse.");
+        assert_policy_typechecks(policy);
+
+        let policy = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action == Action::"act1", resource) when { resource.name == "foo" };"#,
+    )
+    .expect("Policy should parse.");
+        assert_policy_typecheck_fails(
+            policy,
+            vec![ValidationError::unsafe_attribute_access(
+                Expr::get_attr(Expr::var(Var::Resource), "name".into()),
+                PolicyID::from_string("0"),
+                default_access(),
+                None,
+                true,
+            )],
+        );
+    }
+
+    #[test]
+    fn spec_resource_unspec_principal() {
+        let policy = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action == Action::"act2", resource) when { principal.name == "foo" };"#,
+    )
+    .expect("Policy should parse.");
+        assert_policy_typecheck_fails(
+            policy,
+            vec![ValidationError::unsafe_attribute_access(
+                Expr::get_attr(Expr::var(Var::Principal), "name".into()),
+                PolicyID::from_string("0"),
+                default_access(),
+                None,
+                true,
+            )],
+        );
+
+        let policy = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action == Action::"act2", resource) when { resource.name == "foo" };"#,
+    )
+    .expect("Policy should parse.");
+        assert_policy_typechecks(policy);
+    }
+
+    #[test]
+    fn unspec_resource_unspec_principal() {
+        let policy = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action == Action::"act3", resource) when { principal.name == "foo" };"#,
+    )
+    .expect("Policy should parse.");
+        assert_policy_typecheck_fails(
+            policy,
+            vec![ValidationError::unsafe_attribute_access(
+                Expr::get_attr(Expr::var(Var::Principal), "name".into()),
+                PolicyID::from_string("0"),
+                default_access(),
+                None,
+                true,
+            )],
+        );
+
+        let policy = parse_policy(
+        Some("0".to_string()),
+        r#"permit(principal, action == Action::"act3", resource) when { resource.name == "foo" };"#,
+    )
+    .expect("Policy should parse.");
+        assert_policy_typecheck_fails(
+            policy,
+            vec![ValidationError::unsafe_attribute_access(
+                Expr::get_attr(Expr::var(Var::Resource), "name".into()),
+                PolicyID::from_string("0"),
+                default_access(),
+                None,
+                true,
+            )],
+        );
+    }
 }

--- a/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
@@ -20,8 +20,6 @@ use cool_asserts::assert_matches;
 
 use crate::{NamespaceDefinition, RawName};
 
-use super::test_utils;
-
 fn schema_with_unspecified() -> &'static str {
     r#"
 {
@@ -64,11 +62,14 @@ fn unspecified_does_not_parse() {
     );
 }
 
-#[cfg(feature = "deprecated_unspecified")]
+#[cfg(feature = "rfc55_backwards_compatible")]
 mod backwards_compat_tests {
     use crate::{
-        compat, schema_file_format, schema_file_format::DEFAULT_CEDAR_TYPE,
-        typecheck::AttributeAccess, types::EntityLUB, RawName, ValidationError,
+        compat, schema_file_format,
+        schema_file_format::DEFAULT_CEDAR_TYPE,
+        typecheck::{test::test_utils, AttributeAccess},
+        types::EntityLUB,
+        RawName, ValidationError,
     };
     use cedar_policy_core::{
         ast::{Expr, PolicyID, StaticPolicy, Var},

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -39,6 +39,9 @@ default = ["ipaddr", "decimal"]
 ipaddr = ["cedar-policy-core/ipaddr", "cedar-policy-validator/ipaddr"]
 decimal = ["cedar-policy-core/decimal", "cedar-policy-validator/decimal"]
 
+# Backwards Compatibility APIs
+deprecated_unspecified = ["cedar-policy-validator/deprecated_unspecified"]
+
 # Features for memory or runtime profiling
 heap-profiling = ["dep:dhat"]
 corpus-timing = []

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -40,7 +40,7 @@ ipaddr = ["cedar-policy-core/ipaddr", "cedar-policy-validator/ipaddr"]
 decimal = ["cedar-policy-core/decimal", "cedar-policy-validator/decimal"]
 
 # Backwards Compatibility APIs
-deprecated_unspecified = ["cedar-policy-validator/deprecated_unspecified"]
+rfc55_backwards_compatible = ["cedar-policy-validator/rfc55_backwards_compatible"]
 
 # Features for memory or runtime profiling
 heap-profiling = ["dep:dhat"]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1206,11 +1206,13 @@ impl SchemaFragment {
         })
     }
 
-    #[cfg(feature = "deprecated_unspecified")]
+    #[cfg(feature = "rfc55_backwards_compatible")]
     #[deprecated]
-    /// Create an `SchemaFragment` from a JSON value (which should be an
-    /// object of the shape required for Cedar schemas).
-    pub fn from_json_value_30compat(json: serde_json::Value) -> Result<Self, SchemaError> {
+    /// Create a `SchemaFragment` from a JSON value (which should be an
+    /// object of the shape required for Cedar schemas). This function is provided
+    /// to provide backwards-compatible behavior with Cedar version 3.x. It will
+    /// be removed in a future release.
+    pub fn from_json_value_3_x_compatible(json: serde_json::Value) -> Result<Self, SchemaError> {
         let compat =
             cedar_policy_validator::compat::schema_file_format::SchemaFragment::from_json_value(
                 json,
@@ -3154,9 +3156,12 @@ impl Request {
     ///
     /// If `schema` is present, this constructor will validate that the
     /// `Request` complies with the given `schema`.
-    #[cfg(feature = "deprecated_unspecified")]
+    ///
+    /// This function is provided to provide backwards-compatible behavior with
+    /// Cedar version 3.x. It will be removed in a future release.
+    #[cfg(feature = "rfc55_backwards_compatible")]
     #[deprecated]
-    pub fn unspecified_new(
+    pub fn new_3_x_compatible(
         principal: Option<EntityUid>,
         action: Option<EntityUid>,
         resource: Option<EntityUid>,
@@ -3185,9 +3190,6 @@ impl Request {
     ///
     /// Note that you can create the `EntityUid`s using `.parse()` on any
     /// string (via the `FromStr` implementation for `EntityUid`).
-    /// The principal, action, and resource fields are optional to support
-    /// the case where these fields do not contribute to authorization
-    /// decisions (e.g., because they are not used in your policies).
     ///
     /// If `schema` is present, this constructor will validate that the
     /// `Request` complies with the given `schema`.

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -225,7 +225,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
         EntityTypeName::from_str("Account").unwrap(),
         EntityId::from_str("jane").unwrap(),
     );
-    #[cfg(feature = "deprecated_unspecified")]
+    #[cfg(feature = "rfc55_backwards_compatible")]
     {
         let request3a = Request::unspecified_new(
             Some(principal.clone()),
@@ -258,7 +258,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
             .decision(),
         Decision::Deny
     );
-    #[cfg(feature = "deprecated_unspecified")]
+    #[cfg(feature = "rfc55_backwards_compatible")]
     {
         // Requesting with the unspecified principal or resource will return Deny (but not fail)
         let request4a = Request::unspecified_new(

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -18,6 +18,7 @@ use cedar_policy::*;
 
 use std::{error::Error, str::FromStr};
 
+#[allow(deprecated)]
 #[test]
 fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
     // Startup the Authorizer with all extensions
@@ -273,9 +274,14 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
                 .decision(),
             Decision::Deny
         );
-        let request5a =
-            Request::unspecified_new(Some(principal), Some(action), None, Context::empty(), None)
-                .unwrap();
+        let request5a = Request::unspecified_new(
+            Some(principal.clone()),
+            Some(action.clone()),
+            None,
+            Context::empty(),
+            None,
+        )
+        .unwrap();
         assert_eq!(
             auth.is_authorized(&request5a, &policies, &entities)
                 .decision(),


### PR DESCRIPTION
## Description of changes
Implements backwards compatible JSON parsing of schemas as specified in RFC 55.

## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):


- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

