### PR TITLE
Added more comments to fixes in #1026

### DIFF
--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -443,8 +443,15 @@ impl PartialResponse {
                 let expr = residual.substitute(mapping);
                 let extns = Extensions::all_available();
                 let eval = RestrictedEvaluator::new(&extns);
-                let partial_value =
-                    eval.partial_interpret(BorrowedRestrictedExpr::new_unchecked(&expr))?;
+                let partial_value = eval.partial_interpret
+                    // Substituting a partial context should produce a
+                    // restricted expression because a partial context is a
+                    // restricted expression and remains so after unknown
+                    // substitution, by the inductive definition of restricted
+                    // expressions
+                    (BorrowedRestrictedExpr::new_unchecked(&expr))?;
+                // Using the unchecked constructor of `Context` is justified
+                // because partially evaluating a context should yield a record
                 context = Some(Context::from_partial_value_unchecked(partial_value));
             }
         }


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

