### PR TITLE
build downstream wasm example

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,11 +31,6 @@ jobs:
       - run: cargo test --verbose --features "experimental"
       - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
 
-  run-integration-tests:
-    uses: ./.github/workflows/run_integration_tests_reusable.yml
-    with:
-      cedar_policy_ref: ${{ github.ref }}
-
   # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
   # don't effect it. As a side effect, this will run in parallel, saving some
   # time.

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -58,3 +58,10 @@ jobs:
     with:
       cedar_policy_ref: ${{ github.ref }}
       cedar_examples_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+
+  run-integration-tests:
+    needs: get-branch-name
+    uses: ./.github/workflows/run_integration_tests_reusable.yml
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_integration_tests_ref:  ${{ needs.get-branch-name.outputs.branch_name }}

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -51,3 +51,10 @@ jobs:
     with:
       cedar_policy_ref: ${{ github.ref }}
       cedar_examples_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+
+  build-wasm:
+    needs: get-branch-name
+    uses: cedar-policy/cedar-examples/.github/workflows/build_wasm_example_reusable.yml@main
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_examples_ref: ${{ needs.get-branch-name.outputs.branch_name }}


### PR DESCRIPTION
## Description of changes

* Build the new Wasm example in CI. This should help prevent us from making unintentional breaking changes.'
* Use the `get-branch-name` trick when running the integration tests. This doesn't matter for the `main` branch, but will be useful when I merge these changes back to `release/3.2.x`, and in the future when we make new release branches.