### PR TITLE
build downstream wasm example (#1034)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,11 +31,6 @@ jobs:
       - run: cargo test --verbose --features "experimental"
       - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
 
-  run-integration-tests:
-    uses: ./.github/workflows/run_integration_tests_reusable.yml
-    with:
-      cedar_policy_ref: ${{ github.ref }}
-
   # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
   # don't affect it. As a side effect, this will run in parallel, saving some
   # time.

--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -51,3 +51,17 @@ jobs:
     with:
       cedar_policy_ref: ${{ github.ref }}
       cedar_examples_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+
+  build-wasm:
+    needs: get-branch-name
+    uses: cedar-policy/cedar-examples/.github/workflows/build_wasm_example_reusable.yml@main
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_examples_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+
+  run-integration-tests:
+    needs: get-branch-name
+    uses: ./.github/workflows/run_integration_tests_reusable.yml
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_integration_tests_ref:  ${{ needs.get-branch-name.outputs.branch_name }}


### PR DESCRIPTION
## Description of changes

Backport of #1034. Doesn't require a new release since it only impacts CI.