### PR TITLE
More tasks from #745

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -41,10 +41,10 @@ pub enum HumanSchemaError {
 #[error("error parsing schema: {errs}")]
 pub struct HumanSyntaxParseError {
     /// Underlying parse error(s)
-    pub errs: human_schema::parser::HumanSyntaxParseErrors,
+    errs: human_schema::parser::HumanSyntaxParseErrors,
     /// Did the schema look like it was intended to be JSON format instead of
     /// human?
-    pub suspect_json_format: bool,
+    suspect_json_format: bool,
 }
 
 impl Diagnostic for HumanSyntaxParseError {
@@ -104,9 +104,15 @@ impl HumanSyntaxParseError {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn inner(&self) -> &human_schema::parser::HumanSyntaxParseErrors {
+    /// Underlying parse error(s)
+    pub fn inner(&self) -> &human_schema::parser::HumanSyntaxParseErrors {
         &self.errs
+    }
+
+    /// Did the schema look like it was intended to be JSON format instead of
+    /// human?
+    pub fn suspect_json_format(&self) -> bool {
+        self.suspect_json_format
     }
 }
 

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -41,10 +41,10 @@ pub enum HumanSchemaError {
 #[error("error parsing schema: {errs}")]
 pub struct HumanSyntaxParseError {
     /// Underlying parse error(s)
-    errs: human_schema::parser::HumanSyntaxParseErrors,
+    pub errs: human_schema::parser::HumanSyntaxParseErrors,
     /// Did the schema look like it was intended to be JSON format instead of
     /// human?
-    suspect_json_format: bool,
+    pub suspect_json_format: bool,
 }
 
 impl Diagnostic for HumanSyntaxParseError {

--- a/cedar-policy-validator/src/human_schema.rs
+++ b/cedar-policy-validator/src/human_schema.rs
@@ -22,5 +22,5 @@ pub mod fmt;
 pub mod parser;
 mod test;
 pub mod to_json_schema;
-pub use err::ParseError;
 pub use err::{schema_warnings, SchemaWarning};
+pub use err::{ParseError, ParseErrors, ToJsonSchemaError, ToJsonSchemaErrors};

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -295,7 +295,7 @@ pub struct AttrDecl {
 }
 
 /// The target of a [`PRAppDecl`]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PR {
     /// Applies to the `principal` variable
     Principal,

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -652,35 +652,6 @@ impl Diagnostic for NoPrincipalOrResource {
     }
 }
 
-// impl Diagnostic for ToJsonSchemaError {
-//     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-//         match self {
-//             ToJsonSchemaError::DuplicateDeclarations { loc1, loc2, .. }
-//             | ToJsonSchemaError::DuplicateContext { loc1, loc2 }
-//             | ToJsonSchemaError::DuplicatePrincipalOrResource { loc1, loc2, .. }
-//             | ToJsonSchemaError::DuplicateKeys { loc1, loc2, .. } => Some(Box::new(
-//                 vec![
-//                     LabeledSpan::underline(loc1.span),
-//                     LabeledSpan::underline(loc2.span),
-//                 ]
-//                 .into_iter(),
-//             )),
-//             ToJsonSchemaError::DuplicateNameSpaces { loc1, loc2, .. } => {
-//                 Some(Box::new([loc1, loc2].into_iter().filter_map(|loc| {
-//                     Some(LabeledSpan::underline(loc.as_ref()?.span))
-//                 })))
-//             }
-//             ToJsonSchemaError::UnknownTypeName(node) => Some(Box::new(std::iter::once(
-//                 LabeledSpan::underline(node.loc.span),
-//             ))),
-//             ToJsonSchemaError::UseReservedNamespace(loc)
-//             | ToJsonSchemaError::NoPrincipalOrResource { loc, .. } => {
-//                 Some(Box::new(std::iter::once(LabeledSpan::underline(loc.span))))
-//             }
-//         }
-//     }
-// }
-
 /// Error subtypes for [`SchemaWarning`]
 pub mod schema_warnings {
     use cedar_policy_core::parser::Loc;

--- a/cedar-policy-validator/src/human_schema/err.rs
+++ b/cedar-policy-validator/src/human_schema/err.rs
@@ -190,8 +190,14 @@ impl ParseErrors {
         Some(Self(Box::new(NonEmpty::from_vec(v)?)))
     }
 
+    /// (Borrowed) Iterator over reported parse errors
     pub fn iter(&self) -> impl Iterator<Item = &ParseError> {
         self.0.iter()
+    }
+
+    /// Iterator over reported parse errors
+    pub fn into_iter(self) -> impl Iterator<Item = ParseError> {
+        self.0.into_iter()
     }
 }
 
@@ -260,6 +266,10 @@ impl ToJsonSchemaErrors {
 
     pub fn iter(&self) -> impl Iterator<Item = &ToJsonSchemaError> {
         self.0.iter()
+    }
+
+    pub fn into_iter(self) -> impl Iterator<Item = ToJsonSchemaError> {
+        self.0.into_iter()
     }
 }
 

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -68,7 +68,7 @@ fn parse_collect_errors<'a, P, T>(
             return Err(ParseErrors::new(e.into(), errors));
         }
     };
-    match ParseErrors::from_iter(errors) {
+    match ParseErrors::try_from_iter(errors) {
         Some(errors) => Err(errors),
         // No Errors: good to return parse
         None => Ok(parsed),

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -29,7 +29,7 @@ mod demo_tests {
     use smol_str::ToSmolStr;
 
     use crate::{
-        human_schema::{self, ast::PR, err::DuplicatePrincipalOrResource, err::ToJsonSchemaError},
+        human_schema::{self, ast::PR, err::ToJsonSchemaError},
         ActionType, ApplySpec, AttributesOrContext, EntityType, HumanSchemaError,
         NamespaceDefinition, RawName, SchemaFragment, SchemaTypeVariant, TypeOfAttribute,
     };

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -29,7 +29,7 @@ mod demo_tests {
     use smol_str::ToSmolStr;
 
     use crate::{
-        human_schema::{self, ast::PR, err::ToJsonSchemaError},
+        human_schema::{self, ast::PR, err::DuplicatePrincipalOrResource, err::ToJsonSchemaError},
         ActionType, ApplySpec, AttributesOrContext, EntityType, HumanSchemaError,
         NamespaceDefinition, RawName, SchemaFragment, SchemaTypeVariant, TypeOfAttribute,
     };
@@ -293,10 +293,7 @@ mod demo_tests {
                     .any(|err| {
                         matches!(
                             err,
-                            ToJsonSchemaError::DuplicatePrincipalOrResource {
-                                kind: PR::Principal,
-                                ..
-                            }
+                            ToJsonSchemaError::DuplicatePrincipalOrResource(err) if err.kind() == PR::Principal
                         )
                     })
                 );
@@ -329,10 +326,7 @@ mod demo_tests {
                     .any(|err| {
                         matches!(
                             err,
-                            ToJsonSchemaError::DuplicatePrincipalOrResource {
-                                kind: PR::Resource,
-                                ..
-                            }
+                            ToJsonSchemaError::DuplicatePrincipalOrResource(err) if err.kind() == PR::Resource
                         )
                     }));
             }));

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -219,59 +219,6 @@ pub mod human_schema_errors {
         pub errors: cedar_policy_validator::HumanSyntaxParseError,
     }
 
-    /// Errors parsing a schema in human-readable syntax
-    #[derive(Debug, Error, Diagnostic)]
-    #[error(transparent)]
-    pub enum HumanSyntaxParseError {
-        /// Syntax Error(s)
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        Syntax(#[from] SyntaxError),
-        /// Error converting schema into internal representation
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        ToJsonSchema(#[from] ToJsonSchemaErrors),
-        /// IO Errors while parsing
-        #[error(transparent)]
-        #[diagnostic(transparent)]
-        IoError(#[from] IoError),
-    }
-
-    /// Errors parsing a schema
-    #[derive(Debug, Error, Diagnostic)]
-    #[error(transparent)]
-    pub struct SyntaxError {
-        #[from]
-        errs: cedar_policy_validator::human_schema::ParseErrors,
-    }
-
-    impl SyntaxError {
-        /// Iterate over the errors
-        pub fn iter(
-            &self,
-        ) -> impl Iterator<Item = &cedar_policy_validator::human_schema::ParseError> {
-            self.errs.iter()
-        }
-    }
-
-    /// Errors converting schema into internal representation
-    #[derive(Debug, Error, Diagnostic)]
-    #[error(transparent)]
-    pub struct ToJsonSchemaErrors {
-        #[from]
-        errs: cedar_policy_validator::human_schema::ToJsonSchemaErrors,
-    }
-
-    impl ToJsonSchemaErrors {
-        /// Iterate over the errors
-        pub fn iter(
-            &self,
-        ) -> impl Iterator<Item = &cedar_policy_validator::human_schema::ToJsonSchemaError>
-        {
-            self.errs.iter()
-        }
-    }
-
     /// IO error while parsing a human-readable schema
     #[derive(Debug, Error, Diagnostic)]
     #[error(transparent)]

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -213,7 +213,11 @@ pub mod human_schema_errors {
     #[derive(Debug, Error, Diagnostic)]
     #[error(transparent)]
     #[diagnostic(transparent)]
-    pub struct ParseError(#[from] pub(super) cedar_policy_validator::HumanSyntaxParseError);
+    pub struct ParseError {
+        /// The errors reported by the parser
+        #[from]
+        pub errors: cedar_policy_validator::HumanSyntaxParseError,
+    }
 
     /// IO error while parsing a human-readable schema
     #[derive(Debug, Error, Diagnostic)]
@@ -247,8 +251,8 @@ impl From<cedar_policy_validator::HumanSchemaError> for HumanSchemaError {
             cedar_policy_validator::HumanSchemaError::IO(e) => {
                 human_schema_errors::IoError(e).into()
             }
-            cedar_policy_validator::HumanSchemaError::Parsing(e) => {
-                human_schema_errors::ParseError(e).into()
+            cedar_policy_validator::HumanSchemaError::Parsing(errors) => {
+                human_schema_errors::ParseError { errors }.into()
             }
         }
     }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -219,6 +219,59 @@ pub mod human_schema_errors {
         pub errors: cedar_policy_validator::HumanSyntaxParseError,
     }
 
+    /// Errors parsing a schema in human-readable syntax
+    #[derive(Debug, Error, Diagnostic)]
+    #[error(transparent)]
+    pub enum HumanSyntaxParseError {
+        /// Syntax Error(s)
+        #[error(transparent)]
+        #[diagnostic(transparent)]
+        Syntax(#[from] SyntaxError),
+        /// Error converting schema into internal representation
+        #[error(transparent)]
+        #[diagnostic(transparent)]
+        ToJsonSchema(#[from] ToJsonSchemaErrors),
+        /// IO Errors while parsing
+        #[error(transparent)]
+        #[diagnostic(transparent)]
+        IoError(#[from] IoError),
+    }
+
+    /// Errors parsing a schema
+    #[derive(Debug, Error, Diagnostic)]
+    #[error(transparent)]
+    pub struct SyntaxError {
+        #[from]
+        errs: cedar_policy_validator::human_schema::ParseErrors,
+    }
+
+    impl SyntaxError {
+        /// Iterate over the errors
+        pub fn iter(
+            &self,
+        ) -> impl Iterator<Item = &cedar_policy_validator::human_schema::ParseError> {
+            self.errs.iter()
+        }
+    }
+
+    /// Errors converting schema into internal representation
+    #[derive(Debug, Error, Diagnostic)]
+    #[error(transparent)]
+    pub struct ToJsonSchemaErrors {
+        #[from]
+        errs: cedar_policy_validator::human_schema::ToJsonSchemaErrors,
+    }
+
+    impl ToJsonSchemaErrors {
+        /// Iterate over the errors
+        pub fn iter(
+            &self,
+        ) -> impl Iterator<Item = &cedar_policy_validator::human_schema::ToJsonSchemaError>
+        {
+            self.errs.iter()
+        }
+    }
+
     /// IO error while parsing a human-readable schema
     #[derive(Debug, Error, Diagnostic)]
     #[error(transparent)]

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -17,7 +17,7 @@
 //! This module defines the publicly exported identifier types including
 //! `EntityUid` and `PolicyId`.
 
-pub use crate::entities_json_errors::JsonDeserializationError;
+use crate::entities_json_errors::JsonDeserializationError;
 use crate::ParseErrors;
 use cedar_policy_core::ast;
 use cedar_policy_core::entities::json::err::JsonDeserializationErrorContext;

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -17,7 +17,7 @@
 //! This module defines the publicly exported identifier types including
 //! `EntityUid` and `PolicyId`.
 
-use crate::entities_json_errors::JsonDeserializationError;
+pub use crate::entities_json_errors::JsonDeserializationError;
 use crate::ParseErrors;
 use cedar_policy_core::ast;
 use cedar_policy_core::entities::json::err::JsonDeserializationErrorContext;
@@ -232,13 +232,11 @@ impl EntityUid {
     /// # assert_eq!(euid.id(), &EntityId::from_str("123abc").unwrap());
     /// ```
     #[allow(clippy::result_large_err)]
-    pub fn from_json(json: serde_json::Value) -> Result<Self, impl miette::Diagnostic> {
+    pub fn from_json(json: serde_json::Value) -> Result<Self, JsonDeserializationError> {
         let parsed: cedar_policy_core::entities::EntityUidJson = serde_json::from_value(json)?;
-        Ok::<Self, JsonDeserializationError>(
-            parsed
-                .into_euid(|| JsonDeserializationErrorContext::EntityUid)?
-                .into(),
-        )
+        Ok(parsed
+            .into_euid(|| JsonDeserializationErrorContext::EntityUid)?
+            .into())
     }
 
     /// Testing utility for creating `EntityUids` a bit easier


### PR DESCRIPTION
## Description of changes
Cleans up two remaining error tasks
* `EntityUid::from_json` returns a concrete type instead of an existential
* `HumanSchemaError::Parse` is more transparent
## Issue #, if available
#745
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

