### PR TITLE
Fix latent bug in `contains_at_least_two`

### DIFF
--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -262,7 +262,7 @@ fn contains_at_least_two(s: &str, c: char) -> bool {
 #[cfg(kani)]
 mod proof {
 
-    /// Prove that `contains_two_correct` does not panic for strings with length <= 4 
+    /// Prove that `contains_two_correct` does not panic for strings with length <= 4
     #[kani::proof]
     #[kani::unwind(5)]
     fn contains_at_least_two_correct() {

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -269,7 +269,7 @@ fn contains_at_least_two(s: &str, c: char) -> bool {
 #[cfg(kani)]
 mod proof {
 
-    /// Prove that `contains_two_correct` does not panic for strings with length <= 4
+    /// Prove that `contains_two_correct` does not panic for strings with length <= 6
     #[kani::proof]
     #[kani::unwind(7)]
     fn contains_at_least_two_correct() {

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -275,7 +275,7 @@ mod proof {
     fn contains_at_least_two_correct() {
         let buf: [u8; 6] = kani::any();
         let len: usize = kani::any();
-        kani::assume(len <= 4);
+        kani::assume(len <= 6);
         let slice = &buf[0..len];
         if let Ok(s) = std::str::from_utf8(slice) {
             let pat = kani::any();

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -242,7 +242,7 @@ fn contains_at_least_two(s: &str, c: char) -> bool {
     let idx = s.find(c);
     match idx {
         Some(i) => {
-            // For this slicing operation not to panic, two preconditoins must be met:
+            // For this slicing operation not to panic, two preconditions must be met:
             // 1) `i + 1` must be <= `s.len()`
             //     This is met because `i` comes from `s.find()` meaning it must be < `s.len()`
             // 2) `i + 1` must be a character boundary

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -242,7 +242,7 @@ fn contains_at_least_two(s: &str, c: char) -> bool {
     let idx = s.find(c);
     match idx {
         Some(i) => {
-            // For this slicing operation not to panic, two preconditoins must be met:
+            // For this slicing operation not to panic, two preconditions must be met:
             // 1) `i + c.len_utf()` must be <= `s.len()`
             //     This is met because:
             //     i := s.find(c) meaning:


### PR DESCRIPTION
## Description of changes
The function `contains_at_least_two` is used in the construction of IP Address parsing errors to provide better error messages. 
Currently it has a bug, if called with a multibyte character as the search query, it can end up slicing a `&str` across a non-char boundary, resulting in a panic. 
As currently implemented, it is only ever called with `':'` or `'.'` as queries, which are both single-byte chars, meaning the panic is currently  unreachable from public APIs. That said, this is an undocumented invariant, which could be exposed or violated easily if this code was refactored to allow for easier sharing.

As an example: the string `"\u{f1b}"` and the query `'\u{f1b}'` would have caused a panic in the old version of the code

In addition this adds a Kani verification harness, which is how the bug was found.
## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

