### PR TITLE
Parallelize CLI tests

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -31,6 +31,7 @@ assert_cmd = "2.0"
 tempfile = "3"
 glob = "0.3.1"
 predicates = "3.1.0"
+rstest = "0.21.0"
 
 # We override the name of the binary for src/main.rs, which otherwise would be
 # cedar-policy-cli (matching the crate name).

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -29,6 +29,8 @@ use cedar_policy_cli::{
     EvaluateArgs, LinkArgs, PoliciesArgs, PolicyFormat, RequestArgs, ValidateArgs,
 };
 
+use rstest::rstest;
+
 fn run_check_parse_test(policies_file: impl Into<String>, expected_exit_code: CedarExitCode) {
     let cmd = CheckParseArgs {
         policies: PoliciesArgs {

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -447,11 +447,114 @@ fn test_authorize_samples() {
     );
 }
 
+#[rstest]
+#[case(
+    "sample-data/doesnotexist.cedar",
+    "sample-data/sandbox_a/schema.cedarschema.json",
+    CedarExitCode::Failure
+)]
+#[case(
+    "sample-data/sandbox_a/policies_1.cedar",
+    "sample-data/doesnotexist.json",
+    CedarExitCode::Failure
+)]
+#[case(
+    "sample-data/sandbox_a/policies_1.cedar",
+    "sample-data/sandbox_a/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+// Contains misspelled entity type.
+#[case(
+    "sample-data/sandbox_a/policies_1_bad.cedar",
+    "sample-data/sandbox_a/schema.cedarschema.json",
+    CedarExitCode::ValidationFailure
+)]
+#[case(
+    "sample-data/sandbox_a/policies_2.cedar",
+    "sample-data/sandbox_a/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/sandbox_a/policies_3.cedar",
+    "sample-data/sandbox_a/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/sandbox_b/policies_4.cedar",
+    "sample-data/sandbox_b/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+// Contains an access to an optional attribute without a `has` check.
+#[case(
+    "sample-data/sandbox_b/policies_5_bad.cedar",
+    "sample-data/sandbox_b/schema.cedarschema.json",
+    CedarExitCode::ValidationFailure
+)]
+#[case(
+    "sample-data/sandbox_b/policies_5.cedar",
+    "sample-data/sandbox_b/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/sandbox_b/policies_6.cedar",
+    "sample-data/sandbox_b/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample1/policy.cedar",
+    "sample-data/tiny_sandboxes/sample1/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample2/policy.cedar",
+    "sample-data/tiny_sandboxes/sample2/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample3/policy.cedar",
+    "sample-data/tiny_sandboxes/sample3/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample4/policy.cedar",
+    "sample-data/tiny_sandboxes/sample4/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample5/policy.cedar",
+    "sample-data/tiny_sandboxes/sample5/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample6/policy.cedar",
+    "sample-data/tiny_sandboxes/sample6/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample7/policy.cedar",
+    "sample-data/tiny_sandboxes/sample7/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample8/policy.cedar",
+    "sample-data/tiny_sandboxes/sample8/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample9/policy.cedar",
+    "sample-data/tiny_sandboxes/sample9/schema.cedarschema.json",
+    CedarExitCode::Success
+)]
+#[case(
+    "sample-data/tiny_sandboxes/sample9/policy_bad.cedar",
+    "sample-data/tiny_sandboxes/sample9/schema.cedarschema.json",
+    CedarExitCode::ValidationFailure
+)]
 #[track_caller]
-fn run_validate_test(
-    policies_file: impl Into<String>,
-    schema_file: impl Into<String>,
-    exit_code: CedarExitCode,
+fn test_validate_samples(
+    #[case] policies_file: impl Into<String>,
+    #[case] schema_file: impl Into<String>,
+    #[case] exit_code: CedarExitCode,
 ) {
     let policies_file = policies_file.into();
     let schema_file = schema_file.into();
@@ -488,112 +591,6 @@ fn run_validate_test(
     };
     let output = validate(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd)
-}
-
-#[test]
-fn test_validate_samples() {
-    run_validate_test(
-        "sample-data/doesnotexist.cedar",
-        "sample-data/sandbox_a/schema.cedarschema.json",
-        CedarExitCode::Failure,
-    );
-    run_validate_test(
-        "sample-data/sandbox_a/policies_1.cedar",
-        "sample-data/doesnotexist.json",
-        CedarExitCode::Failure,
-    );
-    run_validate_test(
-        "sample-data/sandbox_a/policies_1.cedar",
-        "sample-data/sandbox_a/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    // Contains misspelled entity type.
-    run_validate_test(
-        "sample-data/sandbox_a/policies_1_bad.cedar",
-        "sample-data/sandbox_a/schema.cedarschema.json",
-        CedarExitCode::ValidationFailure,
-    );
-    run_validate_test(
-        "sample-data/sandbox_a/policies_2.cedar",
-        "sample-data/sandbox_a/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/sandbox_a/policies_3.cedar",
-        "sample-data/sandbox_a/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/sandbox_b/policies_4.cedar",
-        "sample-data/sandbox_b/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    // Contains an access to an optional attribute without a `has` check.
-    run_validate_test(
-        "sample-data/sandbox_b/policies_5_bad.cedar",
-        "sample-data/sandbox_b/schema.cedarschema.json",
-        CedarExitCode::ValidationFailure,
-    );
-    run_validate_test(
-        "sample-data/sandbox_b/policies_5.cedar",
-        "sample-data/sandbox_b/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/sandbox_b/policies_6.cedar",
-        "sample-data/sandbox_b/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample1/policy.cedar",
-        "sample-data/tiny_sandboxes/sample1/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample2/policy.cedar",
-        "sample-data/tiny_sandboxes/sample2/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample3/policy.cedar",
-        "sample-data/tiny_sandboxes/sample3/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample4/policy.cedar",
-        "sample-data/tiny_sandboxes/sample4/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample5/policy.cedar",
-        "sample-data/tiny_sandboxes/sample5/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample6/policy.cedar",
-        "sample-data/tiny_sandboxes/sample6/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample7/policy.cedar",
-        "sample-data/tiny_sandboxes/sample7/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample8/policy.cedar",
-        "sample-data/tiny_sandboxes/sample8/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample9/policy.cedar",
-        "sample-data/tiny_sandboxes/sample9/schema.cedarschema.json",
-        CedarExitCode::Success,
-    );
-    run_validate_test(
-        "sample-data/tiny_sandboxes/sample9/policy_bad.cedar",
-        "sample-data/tiny_sandboxes/sample9/schema.cedarschema.json",
-        CedarExitCode::ValidationFailure,
-    );
 }
 
 #[rstest]

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -19,6 +19,7 @@
 // PANIC SAFETY tests
 #![allow(clippy::unwrap_used)]
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use cedar_policy::EvalResult;
 use cedar_policy::SlotId;
@@ -115,27 +116,6 @@ fn run_link_test(
     };
     let output = link(&cmd);
     assert_eq!(output, expected);
-}
-
-// PANIC SAFETY: this is all test code
-#[allow(clippy::expect_used)]
-// PANIC SAFETY: this is all test code
-#[allow(clippy::unwrap_used)]
-#[track_caller]
-fn run_format_test(policies_file: &str) {
-    let original = std::fs::read_to_string(policies_file).unwrap();
-    let format_cmd = assert_cmd::Command::cargo_bin("cedar")
-        .expect("bin exists")
-        .arg("format")
-        .arg("-p")
-        .arg(policies_file)
-        .assert();
-    let formatted =
-        std::str::from_utf8(&format_cmd.get_output().stdout).expect("output should be decodable");
-    assert_eq!(
-        original, formatted,
-        "\noriginal:\n{original}\n\nformatted:\n{formatted}",
-    );
 }
 
 fn run_authorize_test_context(
@@ -903,11 +883,27 @@ fn test_link_samples() {
     );
 }
 
-#[test]
-fn test_format_samples() {
-    use glob::glob;
-    let ps_files = glob("sample-data/**/polic*.cedar").unwrap();
-    ps_files.for_each(|ps_file| run_format_test(ps_file.unwrap().to_str().unwrap()));
+#[rstest]
+// PANIC SAFETY: this is all test code
+#[allow(clippy::expect_used)]
+// PANIC SAFETY: this is all test code
+#[allow(clippy::unwrap_used)]
+#[track_caller]
+fn test_format_samples(#[files("sample-data/**/polic*.cedar")] path: PathBuf) {
+    let policies_file = path.to_str().unwrap();
+    let original = std::fs::read_to_string(policies_file).unwrap();
+    let format_cmd = assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("format")
+        .arg("-p")
+        .arg(policies_file)
+        .assert();
+    let formatted =
+        std::str::from_utf8(&format_cmd.get_output().stdout).expect("output should be decodable");
+    assert_eq!(
+        original, formatted,
+        "\noriginal:\n{original}\n\nformatted:\n{formatted}",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description of changes

Parallelized some tests in the CLI crate for increased performance and distinct error reporting. There are more conversions to be done, just started with the most straight forward onces to see if this is a way we want to go.

## Issue #, if available

Somewhat related to https://github.com/cedar-policy/cedar/issues/438, which applies to parallelization of corpus tests.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


