### PR TITLE
disallow `partial_evaluation` extension in schemas

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -56,9 +56,15 @@ impl Extension {
         self.functions.get(name)
     }
 
-    /// Get an iterator over the function names
+    /// Iterate over the functions
     pub fn funcs(&self) -> impl Iterator<Item = &ExtensionFunction> {
         self.functions.values()
+    }
+
+    /// Iterate over the extension types that can be produced by any functions
+    /// in this extension
+    pub fn ext_types(&self) -> impl Iterator<Item = &Name> + '_ {
+        self.funcs().flat_map(|func| func.ext_types())
     }
 }
 
@@ -318,6 +324,14 @@ impl ExtensionFunction {
             ExtensionOutputValue::Known(v) => Ok(PartialValue::Value(v)),
             ExtensionOutputValue::Unknown(u) => Ok(PartialValue::Residual(Expr::unknown(u))),
         }
+    }
+
+    /// Iterate over the extension types that could be produced by this
+    /// function, if any
+    pub fn ext_types(&self) -> impl Iterator<Item = &Name> + '_ {
+        self.return_type
+            .iter()
+            .flat_map(|ret_ty| ret_ty.contained_ext_types())
     }
 }
 

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -168,6 +168,22 @@ impl SchemaType {
             }
         }
     }
+
+    /// Iterate over all extension function types contained in this SchemaType
+    pub fn contained_ext_types(&self) -> Box<dyn Iterator<Item = &Name> + '_> {
+        match self {
+            Self::Extension { name } => Box::new(std::iter::once(name)),
+            Self::Set { element_ty } => element_ty.contained_ext_types(),
+            Self::Record { attrs, .. } => Box::new(
+                attrs
+                    .values()
+                    .flat_map(|ty| ty.attr_type.contained_ext_types()),
+            ),
+            Self::Bool | Self::Long | Self::String | Self::EmptySet | Self::Entity { .. } => {
+                Box::new(std::iter::empty())
+            }
+        }
+    }
 }
 
 impl AttributeType {

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -73,6 +73,14 @@ impl<'a> Extensions<'a> {
         self.extensions.iter().map(|ext| ext.name())
     }
 
+    /// Get all extension type names declared by active extensions.
+    ///
+    /// (More specifically, all extension type names such that any function in
+    /// an active extension could produce a value of that extension type.)
+    pub fn ext_types(&self) -> impl Iterator<Item = &Name> {
+        self.extensions.iter().flat_map(|ext| ext.ext_types())
+    }
+
     /// Get the extension function with the given name, from these extensions.
     ///
     /// Returns an error if the function is not defined by any extension, or if

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -29,9 +29,6 @@ use smol_str::ToSmolStr;
 
 use crate::{RawName, SchemaTypeVariant};
 
-const IPADDR_EXTENSION: &str = "ipaddr";
-const DECIMAL_EXTENSION: &str = "decimal";
-pub const EXTENSIONS: [&str; 2] = [IPADDR_EXTENSION, DECIMAL_EXTENSION];
 pub const BUILTIN_TYPES: [&str; 3] = ["Long", "String", "Bool"];
 
 pub(super) const CEDAR_NAMESPACE: &str = "__cedar";

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -27,6 +27,7 @@ use super::{
     err::{self, ParseError, ParseErrors, SchemaWarning, ToJsonSchemaErrors},
     to_json_schema::{custom_schema_to_json_schema, custom_type_to_json_type},
 };
+use cedar_policy_core::extensions::Extensions;
 
 lalrpop_mod!(
     #[allow(warnings, unused, missing_docs, missing_debug_implementations)]
@@ -95,24 +96,28 @@ pub enum HumanSyntaxParseErrors {
 }
 
 /// Parse a type, in human syntax, into a [`crate::SchemaType`]
-pub fn parse_type(src: &str) -> Result<crate::SchemaType<crate::RawName>, HumanSyntaxParseErrors> {
+pub fn parse_type(
+    src: &str,
+    extensions: Extensions<'_>,
+) -> Result<crate::SchemaType<crate::RawName>, HumanSyntaxParseErrors> {
     let ty = parse_collect_errors(&*TYPE_PARSER, grammar::TypeParser::parse, src)?;
-    Ok(custom_type_to_json_type(ty)?)
+    Ok(custom_type_to_json_type(ty, extensions)?)
 }
 
 /// Parse a schema fragment, in human syntax, into a [`crate::SchemaFragment`],
 /// possibly generating warnings
-pub fn parse_natural_schema_fragment(
+pub fn parse_natural_schema_fragment<'a>(
     src: &str,
+    extensions: Extensions<'a>,
 ) -> Result<
     (
         crate::SchemaFragment<crate::RawName>,
-        impl Iterator<Item = SchemaWarning>,
+        impl Iterator<Item = SchemaWarning> + 'a,
     ),
     HumanSyntaxParseErrors,
 > {
     let ast: Schema = parse_collect_errors(&*SCHEMA_PARSER, grammar::SchemaParser::parse, src)?;
-    let tuple = custom_schema_to_json_schema(ast)?;
+    let tuple = custom_schema_to_json_schema(ast, extensions)?;
     Ok(tuple)
 }
 

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -24,6 +24,7 @@ mod demo_tests {
         iter::{empty, once},
     };
 
+    use cedar_policy_core::extensions::Extensions;
     use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
     use cool_asserts::assert_matches;
     use smol_str::ToSmolStr;
@@ -42,7 +43,7 @@ mod demo_tests {
         let src = r#"
             action "Foo";
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) = SchemaFragment::from_str_natural(src, Extensions::none()).unwrap();
         let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
             ActionType {
@@ -60,7 +61,7 @@ mod demo_tests {
         let src = r#"
         action "Foo" appliesTo { context: {} };
         "#;
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -79,7 +80,7 @@ mod demo_tests {
         action "Foo" appliesTo { principal: a, context: {}  };
         "#;
 
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -97,7 +98,7 @@ mod demo_tests {
         entity a;
         action "Foo" appliesTo { resource: a, context: {}  };
         "#;
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -117,7 +118,7 @@ mod demo_tests {
                 resource : [a]
             };
         "#;
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -138,7 +139,7 @@ mod demo_tests {
                 resource : [a, b]
             };
         "#;
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -158,7 +159,7 @@ mod demo_tests {
                 principal: [a]
             };
         "#;
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -179,7 +180,7 @@ mod demo_tests {
                 principal: [a, b]
             };
         "#;
-        match SchemaFragment::from_str_natural(src) {
+        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -203,7 +204,8 @@ mod demo_tests {
                 resource: [c, d]
             };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
@@ -242,7 +244,8 @@ mod demo_tests {
                 principal: [a, b]
             };
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
@@ -282,7 +285,7 @@ mod demo_tests {
             };
         "#;
         // Can't unwrap here as impl iter doesn't implement debug
-        let err = match SchemaFragment::from_str_natural(src) {
+        let err = match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Err(e) => e,
             _ => panic!("Should have failed to parse"),
         };
@@ -317,7 +320,7 @@ mod demo_tests {
             };
         "#;
         // Can't unwrap here as impl iter doesn't implement debug
-        let err = match SchemaFragment::from_str_natural(src) {
+        let err = match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Err(e) => e,
             _ => panic!("Should have failed to parse"),
         };
@@ -363,7 +366,8 @@ mod demo_tests {
             principal: [E],
             resource: [E]
         };
-    "#
+    "#,
+            Extensions::all_available(),
         )
         .is_ok());
         assert!(SchemaFragment::from_str_natural(
@@ -374,7 +378,8 @@ mod demo_tests {
         principal: [E],
         resource: [E]
     };
-"#
+"#,
+            Extensions::all_available(),
         )
         .is_ok());
         assert!(SchemaFragment::from_str_natural(
@@ -385,7 +390,8 @@ action "Foo" appliesTo {
     principal: [E],
     resource: [E]
 };
-"#
+"#,
+            Extensions::all_available(),
         )
         .is_ok());
         assert!(SchemaFragment::from_str_natural(
@@ -396,7 +402,8 @@ namespace Baz {action "Foo" appliesTo {
     principal: [E],
     resource: [E]
 };}
-"#
+"#,
+            Extensions::all_available(),
         )
         .is_ok());
         assert!(SchemaFragment::from_str_natural(
@@ -413,7 +420,8 @@ namespace Baz {action "Foo" appliesTo {
         };
         action view appliesTo { context: authcontext, principal: [E], resource: [E] };
         action upload appliesTo { context: authcontext, principal: [E], resource: [E]};
-"#
+"#,
+            Extensions::all_available(),
         )
         .is_ok());
     }
@@ -462,6 +470,7 @@ namespace Baz {action "Foo" appliesTo {
         };
         }
         "#,
+            Extensions::all_available(),
         )
         .expect("schema should parse");
     }
@@ -481,6 +490,7 @@ namespace Baz {action "Foo" appliesTo {
         };
         }
         "#,
+            Extensions::all_available(),
         ) {
             Ok(_) => panic!("this is not a valid schema"),
             Err(err) => {
@@ -516,6 +526,7 @@ namespace Baz {action "Foo" appliesTo {
                 memberOfTypes: UserGroup
             };
         }"#,
+            Extensions::all_available(),
         )
         .expect("Schema should parse");
         assert!(warnings.collect::<Vec<_>>().is_empty());
@@ -655,6 +666,7 @@ namespace Baz {action "Foo" appliesTo {
             entity Public in [DocumentShare];
             entity Drive;
         }"#,
+            Extensions::all_available(),
         )
         .expect("failed to parse");
         assert!(warnings.collect::<Vec<_>>().is_empty());
@@ -788,7 +800,8 @@ namespace Baz {action "Foo" appliesTo {
         entity B;
         action Foo appliesTo { principal : A, resource : B  };
         "#;
-        let (_, warnings) = SchemaFragment::from_str_natural(src).unwrap();
+        let (_, warnings) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
     }
 
@@ -857,7 +870,8 @@ namespace Baz {action "Foo" appliesTo {
         }
         "#;
 
-        let (_, warnings) = SchemaFragment::from_str_natural(src).unwrap();
+        let (_, warnings) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
     }
 
@@ -877,7 +891,8 @@ namespace Baz {action "Foo" appliesTo {
             };
         }
         "#;
-        let (fragment, warnings) = SchemaFragment::from_str_natural(src).unwrap();
+        let (fragment, warnings) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
         let service = fragment.0.get(&Some("Service".parse().unwrap())).unwrap();
         let resource = service
@@ -907,7 +922,7 @@ namespace Baz {action "Foo" appliesTo {
     fn expected_tokens() {
         #[track_caller]
         fn assert_labeled_span(src: &str, label: impl Into<String>) {
-            assert_matches!(SchemaFragment::from_str_natural(src).map(|(s, _)| s), Err(e) => {
+            assert_matches!(SchemaFragment::from_str_natural(src, Extensions::all_available()).map(|(s, _)| s), Err(e) => {
                 let actual_label = e.labels().and_then(|l| {
                     l.exactly_one()
                         .ok()
@@ -1164,13 +1179,14 @@ mod parser_tests {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod translator_tests {
+    use cedar_policy_core::ast as cedar_ast;
+    use cedar_policy_core::extensions::Extensions;
     use cedar_policy_core::FromNormalizedStr;
 
     use crate::{
         types::{EntityLUB, Type},
         SchemaFragment, SchemaTypeVariant, TypeOfAttribute, ValidatorSchema,
     };
-    use cedar_policy_core::ast as cedar_ast;
 
     #[test]
     fn use_reserved_namespace() {
@@ -1178,6 +1194,7 @@ mod translator_tests {
             r#"
           namespace __cedar {}
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err(), "__cedar namespace shouldn't be allowed");
 
@@ -1185,6 +1202,7 @@ mod translator_tests {
             r#"
           namespace __cedar::Foo {}
         "#,
+            Extensions::all_available(),
         );
         assert!(
             schema.is_err(),
@@ -1199,6 +1217,7 @@ mod translator_tests {
           namespace A {}
           namespace A {}
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err(), "duplicate namespaces shouldn't be allowed");
     }
@@ -1210,6 +1229,7 @@ mod translator_tests {
           action A;
           action A appliesTo { context: {}};
         "#,
+            Extensions::all_available(),
         );
         assert!(
             schema.is_err(),
@@ -1220,6 +1240,7 @@ mod translator_tests {
           action A;
           action "A";
         "#,
+            Extensions::all_available(),
         );
         assert!(
             schema.is_err(),
@@ -1233,6 +1254,7 @@ mod translator_tests {
           action "A";
             };
         "#,
+            Extensions::all_available(),
         );
         assert!(
             schema.is_err(),
@@ -1244,6 +1266,7 @@ mod translator_tests {
           namespace X { action A; }
           action A;
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_ok());
     }
@@ -1255,6 +1278,7 @@ mod translator_tests {
           entity A;
           entity A {};
         "#,
+            Extensions::all_available(),
         );
         assert!(
             schema.is_err(),
@@ -1264,6 +1288,7 @@ mod translator_tests {
             r#"
           entity A,A {};
         "#,
+            Extensions::all_available(),
         )
         .is_err());
         assert!(SchemaFragment::from_str_natural(
@@ -1271,6 +1296,7 @@ mod translator_tests {
           namespace X { entity A; }
           entity A {};
         "#,
+            Extensions::all_available(),
         )
         .is_ok());
     }
@@ -1282,6 +1308,7 @@ mod translator_tests {
           type A = Bool;
           type A = Long;
         "#,
+            Extensions::all_available(),
         );
         assert!(
             schema.is_err(),
@@ -1292,6 +1319,7 @@ mod translator_tests {
           namespace X { type A = Bool; }
           type A = Long;
         "#,
+            Extensions::all_available(),
         )
         .is_ok());
     }
@@ -1314,6 +1342,7 @@ mod translator_tests {
             };
           }
         "#,
+            Extensions::all_available(),
         )
         .expect("should be a valid natural schema");
         let validator_schema: ValidatorSchema =
@@ -1370,6 +1399,7 @@ mod translator_tests {
                 entity Y;
             }
             "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema =
@@ -1409,6 +1439,7 @@ mod translator_tests {
             };
             type id = String;
           }"#,
+            Extensions::all_available(),
         )
         .unwrap();
         let demo = schema.0.get(&Some("Demo".parse().unwrap())).unwrap();
@@ -1460,6 +1491,7 @@ mod translator_tests {
                 entity Y;
             }
             "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema =
@@ -1486,6 +1518,7 @@ mod translator_tests {
                 entity Z;
             }
             "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1509,7 +1542,8 @@ mod translator_tests {
         entity Foo in [namespace] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["namespace".parse().unwrap()]);
@@ -1523,7 +1557,7 @@ mod translator_tests {
         entity Foo in [in] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src).is_err());
+        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1533,7 +1567,8 @@ mod translator_tests {
         entity Foo in [Set] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Set".parse().unwrap()]);
@@ -1546,7 +1581,8 @@ mod translator_tests {
         entity Foo in [appliesTo] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["appliesTo".parse().unwrap()]);
@@ -1559,7 +1595,8 @@ mod translator_tests {
         entity Foo in [principal ] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["principal".parse().unwrap()]);
@@ -1572,7 +1609,8 @@ mod translator_tests {
         entity Foo in [resource] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["resource".parse().unwrap()]);
@@ -1585,7 +1623,8 @@ mod translator_tests {
         entity Foo in [action] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["action".parse().unwrap()]);
@@ -1598,7 +1637,8 @@ mod translator_tests {
         entity Foo in [context] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["context".parse().unwrap()]);
@@ -1611,7 +1651,8 @@ mod translator_tests {
         entity Foo in [attributes] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["attributes".parse().unwrap()]);
@@ -1624,7 +1665,8 @@ mod translator_tests {
         entity Foo in [Bool] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Bool".parse().unwrap()]);
@@ -1637,7 +1679,8 @@ mod translator_tests {
         entity Foo in [Long] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Long".parse().unwrap()]);
@@ -1650,7 +1693,8 @@ mod translator_tests {
         entity Foo in [String] = {};
         "#;
 
-        let (schema, _) = SchemaFragment::from_str_natural(src).unwrap();
+        let (schema, _) =
+            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["String".parse().unwrap()]);
@@ -1663,7 +1707,7 @@ mod translator_tests {
         entity Foo in [if] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src).is_err());
+        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1673,7 +1717,7 @@ mod translator_tests {
         entity Foo in [like] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src).is_err());
+        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1683,7 +1727,7 @@ mod translator_tests {
         entity Foo in [true] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src).is_err());
+        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1693,7 +1737,7 @@ mod translator_tests {
         entity Foo in [false] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src).is_err());
+        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1703,7 +1747,7 @@ mod translator_tests {
         entity Foo in [has] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src).is_err());
+        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1713,6 +1757,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { principal: A, principal: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
 
@@ -1721,6 +1766,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { principal: A, resource: B, principal: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
     }
@@ -1732,6 +1778,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { resource: A, resource: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
 
@@ -1740,6 +1787,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { resource: A, principal: B, resource: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
     }
@@ -1751,6 +1799,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { context: A, context: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
 
@@ -1759,6 +1808,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { principal: C, context: A, context: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
 
@@ -1767,6 +1817,7 @@ mod translator_tests {
         entity foo;
         action a appliesTo { resource: C, context: A, context: A };
         "#,
+            Extensions::all_available(),
         );
         assert!(schema.is_err());
     }
@@ -1780,6 +1831,7 @@ mod common_type_references {
         types::{AttributeType, EntityRecordKind, Type},
         SchemaError, SchemaFragment, ValidatorSchema,
     };
+    use cedar_policy_core::extensions::Extensions;
 
     #[test]
     fn basic() {
@@ -1791,6 +1843,7 @@ mod common_type_references {
             a: a,
         };
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1812,6 +1865,7 @@ mod common_type_references {
             a: a,
         };
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1837,6 +1891,7 @@ mod common_type_references {
             type a = Long;
         }
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1860,6 +1915,7 @@ mod common_type_references {
             a: a,
         };
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1880,6 +1936,7 @@ mod common_type_references {
             a: a,
         };
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1905,6 +1962,7 @@ mod common_type_references {
             type a = Set<Long>;
         }
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1928,6 +1986,7 @@ mod common_type_references {
             a: a,
         };
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1949,6 +2008,7 @@ mod common_type_references {
             a: a,
         };
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -1974,6 +2034,7 @@ mod common_type_references {
             type a = Set<Long>;
         }
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: ValidatorSchema = schema.try_into().unwrap();
@@ -2002,6 +2063,7 @@ mod common_type_references {
             type a = A::b;
         }
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: Result<ValidatorSchema, _> = schema.try_into();
@@ -2023,6 +2085,7 @@ mod common_type_references {
             type a = A::a;
         }
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: Result<ValidatorSchema, _> = schema.try_into();
@@ -2045,6 +2108,7 @@ mod common_type_references {
             type a = A::a;
         }
         "#,
+            Extensions::all_available(),
         )
         .unwrap();
         let validator_schema: Result<ValidatorSchema, _> = schema.try_into();

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -209,8 +209,9 @@ impl ValidatorSchema {
     pub fn from_file_natural(
         r: impl std::io::Read,
         extensions: Extensions<'_>,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (fragment, warnings) = SchemaFragment::from_file_natural(r)?;
+    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + '_), HumanSchemaError>
+    {
+        let (fragment, warnings) = SchemaFragment::from_file_natural(r, extensions)?;
         let schema_and_warnings =
             Self::from_schema_frag(fragment, ActionBehavior::default(), extensions)
                 .map(|schema| (schema, warnings))?;
@@ -219,11 +220,12 @@ impl ValidatorSchema {
 
     /// Construct a [`ValidatorSchema`] from a string containing Cedar "natural"
     /// schema syntax.
-    pub fn from_str_natural(
+    pub fn from_str_natural<'a>(
         src: &str,
-        extensions: Extensions<'_>,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (fragment, warnings) = SchemaFragment::from_str_natural(src)?;
+        extensions: Extensions<'a>,
+    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
+    {
+        let (fragment, warnings) = SchemaFragment::from_str_natural(src, extensions)?;
         let schema_and_warnings =
             Self::from_schema_frag(fragment, ActionBehavior::default(), extensions)
                 .map(|schema| (schema, warnings))?;

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2333,6 +2333,33 @@ mod test {
                     .help("did you mean `ipaddr`?")
                     .build());
         });
+
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "ty": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Extension",
+                                "name": "partial_evaluation",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": { },
+                "actions": { },
+            }
+        });
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
+        assert_matches!(schema, Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("unknown extension type `partial_evaluation`")
+                    .help("did you mean `decimal`?")
+                    .build());
+        });
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -681,8 +681,10 @@ pub(crate) fn try_schema_type_into_validator_type(
             Ok(Type::named_entity_reference(name.into()).into())
         }
         SchemaType::Type(SchemaTypeVariant::Extension { name }) => {
+            // don't allow the `partial_evaluation` extension type in schemas
+            let is_pe = name.as_ref() == "partial_evaluation";
             let extension_type_name = Name::unqualified_name(name);
-            if extensions.ext_names().contains(&extension_type_name) {
+            if extensions.ext_names().contains(&extension_type_name) && !is_pe {
                 Ok(Type::extension(extension_type_name).into())
             } else {
                 let suggested_replacement = fuzzy_search(
@@ -690,6 +692,7 @@ pub(crate) fn try_schema_type_into_validator_type(
                     &extensions
                         .ext_names()
                         .map(|n| n.to_string())
+                        .filter(|s| s != "partial_evaluation") // never suggest specifically `partial_evaluation`
                         .collect::<Vec<_>>(),
                 );
                 Err(SchemaError::UnknownExtensionType(

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -681,18 +681,15 @@ pub(crate) fn try_schema_type_into_validator_type(
             Ok(Type::named_entity_reference(name.into()).into())
         }
         SchemaType::Type(SchemaTypeVariant::Extension { name }) => {
-            // don't allow the `partial_evaluation` extension type in schemas
-            let is_pe = name.as_ref() == "partial_evaluation";
             let extension_type_name = Name::unqualified_name(name);
-            if extensions.ext_names().contains(&extension_type_name) && !is_pe {
+            if extensions.ext_types().contains(&extension_type_name) {
                 Ok(Type::extension(extension_type_name).into())
             } else {
                 let suggested_replacement = fuzzy_search(
                     &extension_type_name.to_string(),
                     &extensions
-                        .ext_names()
+                        .ext_types()
                         .map(|n| n.to_string())
-                        .filter(|s| s != "partial_evaluation") // never suggest specifically `partial_evaluation`
                         .collect::<Vec<_>>(),
                 );
                 Err(SchemaError::UnknownExtensionType(

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -490,26 +490,6 @@ impl<N> SchemaType<N> {
         }
     }
 
-    /// Is this [`SchemaType`] an extension type, or does it contain one
-    /// (recursively)? Returns `None` if this is a `TypeDef` because we can't
-    /// easily properly check the type of a typedef, accounting for namespaces,
-    /// without first converting to a [`crate::types::Type`].
-    pub fn is_extension(&self) -> Option<bool> {
-        match self {
-            Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
-            Self::Type(SchemaTypeVariant::Set { element }) => element.is_extension(),
-            Self::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
-                .values()
-                .try_fold(false, |a, e| match e.ty.is_extension() {
-                    Some(true) => Some(true),
-                    Some(false) => Some(a),
-                    None => None,
-                }),
-            Self::Type(_) => Some(false),
-            Self::TypeDef { .. } => None,
-        }
-    }
-
     /// Is this [`SchemaType`] an empty record? This function is used by the `Display`
     /// implementation to avoid printing unnecessary entity/action data.
     pub fn is_empty_record(&self) -> bool {

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -17,6 +17,7 @@
 use cedar_policy_core::{
     ast::{Id, Name},
     entities::CedarValueJson,
+    extensions::Extensions,
     FromNormalizedStr,
 };
 use serde::{
@@ -130,19 +131,24 @@ impl SchemaFragment<RawName> {
     }
 
     /// Parse the schema (in natural schema syntax) from a string
-    pub fn from_str_natural(
+    pub fn from_str_natural<'a>(
         src: &str,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        parse_natural_schema_fragment(src).map_err(|e| HumanSyntaxParseError::new(e, src).into())
+        extensions: Extensions<'a>,
+    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
+    {
+        parse_natural_schema_fragment(src, extensions)
+            .map_err(|e| HumanSyntaxParseError::new(e, src).into())
     }
 
     /// Parse the schema (in natural schema syntax) from a reader
-    pub fn from_file_natural(
+    pub fn from_file_natural<'a>(
         mut file: impl std::io::Read,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
+        extensions: Extensions<'a>,
+    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
+    {
         let mut src = String::new();
         file.read_to_string(&mut src)?;
-        Self::from_str_natural(&src)
+        Self::from_str_natural(&src, extensions)
     }
 }
 
@@ -2058,7 +2064,7 @@ mod test_duplicates_error {
         let src = r#"{
             "Foo": {
               "entityTypes" : {},
-              "actions": { 
+              "actions": {
                 "foo" : {
                     "appliesTo" : {
                         "principalTypes" : ["a"]
@@ -2076,7 +2082,7 @@ mod test_duplicates_error {
         let src = r#"{
             "Foo": {
               "entityTypes" : {},
-              "actions": { 
+              "actions": {
                 "foo" : {
                     "appliesTo" : {
                         "resourceTypes" : ["a"]
@@ -2094,7 +2100,7 @@ mod test_duplicates_error {
         let src = r#"{
             "Foo": {
               "entityTypes" : {},
-              "actions": { 
+              "actions": {
                 "foo" : {
                     "appliesTo" : {
                     }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -490,6 +490,26 @@ impl<N> SchemaType<N> {
         }
     }
 
+    /// Is this [`SchemaType`] an extension type, or does it contain one
+    /// (recursively)? Returns `None` if this is a `TypeDef` because we can't
+    /// easily properly check the type of a typedef, accounting for namespaces,
+    /// without first converting to a [`crate::types::Type`].
+    pub fn is_extension(&self) -> Option<bool> {
+        match self {
+            Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
+            Self::Type(SchemaTypeVariant::Set { element }) => element.is_extension(),
+            Self::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
+                .values()
+                .try_fold(false, |a, e| match e.ty.is_extension() {
+                    Some(true) => Some(true),
+                    Some(false) => Some(a),
+                    None => None,
+                }),
+            Self::Type(_) => Some(false),
+            Self::TypeDef { .. } => None,
+        }
+    }
+
     /// Is this [`SchemaType`] an empty record? This function is used by the `Display`
     /// implementation to avoid printing unnecessary entity/action data.
     pub fn is_empty_record(&self) -> bool {

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -25,6 +25,7 @@ use std::vec;
 
 use cedar_policy_core::{
     ast::{EntityUID, Expr, PolicyID, StaticPolicy},
+    extensions::Extensions,
     parser::parse_policy,
 };
 
@@ -555,6 +556,7 @@ fn multi_namespace_action_eq() {
                 action "Action" appliesTo { context: {}, principal : [E], resource : [E]};
             }
         "#,
+        Extensions::all_available(),
     )
     .unwrap();
 
@@ -604,6 +606,7 @@ fn multi_namespace_action_in() {
             }
             namespace NS4 { action "Group"; }
         "#,
+        Extensions::all_available(),
     )
     .unwrap();
 
@@ -673,6 +676,7 @@ fn test_cedar_policy_642() {
             };
         }
         "#,
+        Extensions::all_available(),
     )
     .unwrap();
 
@@ -699,6 +703,7 @@ fn multi_namespace_action_group_cycle() {
             namespace B { action "Act" in A::Action::"Act"; }
             namespace C { action "Act" in B::Action::"Act"; }
         "#,
+        Extensions::all_available(),
     )
     .unwrap();
     assert_matches!(

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -17,20 +17,19 @@
 //! Contains test for strict typechecking.
 // GRCOV_STOP_COVERAGE
 
-use cedar_policy_core::ast::PolicyID;
 use cool_asserts::assert_matches;
 use serde_json::json;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use cedar_policy_core::parser::Loc;
 use cedar_policy_core::{
-    ast::{EntityUID, Expr},
-    parser::parse_policy_template,
+    ast::{EntityUID, Expr, PolicyID},
+    extensions::Extensions,
+    parser::{parse_policy_template, Loc},
 };
 
-use crate::typecheck::Typechecker;
 use crate::{
+    typecheck::Typechecker,
     types::{AttributeType, EffectSet, OpenTag, RequestEnv, Type},
     validation_errors::LubContext,
     validation_errors::LubHelp,
@@ -707,6 +706,7 @@ fn qualified_record_attr() {
         r#"
         entity Foo;
         action A appliesTo { context: {num_of_things?: Long }, principal : [Foo], resource : [Foo] };"#,
+        Extensions::all_available(),
     )
     .unwrap();
     let p = parse_policy_template(

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -2118,7 +2118,7 @@ mod test {
     fn assert_type_display_roundtrip(ty: Type) {
         let type_str = ty.to_string();
         println!("{type_str}");
-        let parsed_schema_type = parse_type(&type_str)
+        let parsed_schema_type = parse_type(&type_str, Extensions::all_available())
             .expect("String representation should have parsed into a schema type");
         let type_from_schema_type = try_schema_type_into_validator_type(
             parsed_schema_type.qualify_type_references(None),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1218,7 +1218,10 @@ impl SchemaFragment {
     pub fn from_file_natural(
         r: impl std::io::Read,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (lossless, warnings) = cedar_policy_validator::SchemaFragment::from_file_natural(r)?;
+        let (lossless, warnings) = cedar_policy_validator::SchemaFragment::from_file_natural(
+            r,
+            Extensions::all_available(),
+        )?;
         Ok((
             Self {
                 value: lossless.clone().try_into()?,
@@ -1232,7 +1235,10 @@ impl SchemaFragment {
     pub fn from_str_natural(
         src: &str,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (lossless, warnings) = cedar_policy_validator::SchemaFragment::from_str_natural(src)?;
+        let (lossless, warnings) = cedar_policy_validator::SchemaFragment::from_str_natural(
+            src,
+            Extensions::all_available(),
+        )?;
         Ok((
             Self {
                 value: lossless.clone().try_into()?,
@@ -1242,7 +1248,7 @@ impl SchemaFragment {
         ))
     }
 
-    /// Create a `SchemaFragment` directly from a file.
+    /// Create a [`SchemaFragment`] directly from a file.
     pub fn from_file(file: impl std::io::Read) -> Result<Self, SchemaError> {
         let lossless = cedar_policy_validator::SchemaFragment::from_file(file)?;
         Ok(Self {
@@ -1271,7 +1277,7 @@ impl SchemaFragment {
 impl TryInto<Schema> for SchemaFragment {
     type Error = SchemaError;
 
-    /// Convert `SchemaFragment` into a `Schema`. To build the `Schema` we
+    /// Convert [`SchemaFragment`] into a [`Schema`]. To build the [`Schema`] we
     /// need to have all entity types defined, so an error will be returned if
     /// any undeclared entity types are referenced in the schema fragment.
     fn try_into(self) -> Result<Schema, Self::Error> {


### PR DESCRIPTION
## Description of changes

Disallows the `partial_evaluation` extension type in schemas.  This extension is only for partial evaluation and doesn't make sense in schemas.

I'm unclear if this is a breaking change, because while this was previously allowed in schemas, I'm unclear if you could successfully use the resulting schema for anything (like validating policies using the `partial_evaluation` type, validating requests, schema-based parsing of entities, etc).

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

