### PR TITLE
Remove custom serialization for PatternElem under the arbitrary feature

### DIFF
--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -19,37 +19,17 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 /// Represent an element in a pattern literal (the RHS of the like operation)
-#[derive(Deserialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
 // We need special serialization for patterns because Rust's unicode escape
 // sequences (e.g., `\u{1234}`) can appear in serialized strings and it's difficult
 // to parse these into characters in the formal model. Instead we serialize the
 // unicode values of Rust characters.
-#[cfg_attr(not(feature = "arbitrary"), derive(Serialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
     /// A character literal
     Char(char),
     /// The wildcard `*`
     Wildcard,
-}
-
-#[cfg(feature = "arbitrary")]
-impl Serialize for PatternElem {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // Helper enum for serialization
-        #[derive(Debug, Serialize)]
-        enum PatternElemU32 {
-            Char(u32),
-            Wildcard,
-        }
-        match self {
-            Self::Char(c) => PatternElemU32::Char(*c as u32).serialize(serializer),
-            Self::Wildcard => PatternElemU32::Wildcard.serialize(serializer),
-        }
-    }
 }
 
 /// Represent a pattern literal (the RHS of the like operator)

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -20,10 +20,6 @@ use serde::{Deserialize, Serialize};
 
 /// Represent an element in a pattern literal (the RHS of the like operation)
 #[derive(Deserialize, Serialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
-// We need special serialization for patterns because Rust's unicode escape
-// sequences (e.g., `\u{1234}`) can appear in serialized strings and it's difficult
-// to parse these into characters in the formal model. Instead we serialize the
-// unicode values of Rust characters.
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
     /// A character literal


### PR DESCRIPTION
## Description of changes
Removed the custom implementation of Serialize for PatternElem under the arbitrary feature.

This was originally created for the Dafny as it didn't support unicode escape sequences.

## Issue #, if available
Issue #1042 
## Checklist for requesting a review

The change in this PR is:
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR:
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec):
- [x] Requires updates, and I have made / will make these updates myself.

I will add a comment linking to the PR in cedar-spec as soon as possible




