### PR TITLE
Add help text for some invalid policy scope expressions

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3620,7 +3620,7 @@ mod tests {
                     "expected an entity uid or matching template slot, found name `User`",
                 )
                 .help(
-                    "try using `is` to test for an entity type"
+                    "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
                 )
                 .exactly_one_underline("User").build(),
             ),
@@ -3638,7 +3638,7 @@ mod tests {
                     "expected an entity uid or matching template slot, found name `File`",
                 )
                 .help(
-                    "try using `is` to test for an entity type"
+                    "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
                 )
                 .exactly_one_underline("File").build(),
             ),
@@ -4204,7 +4204,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"expected an entity uid or matching template slot, found literal `"alice"`"#
             ).help(
-                "try including the entity type if you intended this string to be an entity identifier"
+                "try including the entity type if you intended this string to be an entity uid"
             ).exactly_one_underline(r#""alice""#).build());
         });
         let p_src = r#"permit(principal in "bob_friends", action, resource);"#;
@@ -4212,7 +4212,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"expected an entity uid or matching template slot, found literal `"bob_friends"`"#
             ).help(
-                "try including the entity type if you intended this string to be an entity identifier"
+                "try including the entity type if you intended this string to be an entity uid"
             ).exactly_one_underline(r#""bob_friends""#).build());
         });
         let p_src = r#"permit(principal, action, resource in "jane_photos");"#;
@@ -4220,7 +4220,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"expected an entity uid or matching template slot, found literal `"jane_photos"`"#
             ).help(
-                "try including the entity type if you intended this string to be an entity identifier"
+                "try including the entity type if you intended this string to be an entity uid"
             ).exactly_one_underline(r#""jane_photos""#).build());
         });
         let p_src = r#"permit(principal, action in ["view_actions"], resource);"#;
@@ -4228,7 +4228,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 r#"expected an entity uid, found literal `"view_actions"`"#
             ).help(
-                "try including the entity type if you intended this string to be an entity identifier"
+                "try including the entity type if you intended this string to be an entity uid"
             ).exactly_one_underline(r#""view_actions""#).build());
         });
     }
@@ -4240,7 +4240,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found name `User`"
             ).help(
-                "try using `is` to test for an entity type"
+                    "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
             ).exactly_one_underline("User").build());
         });
         let p_src = r#"permit(principal in Group, action, resource);"#;
@@ -4248,7 +4248,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found name `Group`"
             ).help(
-                "try using `is` to test for an entity type"
+                "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
             ).exactly_one_underline("Group").build());
         });
         let p_src = r#"permit(principal, action, resource in Album);"#;
@@ -4256,7 +4256,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found name `Album`"
             ).help(
-                "try using `is` to test for an entity type"
+                "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
             ).exactly_one_underline("Album").build());
         });
         // Testing for absence of help message because actions scope doesn't support `is`.
@@ -4275,7 +4275,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found a `&&` expression"
             ).help(
-                "The policy scope can only contain one constraint per variable. Consider moving the second operand of this `&&` into a `when` condition.",
+                "the policy scope can only contain one constraint per variable. Consider moving the second operand of this `&&` into a `when` condition",
             ).exactly_one_underline(r#"User::"alice" && principal in Group::"jane_friends""#).build());
         });
     }
@@ -4288,7 +4288,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found a `||` expression"
             ).help(
-                "The policy scope can only contain one constraint per variable. Consider moving the second operand of this `||` into a new policy.",
+                "the policy scope can only contain one constraint per variable. Consider moving the second operand of this `||` into a new policy",
             ).exactly_one_underline(r#"User::"alice" || principal == User::"bob""#).build());
         });
     }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3618,7 +3618,11 @@ mod tests {
                 r#"permit(principal is User in User, action, resource);"#,
                 ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found name `User`",
-                ).exactly_one_underline("User").build(),
+                )
+                .help(
+                    "try using `is` to test for an entity type"
+                )
+                .exactly_one_underline("User").build(),
             ),
             (
                 r#"permit(principal is User::"Alice" in Group::"f", action, resource);"#,
@@ -3632,7 +3636,11 @@ mod tests {
                 r#"permit(principal, action, resource is File in File);"#,
                 ExpectedErrorMessageBuilder::error(
                     "expected an entity uid or matching template slot, found name `File`",
-                ).exactly_one_underline("File").build(),
+                )
+                .help(
+                    "try using `is` to test for an entity type"
+                )
+                .exactly_one_underline("File").build(),
             ),
             (
                 r#"permit(principal, action, resource is File::"file" in Folder::"folder");"#,
@@ -4186,6 +4194,102 @@ mod tests {
         let p_src = r#"permit(principal, action == [Action::"view", Action::"edit"], resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error("expected single entity uid, found set of entity uids").exactly_one_underline(r#"[Action::"view", Action::"edit"]"#).build());
+        });
+    }
+
+    #[test]
+    fn scope_compare_to_string() {
+        let p_src = r#"permit(principal == "alice", action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                r#"expected an entity uid or matching template slot, found literal `"alice"`"#
+            ).help(
+                "try including the entity type if you intended this string to be an entity identifier"
+            ).exactly_one_underline(r#""alice""#).build());
+        });
+        let p_src = r#"permit(principal in "bob_friends", action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                r#"expected an entity uid or matching template slot, found literal `"bob_friends"`"#
+            ).help(
+                "try including the entity type if you intended this string to be an entity identifier"
+            ).exactly_one_underline(r#""bob_friends""#).build());
+        });
+        let p_src = r#"permit(principal, action, resource in "jane_photos");"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                r#"expected an entity uid or matching template slot, found literal `"jane_photos"`"#
+            ).help(
+                "try including the entity type if you intended this string to be an entity identifier"
+            ).exactly_one_underline(r#""jane_photos""#).build());
+        });
+        let p_src = r#"permit(principal, action in ["view_actions"], resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                r#"expected an entity uid, found literal `"view_actions"`"#
+            ).help(
+                "try including the entity type if you intended this string to be an entity identifier"
+            ).exactly_one_underline(r#""view_actions""#).build());
+        });
+    }
+
+    #[test]
+    fn scope_compare_to_name() {
+        let p_src = r#"permit(principal == User, action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                "expected an entity uid or matching template slot, found name `User`"
+            ).help(
+                "try using `is` to test for an entity type"
+            ).exactly_one_underline("User").build());
+        });
+        let p_src = r#"permit(principal in Group, action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                "expected an entity uid or matching template slot, found name `Group`"
+            ).help(
+                "try using `is` to test for an entity type"
+            ).exactly_one_underline("Group").build());
+        });
+        let p_src = r#"permit(principal, action, resource in Album);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                "expected an entity uid or matching template slot, found name `Album`"
+            ).help(
+                "try using `is` to test for an entity type"
+            ).exactly_one_underline("Album").build());
+        });
+        // Testing for absence of help message because actions scope doesn't support `is`.
+        let p_src = r#"permit(principal, action == Action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                "expected an entity uid, found name `Action`"
+            ).exactly_one_underline("Action").build());
+        });
+    }
+
+    #[test]
+    fn scope_and() {
+        let p_src = r#"permit(principal == User::"alice" && principal in Group::"jane_friends", action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                "expected an entity uid or matching template slot, found a `&&` expression"
+            ).help(
+                "The policy scope can only contain one constraint per variable. Consider moving the second operand of this `&&` into a `when` condition.",
+            ).exactly_one_underline(r#"User::"alice" && principal in Group::"jane_friends""#).build());
+        });
+    }
+
+    #[test]
+    fn scope_or() {
+        let p_src =
+            r#"permit(principal == User::"alice" || principal == User::"bob", action, resource);"#;
+        assert_matches!(parse_policy_template(None, p_src), Err(e) => {
+            expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
+                "expected an entity uid or matching template slot, found a `||` expression"
+            ).help(
+                "The policy scope can only contain one constraint per variable. Consider moving the second operand of this `||` into a new policy.",
+            ).exactly_one_underline(r#"User::"alice" || principal == User::"bob""#).build());
         });
     }
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -3620,7 +3620,7 @@ mod tests {
                     "expected an entity uid or matching template slot, found name `User`",
                 )
                 .help(
-                    "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
+                    "try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid"
                 )
                 .exactly_one_underline("User").build(),
             ),
@@ -3638,7 +3638,7 @@ mod tests {
                     "expected an entity uid or matching template slot, found name `File`",
                 )
                 .help(
-                    "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
+                    "try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid"
                 )
                 .exactly_one_underline("File").build(),
             ),
@@ -4240,7 +4240,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found name `User`"
             ).help(
-                    "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
+                    "try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid"
             ).exactly_one_underline("User").build());
         });
         let p_src = r#"permit(principal in Group, action, resource);"#;
@@ -4248,7 +4248,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found name `Group`"
             ).help(
-                "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
+                "try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid"
             ).exactly_one_underline("Group").build());
         });
         let p_src = r#"permit(principal, action, resource in Album);"#;
@@ -4256,7 +4256,7 @@ mod tests {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid or matching template slot, found name `Album`"
             ).help(
-                "try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid"
+                "try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid"
             ).exactly_one_underline("Album").build());
         });
         // Testing for absence of help message because actions scope doesn't support `is`.

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -222,7 +222,7 @@ impl Node<Option<cst::Primary>> {
                         T::err_str(),
                         found,
                         if var != ast::Var::Action {
-                            Some("try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid".to_string())
+                            Some("try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid".to_string())
                         } else {
                             // We don't allow `is` in the action scope, so we won't suggest trying it.
                             None

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -205,7 +205,7 @@ impl Node<Option<cst::Primary>> {
                         T::err_str(),
                         found,
                         match lit {
-                            Literal::Str(_) => Some("try including the entity type if you intended this string to be an entity identifier"),
+                            Literal::Str(_) => Some("try including the entity type if you intended this string to be an entity uid"),
                             _ => None,
                         }
                     ))
@@ -222,7 +222,7 @@ impl Node<Option<cst::Primary>> {
                         T::err_str(),
                         found,
                         if var != ast::Var::Action {
-                            Some("try using `is` to test for an entity type".to_string())
+                            Some("try using `is` to test for an entity type or including an identifier string you intended this name to be an entity uid".to_string())
                         } else {
                             // We don't allow `is` in the action scope, so we won't suggest trying it.
                             None
@@ -233,7 +233,7 @@ impl Node<Option<cst::Primary>> {
             cst::Primary::Expr(x) => x.to_ref_or_refs::<T>(var),
             cst::Primary::EList(lst) => {
                 // Calling `create_multiple_refs` first so that we error
-                // immediately if we see a set when we don't except one.
+                // immediately if we see a set when we don't expect one.
                 let create_multiple_refs = T::create_multiple_refs(&self.loc)?;
                 let v = ParseErrors::transpose(lst.iter().map(|expr| expr.to_ref(var)))?;
                 Ok(create_multiple_refs(v))
@@ -359,7 +359,7 @@ impl Node<Option<cst::Or>> {
                 .to_ast_err(ToASTErrorKind::wrong_node(
                     T::err_str(),
                     "a `||` expression",
-                    Some("The policy scope can only contain one constraint per variable. Consider moving the second operand of this `||` into a new policy."),
+                    Some("the policy scope can only contain one constraint per variable. Consider moving the second operand of this `||` into a new policy"),
                 ))
                 .into()),
         }
@@ -376,7 +376,7 @@ impl Node<Option<cst::And>> {
                 .to_ast_err(ToASTErrorKind::wrong_node(
                     T::err_str(),
                     "a `&&` expression",
-                    Some("The policy scope can only contain one constraint per variable. Consider moving the second operand of this `&&` into a `when` condition."),
+                    Some("the policy scope can only contain one constraint per variable. Consider moving the second operand of this `&&` into a `when` condition"),
                 ))
                 .into()),
         }


### PR DESCRIPTION
## Description of changes

Provide suggested fixes for mistakes like `principal == User` (might have meant `is`), `resource == "vacation.jpg"` (might have forgotten to include entity type).

Also fixes #568.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

