### PR TITLE
Add Derive(Deserialize) to AST structs

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -293,7 +293,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Eid {
 }
 
 /// Entity datatype
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Entity {
     /// UID
     uid: EntityUID,
@@ -542,7 +542,7 @@ impl std::fmt::Display for Entity {
 /// (Extension values can't be directly serialized, but can be serialized as
 /// `RestrictedExpr`)
 #[serde_as]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct PartialValueSerializedAsExpr(
     #[serde_as(as = "TryFromInto<RestrictedExpr>")] PartialValue,
 );

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -19,37 +19,17 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 /// Represent an element in a pattern literal (the RHS of the like operation)
-#[derive(Deserialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
 // We need special serialization for patterns because Rust's unicode escape
 // sequences (e.g., `\u{1234}`) can appear in serialized strings and it's difficult
 // to parse these into characters in the formal model. Instead we serialize the
 // unicode values of Rust characters.
-#[cfg_attr(not(feature = "arbitrary"), derive(Serialize))]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
     /// A character literal
     Char(char),
     /// The wildcard `*`
     Wildcard,
-}
-
-#[cfg(feature = "arbitrary")]
-impl Serialize for PatternElem {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // Helper enum for serialization
-        #[derive(Debug, Serialize)]
-        enum PatternElemU32 {
-            Char(u32),
-            Wildcard,
-        }
-        match self {
-            Self::Char(c) => PatternElemU32::Char(*c as u32).serialize(serializer),
-            Self::Wildcard => PatternElemU32::Wildcard.serialize(serializer),
-        }
-    }
 }
 
 /// Represent a pattern literal (the RHS of the like operator)

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -20,10 +20,6 @@ use serde::{Deserialize, Serialize};
 
 /// Represent an element in a pattern literal (the RHS of the like operation)
 #[derive(Deserialize, Serialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
-// We need special serialization for patterns because Rust's unicode escape
-// sequences (e.g., `\u{1234}`) can appear in serialized strings and it's difficult
-// to parse these into characters in the formal model. Instead we serialize the
-// unicode values of Rust characters.
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
     /// A character literal

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -285,6 +285,16 @@ impl TryFrom<PartialValue> for RestrictedExpr {
     }
 }
 
+impl From<RestrictedExpr> for PartialValue {
+    fn from(e: RestrictedExpr) -> Self {
+        let value_result = Value::try_from(e.0.to_owned());
+        match value_result {
+            Ok(v) => PartialValue::Value(v),
+            Err(_) => PartialValue::Residual(e.0.to_owned())
+        } 
+    }
+}
+
 /// Errors when converting `PartialValue` to `RestrictedExpr`
 #[derive(Debug, PartialEq, Diagnostic, Error)]
 pub enum PartialValueToRestrictedExprError {


### PR DESCRIPTION
## Description of changes
Added Derive(Deserialize) to the AST structs used within `AuthorizationRequest`.

This allows us to test roundtrip equality which catches issues like #1042 

Note that this assumes that PR #1047 is merged first. 


## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- This PR by itself does not affect DRT, but #1047 which this is based on does.
