### PR TITLE
Enforce context invariant

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -28,8 +28,8 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use super::{
-    BorrowedRestrictedExpr, EntityUID, Expr, ExprBuilder, ExprKind, ExpressionConstructionError,
-    PartialValue, RestrictedExpr, Unknown, Value, ValueKind, Var,
+    BorrowedRestrictedExpr, EntityUID, Expr, ExprKind, ExpressionConstructionError, PartialValue,
+    RestrictedExpr, Unknown, Value, ValueKind, Var,
 };
 
 /// Represents the request tuple <P, A, R, C> (see the Cedar design doc).
@@ -453,7 +453,7 @@ impl From<Context> for PartialValue {
                 // expression. By INVARIANT(unknown), at least one expr in
                 // `attrs` contains an unknown, so the `record_arc` expression
                 // contains at least one unknown.
-                PartialValue::Residual(ExprBuilder::new().record_arc(attrs))
+                PartialValue::Residual(Expr::record_arc(attrs))
             }
         }
     }

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -22,7 +22,6 @@ use crate::extensions::Extensions;
 use crate::parser::Loc;
 use miette::Diagnostic;
 use serde::Serialize;
-use serde_with::serde_as;
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -396,12 +395,12 @@ impl IntoIterator for Context {
 impl From<Context> for RestrictedExpr {
     fn from(value: Context) -> Self {
         match value {
-            Context::Value(record) => Value::record_arc(record, None).into(),
-            Context::Residual(record) => {
+            Context::Value(attrs) => Value::record_arc(attrs, None).into(),
+            Context::Residual(attrs) => {
                 // By INVARIANT(restricted), all attributes expressions are
                 // restricted expressions, so the result of `record_arc` will be
                 // a restricted expression.
-                RestrictedExpr::new_unchecked(Expr::record_arc(record))
+                RestrictedExpr::new_unchecked(Expr::record_arc(attrs))
             }
         }
     }
@@ -410,9 +409,7 @@ impl From<Context> for RestrictedExpr {
 impl From<Context> for PartialValue {
     fn from(ctx: Context) -> PartialValue {
         match ctx {
-            Context::Value(attrs) => {
-                PartialValue::Value(Value::new(ValueKind::Record(attrs), None))
-            }
+            Context::Value(attrs) => Value::record_arc(attrs, None).into(),
             Context::Residual(attrs) => {
                 // A `PartialValue::Residual` must contain an unknown in the
                 // expression. By INVARIANT(unknown), at least on expr in

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -123,6 +123,14 @@ impl Value {
         }
     }
 
+    /// Create a record with the given attributes/value mapping.
+    pub fn record_arc(pairs: Arc<BTreeMap<SmolStr, Value>>, loc: Option<Loc>) -> Self {
+        Self {
+            value: ValueKind::record_arc(pairs),
+            loc,
+        }
+    }
+
     /// Return the `Value`, but with the given `Loc` (or `None`)
     pub fn with_maybe_source_loc(self, loc: Option<Loc>) -> Self {
         Self { loc, ..self }
@@ -182,6 +190,11 @@ impl ValueKind {
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect(),
         ))
+    }
+
+    /// Create a record with the given attributes/value mapping.
+    pub fn record_arc(pairs: Arc<BTreeMap<SmolStr, Value>>) -> Self {
+        Self::Record(pairs)
     }
 
     /// If the value is a `Literal`, get a reference to the underlying `Literal`

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -96,6 +96,8 @@ impl<'e> RestrictedEvaluator<'e> {
     /// Interpret a `RestrictedExpr` into a `Value` in this evaluation environment.
     ///
     /// May return an error, for instance if an extension function returns an error
+    ///
+    /// INVARIANT: If this returns a residual, the residual expression must be a valid restricted expression.
     pub fn partial_interpret(&self, expr: BorrowedRestrictedExpr<'_>) -> Result<PartialValue> {
         stack_size_check()?;
 
@@ -124,6 +126,8 @@ impl<'e> RestrictedEvaluator<'e> {
     /// `partial_interpret()` -- ie, so we can make sure the source locations of
     /// all errors are set properly before returning them from
     /// `partial_interpret()`.
+    ///
+    /// INVARIANT: If this returns a residual, the residual expression must be a valid restricted expression.
     fn partial_interpret_internal(
         &self,
         expr: &BorrowedRestrictedExpr<'_>,

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -223,7 +223,7 @@ impl ast::RequestSchema for ValidatorSchema {
                 if let Some(context) = request.context() {
                     let expected_context_ty = validator_action_id.context_type();
                     if !expected_context_ty
-                        .typecheck_partial_value(context.as_ref(), extensions)
+                        .typecheck_partial_value(&context.clone().into(), extensions)
                         .map_err(RequestValidationError::TypeOfContext)?
                     {
                         return Err(request_validation_errors::InvalidContextError {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3424,21 +3424,9 @@ mod context {
         type Item = (String, RestrictedExpression);
 
         fn next(&mut self) -> Option<Self::Item> {
-            self.inner.next().map(|(k, v)| {
-                (
-                    k.to_string(),
-                    match v {
-                        ast::PartialValue::Value(val) => {
-                            RestrictedExpression(ast::RestrictedExpr::from(val))
-                        }
-                        ast::PartialValue::Residual(exp) => {
-                            // `exp` is guaranteed to be a valid `RestrictedExpr`
-                            // since it was originally stored in a `Context`
-                            RestrictedExpression(ast::RestrictedExpr::new_unchecked(exp))
-                        }
-                    },
-                )
-            })
+            self.inner
+                .next()
+                .map(|(k, v)| (k.to_string(), RestrictedExpression(v)))
         }
     }
 }


### PR DESCRIPTION
## Description of changes

Fix #541. Statically enforce invariant that `Context` must contain a record. Also documents that the context must be a restricted expressions, but doesn't enforce this invariant.

I also found that the `into_values` function did not properly enforce the invariant on `PartialValue`. It could construct a `PartialValue` that did not contain an unknown because it assumed that all attributes of a `PartialValue` record would contain a unknown when it's only the case that at least one will. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

