### PR TITLE
Add help message  for `== <name>` in action scope

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -4259,11 +4259,12 @@ mod tests {
                 "try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid"
             ).exactly_one_underline("Album").build());
         });
-        // Testing for absence of help message because actions scope doesn't support `is`.
         let p_src = r#"permit(principal, action == Action, resource);"#;
         assert_matches!(parse_policy_template(None, p_src), Err(e) => {
             expect_err(p_src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
                 "expected an entity uid, found name `Action`"
+            ).help(
+                "try including an identifier string if you intended this name to be an entity uid"
             ).exactly_one_underline("Action").build());
         });
     }

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -225,7 +225,7 @@ impl Node<Option<cst::Primary>> {
                             Some("try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid".to_string())
                         } else {
                             // We don't allow `is` in the action scope, so we won't suggest trying it.
-                            None
+                            Some("try including an identifier string if you intended this name to be an entity uid".to_string())
                         },
                     ))
                     .into())


### PR DESCRIPTION
Follow up to #1048 I thought to do a second after merging 