### PR TITLE
Improve parse error recovery behavior

### DIFF
--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -392,7 +392,6 @@ mod tests {
                     .build(),
             );
         }
-        // Lots of errors! All of them are "unrecognized token" errors from the text->CST parser
         expect_n_errors(src, &errs, 2);
         assert!(errs.iter().all(|err| matches!(err, ParseError::ToCST(_))));
     }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -379,21 +379,9 @@ mod tests {
             unless { resource in principal.account };
         "#;
         let errs = parse_policyset(src).expect_err("expected parsing to fail");
-        // Lots of errors! All of them are "unrecognized token" errors from the text->CST parser
-        expect_n_errors(src, &errs, 16);
-        assert!(errs.iter().all(|err| matches!(err, ParseError::ToCST(_))));
         let unrecognized_tokens = vec![
             ("or", "expected `!=`, `&&`, `(`, `*`, `+`, `-`, `.`, `::`, `<`, `<=`, `==`, `>`, `>=`, `[`, `||`, `}`, `has`, `in`, `is`, or `like`"), 
-            ("if", "expected `(`"), 
-            ("c", "expected `(`"), 
-            ("but", "expected `(`"), 
-            ("not", "expected `(`"), 
-            ("z", "expected `(`"), 
-            ("}", "expected `(`"), 
-            ("{", "expected `(`"), 
-            ("else", "expected `(`"), 
-            ("d", "expected `(`"), 
-            ("f", "expected `(`"),
+            ("if", "expected `!=`, `&&`, `(`, `*`, `+`, `-`, `.`, `::`, `<`, `<=`, `==`, `>`, `>=`, `[`, `||`, `}`, `has`, `in`, `is`, or `like`"),
         ];
         for (token, label) in unrecognized_tokens {
             expect_some_error_matches(
@@ -404,6 +392,9 @@ mod tests {
                     .build(),
             );
         }
+        // Lots of errors! All of them are "unrecognized token" errors from the text->CST parser
+        expect_n_errors(src, &errs, 2);
+        assert!(errs.iter().all(|err| matches!(err, ParseError::ToCST(_))));
     }
 
     #[test]

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -112,7 +112,7 @@ pub Policy: Node<Option<cst::Policy>> = {
     ";"
     <r:@R>
     => Node::with_source_loc(Some(cst::Policy{ annotations,effect,variables,conds }), Loc::new(l..r, Arc::clone(src))),
-    <l:@L> <err:!> <r:@R> => { errors.push(err); Node::with_source_loc(None, Loc::new(l..r, Arc::clone(src))) },
+    <l:@L> <err:!> ";" <r:@R> => { errors.push(err); Node::with_source_loc(None, Loc::new(l..r, Arc::clone(src))) },
 }
 
 // VariableDef := Variable [':' Name] ['is' Add] [('in' | '==') Expr]

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1122,7 +1122,7 @@ mod tests {
     fn error_recovery() {
         // After hitting an unexpected `!`, the parser skips ahead until it
         // finds a `;`, skipping over the body of the policy where it used to
-        // emit a lot of useless pares errors, after which it attempts to parse
+        // emit a lot of useless parse errors, after which it attempts to parse
         // another policy. There is no error in that policy, so it reports
         // exactly one error.
         let src = r#"
@@ -1138,7 +1138,7 @@ mod tests {
                 .build(),
         );
 
-        // Now there is another error which should be also be reported.
+        // Now there is another error which should also be reported.
         let src = r#"
             permit(principal, action, !) when { principal.foo == resource.bar};
             permit(principal, action, +);

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1037,19 +1037,11 @@ mod tests {
             @bad-annotation("bad") permit (principal, action, resource);
         "#;
         let errs = assert_parse_fails(parse_policies, src);
-        expect_n_errors(src, &errs, 2);
-        expect_some_error_matches(
+        expect_exactly_one_error(
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `-`")
                 .exactly_one_underline_with_label("-", "expected `(`")
-                .build(),
-        );
-        expect_some_error_matches(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `\"bad\"`")
-                .exactly_one_underline_with_label("\"bad\"", "expected `)` or identifier")
                 .build(),
         );
 
@@ -1069,19 +1061,11 @@ mod tests {
             @bad_annotation(bad_annotation) permit (principal, action, resource);
         "#;
         let errs = assert_parse_fails(parse_policies, src);
-        expect_n_errors(src, &errs, 2);
-        expect_some_error_matches(
+        expect_exactly_one_error(
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `bad_annotation`")
                 .exactly_one_underline_with_label("bad_annotation", "expected string literal")
-                .build(),
-        );
-        expect_some_error_matches(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `)`")
-                .exactly_one_underline_with_label(")", "expected `(`")
                 .build(),
         );
 
@@ -1089,27 +1073,11 @@ mod tests {
             permit (@comment("your name here") principal, action, resource);
         "#;
         let errs = assert_parse_fails(parse_policies, src);
-        expect_n_errors(src, &errs, 4);
-        expect_some_error_matches(
+        expect_exactly_one_error(
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `@`")
                 .exactly_one_underline_with_label("@", "expected `)` or identifier")
-                .build(),
-        );
-        // 2 copies of the `,` error
-        expect_some_error_matches(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `,`")
-                .exactly_one_underline_with_label(",", "expected `(`")
-                .build(),
-        );
-        expect_some_error_matches(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `)`")
-                .exactly_one_underline_with_label(")", "expected `(`")
                 .build(),
         );
 
@@ -1118,22 +1086,11 @@ mod tests {
             permit(principal, action, resource);
         "#;
         let errs = assert_parse_fails(parse_policies, src);
-        expect_n_errors(src, &errs, 2);
-        expect_some_error_matches(
+        expect_exactly_one_error(
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `mom`")
                 .exactly_one_underline_with_label("mom", "expected `(`")
-                .build(),
-        );
-        expect_some_error_matches(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `\"this should be invalid\"`")
-                .exactly_one_underline_with_label(
-                    "\"this should be invalid\"",
-                    "expected `)` or identifier",
-                )
                 .build(),
         );
 
@@ -1142,22 +1099,11 @@ mod tests {
             permit(principal, action, resource);
         "#;
         let errs = assert_parse_fails(parse_policies, src);
-        expect_n_errors(src, &errs, 2);
-        expect_some_error_matches(
+        expect_exactly_one_error(
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `+`")
                 .exactly_one_underline_with_label("+", "expected `(`")
-                .build(),
-        );
-        expect_some_error_matches(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `\"this should be invalid\"`")
-                .exactly_one_underline_with_label(
-                    "\"this should be invalid\"",
-                    "expected `)` or identifier",
-                )
                 .build(),
         );
     }
@@ -1175,8 +1121,10 @@ mod tests {
     #[test]
     fn error_recovery() {
         // After hitting an unexpected `!`, the parser skips ahead until it
-        // finds a `;` after which it attempts to parse another policy. There is
-        // no error in that policy, so it reports exactly one error.
+        // finds a `;`, skipping over the body of the policy where it used to
+        // emit a lot of useless pares errors, after which it attempts to parse
+        // another policy. There is no error in that policy, so it reports
+        // exactly one error.
         let src = r#"
             permit(principal, action, !) when { principal.foo == resource.bar};
             permit(principal, action, resource);

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -3708,11 +3708,8 @@ mod issue_326 {
         use std::str::FromStr;
 
         let src = r"
-            permit (
-                principal
-                action
-                resource
-            );
+            permit(principal action resource);
+            permit(principal, action resource);
         ";
         assert_matches!(PolicySet::from_str(src), Err(e) => {
             assert!(e.to_string().contains("unexpected token `action`"), "actual error message was {e}");


### PR DESCRIPTION
## Description of changes

Emit fewer useless parser errors after failing to parse early in a policy:

For a policy set 

```cedar
permit(principal, action resource) when { principal.foo == resource.bar };
```

We currently emit

```
  × failed to parse policy set
  ╰─▶ unexpected token `resource`
   ╭─[<stdin>:1:26]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                          ────┬───
   ·                              ╰── expected `!=`, `)`, `,`, `:`, `<`, `<=`, `==`, `>`, `>=`, `in`, or `is`
 2 │ permit(principal, action, resource);
   ╰────

Error:   × unexpected token `)`
   ╭─[<stdin>:1:34]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                                  ┬
   ·                                  ╰── expected `(`
 2 │ permit(principal, action, resource);
   ╰────
Error:   × unexpected token `{`
   ╭─[<stdin>:1:41]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                                         ┬
   ·                                         ╰── expected `(`
 2 │ permit(principal, action, resource);
   ╰────
Error:   × unexpected token `.`
   ╭─[<stdin>:1:52]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                                                    ┬
   ·                                                    ╰── expected `(`
 2 │ permit(principal, action, resource);
   ╰────
Error:   × unexpected token `==`
   ╭─[<stdin>:1:57]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                                                         ─┬
   ·                                                          ╰── expected `(`
 2 │ permit(principal, action, resource);
   ╰────
Error:   × unexpected token `.`
   ╭─[<stdin>:1:68]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                                                                    ┬
   ·                                                                    ╰── expected `(`
 2 │ permit(principal, action, resource);
   ╰────
Error:   × unexpected token `}`
   ╭─[<stdin>:1:73]
 1 │ permit(principal, action resource) when { principal.foo == resource.bar };
   ·                                                                         ┬
   ·                                                                         ╰── expected `(`
 2 │ permit(principal, action, resource);
   ╰────
```

with this change everything after the first error is skipped. If there are any other policies in the policy set, they will be parsed, and any errors in those policies will still be reported.

See #1054 for a more involved change we could also make

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

