### PR TITLE
use `PolicyId` when constructing policies

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -2203,7 +2203,7 @@ mod test {
     #[test]
     fn unexpected_templates() {
         let policy_str = r#"permit(principal == ?principal, action, resource);"#;
-        assert_matches!(parse_policy(Some("id".into()), policy_str), Err(e) => {
+        assert_matches!(parse_policy(Some(PolicyID::from_string("id")), policy_str), Err(e) => {
             expect_exactly_one_error(policy_str, &e, &ExpectedErrorMessageBuilder::error(
                 "expected a static policy, got a template containing the slot ?principal"
                 )
@@ -2215,7 +2215,7 @@ mod test {
 
         let policy_str =
             r#"permit(principal == ?principal, action, resource) when { ?principal == 3 } ;"#;
-        assert_matches!(parse_policy(Some("id".into()), policy_str), Err(e) => {
+        assert_matches!(parse_policy(Some(PolicyID::from_string("id")), policy_str), Err(e) => {
             expect_some_error_matches(policy_str, &e, &ExpectedErrorMessageBuilder::error(
                 "expected a static policy, got a template containing the slot ?principal"
                 )

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -511,11 +511,14 @@ mod test {
     #[test]
     fn link_conflicts() {
         let mut pset = PolicySet::new();
-        let p1 = parser::parse_policy(Some("id".into()), "permit(principal,action,resource);")
-            .expect("Failed to parse");
+        let p1 = parser::parse_policy(
+            Some(PolicyID::from_string("id")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         pset.add_static(p1).expect("Failed to add!");
         let template = parser::parse_policy_template(
-            Some("t".into()),
+            Some(PolicyID::from_string("t")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Failed to parse");
@@ -544,16 +547,18 @@ mod test {
     #[test]
     fn policyset_add() {
         let mut pset = PolicySet::new();
-        let static_policy =
-            parser::parse_policy(Some("id".into()), "permit(principal,action,resource);")
-                .expect("Failed to parse");
+        let static_policy = parser::parse_policy(
+            Some(PolicyID::from_string("id")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         let static_policy: Policy = static_policy.into();
         pset.add(static_policy)
             .expect("Adding static policy in Policy form should succeed");
 
         let template = Arc::new(
             parser::parse_policy_template(
-                Some("t".into()),
+                Some(PolicyID::from_string("t")),
                 "permit(principal == ?principal, action, resource);",
             )
             .expect("Failed to parse"),
@@ -601,7 +606,7 @@ mod test {
 
         let template2 = Arc::new(
             parser::parse_policy_template(
-                Some("t".into()),
+                Some(PolicyID::from_string("t")),
                 "forbid(principal, action, resource == ?resource);",
             )
             .expect("Failed to parse"),
@@ -630,10 +635,13 @@ mod test {
     #[test]
     fn policy_conflicts() {
         let mut pset = PolicySet::new();
-        let p1 = parser::parse_policy(Some("id".into()), "permit(principal,action,resource);")
-            .expect("Failed to parse");
+        let p1 = parser::parse_policy(
+            Some(PolicyID::from_string("id")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         let p2 = parser::parse_policy(
-            Some("id".into()),
+            Some(PolicyID::from_string("id")),
             "permit(principal,action,resource) when { false };",
         )
         .expect("Failed to parse");
@@ -647,12 +655,12 @@ mod test {
     #[test]
     fn template_filtering() {
         let template = parser::parse_policy_template(
-            Some("template".into()),
+            Some(PolicyID::from_string("template")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
         let static_policy = parser::parse_policy(
-            Some("static".into()),
+            Some(PolicyID::from_string("static")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -233,25 +233,25 @@ mod test {
         forbid(principal, action, resource);
         "#;
 
-        let p1 = parser::parse_policy(Some("1".into()), p1_src).unwrap();
+        let p1 = parser::parse_policy(Some(PolicyID::from_string("1")), p1_src).unwrap();
         pset.add_static(p1).unwrap();
 
         let ans = a.is_authorized(q.clone(), &pset, &entities);
         assert_eq!(ans.decision, Decision::Allow);
 
-        pset.add_static(parser::parse_policy(Some("2".into()), p2_src).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("2")), p2_src).unwrap())
             .unwrap();
 
         let ans = a.is_authorized(q.clone(), &pset, &entities);
         assert_eq!(ans.decision, Decision::Allow);
 
-        pset.add_static(parser::parse_policy(Some("3".into()), p3_src).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("3")), p3_src).unwrap())
             .unwrap();
 
         let ans = a.is_authorized(q.clone(), &pset, &entities);
         assert_eq!(ans.decision, Decision::Allow);
 
-        pset.add_static(parser::parse_policy(Some("4".into()), p4_src).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("4")), p4_src).unwrap())
             .unwrap();
 
         let ans = a.is_authorized(q, &pset, &entities);
@@ -407,15 +407,15 @@ mod test {
         };
         "#;
 
-        pset.add_static(parser::parse_policy(Some("1".to_string()), src1).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("1")), src1).unwrap())
             .unwrap();
-        pset.add_static(parser::parse_policy(Some("2".to_string()), src2).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("2")), src2).unwrap())
             .unwrap();
 
         let r = a.is_authorized_core(q.clone(), &pset, &es).decision();
         assert_eq!(r, Some(Decision::Allow));
 
-        pset.add_static(parser::parse_policy(Some("3".to_string()), src3).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("3")), src3).unwrap())
             .unwrap();
 
         let r = a.is_authorized_core(q.clone(), &pset, &es).decision();
@@ -454,9 +454,9 @@ mod test {
             unknown("test")
         };
         "#;
-        pset.add_static(parser::parse_policy(Some("1".to_string()), src1).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("1")), src1).unwrap())
             .unwrap();
-        pset.add_static(parser::parse_policy(Some("2".to_string()), src2).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("2")), src2).unwrap())
             .unwrap();
 
         let r = a.is_authorized_core(q.clone(), &pset, &es);
@@ -501,7 +501,7 @@ mod test {
         permit(principal, action, resource) when { false };
         "#;
 
-        pset.add_static(parser::parse_policy(Some("1".into()), src1).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("1")), src1).unwrap())
             .unwrap();
         let r = a.is_authorized_core(q.clone(), &pset, &es);
         assert_eq!(r.decision(), Some(Decision::Deny));
@@ -510,7 +510,7 @@ mod test {
         forbid(principal, action, resource) when { unknown("a") };
         "#;
 
-        pset.add_static(parser::parse_policy(Some("2".into()), src2).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("2")), src2).unwrap())
             .unwrap();
         let r = a.is_authorized_core(q.clone(), &pset, &es);
         assert_eq!(r.decision(), Some(Decision::Deny));
@@ -522,9 +522,9 @@ mod test {
         permit(principal, action, resource) when { true };
         "#;
 
-        pset.add_static(parser::parse_policy(Some("3".into()), src3).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("3")), src3).unwrap())
             .unwrap();
-        pset.add_static(parser::parse_policy(Some("4".into()), src4).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("4")), src4).unwrap())
             .unwrap();
         let r = a.is_authorized_core(q.clone(), &pset, &es);
         assert_eq!(r.decision(), Some(Decision::Deny));
@@ -566,9 +566,9 @@ mod test {
         forbid(principal, action, resource) when { true };
         "#;
 
-        pset.add_static(parser::parse_policy(Some("1".into()), src1).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("1")), src1).unwrap())
             .unwrap();
-        pset.add_static(parser::parse_policy(Some("2".into()), src2).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("2")), src2).unwrap())
             .unwrap();
 
         let r = a.is_authorized_core(q.clone(), &pset, &es);
@@ -580,7 +580,7 @@ mod test {
         let r2: Response = r.reauthorize(&map, &a, &es).unwrap().into();
         assert_eq!(r2.decision, Decision::Allow);
 
-        pset.add_static(parser::parse_policy(Some("3".into()), src3).unwrap())
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("3")), src3).unwrap())
             .unwrap();
         let r = a.is_authorized_core(q.clone(), &pset, &es);
         assert_eq!(r.decision(), Some(Decision::Deny));

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -4222,7 +4222,7 @@ pub mod test {
     #[test]
     fn template_interp() {
         let t = parse_policy_template(
-            Some("template".to_string()),
+            Some(PolicyID::from_string("template")),
             r#"permit(principal == ?principal, action, resource);"#,
         )
         .expect("Parse Error");

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -104,13 +104,10 @@ pub fn parse_policyset_to_ests_and_pset(
 /// If `id` is Some, then the resulting template will have that `id`.
 /// If the `id` is None, the parser will use "policy0".
 pub fn parse_policy_template(
-    id: Option<String>,
+    id: Option<ast::PolicyID>,
     text: &str,
 ) -> Result<ast::Template, err::ParseErrors> {
-    let id = match id {
-        Some(id) => ast::PolicyID::from_string(id),
-        None => ast::PolicyID::from_string("policy0"),
-    };
+    let id = id.unwrap_or(ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
     cst.to_policy_template(id)
 }
@@ -135,11 +132,11 @@ pub fn parse_policy_template_to_est_and_ast(
 /// simple main function for parsing a policy.
 /// If `id` is Some, then the resulting policy will have that `id`.
 /// If the `id` is None, the parser will use "policy0".
-pub fn parse_policy(id: Option<String>, text: &str) -> Result<ast::StaticPolicy, err::ParseErrors> {
-    let id = match id {
-        Some(id) => ast::PolicyID::from_string(id),
-        None => ast::PolicyID::from_string("policy0"),
-    };
+pub fn parse_policy(
+    id: Option<ast::PolicyID>,
+    text: &str,
+) -> Result<ast::StaticPolicy, err::ParseErrors> {
+    let id = id.unwrap_or(ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
     cst.to_policy(id)
 }
@@ -148,13 +145,10 @@ pub fn parse_policy(id: Option<String>, text: &str) -> Result<ast::StaticPolicy,
 /// EST of the original policy without any of the lossy transforms involved in
 /// converting to AST.
 pub fn parse_policy_to_est_and_ast(
-    id: Option<String>,
+    id: Option<ast::PolicyID>,
     text: &str,
 ) -> Result<(est::Policy, ast::StaticPolicy), err::ParseErrors> {
-    let id = match id {
-        Some(id) => ast::PolicyID::from_string(id),
-        None => ast::PolicyID::from_string("policy0"),
-    };
+    let id = id.unwrap_or(ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
     let ast = cst.to_policy(id)?;
     let est = cst.try_into_inner()?.try_into()?;
@@ -338,7 +332,7 @@ mod tests {
         for template in all_templates().map(Template::from) {
             let id = template.id();
             let src = format!("{template}");
-            let parsed = parse_policy_template(Some(id.to_string()), &src).unwrap();
+            let parsed = parse_policy_template(Some(ast::PolicyID::from_string(id)), &src).unwrap();
             assert_eq!(
                 parsed.slots().collect::<HashSet<_>>(),
                 template.slots().collect::<HashSet<_>>()

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2737,7 +2737,7 @@ mod tests {
     #[test]
     fn issue_wf_5046() {
         let policy = parse_policy(
-            Some("WF-5046".into()),
+            Some(ast::PolicyID::from_string("WF-5046")),
             r#"permit(
             principal,
             action in [Action::"action"],

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -261,13 +261,13 @@ mod test {
         let validator = Validator::new(schema);
 
         let policy_a_src = r#"permit(principal in foo_type::"a", action == Action::"actin", resource == bar_type::"b");"#;
-        let policy_a = parser::parse_policy(Some("pola".to_string()), policy_a_src)
+        let policy_a = parser::parse_policy(Some(PolicyID::from_string("pola")), policy_a_src)
             .expect("Test Policy Should Parse");
         set.add_static(policy_a.clone())
             .expect("Policy already present in PolicySet");
 
         let policy_b_src = r#"permit(principal in foo_tye::"a", action == Action::"action", resource == br_type::"b");"#;
-        let policy_b = parser::parse_policy(Some("polb".to_string()), policy_b_src)
+        let policy_b = parser::parse_policy(Some(PolicyID::from_string("polb")), policy_b_src)
             .expect("Test Policy Should Parse");
         set.add_static(policy_b.clone())
             .expect("Policy already present in PolicySet");
@@ -357,7 +357,7 @@ mod test {
         let validator = Validator::new(schema);
 
         let t = parser::parse_policy_template(
-            Some("template".to_string()),
+            Some(PolicyID::from_string("template")),
             r#"permit(principal == some_namespace::User::"Alice", action, resource in ?resource);"#,
         )
         .expect("Parse Error");

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -1461,7 +1461,7 @@ mod test {
         .try_into()
         .unwrap();
         let policy = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal == a::"p", action, resource == a::"r");"#,
         )
         .unwrap();
@@ -1476,7 +1476,7 @@ mod test {
 #[cfg(feature = "partial-validate")]
 mod partial_schema {
     use cedar_policy_core::{
-        ast::{StaticPolicy, Template},
+        ast::{PolicyID, StaticPolicy, Template},
         parser::parse_policy,
     };
 
@@ -1508,21 +1508,21 @@ mod partial_schema {
     #[test]
     fn undeclared_entity_type_partial_schema() {
         let policy = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal == User::"alice", action, resource);"#,
         )
         .unwrap();
         assert_validates_with_empty_schema(policy);
 
         let policy = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view", resource);"#,
         )
         .unwrap();
         assert_validates_with_empty_schema(policy);
 
         let policy = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource == Photo::"party.jpg");"#,
         )
         .unwrap();

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -167,7 +167,7 @@ mod test {
         "#;
 
         let mut s = PolicySet::new();
-        let p = parse_policy(Some("test".to_string()), src).unwrap();
+        let p = parse_policy(Some(PolicyID::from_string("test")), src).unwrap();
         s.add_static(p).unwrap();
         let warnings =
             confusable_string_checks(s.policies().map(|p| p.template())).collect::<Vec<_>>();
@@ -196,7 +196,7 @@ mod test {
         };
         "#;
         let mut s = PolicySet::new();
-        let p = parse_policy(Some("test".to_string()), src).unwrap();
+        let p = parse_policy(Some(PolicyID::from_string("test")), src).unwrap();
         s.add_static(p).unwrap();
         let warnings = confusable_string_checks(s.policies().map(|p| p.template()));
         assert_eq!(warnings.count(), 2);
@@ -210,7 +210,7 @@ mod test {
         };
         "#;
         let mut s = PolicySet::new();
-        let p = parse_policy(Some("test".to_string()), src).unwrap();
+        let p = parse_policy(Some(PolicyID::from_string("test")), src).unwrap();
         s.add_static(p).unwrap();
         let warnings =
             confusable_string_checks(s.policies().map(|p| p.template())).collect::<Vec<_>>();
@@ -239,7 +239,7 @@ mod test {
         };
         "#;
         let mut s = PolicySet::new();
-        let p = parse_policy(Some("test".to_string()), src).unwrap();
+        let p = parse_policy(Some(PolicyID::from_string("test")), src).unwrap();
         s.add_static(p).unwrap();
         let warnings =
             confusable_string_checks(s.policies().map(|p| p.template())).collect::<Vec<_>>();

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -496,7 +496,7 @@ fn assert_policy_typecheck_fails_namespace_schema(
 #[test]
 fn namespaced_entity_is_wrong_type_and() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
             permit(principal, action, resource)
             when {
@@ -520,7 +520,7 @@ fn namespaced_entity_is_wrong_type_and() {
 #[test]
 fn namespaced_entity_is_wrong_type_when() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
             permit(principal, action, resource)
             when {

--- a/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
@@ -78,7 +78,7 @@ fn assert_policy_typecheck_fails_optional_schema(
 #[test]
 fn simple_and_guard_principal() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -88,7 +88,7 @@ fn simple_and_guard_principal() {
 #[test]
 fn simple_and_guard_resource() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { resource has name && resource.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -98,7 +98,7 @@ fn simple_and_guard_resource() {
 #[test]
 fn principal_and_resource_in_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { resource has name && principal has age && resource.name == "foo" && principal.age == 1};"#,
     )
     .expect("Policy should parse.");
@@ -108,7 +108,7 @@ fn principal_and_resource_in_effect() {
 #[test]
 fn and_branches_union() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name && principal has age) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -118,7 +118,7 @@ fn and_branches_union() {
 #[test]
 fn and_rhs_true_has_lhs_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name && true) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -128,7 +128,7 @@ fn and_rhs_true_has_lhs_effect() {
 #[test]
 fn and_lhs_true_has_rhs_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (true && principal has name) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -138,7 +138,7 @@ fn and_lhs_true_has_rhs_effect() {
 #[test]
 fn and_branches_use_prior_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name) && (principal.name == "foo" && principal.name == "foo") };"#,
     )
     .expect("Policy should parse.");
@@ -148,7 +148,7 @@ fn and_branches_use_prior_effect() {
 #[test]
 fn and_short_circuit_without_error() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has age || (false && principal.name == "foo") };"#,
     )
     .expect("Policy should parse.");
@@ -158,7 +158,7 @@ fn and_short_circuit_without_error() {
 #[test]
 fn or_branches_intersect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name || principal has name) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -168,7 +168,7 @@ fn or_branches_intersect() {
 #[test]
 fn or_lhs_false_has_rhs_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (false || principal has name) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -178,7 +178,7 @@ fn or_lhs_false_has_rhs_effect() {
 #[test]
 fn or_rhs_false_has_lhs_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name || false) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -188,7 +188,7 @@ fn or_rhs_false_has_lhs_effect() {
 #[test]
 fn or_branches_use_prior_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name) && (principal.name == "foo" || principal.name == "foo") };"#,
     )
     .expect("Policy should parse.");
@@ -198,7 +198,7 @@ fn or_branches_use_prior_effect() {
 #[test]
 fn then_guarded_access_by_test() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { if principal has name then principal.name == "foo" else false };"#,
     )
     .expect("Policy should parse.");
@@ -208,7 +208,7 @@ fn then_guarded_access_by_test() {
 #[test]
 fn then_guarded_access_by_prior_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && (if principal has age then principal.name == "foo" else false) };"#,
     )
     .expect("Policy should parse.");
@@ -218,7 +218,7 @@ fn then_guarded_access_by_prior_effect() {
 #[test]
 fn else_guarded_access_by_prior_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && (if principal has age then false else principal.name == "foo") };"#,
     )
     .expect("Policy should parse.");
@@ -228,7 +228,7 @@ fn else_guarded_access_by_prior_effect() {
 #[test]
 fn if_true_short_circuit_without_error() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && (if true then principal.name == "foo" else principal.age == 1)};"#,
     )
     .expect("Policy should parse.");
@@ -238,7 +238,7 @@ fn if_true_short_circuit_without_error() {
 #[test]
 fn if_false_short_circuit_without_error() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && (if false then principal.age == 1 else principal.name == "foo")};"#,
     )
     .expect("Policy should parse.");
@@ -248,7 +248,7 @@ fn if_false_short_circuit_without_error() {
 #[test]
 fn if_then_else_then_else_same() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(principal, action, resource)
         when {
@@ -267,7 +267,7 @@ fn if_then_else_then_else_same() {
 #[test]
 fn if_then_else_can_use_guard_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(principal, action, resource)
         when {
@@ -286,7 +286,7 @@ fn if_then_else_can_use_guard_effect() {
 #[test]
 fn if_then_else_guard_union_then_equal_else() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(principal, action, resource)
         when {
@@ -304,7 +304,7 @@ fn if_then_else_guard_union_then_equal_else() {
 #[test]
 fn guarded_has_true_short_circuits() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(principal, action, resource)
         when {
@@ -335,7 +335,7 @@ fn assert_name_access_fails(policy: StaticPolicy) {
 #[test]
 fn unguarded_access_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -345,7 +345,7 @@ fn unguarded_access_fails() {
 #[test]
 fn else_access_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { if principal has name then false else principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -355,7 +355,7 @@ fn else_access_fails() {
 #[test]
 fn or_rhs_access_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name || principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -365,7 +365,7 @@ fn or_rhs_access_fails() {
 #[test]
 fn or_lhs_access_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.name == "foo" || principal has name };"#,
     )
     .expect("Policy should parse.");
@@ -375,7 +375,7 @@ fn or_lhs_access_fails() {
 #[test]
 fn or_branches_empty_intersect_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name || principal has age) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -385,7 +385,7 @@ fn or_branches_empty_intersect_fails() {
 #[test]
 fn and_lhs_access_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.name == "foo" && principal has name };"#,
     )
     .expect("Policy should parse.");
@@ -395,7 +395,7 @@ fn and_lhs_access_fails() {
 #[test]
 fn if_then_else_else_access_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(principal, action, resource)
         when {
@@ -411,7 +411,7 @@ fn if_then_else_else_access_fails() {
 #[test]
 fn if_then_else_as_guard_empty_intersect_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(principal, action, resource)
         when {
@@ -430,7 +430,7 @@ fn if_then_else_as_guard_empty_intersect_fails() {
 #[test]
 fn resource_effect_access_principal_fails() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { resource has name && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -440,7 +440,7 @@ fn resource_effect_access_principal_fails() {
 #[test]
 fn not_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { !(principal has name) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -450,7 +450,7 @@ fn not_no_effect() {
 #[test]
 fn true_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { true && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -460,7 +460,7 @@ fn true_no_effect() {
 #[test]
 fn set_contains_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { [principal has name].contains(principal has name) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -470,7 +470,7 @@ fn set_contains_no_effect() {
 #[test]
 fn contains_all_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { [principal has name].containsAll([principal has name]) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -480,7 +480,7 @@ fn contains_all_no_effect() {
 #[test]
 fn contains_any_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { [principal has name].containsAny([principal has name]) && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -490,7 +490,7 @@ fn contains_any_no_effect() {
 #[test]
 fn like_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { "foo" like "bar" && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -500,7 +500,7 @@ fn like_no_effect() {
 #[test]
 fn record_attr_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { {name: true}.name && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -510,7 +510,7 @@ fn record_attr_no_effect() {
 #[test]
 fn record_attr_has_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { {name: true} has name && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -520,7 +520,7 @@ fn record_attr_has_no_effect() {
 #[test]
 fn in_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in resource && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -530,7 +530,7 @@ fn in_no_effect() {
 #[test]
 fn in_list_no_effect() {
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in [resource] && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -573,14 +573,14 @@ fn record_optional_attrs() {
     .expect("Expected valid schema.");
 
     let passing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.record has name && principal.record.name == "foo" };"#,
     )
     .expect("Policy should parse.");
     assert_policy_typechecks(schema.clone(), passing_policy);
 
     let failing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.record has other && principal.record.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -601,7 +601,7 @@ fn record_optional_attrs() {
     );
 
     let failing_policy2 = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.record has name && principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -669,14 +669,14 @@ fn action_attrs_passing() {
     .expect("Expected valid schema.");
 
     let passing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action in [Action::"view", Action::"edit"], resource) when { action.isReadOnly };"#,
     )
     .expect("Policy should parse.");
     assert_policy_typechecks(schema.clone(), passing_policy);
 
     let passing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"edit", resource) when { action.canUndo };"#,
     )
     .expect("Policy should parse.");
@@ -685,7 +685,7 @@ fn action_attrs_passing() {
     //This doesn't work when the UB of two ActionEntities is AnyEntity
 
     // let passing_policy = parse_policy(
-    //     Some("0".to_string()),
+    //     Some(PolicyID::from_string("0")),
     //     r#"
     //     permit(
     //         principal == User::"bob",
@@ -701,7 +701,7 @@ fn action_attrs_passing() {
     // assert_policy_typechecks(schema.clone(), passing_policy);
 
     let passing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(
             principal == User::"bob",
@@ -766,7 +766,7 @@ fn action_attrs_failing() {
     .expect("Expected valid schema.");
 
     let failing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"view", resource) when { action.canUndo };"#,
     )
     .expect("Policy should parse.");
@@ -785,7 +785,7 @@ fn action_attrs_failing() {
     // No error is returned, but the typechecker identifies that `action has ""`
     // is always false.
     let failing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"view", resource) when { action has "" };"#,
     )
     .expect("Policy should parse.");
@@ -801,7 +801,7 @@ fn action_attrs_failing() {
     // Fails because OtherNamespace::Action::"view" is not defined in the schema.
     // However, this will be detected by a different pass, so no error is reported.
     let failing_policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"
         permit(
             principal,

--- a/cedar-policy-validator/src/typecheck/test/partial.rs
+++ b/cedar-policy-validator/src/typecheck/test/partial.rs
@@ -19,8 +19,8 @@
 
 use std::collections::HashSet;
 
-use cedar_policy_core::ast::{Expr, Template, Var};
-use cedar_policy_core::{ast::StaticPolicy, parser::parse_policy};
+use cedar_policy_core::ast::{Expr, PolicyID, StaticPolicy, Template, Var};
+use cedar_policy_core::parser::parse_policy;
 
 use super::test_utils::{assert_expected_type_errors, assert_expected_warnings, empty_schema_file};
 use crate::typecheck::Typechecker;
@@ -374,13 +374,13 @@ mod passes_empty_schema {
     #[test]
     fn context_attr() {
         let p = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { context.foo };"#,
         )
         .expect("Policy should parse.");
         assert_typechecks_partial_schema(p);
         let p = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { context.foo.bar };"#,
         )
         .expect("Policy should parse.");
@@ -625,7 +625,7 @@ mod passes_partial_schema {
     #[test]
     fn policy_in_set_action_and_other() {
         let p = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { User::"alice" in [action, User::"alice"] };"#,
         ).expect("Policy should parse.");
         assert_typechecks_partial_schema(p);
@@ -634,7 +634,7 @@ mod passes_partial_schema {
     #[test]
     fn policy_action_in_set_action_and_other() {
         let p = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { action in [action, User::"alice"] };"#,
         )
         .expect("Policy should parse.");
@@ -644,7 +644,7 @@ mod passes_partial_schema {
     #[test]
     fn context_attr() {
         let p = parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view_photo", resource) when { context.foo };"#,
         )
         .expect("Policy should parse.");

--- a/cedar-policy-validator/src/typecheck/test/policy.rs
+++ b/cedar-policy-validator/src/typecheck/test/policy.rs
@@ -178,7 +178,7 @@ fn entity_literal_typechecks() {
 #[test]
 fn policy_checked_in_multiple_envs() {
     let t = parse_policy_template(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"view_photo", resource) when { resource.file_type == "jpg" };"#
     ).expect("Policy should parse.");
 
@@ -206,7 +206,7 @@ fn policy_checked_in_multiple_envs() {
     );
 
     let t = parse_policy_template(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"delete_group", resource) when { resource.file_type == "jpg" };"#
     ).expect("Policy should parse.");
     let schema = simple_schema_file()
@@ -239,7 +239,7 @@ fn policy_checked_in_multiple_envs() {
 #[test]
 fn policy_single_action_attribute_access() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view_photo", resource) when { resource.file_type == "jpg" };"#
         ).expect("Policy should parse."));
 }
@@ -250,7 +250,7 @@ fn policy_principal_action_attribute_access() {
     // principal condition refines this to User, so we can access the age
     // attribute.
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal == User::"alice", action == Action::"view_photo", resource) when { principal.age > 21 };"#
         ).expect("Policy should parse."));
 }
@@ -259,7 +259,7 @@ fn policy_principal_action_attribute_access() {
 fn policy_action_multiple_principal_attribute_access() {
     // The attribute name is defined for User and Group.
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view_photo", resource) when { principal.name == "alice" };"#
         ).expect("Policy should parse."));
 }
@@ -270,7 +270,7 @@ fn policy_no_conditions_attribute_access() {
     // so the action condition isn't required either.
     assert_policy_typechecks_simple_schema(
         parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { principal.name == "alice" };"#,
         )
         .expect("Policy should parse."),
@@ -283,7 +283,7 @@ fn policy_resource_narrows_principal() {
     // "view_photo", so we know the action is "delete_group", which only
     // accepts User as the principal.
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource == Group::"jane_friends") when { principal.age > 22};"#
         ).expect("Policy should parse."));
 }
@@ -291,7 +291,7 @@ fn policy_resource_narrows_principal() {
 #[test]
 fn policy_action_in() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action in [Action::"delete_group", Action::"view_photo"], resource in Album::"vacation_photos") when { resource.file_type == "png" };"#
         ).expect("Policy should parse."));
 }
@@ -300,7 +300,7 @@ fn policy_action_in() {
 fn policy_invalid_attribute() {
     assert_policy_typecheck_fails_simple_schema(
             parse_policy(
-                Some("0".to_string()),
+                Some(PolicyID::from_string("0")),
                 r#"permit(principal, action in [Action::"delete_group", Action::"view_photo"], resource) when { resource.file_type == "jpg" };"#
             ).expect("Policy should parse."),
             vec![
@@ -319,7 +319,7 @@ fn policy_invalid_attribute() {
 fn policy_invalid_attribute_2() {
     assert_policy_typecheck_fails_simple_schema(
             parse_policy(
-                Some("0".to_string()),
+                Some(PolicyID::from_string("0")),
                 r#"permit(principal, action == Action::"view_photo", resource) when { principal.age > 21 };"#
             ).expect("Policy should parse."),
             vec![
@@ -338,7 +338,7 @@ fn policy_invalid_attribute_2() {
 fn policy_context_invalid_attribute() {
     assert_policy_typecheck_fails_simple_schema(
         parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view_photo", resource) when { context.fake };"#,
         )
         .expect("Policy should parse."),
@@ -358,7 +358,7 @@ fn policy_context_invalid_attribute() {
 #[test]
 fn policy_entity_type_attr() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view_photo", resource) when { resource.owner.age > 0 };"#
         ).expect("Policy should parse."));
 }
@@ -366,7 +366,7 @@ fn policy_entity_type_attr() {
 #[test]
 fn policy_entity_type_action_in() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action in Action::"view_photo", resource) when { resource.owner.age > 0 };"#
         ).expect("Policy should parse."));
 }
@@ -374,7 +374,7 @@ fn policy_entity_type_action_in() {
 #[test]
 fn policy_entity_type_action_in_body() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { action in Action::"view_photo" && resource.owner.age > 0 };"#
         ).expect("Policy should parse."));
 }
@@ -382,7 +382,7 @@ fn policy_entity_type_action_in_body() {
 #[test]
 fn policy_entity_type_action_in_set() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action in [Action::"view_photo"], resource) when { resource.owner.age > 0 };"#
         ).expect("Policy should parse."));
 }
@@ -390,7 +390,7 @@ fn policy_entity_type_action_in_set() {
 #[test]
 fn policy_entity_type_principal_in_set() {
     assert_policy_typechecks_permissive_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { principal in [User::"admin", Group::"admin"] || true};"#
         ).expect("Policy should parse."));
 }
@@ -398,7 +398,7 @@ fn policy_entity_type_principal_in_set() {
 #[test]
 fn policy_entity_type_principal_in_set_user_only() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { principal in [User::"admin"] && principal.age == 0};"#
         ).expect("Policy should parse."));
 }
@@ -406,7 +406,7 @@ fn policy_entity_type_principal_in_set_user_only() {
 #[test]
 fn policy_lub_entity_type_attr() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"view_photo", resource) when { resource.owner.favorite.file_type == "png" };"#
         ).expect("Policy should parse."));
 }
@@ -414,7 +414,7 @@ fn policy_lub_entity_type_attr() {
 #[test]
 fn policy_impossible_scope() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal == Group::"foo", action == Action::"delete_group", resource);"#,
     )
     .expect("Policy should parse.");
@@ -430,7 +430,7 @@ fn policy_impossible_scope() {
 #[test]
 fn policy_impossible_literal_euids() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { Group::"foo" in User::"bar" };"#,
     )
     .expect("Policy should parse.");
@@ -446,7 +446,7 @@ fn policy_impossible_literal_euids() {
 #[test]
 fn policy_impossible_not_has() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { ! ({name: "alice"} has name)};"#,
     )
     .expect("Policy should parse.");
@@ -462,7 +462,7 @@ fn policy_impossible_not_has() {
 #[test]
 fn policy_if_entities_lub() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { (if principal.name == "foo" then User::"alice" else User::"bob").age > 21};"#
         ).expect("Policy should parse."));
 }
@@ -470,7 +470,7 @@ fn policy_if_entities_lub() {
 #[test]
 fn policy_in_action_impossible() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { User::"alice" in [action] };"#,
     )
     .expect("Policy should parse.");
@@ -483,7 +483,7 @@ fn policy_in_action_impossible() {
     );
 
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { User::"alice" in [Action::"view_photo"] };"#,
     )
     .expect("Policy should parse.");
@@ -496,7 +496,7 @@ fn policy_in_action_impossible() {
     );
 
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in [action] };"#,
     )
     .expect("Policy should parse.");
@@ -509,7 +509,7 @@ fn policy_in_action_impossible() {
     );
 
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in action };"#,
     )
     .expect("Policy should parse.");
@@ -522,7 +522,7 @@ fn policy_in_action_impossible() {
     );
 
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in Action::"view_photo" };"#,
     )
     .expect("Policy should parse.");
@@ -535,7 +535,7 @@ fn policy_in_action_impossible() {
     );
 
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in [Action::"view_photo", Action::"delete_group"] };"#,
     )
     .expect("Policy should parse.");
@@ -548,7 +548,7 @@ fn policy_in_action_impossible() {
     );
 
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in [Action::"view_photo", Photo::"bar"] };"#,
     )
     .expect("Policy should parse.");
@@ -564,7 +564,7 @@ fn policy_in_action_impossible() {
 #[test]
 fn policy_action_in_impossible() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { action in [User::"alice"] };"#,
     )
     .expect("Policy should parse.");
@@ -580,7 +580,7 @@ fn policy_action_in_impossible() {
 #[test]
 fn policy_entity_has_then_get() {
     assert_policy_typechecks_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { principal has age && principal.age > 0};"#,
         ).expect("Policy should parse."));
 }
@@ -588,7 +588,7 @@ fn policy_entity_has_then_get() {
 #[test]
 fn policy_entity_top_has() {
     assert_policy_typechecks_permissive_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { (if principal.name == "foo" then principal else resource) has name || true };"#,
         ).expect("Policy should parse."));
 }
@@ -596,7 +596,7 @@ fn policy_entity_top_has() {
 #[test]
 fn entity_lub_access_attribute() {
     assert_policy_typechecks_permissive_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { (if 1 > 0 then User::"alice" else Group::"alice_friends").name like "foo"};"#
         ).expect("Policy should parse."));
 }
@@ -604,7 +604,7 @@ fn entity_lub_access_attribute() {
 #[test]
 fn entity_lub_no_common_attributes_is_entity() {
     assert_policy_typechecks_permissive_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { principal in (if 1 > 0 then User::"alice" else Photo::"vacation.jpg")};"#
         ).expect("Policy should parse."));
 }
@@ -612,7 +612,7 @@ fn entity_lub_no_common_attributes_is_entity() {
 #[test]
 fn entity_lub_cant_access_attribute_not_shared() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource == Group::"foo") when { (if 1 > 0 then User::"alice" else Photo::"vacation.jpg").name == "bob"};"#,
     )
     .expect("Policy should parse.");
@@ -636,7 +636,7 @@ fn entity_lub_cant_access_attribute_not_shared() {
 #[test]
 fn entity_attribute_recommendation() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"view_photo", resource) when {resource.filetype like "*jpg" }; "#
     ).expect("Policy should parse");
     let expected = ValidationError::unsafe_attribute_access(
@@ -655,7 +655,7 @@ fn entity_attribute_recommendation() {
 #[test]
 fn entity_lub_no_common_attributes_might_have_declared_attribute() {
     assert_policy_typechecks_permissive_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { (if 1 > 0 then User::"alice" else Photo::"vacation.jpg") has age || true };"#
         ).expect("Policy should parse."));
 }
@@ -663,7 +663,7 @@ fn entity_lub_no_common_attributes_might_have_declared_attribute() {
 #[test]
 fn entity_lub_cant_have_undeclared_attribute() {
     let p = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (if 1 > 0 then User::"alice" else Photo::"vacation.jpg") has foo};"#,
     )
     .expect("Policy should parse.");
@@ -773,7 +773,7 @@ fn is_action() {
 #[test]
 fn entity_record_lub_is_none() {
     assert_policy_typecheck_fails_simple_schema(parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action, resource) when { (if 1 > 0 then User::"alice" else {name: "bob"}).name == "jane" };"#
         ).expect("Policy should parse."),
         vec![
@@ -825,7 +825,7 @@ fn optional_attr_fail() {
     )
     .expect("Expected valid schema");
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal.name == "foo" };"#,
     )
     .expect("Policy should parse.");
@@ -866,7 +866,7 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
     )
     .expect("Expected valid schema");
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { 1 > true };"#,
     )
     .expect("Policy should parse.");
@@ -903,7 +903,7 @@ fn action_groups() {
     assert_policy_typechecks(
         schema.clone(),
         parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action in Action::"group", resource);"#,
         )
         .expect("Policy should parse."),
@@ -912,7 +912,7 @@ fn action_groups() {
     assert_policy_typechecks(
         schema.clone(),
         parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action in Action::"act", resource);"#,
         )
         .expect("Policy should parse."),
@@ -923,7 +923,7 @@ fn action_groups() {
     // by their Uid without considering the type, so `Entity::"group"` might
     // have been treated the same as `Action::"group"` in some cases.
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { action in Entity::"group" };"#,
     )
     .expect("Policy should parse.");
@@ -937,7 +937,7 @@ fn action_groups() {
     );
 
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { action in Entity::"act" };"#,
     )
     .expect("Policy should parse.");
@@ -951,7 +951,7 @@ fn action_groups() {
     );
 
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { Entity::"group" in action };"#,
     )
     .expect("Policy should parse.");
@@ -965,7 +965,7 @@ fn action_groups() {
     );
 
     let policy = parse_policy(
-        Some("0".to_string()),
+        Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { Entity::"act" in action };"#,
     )
     .expect("Policy should parse.");
@@ -1072,7 +1072,7 @@ fn validate_policy_with_typedef_schema() {
     assert_policy_typechecks(
         namespace_def,
         parse_policy(
-            Some("0".to_string()),
+            Some(PolicyID::from_string("0")),
             r#"permit(principal, action == Action::"act", resource) when { principal.flag };"#,
         )
         .expect("Policy should parse."),

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -35,6 +35,8 @@ Cedar Language Version: 4.0
 - Changed JSON schema parser so that `Set`, `Entity`, `Record`, and `Extension`
   can be common type names; updated the error message when common type names
   conflict with built-in primitive type names (#974, partially resolving #973)
+- Changed `Policy::parse` and `Template::parse` to accept an `Option<PolicyId>`
+  instead of `Option<String>` to set the policy id (resolving #1049)
 
 ### Removed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2101,8 +2101,8 @@ impl Template {
     /// If `id` is Some, then the resulting template will have that `id`.
     /// If the `id` is None, the parser will use the default "policy0".
     /// The behavior around None may change in the future.
-    pub fn parse(id: Option<String>, src: impl AsRef<str>) -> Result<Self, ParseErrors> {
-        let ast = parser::parse_policy_template(id, src.as_ref())?;
+    pub fn parse(id: Option<PolicyId>, src: impl AsRef<str>) -> Result<Self, ParseErrors> {
+        let ast = parser::parse_policy_template(id.map(Into::into), src.as_ref())?;
         Ok(Self {
             ast,
             lossless: LosslessPolicy::policy_or_template_text(src.as_ref()),
@@ -2538,8 +2538,8 @@ impl Policy {
     /// This can fail if the policy fails to parse.
     /// It can also fail if a template was passed in, as this function only accepts static
     /// policies
-    pub fn parse(id: Option<String>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {
-        let inline_ast = parser::parse_policy(id, policy_src.as_ref())?;
+    pub fn parse(id: Option<PolicyId>, policy_src: impl AsRef<str>) -> Result<Self, ParseErrors> {
+        let inline_ast = parser::parse_policy(id.map(Into::into), policy_src.as_ref())?;
         let (_, ast) = ast::Template::link_static_policy(inline_ast);
         Ok(Self {
             ast,

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -313,9 +313,9 @@ impl From<ast::EntityUID> for EntityUid {
 
 /// Unique ids assigned to policies and templates.
 ///
-/// A [`PolicyId`] can can be constructed using [`PolicyId::from_str`] or by
-/// calling `parse()` on a string.
-/// This implementation is [`Infallible`], so the parsed [`EntityId`] can be extracted safely.
+/// A [`PolicyId`] can can be constructed using [`PolicyId::new`] or by calling
+/// `parse()` on a string. The `parse()` implementation is [`Infallible`], so
+/// the parsed [`EntityId`] can be extracted safely.
 /// Examples:
 /// ```
 /// # use cedar_policy::PolicyId;

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -283,7 +283,7 @@ impl Policy {
             .clone()
             .map_or(String::new(), |id| format!(" with id `{id}`"));
         match self {
-            Self::Human(str) => crate::Policy::parse(id.map(|id| id.to_string()), str)
+            Self::Human(str) => crate::Policy::parse(id, str)
                 .wrap_err(format!("failed to parse policy{msg} from string")),
             Self::Json(json) => crate::Policy::from_json(id, json.into())
                 .wrap_err(format!("failed to parse policy{msg} from JSON")),
@@ -316,7 +316,7 @@ impl Template {
             .map(|id| format!(" with id `{id}`"))
             .unwrap_or_default();
         match self {
-            Self::Human(str) => crate::Template::parse(id.map(|id| id.to_string()), str)
+            Self::Human(str) => crate::Template::parse(id, str)
                 .wrap_err(format!("failed to parse template{msg} from string")),
             Self::Json(json) => crate::Template::from_json(id, json.into())
                 .wrap_err(format!("failed to parse template{msg} from JSON")),

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -478,12 +478,12 @@ mod scope_constraints_tests {
 
     fn link(src: &str, values: HashMap<SlotId, EntityUid>) -> Policy {
         let mut pset = PolicySet::new();
-        let template = Template::parse(Some("Id".to_string()), src).unwrap();
+        let template = Template::parse(Some(PolicyId::new("Id")), src).unwrap();
 
         pset.add_template(template).unwrap();
 
-        let link_id = PolicyId::from_str("link").unwrap();
-        pset.link(PolicyId::from_str("Id").unwrap(), link_id.clone(), values)
+        let link_id = PolicyId::new("link");
+        pset.link(PolicyId::new("Id"), link_id.clone(), values)
             .unwrap();
         pset.policy(&link_id).unwrap().clone()
     }
@@ -497,11 +497,14 @@ mod policy_set_tests {
     #[test]
     fn template_link_lookup() {
         let mut pset = PolicySet::new();
-        let p = Policy::parse(Some("p".into()), "permit(principal,action,resource);")
-            .expect("Failed to parse");
+        let p = Policy::parse(
+            Some(PolicyId::new("p")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         pset.add(p).expect("Failed to add");
         let template = Template::parse(
-            Some("t".into()),
+            Some(PolicyId::new("t")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Failed to parse");
@@ -509,15 +512,11 @@ mod policy_set_tests {
 
         let env: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
-        pset.link(
-            PolicyId::from_str("t").unwrap(),
-            PolicyId::from_str("id").unwrap(),
-            env.clone(),
-        )
-        .expect("Failed to link");
+        pset.link(PolicyId::new("t"), PolicyId::new("id"), env.clone())
+            .expect("Failed to link");
 
-        let p0 = pset.policy(&PolicyId::from_str("p").unwrap()).unwrap();
-        let tp = pset.policy(&PolicyId::from_str("id").unwrap()).unwrap();
+        let p0 = pset.policy(&PolicyId::new("p")).unwrap();
+        let tp = pset.policy(&PolicyId::new("id")).unwrap();
 
         assert_eq!(
             p0.template_links(),
@@ -534,11 +533,14 @@ mod policy_set_tests {
     #[test]
     fn link_conflicts() {
         let mut pset = PolicySet::new();
-        let p1 = Policy::parse(Some("id".into()), "permit(principal,action,resource);")
-            .expect("Failed to parse");
+        let p1 = Policy::parse(
+            Some(PolicyId::new("id")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         pset.add(p1).expect("Failed to add");
         let template = Template::parse(
-            Some("t".into()),
+            Some(PolicyId::new("t")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Failed to parse");
@@ -548,11 +550,7 @@ mod policy_set_tests {
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
 
         let before_link = pset.clone();
-        let r = pset.link(
-            PolicyId::from_str("t").unwrap(),
-            PolicyId::from_str("id").unwrap(),
-            env,
-        );
+        let r = pset.link(PolicyId::new("t"), PolicyId::new("id"), env);
 
         assert_matches!(
             r,
@@ -569,12 +567,15 @@ mod policy_set_tests {
     #[test]
     fn policyset_add() {
         let mut pset = PolicySet::new();
-        let static_policy = Policy::parse(Some("id".into()), "permit(principal,action,resource);")
-            .expect("Failed to parse");
+        let static_policy = Policy::parse(
+            Some(PolicyId::new("id")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         pset.add(static_policy).expect("Failed to add");
 
         let template = Template::parse(
-            Some("t".into()),
+            Some(PolicyId::new("t")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Failed to parse");
@@ -582,44 +583,32 @@ mod policy_set_tests {
 
         let env1: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test1"))).collect();
-        pset.link(
-            PolicyId::from_str("t").unwrap(),
-            PolicyId::from_str("link").unwrap(),
-            env1,
-        )
-        .expect("Failed to link");
+        pset.link(PolicyId::new("t"), PolicyId::new("link"), env1)
+            .expect("Failed to link");
 
         let env2: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test2"))).collect();
 
         let err = pset
-            .link(
-                PolicyId::from_str("t").unwrap(),
-                PolicyId::from_str("link").unwrap(),
-                env2.clone(),
-            )
+            .link(PolicyId::new("t"), PolicyId::new("link"), env2.clone())
             .expect_err("Should have failed due to conflict with existing link id");
         match err {
             PolicySetError::Linking(_) => (),
             e => panic!("Wrong error: {e}"),
         }
 
-        pset.link(
-            PolicyId::from_str("t").unwrap(),
-            PolicyId::from_str("link2").unwrap(),
-            env2,
-        )
-        .expect("Failed to link");
+        pset.link(PolicyId::new("t"), PolicyId::new("link2"), env2)
+            .expect("Failed to link");
 
         let template2 = Template::parse(
-            Some("t".into()),
+            Some(PolicyId::new("t")),
             "forbid(principal, action, resource == ?resource);",
         )
         .expect("Failed to parse");
         pset.add_template(template2)
             .expect_err("should have failed due to conflict on template id");
         let template2 = Template::parse(
-            Some("t2".into()),
+            Some(PolicyId::new("t2")),
             "forbid(principal, action, resource == ?resource);",
         )
         .expect("Failed to parse");
@@ -628,19 +617,11 @@ mod policy_set_tests {
         let env3: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::resource(), EntityUid::from_strs("Test", "test3"))).collect();
 
-        pset.link(
-            PolicyId::from_str("t").unwrap(),
-            PolicyId::from_str("unique3").unwrap(),
-            env3.clone(),
-        )
-        .expect_err("should have failed due to conflict on template id");
+        pset.link(PolicyId::new("t"), PolicyId::new("unique3"), env3.clone())
+            .expect_err("should have failed due to conflict on template id");
 
-        pset.link(
-            PolicyId::from_str("t2").unwrap(),
-            PolicyId::from_str("unique3").unwrap(),
-            env3,
-        )
-        .expect("should succeed with unique ids");
+        pset.link(PolicyId::new("t2"), PolicyId::new("unique3"), env3)
+            .expect("should succeed with unique ids");
     }
 
     #[test]
@@ -675,15 +656,18 @@ mod policy_set_tests {
         let entities = Entities::from_json_str(e, None).expect("entity error");
 
         let mut pset = PolicySet::new();
-        let static_policy = Policy::parse(Some("id".into()), "permit(principal,action,resource);")
-            .expect("Failed to parse");
+        let static_policy = Policy::parse(
+            Some(PolicyId::new("id")),
+            "permit(principal,action,resource);",
+        )
+        .expect("Failed to parse");
         pset.add(static_policy).expect("Failed to add");
 
         //Allow
         let response = authorizer.is_authorized(&request, &pset, &entities);
         assert_eq!(response.decision(), Decision::Allow);
 
-        pset.remove_static(PolicyId::from_str("id").unwrap())
+        pset.remove_static(PolicyId::new("id"))
             .expect("Failed to remove static policy");
 
         //Deny
@@ -691,28 +675,24 @@ mod policy_set_tests {
         assert_eq!(response.decision(), Decision::Deny);
 
         let template = Template::parse(
-            Some("t".into()),
+            Some(PolicyId::new("t")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Failed to parse");
         pset.add_template(template).expect("Failed to add");
 
-        let linked_policy_id = PolicyId::from_str("linked").unwrap();
+        let linked_policy_id = PolicyId::new("linked");
         let env1: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
-        pset.link(
-            PolicyId::from_str("t").unwrap(),
-            linked_policy_id.clone(),
-            env1,
-        )
-        .expect("Failed to link");
+        pset.link(PolicyId::new("t"), linked_policy_id.clone(), env1)
+            .expect("Failed to link");
 
         //Allow
         let response = authorizer.is_authorized(&request, &pset, &entities);
         assert_eq!(response.decision(), Decision::Allow);
 
         assert_matches!(
-            pset.remove_static(PolicyId::from_str("t").unwrap()),
+            pset.remove_static(PolicyId::new("t")),
             Err(PolicySetError::PolicyNonexistent(_))
         );
 
@@ -720,7 +700,7 @@ mod policy_set_tests {
         assert_matches!(result, Ok(_));
 
         assert_matches!(
-            pset.remove_static(PolicyId::from_str("t").unwrap()),
+            pset.remove_static(PolicyId::new("t")),
             Err(PolicySetError::PolicyNonexistent(_))
         );
 
@@ -730,12 +710,8 @@ mod policy_set_tests {
 
         let env1: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
-        pset.link(
-            PolicyId::from_str("t").unwrap(),
-            linked_policy_id.clone(),
-            env1,
-        )
-        .expect("Failed to link");
+        pset.link(PolicyId::new("t"), linked_policy_id.clone(), env1)
+            .expect("Failed to link");
 
         //Allow
         let response = authorizer.is_authorized(&request, &pset, &entities);
@@ -743,14 +719,14 @@ mod policy_set_tests {
 
         //Can't remove template that is still linked
         assert_matches!(
-            pset.remove_template(PolicyId::from_str("t").unwrap()),
+            pset.remove_template(PolicyId::new("t")),
             Err(PolicySetError::RemoveTemplateWithActiveLinks(_))
         );
 
         //Unlink first, then remove
         let result = pset.unlink(linked_policy_id);
         assert_matches!(result, Ok(_));
-        pset.remove_template(PolicyId::from_str("t").unwrap())
+        pset.remove_template(PolicyId::new("t"))
             .expect("Failed to remove policy template");
 
         //Deny
@@ -761,7 +737,7 @@ mod policy_set_tests {
     #[test]
     fn pset_removal_prop_test_1() {
         let template = Template::parse(
-            Some("policy0".into()),
+            Some(PolicyId::new("policy0")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -769,14 +745,10 @@ mod policy_set_tests {
         pset.add_template(template).unwrap();
         let env: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
-        pset.link(
-            PolicyId::from_str("policy0").unwrap(),
-            PolicyId::from_str("policy3").unwrap(),
-            env,
-        )
-        .unwrap();
+        pset.link(PolicyId::new("policy0"), PolicyId::new("policy3"), env)
+            .unwrap();
         let template = Template::parse(
-            Some("policy3".into()),
+            Some(PolicyId::new("policy3")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -786,11 +758,11 @@ mod policy_set_tests {
             Err(PolicySetError::AlreadyDefined(_))
         );
         assert_matches!(
-            pset.remove_static(PolicyId::from_str("policy3").unwrap()),
+            pset.remove_static(PolicyId::new("policy3")),
             Err(PolicySetError::PolicyNonexistent(_))
         );
         assert_matches!(
-            pset.remove_template(PolicyId::from_str("policy3").unwrap()),
+            pset.remove_template(PolicyId::new("policy3")),
             Err(PolicySetError::TemplateNonexistent(_))
         );
     }
@@ -798,12 +770,12 @@ mod policy_set_tests {
     #[test]
     fn pset_requests() {
         let template = Template::parse(
-            Some("template".into()),
+            Some(PolicyId::new("template")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
         let static_policy = Policy::parse(
-            Some("static".into()),
+            Some(PolicyId::new("static")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -811,8 +783,8 @@ mod policy_set_tests {
         pset.add_template(template).unwrap();
         pset.add(static_policy).unwrap();
         pset.link(
-            PolicyId::from_str("template").unwrap(),
-            PolicyId::from_str("linked").unwrap(),
+            PolicyId::new("template"),
+            PolicyId::new("linked"),
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect(),
         )
         .expect("Link failure");
@@ -846,7 +818,7 @@ mod policy_set_tests {
         // Linking the `PolicyId` of a static policy should not be allowed.
         // Attempting it should cause an `ExpectedTemplate` error.
         let static_policy = Policy::parse(
-            Some("static".into()),
+            Some(PolicyId::new("static")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -855,8 +827,8 @@ mod policy_set_tests {
 
         let before_link = pset.clone();
         let result = pset.link(
-            PolicyId::from_str("static").unwrap(),
-            PolicyId::from_str("linked").unwrap(),
+            PolicyId::new("static"),
+            PolicyId::new("linked"),
             HashMap::new(),
         );
         assert_matches!(result, Err(PolicySetError::ExpectedTemplate(_)));
@@ -869,7 +841,7 @@ mod policy_set_tests {
     #[test]
     fn link_linked_policy() {
         let template = Template::parse(
-            Some("template".into()),
+            Some(PolicyId::new("template")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -877,16 +849,16 @@ mod policy_set_tests {
         pset.add_template(template).unwrap();
 
         pset.link(
-            PolicyId::from_str("template").unwrap(),
-            PolicyId::from_str("linked").unwrap(),
+            PolicyId::new("template"),
+            PolicyId::new("linked"),
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect(),
         )
         .unwrap();
 
         let before_link = pset.clone();
         let result = pset.link(
-            PolicyId::from_str("linked").unwrap(),
-            PolicyId::from_str("linked2").unwrap(),
+            PolicyId::new("linked"),
+            PolicyId::new("linked2"),
             HashMap::new(),
         );
         assert_matches!(result, Err(PolicySetError::ExpectedTemplate(_)));
@@ -921,16 +893,16 @@ mod policy_set_tests {
     #[test]
     fn unlink_linked_policy() {
         let template = Template::parse(
-            Some("template".into()),
+            Some(PolicyId::new("template")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
         let mut pset = PolicySet::new();
         pset.add_template(template).unwrap();
 
-        let linked_policy_id = PolicyId::from_str("linked").unwrap();
+        let linked_policy_id = PolicyId::new("linked");
         pset.link(
-            PolicyId::from_str("template").unwrap(),
+            PolicyId::new("template"),
             linked_policy_id.clone(),
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect(),
         )
@@ -985,15 +957,15 @@ mod policy_set_tests {
         let mut pset = PolicySet::new();
 
         let template = Template::parse(
-            Some("template".into()),
+            Some(PolicyId::new("template")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
         pset.add_template(template).unwrap();
 
-        let linked_policy_id = PolicyId::from_str("linked").unwrap();
+        let linked_policy_id = PolicyId::new("linked");
         pset.link(
-            PolicyId::from_str("template").unwrap(),
+            PolicyId::new("template"),
             linked_policy_id.clone(),
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect(),
         )
@@ -1001,7 +973,7 @@ mod policy_set_tests {
 
         //add link, count 1
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             1
@@ -1010,7 +982,7 @@ mod policy_set_tests {
         assert_matches!(result, Ok(_));
         //remove link, count 0
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             0
@@ -1019,25 +991,25 @@ mod policy_set_tests {
         assert_matches!(result, Err(PolicySetError::LinkNonexistent(_)));
 
         pset.link(
-            PolicyId::from_str("template").unwrap(),
+            PolicyId::new("template"),
             linked_policy_id.clone(),
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect(),
         )
         .unwrap();
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             1
         );
         pset.link(
-            PolicyId::from_str("template").unwrap(),
-            PolicyId::from_str("linked2").unwrap(),
+            PolicyId::new("template"),
+            PolicyId::new("linked2"),
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect(),
         )
         .unwrap();
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             2
@@ -1045,7 +1017,7 @@ mod policy_set_tests {
 
         //Can't re-add template
         let template = Template::parse(
-            Some("template".into()),
+            Some(PolicyId::new("template")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1056,7 +1028,7 @@ mod policy_set_tests {
 
         //Add another template
         let template = Template::parse(
-            Some("template2".into()),
+            Some(PolicyId::new("template2")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1064,7 +1036,7 @@ mod policy_set_tests {
 
         //template2 count 0
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template2").unwrap())
+            pset.get_linked_policies(PolicyId::new("template2"))
                 .unwrap()
                 .count(),
             0
@@ -1072,7 +1044,7 @@ mod policy_set_tests {
 
         //template count 2
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             2
@@ -1080,13 +1052,13 @@ mod policy_set_tests {
 
         //Can't remove template
         assert_matches!(
-            pset.remove_template(PolicyId::from_str("template").unwrap()),
+            pset.remove_template(PolicyId::new("template")),
             Err(PolicySetError::RemoveTemplateWithActiveLinks(_))
         );
 
         //Can't add policy named template
         let illegal_template_policy = Policy::parse(
-            Some("template".into()),
+            Some(PolicyId::new("template")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -1097,7 +1069,7 @@ mod policy_set_tests {
 
         //Can't add policy named linked
         let illegal_linked_policy = Policy::parse(
-            Some("linked".into()),
+            Some(PolicyId::new("linked")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -1108,31 +1080,31 @@ mod policy_set_tests {
 
         //Can add policy named `policy`
         let static_policy = Policy::parse(
-            Some("policy".into()),
+            Some(PolicyId::new("policy")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
         pset.add(static_policy).unwrap();
 
         //Can remove `policy`
-        pset.remove_static(PolicyId::from_str("policy").unwrap())
+        pset.remove_static(PolicyId::new("policy"))
             .expect("should be able to remove policy");
 
         //Cannot remove "linked"
         assert_matches!(
-            pset.remove_static(PolicyId::from_str("linked").unwrap()),
+            pset.remove_static(PolicyId::new("linked")),
             Err(PolicySetError::PolicyNonexistent(_))
         );
 
         //Cannot remove "template"
         assert_matches!(
-            pset.remove_static(PolicyId::from_str("template").unwrap()),
+            pset.remove_static(PolicyId::new("template")),
             Err(PolicySetError::PolicyNonexistent(_))
         );
 
         //template count 2
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             2
@@ -1142,43 +1114,37 @@ mod policy_set_tests {
         let result = pset.unlink(linked_policy_id);
         assert_matches!(result, Ok(_));
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             1
         );
 
         //remove template2
-        assert_matches!(
-            pset.remove_template(PolicyId::from_str("template2").unwrap()),
-            Ok(_)
-        );
+        assert_matches!(pset.remove_template(PolicyId::new("template2")), Ok(_));
 
         //can't remove template1
         assert_matches!(
-            pset.remove_template(PolicyId::from_str("template").unwrap()),
+            pset.remove_template(PolicyId::new("template")),
             Err(PolicySetError::RemoveTemplateWithActiveLinks(_))
         );
 
         //unlink other policy, template count 0
-        let result = pset.unlink(PolicyId::from_str("linked2").unwrap());
+        let result = pset.unlink(PolicyId::new("linked2"));
         assert_matches!(result, Ok(_));
         assert_eq!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .unwrap()
                 .count(),
             0
         );
 
         //remove template
-        assert_matches!(
-            pset.remove_template(PolicyId::from_str("template").unwrap()),
-            Ok(_)
-        );
+        assert_matches!(pset.remove_template(PolicyId::new("template")), Ok(_));
 
         //can't get count for nonexistent template
         assert_matches!(
-            pset.get_linked_policies(PolicyId::from_str("template").unwrap())
+            pset.get_linked_policies(PolicyId::new("template"))
                 .err()
                 .unwrap(),
             PolicySetError::TemplateNonexistent(_)
@@ -1188,7 +1154,7 @@ mod policy_set_tests {
     #[test]
     fn pset_add_conflict() {
         let template = Template::parse(
-            Some("policy0".into()),
+            Some(PolicyId::new("policy0")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1196,16 +1162,12 @@ mod policy_set_tests {
         pset.add_template(template).unwrap();
         let env: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
-        pset.link(
-            PolicyId::from_str("policy0").unwrap(),
-            PolicyId::from_str("policy1").unwrap(),
-            env,
-        )
-        .unwrap();
+        pset.link(PolicyId::new("policy0"), PolicyId::new("policy1"), env)
+            .unwrap();
 
         //fails for template; static
         let static_policy = Policy::parse(
-            Some("policy0".into()),
+            Some(PolicyId::new("policy0")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -1216,7 +1178,7 @@ mod policy_set_tests {
 
         //fails for link; static
         let static_policy = Policy::parse(
-            Some("policy1".into()),
+            Some(PolicyId::new("policy1")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -1227,7 +1189,7 @@ mod policy_set_tests {
 
         //fails for static; static
         let static_policy = Policy::parse(
-            Some("policy2".into()),
+            Some(PolicyId::new("policy2")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
@@ -1241,7 +1203,7 @@ mod policy_set_tests {
     #[test]
     fn pset_add_template_conflict() {
         let template = Template::parse(
-            Some("policy0".into()),
+            Some(PolicyId::new("policy0")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1249,16 +1211,12 @@ mod policy_set_tests {
         pset.add_template(template).unwrap();
         let env: HashMap<SlotId, EntityUid> =
             std::iter::once((SlotId::principal(), EntityUid::from_strs("Test", "test"))).collect();
-        pset.link(
-            PolicyId::from_str("policy0").unwrap(),
-            PolicyId::from_str("policy3").unwrap(),
-            env,
-        )
-        .unwrap();
+        pset.link(PolicyId::new("policy0"), PolicyId::new("policy3"), env)
+            .unwrap();
 
         //fails for link; template
         let template = Template::parse(
-            Some("policy3".into()),
+            Some(PolicyId::new("policy3")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1269,7 +1227,7 @@ mod policy_set_tests {
 
         //fails for template; template
         let template = Template::parse(
-            Some("policy0".into()),
+            Some(PolicyId::new("policy0")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1280,13 +1238,13 @@ mod policy_set_tests {
 
         //fails for static; template
         let static_policy = Policy::parse(
-            Some("policy1".into()),
+            Some(PolicyId::new("policy1")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
         pset.add(static_policy).unwrap();
         let template = Template::parse(
-            Some("policy1".into()),
+            Some(PolicyId::new("policy1")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1299,7 +1257,7 @@ mod policy_set_tests {
     #[test]
     fn pset_link_conflict() {
         let template = Template::parse(
-            Some("policy0".into()),
+            Some(PolicyId::new("policy0")),
             "permit(principal == ?principal, action, resource);",
         )
         .expect("Template Parse Failure");
@@ -1310,15 +1268,15 @@ mod policy_set_tests {
 
         //fails for link; link
         pset.link(
-            PolicyId::from_str("policy0").unwrap(),
-            PolicyId::from_str("policy3").unwrap(),
+            PolicyId::new("policy0"),
+            PolicyId::new("policy3"),
             env.clone(),
         )
         .unwrap();
         assert_matches!(
             pset.link(
-                PolicyId::from_str("policy0").unwrap(),
-                PolicyId::from_str("policy3").unwrap(),
+                PolicyId::new("policy0"),
+                PolicyId::new("policy3"),
                 env.clone(),
             ),
             Err(PolicySetError::Linking(policy_set_errors::LinkingError {
@@ -1329,8 +1287,8 @@ mod policy_set_tests {
         //fails for template; link
         assert_matches!(
             pset.link(
-                PolicyId::from_str("policy0").unwrap(),
-                PolicyId::from_str("policy0").unwrap(),
+                PolicyId::new("policy0"),
+                PolicyId::new("policy0"),
                 env.clone(),
             ),
             Err(PolicySetError::Linking(policy_set_errors::LinkingError {
@@ -1340,17 +1298,13 @@ mod policy_set_tests {
 
         //fails for static; link
         let static_policy = Policy::parse(
-            Some("policy1".into()),
+            Some(PolicyId::new("policy1")),
             "permit(principal, action, resource);",
         )
         .expect("Static parse failure");
         pset.add(static_policy).unwrap();
         assert_matches!(
-            pset.link(
-                PolicyId::from_str("policy0").unwrap(),
-                PolicyId::from_str("policy1").unwrap(),
-                env,
-            ),
+            pset.link(PolicyId::new("policy0"), PolicyId::new("policy1"), env,),
             Err(PolicySetError::Linking(policy_set_errors::LinkingError {
                 inner: ast::LinkingError::PolicyIdConflict { .. }
             }))
@@ -5030,7 +4984,7 @@ mod authorization_error_tests {
 
         let mut pset = PolicySet::new();
         let static_policy = Policy::parse(
-            Some("id0".into()),
+            Some(PolicyId::new("id0")),
             "permit(principal,action,resource) when {principal.foo == 1};",
         )
         .expect("Failed to parse");

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -40,7 +40,7 @@ fn authorize_custom_request() -> Result<(), Box<dyn Error>> {
     // Or individually
     // Note the id!
     let alice_view = Policy::parse(
-        Some("added policy".to_string()),
+        Some(PolicyId::new("added policy")),
         r#"
         permit(
             principal == User::"alice",
@@ -395,7 +395,7 @@ fn policy_annotations() {
         .parse()
         .unwrap();
     // need a new id to include in set
-    let t = t.new_id(PolicyId::from_str("new_template_id").unwrap());
+    let t = t.new_id(PolicyId::new("new_template_id"));
     assert_eq!(t.annotation("tanno"), Some("good annotation"));
     assert_eq!(t.annotations().next(), Some(("tanno", "good annotation")));
 


### PR DESCRIPTION
## Description of changes

* Changed the public `Policy::parse` and `Template::parse` APIs to use an `Option<PolicyId>` instead of `Option<String>` to set the policy id
* Changed the internal `parse_policy*` APIs similarly
* Updated tests to use `PolicyId::new` instead of `PolicyId::from_str` because it's prettier

The diff is largely just the result of updating test cases. The only interesting edits are in:
* `cedar-policy-core/src/parser.rs`
* `cedar-policy/CHANGELOG.md`
* `cedar-policy/src/api.rs`
* `cedar-policy/src/api/id.rs`
* `cedar-policy/src/ffi/utils.rs`

## Issue #, if available

Resolves #1049

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
