### PR TITLE
Add support for reading json policy set

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added command `translate-policy` that translates a policy set in its human-readable format to the JSON format (except comments).
 - Added a `visualize` option to the command-line interface, allowing entity json
 files to be visualized using the graphviz format.
+- All commands that read policies in JSON format now accept a policy set in addition to a single policy or a policy template.
 
 ### Changed
 

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_mixed_properties.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_mixed_properties.cedar.json
@@ -1,0 +1,10 @@
+{
+    "effect": "",
+    "principal": {},
+    "action": {},
+    "resource": {},
+    "conditions": [],
+    "staticPolicies": {},
+    "templates": {},
+    "templateLinks": []
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_no_matching_properties.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_no_matching_properties.cedar.json
@@ -1,0 +1,10 @@
+{
+    "Xeffect": "",
+    "Xprincipal": {},
+    "Xaction": {},
+    "Xresource": {},
+    "Xconditions": [],
+    "XstaticPolicies": {},
+    "Xtemplates": {},
+    "XtemplateLinks": []
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_set.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_set.cedar.json
@@ -1,0 +1,52 @@
+{
+  "staticPolicies": {
+      "policy0": {
+          "effect": "permit",
+          "principal": {
+              "op": "==",
+              "entity": {
+                  "type": "User",
+                  "id": "bob"
+              }
+          },
+          "action": {
+              "op": "in",
+              "entities": [
+                  {
+                      "type": "Action",
+                      "id": "view"
+                  },
+                  {
+                      "type": "Action",
+                      "id": "edit"
+                  }
+              ]
+          },
+          "resource": {
+              "op": "All"
+          },
+          "conditions": [
+              {
+                  "kind": "when",
+                  "body": {
+                      "==": {
+                          "left": {
+                              ".": {
+                                  "left": {
+                                      "Var": "resource"
+                                  },
+                                  "attr": "owner"
+                              }
+                          },
+                          "right": {
+                              "Var": "principal"
+                          }
+                      }
+                  }
+              }
+          ]
+      }
+  },
+  "templates": {},
+  "templateLinks": []
+}

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1225,8 +1225,8 @@ fn get_json_policy_type(json: &serde_json::Value) -> Result<JsonPolicyType> {
     let has_any_policy_property = policy_properties.iter().any(json_has_property);
 
     match (has_any_policy_set_property, has_any_policy_property) {
-        (false, false) => Err(miette!("Cannot determine if json policy is a single policy or a policy set. Found no matching properties from any of those schemas.")),
-        (true, true) => Err(miette!("Cannot determine if json policy is a single policy or a policy set. Found matching properties from both schemas.")),
+        (false, false) => Err(miette!("cannot determine if json policy is a single policy or a policy set. Found no matching properties from either format")),
+        (true, true) => Err(miette!("cannot determine if json policy is a single policy or a policy set. Found matching properties from both formats")),
         (true, _) => Ok(JsonPolicyType::PolicySet),
         (_, true) => Ok(JsonPolicyType::SinglePolicy),
     }

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1177,34 +1177,64 @@ fn read_human_policy_set(
     rename_from_id_annotation(ps)
 }
 
-/// Read a static policy or a policy template, in Cedar JSON (EST) syntax, from the file given
+/// Read a policy set, static policy or policy template, in Cedar JSON (EST) syntax, from the file given
 /// in `filename`, or from stdin if `filename` is `None`.
 fn read_json_policy_set(
     filename: Option<impl AsRef<Path> + std::marker::Copy>,
 ) -> Result<PolicySet> {
     let context = "JSON policy";
     let json_source = read_from_file_or_stdin(filename, context)?;
-    let json: serde_json::Value = serde_json::from_str(&json_source).into_diagnostic()?;
-    let err_to_report = |err| {
+    let json = serde_json::from_str::<serde_json::Value>(&json_source).into_diagnostic()?;
+    let policy_type = get_json_policy_type(&json)?;
+
+    let add_json_source = |report: Report| {
         let name = filename.map_or_else(
             || "<stdin>".to_owned(),
             |n| n.as_ref().display().to_string(),
         );
-        Report::new(err).with_source_code(NamedSource::new(name, json_source.clone()))
+        report.with_source_code(NamedSource::new(name, json_source.clone()))
     };
 
-    match Policy::from_json(None, json.clone()) {
-        Ok(policy) => PolicySet::from_policies([policy])
-            .wrap_err_with(|| format!("failed to create policy set from {context}")),
-        Err(_) => match Template::from_json(None, json).map_err(err_to_report) {
-            Ok(template) => {
-                let mut ps = PolicySet::new();
-                ps.add_template(template)?;
-                Ok(ps)
-            }
-            Err(err) => Err(err).wrap_err_with(|| format!("failed to parse {context}")),
+    match policy_type {
+        JsonPolicyType::SinglePolicy => match Policy::from_json(None, json.clone()) {
+            Ok(policy) => PolicySet::from_policies([policy])
+                .wrap_err_with(|| format!("failed to create policy set from {context}")),
+            Err(_) => match Template::from_json(None, json)
+                .map_err(|err| add_json_source(Report::new(err)))
+            {
+                Ok(template) => {
+                    let mut ps = PolicySet::new();
+                    ps.add_template(template)?;
+                    Ok(ps)
+                }
+                Err(err) => Err(err).wrap_err_with(|| format!("failed to parse {context}")),
+            },
         },
+        JsonPolicyType::PolicySet => {
+            PolicySet::from_json_value(json).map_err(|err| add_json_source(Report::new(err)))
+        }
     }
+}
+
+fn get_json_policy_type(json: &serde_json::Value) -> Result<JsonPolicyType> {
+    let policy_set_properties = ["staticPolicies", "templates", "templateLinks"];
+    let policy_properties = ["action", "effect", "principal", "resource", "conditions"];
+
+    let json_has_property = |p| json.get(p).is_some();
+    let has_any_policy_set_property = policy_set_properties.iter().any(json_has_property);
+    let has_any_policy_property = policy_properties.iter().any(json_has_property);
+
+    match (has_any_policy_set_property, has_any_policy_property) {
+        (false, false) => Err(miette!("Cannot determine if json policy is a single policy or a policy set. Found no matching properties from any of those schemas.")),
+        (true, true) => Err(miette!("Cannot determine if json policy is a single policy or a policy set. Found matching properties from both schemas.")),
+        (true, _) => Ok(JsonPolicyType::PolicySet),
+        (_, true) => Ok(JsonPolicyType::SinglePolicy),
+    }
+}
+
+enum JsonPolicyType {
+    SinglePolicy,
+    PolicySet,
 }
 
 fn read_schema_file(

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1210,9 +1210,9 @@ fn read_json_policy_set(
                 Err(err) => Err(err).wrap_err_with(|| format!("failed to parse {context}")),
             },
         },
-        JsonPolicyType::PolicySet => {
-            PolicySet::from_json_value(json).map_err(|err| add_json_source(Report::new(err)))
-        }
+        JsonPolicyType::PolicySet => PolicySet::from_json_value(json)
+            .map_err(|err| add_json_source(Report::new(err)))
+            .wrap_err_with(|| format!("failed to create policy set from {context}")),
     }
 }
 

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -30,6 +30,7 @@ use cedar_policy_cli::{
     EvaluateArgs, LinkArgs, PoliciesArgs, PolicyFormat, RequestArgs, ValidateArgs,
 };
 
+use predicates::prelude::*;
 use rstest::rstest;
 
 fn run_check_parse_test(policies_file: impl Into<String>, expected_exit_code: CedarExitCode) {
@@ -998,8 +999,7 @@ fn test_require_policies_for_write() {
 
 #[test]
 fn test_check_parse_json_static_policy() {
-    let json_static_policy: &str =
-        "sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json";
+    let json_policy: &str = "sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json";
 
     assert_cmd::Command::cargo_bin("cedar")
         .expect("bin exists")
@@ -1007,14 +1007,14 @@ fn test_check_parse_json_static_policy() {
         .arg("--policy-format")
         .arg("json")
         .arg("-p")
-        .arg(json_static_policy)
+        .arg(json_policy)
         .assert()
         .code(0);
 }
 
 #[test]
 fn test_check_parse_json_policy_template() {
-    let json_policy_template: &str =
+    let json_policy: &str =
         "sample-data/tiny_sandboxes/json-check-parse/policy_template.cedar.json";
 
     assert_cmd::Command::cargo_bin("cedar")
@@ -1023,9 +1023,60 @@ fn test_check_parse_json_policy_template() {
         .arg("--policy-format")
         .arg("json")
         .arg("-p")
-        .arg(json_policy_template)
+        .arg(json_policy)
         .assert()
         .code(0);
+}
+
+#[test]
+fn test_check_parse_json_policy_set() {
+    let json_policy: &str = "sample-data/tiny_sandboxes/json-check-parse/policy_set.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn test_check_parse_json_policy_mixed_properties() {
+    let json_policy: &str =
+        "sample-data/tiny_sandboxes/json-check-parse/policy_mixed_properties.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "matching properties from both schemas",
+        ));
+}
+
+#[test]
+fn test_check_parse_json_policy_no_matching_properties() {
+    let json_policy: &str =
+        "sample-data/tiny_sandboxes/json-check-parse/policy_no_matching_properties.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("no matching properties"));
 }
 
 #[test]

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1058,7 +1058,7 @@ fn test_check_parse_json_policy_mixed_properties() {
         .assert()
         .code(1)
         .stdout(predicate::str::contains(
-            "matching properties from both schemas",
+            "matching properties from both formats",
         ));
 }
 


### PR DESCRIPTION
## Description of changes
Adds backwards-compatible support for reading json policy sets.

I tried making the code as explicit and self-explaining as possible, as well as keeping the "guesswork" separate from the parsing. (One could want to make it more compact though.)

## Issue #, if available
Resolves #950.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

