### PR TITLE
validator: use refs instead of owned types in a couple places

### DIFF
--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -450,7 +450,7 @@ pub fn context_schema_for_action(
     // as their values are representable. The values are representable
     // because they are taken from the context of a `ValidatorActionId`
     // which was constructed directly from a schema.
-    schema.context_type(action).map(ContextSchema)
+    schema.context_type(action).cloned().map(ContextSchema)
 }
 
 #[cfg(test)]

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -601,7 +601,7 @@ impl ValidatorSchema {
     /// This always returns a closed record type.
     ///
     /// Returns `None` if the action is not in the schema.
-    pub fn context_type(&self, action: &EntityUID) -> Option<Type> {
+    pub fn context_type(&self, action: &EntityUID) -> Option<&Type> {
         // INVARIANT: `ValidatorActionId::context_type` always returns a closed
         // record type
         self.get_action_id(action)
@@ -684,7 +684,7 @@ struct CommonTypeResolver<'a> {
     /// The dependency graph among common type names.
     /// The graph contains a vertex for each `Name` and `graph.get(u)` gives the set of vertices `v` for which `(u,v)` is a directed edge in the graph.
     /// A common type name is prefixed with the namespace id where it's declared.
-    graph: HashMap<Name, HashSet<Name>>,
+    graph: HashMap<&'a Name, HashSet<&'a Name>>,
 }
 
 impl<'a> CommonTypeResolver<'a> {
@@ -694,10 +694,7 @@ impl<'a> CommonTypeResolver<'a> {
     fn new(type_defs: &'a HashMap<Name, SchemaType<Name>>) -> Self {
         let mut graph = HashMap::new();
         for (name, ty) in type_defs {
-            graph.insert(
-                name.clone(),
-                HashSet::from_iter(ty.common_type_references().cloned()),
-            );
+            graph.insert(name, HashSet::from_iter(ty.common_type_references()));
         }
         Self { type_defs, graph }
     }
@@ -712,7 +709,7 @@ impl<'a> CommonTypeResolver<'a> {
     /// If there is a cycle, a type name involving in this cycle is the error
     ///
     /// It implements a variant of Kahn's algorithm
-    fn topo_sort(&self) -> std::result::Result<Vec<Name>, Name> {
+    fn topo_sort(&self) -> std::result::Result<Vec<&'a Name>, Name> {
         // The in-degree map
         // Note that the keys of this map may be a superset of all common type
         // names
@@ -733,8 +730,8 @@ impl<'a> CommonTypeResolver<'a> {
         }
 
         // The set that contains type names with zero incoming edges
-        let mut work_set: HashSet<&Name> = HashSet::new();
-        let mut res: Vec<Name> = Vec::new();
+        let mut work_set: HashSet<&'a Name> = HashSet::new();
+        let mut res: Vec<&'a Name> = Vec::new();
 
         // Find all type names with zero incoming edges
         for (name, degree) in indegrees.iter() {
@@ -743,7 +740,7 @@ impl<'a> CommonTypeResolver<'a> {
                 work_set.insert(name);
                 // The result only contains *declared* type names
                 if self.graph.contains_key(name) {
-                    res.push(name.clone());
+                    res.push(name);
                 }
             }
         }
@@ -767,7 +764,7 @@ impl<'a> CommonTypeResolver<'a> {
                         if *degree == 0 {
                             work_set.insert(dep);
                             if self.graph.contains_key(dep) {
-                                res.push(dep.clone());
+                                res.push(dep);
                             }
                         }
                     }
@@ -777,7 +774,7 @@ impl<'a> CommonTypeResolver<'a> {
 
         // The set of nodes that have not been added to the result
         // i.e., there are still in-coming edges and hence exists a cycle
-        let mut set: HashSet<&Name> = HashSet::from_iter(self.graph.keys().clone());
+        let mut set: HashSet<&Name> = HashSet::from_iter(self.graph.keys().cloned());
         for name in res.iter() {
             set.remove(name);
         }
@@ -835,7 +832,7 @@ impl<'a> CommonTypeResolver<'a> {
 
     // Resolve common type references, returning a map from (fully-qualified)
     // [`Name`] of a common type to its [`Type`] definition
-    fn resolve(&self, extensions: Extensions<'_>) -> Result<HashMap<Name, Type>> {
+    fn resolve(&self, extensions: Extensions<'_>) -> Result<HashMap<&'a Name, Type>> {
         let sorted_names = self.topo_sort().map_err(|n| {
             SchemaError::CycleInCommonTypeReferences(CycleInCommonTypeReferencesError(n))
         })?;
@@ -843,14 +840,14 @@ impl<'a> CommonTypeResolver<'a> {
         let mut resolve_table = HashMap::new();
         let mut tys = HashMap::new();
 
-        for name in sorted_names.iter() {
+        for &name in sorted_names.iter() {
             // PANIC SAFETY: `name.basename()` should be an existing common type id
             #[allow(clippy::unwrap_used)]
             let ty = self.type_defs.get(name).unwrap();
             let substituted_ty = Self::resolve_type(&resolve_table, ty.clone())?;
             resolve_table.insert(name, substituted_ty.clone());
             tys.insert(
-                name.clone(),
+                name,
                 try_schema_type_into_validator_type(substituted_ty, extensions)?
                     .resolve_type_defs(&HashMap::new())?,
             );
@@ -2596,7 +2593,9 @@ mod test_resolver {
             type_defs.extend(def.type_defs.type_defs.into_iter());
         }
         let resolver = CommonTypeResolver::new(&type_defs);
-        resolver.resolve(Extensions::all_available())
+        resolver
+            .resolve(Extensions::all_available())
+            .map(|map| map.into_iter().map(|(k, v)| (k.clone(), v)).collect())
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -63,8 +63,8 @@ impl ValidatorActionId {
     /// The `Type` that this action requires for its context.
     ///
     /// This always returns a closed record type.
-    pub fn context_type(&self) -> Type {
-        self.context.clone()
+    pub fn context_type(&self) -> &Type {
+        &self.context
     }
 
     /// The `EntityType`s that can be the `principal` for this action.

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -550,7 +550,7 @@ impl ActionFragment {
     }
 }
 
-type ResolveFunc<T> = dyn FnOnce(&HashMap<Name, Type>) -> Result<T>;
+type ResolveFunc<T> = dyn FnOnce(&HashMap<&Name, Type>) -> Result<T>;
 /// Represent a type that might be defined in terms of some type definitions
 /// which are not necessarily available in the current namespace.
 pub(crate) enum WithUnresolvedTypeDefs<T> {
@@ -559,7 +559,7 @@ pub(crate) enum WithUnresolvedTypeDefs<T> {
 }
 
 impl<T: 'static> WithUnresolvedTypeDefs<T> {
-    pub fn new(f: impl FnOnce(&HashMap<Name, Type>) -> Result<T> + 'static) -> Self {
+    pub fn new(f: impl FnOnce(&HashMap<&Name, Type>) -> Result<T> + 'static) -> Self {
         Self::WithUnresolved(Box::new(f))
     }
 
@@ -574,7 +574,7 @@ impl<T: 'static> WithUnresolvedTypeDefs<T> {
 
     /// Instantiate any names referencing types with the definition of the type
     /// from the input `HashMap`.
-    pub fn resolve_type_defs(self, type_defs: &HashMap<Name, Type>) -> Result<T> {
+    pub fn resolve_type_defs(self, type_defs: &HashMap<&Name, Type>) -> Result<T> {
         match self {
             WithUnresolvedTypeDefs::WithUnresolved(f) => f(type_defs),
             WithUnresolvedTypeDefs::WithoutUnresolved(v) => Ok(v),


### PR DESCRIPTION
## Description of changes

I'm preparing a large PR for #579, and to reduce the size I'm trying to split out some separable changes into smaller PRs.  This reduces cloning in the validator a few spots by using refs instead of owned types.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

