### PR TITLE
rename `SchemaType::TypeDef`

### DIFF
--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -87,7 +87,7 @@ impl<N: Display> Display for SchemaType<N> {
                 SchemaTypeVariant::Set { element } => write!(f, "Set < {element} >"),
                 SchemaTypeVariant::String => write!(f, "__cedar::String"),
             },
-            SchemaType::TypeDef { type_name } => write!(f, "{type_name}"),
+            SchemaType::CommonTypeRef { type_name } => write!(f, "{type_name}"),
         }
     }
 }

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -908,7 +908,7 @@ namespace Baz {action "Foo" appliesTo {
                 let TypeOfAttribute { ty, required } = attributes.get("tag").unwrap();
                 assert!(required);
                 match ty {
-                    crate::SchemaType::TypeDef { type_name } => {
+                    crate::SchemaType::CommonTypeRef { type_name } => {
                         assert_eq!(type_name, &"AWS::Tag".parse().unwrap())
                     }
                     _ => panic!("Wrong type for attribute"),
@@ -1453,7 +1453,7 @@ mod translator_tests {
                 let TypeOfAttribute { ty, required } = attributes.get("name").unwrap();
                 {
                     assert!(required);
-                    let expected = crate::SchemaType::TypeDef {
+                    let expected = crate::SchemaType::CommonTypeRef {
                         type_name: "id".parse().unwrap(),
                     };
                     assert_eq!(ty, &expected);

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -417,7 +417,7 @@ impl<'a> ConversionContext<'a> {
         decl: Either<Path, Vec<Node<AttrDecl>>>,
     ) -> Result<AttributesOrContext<RawName>, ToJsonSchemaErrors> {
         Ok(AttributesOrContext(match decl {
-            Either::Left(p) => SchemaType::TypeDef {
+            Either::Left(p) => SchemaType::CommonTypeRef {
                 type_name: p.into(),
             },
             Either::Right(attrs) => SchemaType::Type(SchemaTypeVariant::Record {
@@ -499,7 +499,7 @@ impl<'a> ConversionContext<'a> {
         // 3. Primitive types
         // 4. Extension Types
         if namespace_to_search.common_types.contains_key(&base) {
-            Ok(SchemaType::TypeDef { type_name: name })
+            Ok(SchemaType::CommonTypeRef { type_name: name })
         } else if namespace_to_search.entities.contains_key(&base) {
             Ok(SchemaType::Type(SchemaTypeVariant::Entity {
                 name: name.into(),

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -798,7 +798,7 @@ impl<'a> CommonTypeResolver<'a> {
         ty: SchemaType<Name>,
     ) -> Result<SchemaType<Name>> {
         match ty {
-            SchemaType::TypeDef { type_name } => resolve_table
+            SchemaType::CommonTypeRef { type_name } => resolve_table
                 .get(&type_name)
                 .ok_or(SchemaError::UndeclaredCommonTypes(
                     UndeclaredCommonTypesError(type_name),

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -700,12 +700,14 @@ pub(crate) fn try_schema_type_into_validator_type(
                 ))
             }
         }
-        SchemaType::TypeDef { type_name } => Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
-            typ_defs
-                .get(&type_name)
-                .cloned()
-                .ok_or(UndeclaredCommonTypesError(type_name).into())
-        })),
+        SchemaType::CommonTypeRef { type_name } => {
+            Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
+                typ_defs
+                    .get(&type_name)
+                    .cloned()
+                    .ok_or(UndeclaredCommonTypesError(type_name).into())
+            }))
+        }
     }
 }
 

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -467,8 +467,8 @@ impl ActionEntityUID<RawName> {
 pub enum SchemaType<N> {
     /// One of the standard types exposed to users
     Type(SchemaTypeVariant<N>),
-    /// A common type ("typedef")
-    TypeDef {
+    /// Reference to a common type ("typedef")
+    CommonTypeRef {
         /// Name of the common type.
         /// For the important case of `N` = [`RawName`], this is the schema JSON
         /// format, and the `RawName` is exactly how it appears in the schema;
@@ -479,7 +479,7 @@ pub enum SchemaType<N> {
 }
 
 impl<N> SchemaType<N> {
-    /// Return an iterator of common type references ocurred in the type
+    /// Iterate over all common type references which occur in the type
     pub(crate) fn common_type_references(&self) -> Box<dyn Iterator<Item = &N> + '_> {
         match self {
             SchemaType::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
@@ -491,15 +491,15 @@ impl<N> SchemaType<N> {
             SchemaType::Type(SchemaTypeVariant::Set { element }) => {
                 element.common_type_references()
             }
-            SchemaType::TypeDef { type_name } => Box::new(std::iter::once(type_name)),
+            SchemaType::CommonTypeRef { type_name } => Box::new(std::iter::once(type_name)),
             _ => Box::new(std::iter::empty()),
         }
     }
 
     /// Is this [`SchemaType`] an extension type, or does it contain one
-    /// (recursively)? Returns `None` if this is a `TypeDef` because we can't
-    /// easily properly check the type of a typedef, accounting for namespaces,
-    /// without first converting to a [`crate::types::Type`].
+    /// (recursively)? Returns `None` if this is a `CommonTypeRef` because we
+    /// can't easily properly check the type of a typedef, accounting for
+    /// namespaces, without first converting to a [`crate::types::Type`].
     pub fn is_extension(&self) -> Option<bool> {
         match self {
             Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
@@ -512,7 +512,7 @@ impl<N> SchemaType<N> {
                     None => None,
                 }),
             Self::Type(_) => Some(false),
-            Self::TypeDef { .. } => None,
+            Self::CommonTypeRef { .. } => None,
         }
     }
 
@@ -534,7 +534,7 @@ impl SchemaType<RawName> {
     pub fn qualify_type_references(self, ns: Option<&Name>) -> SchemaType<Name> {
         match self {
             Self::Type(stv) => SchemaType::Type(stv.qualify_type_references(ns)),
-            Self::TypeDef { type_name } => SchemaType::TypeDef {
+            Self::CommonTypeRef { type_name } => SchemaType::CommonTypeRef {
                 type_name: type_name.qualify_with(ns),
             },
         }
@@ -543,7 +543,7 @@ impl SchemaType<RawName> {
     fn into_n<N: From<RawName>>(self) -> SchemaType<N> {
         match self {
             Self::Type(stv) => SchemaType::Type(stv.into_n()),
-            Self::TypeDef { type_name } => SchemaType::TypeDef {
+            Self::CommonTypeRef { type_name } => SchemaType::CommonTypeRef {
                 type_name: type_name.into(),
             },
         }
@@ -765,7 +765,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "Set" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Set`
-                            Ok(SchemaType::TypeDef {
+                            Ok(SchemaType::CommonTypeRef {
                                 type_name: N::from(SET_NAME.clone()),
                             })
                         } else {
@@ -787,7 +787,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "Record" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Record`
-                            Ok(SchemaType::TypeDef {
+                            Ok(SchemaType::CommonTypeRef {
                                 type_name: N::from(RECORD_NAME.clone()),
                             })
                         } else {
@@ -826,7 +826,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "Entity" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Entity`
-                            Ok(SchemaType::TypeDef {
+                            Ok(SchemaType::CommonTypeRef {
                                 type_name: N::from(ENTITY_NAME.clone()),
                             })
                         } else {
@@ -850,7 +850,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     }
                     "Extension" => {
                         if remaining_fields.is_empty() {
-                            Ok(SchemaType::TypeDef {
+                            Ok(SchemaType::CommonTypeRef {
                                 type_name: N::from(EXTENSION_NAME.clone()),
                             })
                         } else {
@@ -873,7 +873,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     }
                     type_name => {
                         error_if_any_fields()?;
-                        Ok(SchemaType::TypeDef {
+                        Ok(SchemaType::CommonTypeRef {
                             type_name: N::from(RawName::from_normalized_str(type_name).map_err(
                                 |err| {
                                     serde::de::Error::custom(format!(


### PR DESCRIPTION
## Description of changes

I'm preparing a large PR for https://github.com/cedar-policy/cedar/issues/579, and to reduce the size I'm trying to split out some separable changes into smaller PRs. This renames `SchemaType::TypeDef` to `SchemaType::CommonTypeRef` because (1) we call these "common types" in the docs, so having "common" in the variant name improves clarity; and (2) `Def` -> `Ref` because this is not _defining_ a common-type, but rather _referencing_ a common-type.

This rename is non-breaking and doesn't change the JSON format, because of `serde(untagged)` on this enum.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

