### PR TITLE
rename some types, fields, functions, and variables related to common types

### DIFF
--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -253,7 +253,7 @@ impl ValidatorSchema {
         fragments: impl IntoIterator<Item = ValidatorSchemaFragment>,
         extensions: Extensions<'_>,
     ) -> Result<ValidatorSchema> {
-        let mut type_defs = HashMap::new();
+        let mut common_types = HashMap::new();
         let mut entity_type_fragments: HashMap<EntityType, _> = HashMap::new();
         let mut action_fragments = HashMap::new();
 
@@ -263,8 +263,8 @@ impl ValidatorSchema {
             // already added by the `ValidatorNamespaceDef`, so the same base
             // type name may appear multiple times so long as the namespaces are
             // different.
-            for (name, ty) in ns_def.type_defs.type_defs {
-                match type_defs.entry(name) {
+            for (name, ty) in ns_def.common_types.defs {
+                match common_types.entry(name) {
                     Entry::Vacant(v) => v.insert(ty),
                     Entry::Occupied(o) => {
                         return Err(DuplicateCommonTypeError(o.key().clone()).into());
@@ -272,7 +272,7 @@ impl ValidatorSchema {
                 };
             }
 
-            for (name, entity_type) in ns_def.entity_types.entity_types {
+            for (name, entity_type) in ns_def.entity_types.defs {
                 match entity_type_fragments.entry(name) {
                     Entry::Vacant(v) => v.insert(entity_type),
                     Entry::Occupied(o) => {
@@ -291,8 +291,8 @@ impl ValidatorSchema {
             }
         }
 
-        let resolver = CommonTypeResolver::new(&type_defs);
-        let type_defs = resolver.resolve(extensions)?;
+        let resolver = CommonTypeResolver::new(&common_types);
+        let common_types = resolver.resolve(extensions)?;
 
         // Invert the `parents` relation defined by entities and action so far
         // to get a `children` relation.
@@ -320,7 +320,9 @@ impl ValidatorSchema {
                 // `check_for_undeclared`.
                 let descendants = entity_children.remove(&name).unwrap_or_default();
                 let (attributes, open_attributes) = Self::record_attributes_or_none(
-                    entity_type.attributes.resolve_type_defs(&type_defs)?,
+                    entity_type
+                        .attributes
+                        .resolve_common_type_refs(&common_types)?,
                 )
                 .ok_or(SchemaError::from(ContextOrShapeNotRecordError(
                     ContextOrShape::EntityTypeShape(name.clone()),
@@ -350,11 +352,12 @@ impl ValidatorSchema {
             .into_iter()
             .map(|(name, action)| -> Result<_> {
                 let descendants = action_children.remove(&name).unwrap_or_default();
-                let (context, open_context_attributes) =
-                    Self::record_attributes_or_none(action.context.resolve_type_defs(&type_defs)?)
-                        .ok_or(SchemaError::from(ContextOrShapeNotRecordError(
-                            ContextOrShape::ActionContext(name.clone()),
-                        )))?;
+                let (context, open_context_attributes) = Self::record_attributes_or_none(
+                    action.context.resolve_common_type_refs(&common_types)?,
+                )
+                .ok_or(SchemaError::from(ContextOrShapeNotRecordError(
+                    ContextOrShape::ActionContext(name.clone()),
+                )))?;
                 Ok((
                     name.clone(),
                     ValidatorActionId {
@@ -679,11 +682,20 @@ impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes<RawNam
 /// It facilitates inlining the definitions of common types.
 #[derive(Debug)]
 struct CommonTypeResolver<'a> {
-    /// Common type declarations to resolve
-    type_defs: &'a HashMap<Name, SchemaType<Name>>,
+    /// Definition of each common type.
+    ///
+    /// Definitions (values in the map) may refer to other common-type names,
+    /// but not in a way that causes a cycle.
+    ///
+    /// In this map, names are already fully-qualified, both in common-type
+    /// definitions (keys in the map) and in common-type references appearing in
+    /// [`SchemaType`]s (values in the map).
+    defs: &'a HashMap<Name, SchemaType<Name>>,
     /// The dependency graph among common type names.
     /// The graph contains a vertex for each `Name` and `graph.get(u)` gives the set of vertices `v` for which `(u,v)` is a directed edge in the graph.
-    /// A common type name is prefixed with the namespace id where it's declared.
+    ///
+    /// In this map, names are already fully-qualified, both in keys and values
+    /// in the map.
     graph: HashMap<&'a Name, HashSet<&'a Name>>,
 }
 
@@ -691,12 +703,12 @@ impl<'a> CommonTypeResolver<'a> {
     /// Construct the resolver.
     /// Note that this requires that all common-type references are already
     /// fully qualified, because it uses [`Name`] and not [`RawName`].
-    fn new(type_defs: &'a HashMap<Name, SchemaType<Name>>) -> Self {
+    fn new(defs: &'a HashMap<Name, SchemaType<Name>>) -> Self {
         let mut graph = HashMap::new();
-        for (name, ty) in type_defs {
+        for (name, ty) in defs {
             graph.insert(name, HashSet::from_iter(ty.common_type_references()));
         }
-        Self { type_defs, graph }
+        Self { defs, graph }
     }
 
     /// Perform topological sort on the dependency graph
@@ -843,13 +855,13 @@ impl<'a> CommonTypeResolver<'a> {
         for &name in sorted_names.iter() {
             // PANIC SAFETY: `name.basename()` should be an existing common type id
             #[allow(clippy::unwrap_used)]
-            let ty = self.type_defs.get(name).unwrap();
+            let ty = self.defs.get(name).unwrap();
             let substituted_ty = Self::resolve_type(&resolve_table, ty.clone())?;
             resolve_table.insert(name, substituted_ty.clone());
             tys.insert(
                 name,
                 try_schema_type_into_validator_type(substituted_ty, extensions)?
-                    .resolve_type_defs(&HashMap::new())?,
+                    .resolve_common_type_refs(&HashMap::new())?,
             );
         }
 
@@ -1404,7 +1416,7 @@ mod test {
             Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
-        .resolve_type_defs(&HashMap::new())
+        .resolve_common_type_refs(&HashMap::new())
         .unwrap();
         assert_eq!(ty, Type::named_entity_reference_from_str("NS::Foo"));
     }
@@ -1424,7 +1436,7 @@ mod test {
             Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
-        .resolve_type_defs(&HashMap::new())
+        .resolve_common_type_refs(&HashMap::new())
         .unwrap();
         assert_eq!(ty, Type::named_entity_reference_from_str("NS::Foo"));
     }
@@ -1451,7 +1463,7 @@ mod test {
             Extensions::all_available(),
         )
         .expect("Error converting schema type to type.")
-        .resolve_type_defs(&HashMap::new())
+        .resolve_common_type_refs(&HashMap::new())
         .unwrap();
         assert_eq!(ty, Type::closed_record_with_attributes(None));
     }
@@ -2588,11 +2600,11 @@ mod test_resolver {
     fn resolve(schema_json: serde_json::Value) -> Result<HashMap<Name, Type>, SchemaError> {
         let sfrag: SchemaFragment<RawName> = serde_json::from_value(schema_json).unwrap();
         let schema: ValidatorSchemaFragment = sfrag.try_into().unwrap();
-        let mut type_defs = HashMap::new();
+        let mut defs = HashMap::new();
         for def in schema.0 {
-            type_defs.extend(def.type_defs.type_defs.into_iter());
+            defs.extend(def.common_types.defs.into_iter());
         }
-        let resolver = CommonTypeResolver::new(&type_defs);
+        let resolver = CommonTypeResolver::new(&defs);
         resolver
             .resolve(Extensions::all_available())
             .map(|map| map.into_iter().map(|(k, v)| (k.clone(), v)).collect())

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -258,11 +258,11 @@ impl ValidatorSchema {
         let mut action_fragments = HashMap::new();
 
         for ns_def in fragments.into_iter().flat_map(|f| f.0.into_iter()) {
-            // Build aggregate maps for the declared typedefs, entity types, and
-            // actions, checking that nothing is defined twice.  Namespaces were
-            // already added by the `ValidatorNamespaceDef`, so the same base
-            // type name may appear multiple times so long as the namespaces are
-            // different.
+            // Build aggregate maps for the declared common types, entity types,
+            // and actions, checking that nothing is defined twice.  Namespaces
+            // were already added by the `ValidatorNamespaceDef`, so the same
+            // base type name may appear multiple times so long as the
+            // namespaces are different.
             for (name, ty) in ns_def.common_types.defs {
                 match common_types.entry(name) {
                     Entry::Vacant(v) => v.insert(ty),

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -101,7 +101,7 @@ impl ValidatorNamespaceDef {
         // Convert the type defs, actions and entity types from the schema file
         // into the representation used by the validator.
         let common_types =
-            CommonTypeDefs::from_raw_typedefs(namespace_def.common_types, namespace.as_ref())?;
+            CommonTypeDefs::from_raw_common_types(namespace_def.common_types, namespace.as_ref())?;
         let actions =
             ActionsDef::from_raw_actions(namespace_def.actions, namespace.as_ref(), extensions)?;
         let entity_types = EntityTypesDef::from_raw_entity_types(
@@ -177,7 +177,7 @@ pub struct CommonTypeDefs {
 impl CommonTypeDefs {
     /// Construct a [`CommonTypeDefs`] by converting the structures used by the
     /// schema format to those used internally by the validator.
-    pub(crate) fn from_raw_typedefs(
+    pub(crate) fn from_raw_common_types(
         schema_file_type_def: HashMap<Id, SchemaType<RawName>>,
         schema_namespace: Option<&Name>,
     ) -> Result<Self> {

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -64,22 +64,22 @@ fn is_primitive_type_name(name: &str) -> bool {
 /// longer applies: `Foo` refers specifically to the entity/common type `Foo`
 /// in the empty namespace, not `Foo` in the current namespace, wherever `Foo`
 /// appears (in common type definitions, entity attribute definitions, or
-/// as a key in the `type_defs` / `entity_types` maps).
+/// as a key in the `common_types` / `entity_types` maps).
 #[derive(Debug)]
 pub struct ValidatorNamespaceDef {
     /// The (fully-qualified) name of the namespace this is a definition of, or
     /// `None` if this is a definition for the empty namespace.
     ///
     /// This is informational only; it does not change the semantics of any
-    /// definition in `type_defs`, `entity_types`, or `actions`. All
-    /// entity/common type names in `type_defs`, `entity_types`, and `actions`
-    /// are already fully qualified/disambiguated at all appearances.
+    /// definition in `common_types`, `entity_types`, or `actions`. All
+    /// entity/common type names in `common_types`, `entity_types`, and
+    /// `actions` are already fully qualified/disambiguated at all appearances.
     /// This `namespace` field is used only in tests and by the `cedar_policy`
     /// function `SchemaFragment::namespaces()`.
     namespace: Option<Name>,
     /// Common type definitions, which can be used to define entity
     /// type attributes, action contexts, and other common types.
-    pub(super) type_defs: TypeDefs,
+    pub(super) common_types: CommonTypeDefs,
     /// Entity type declarations.
     pub(super) entity_types: EntityTypesDef,
     /// Action declarations.
@@ -100,8 +100,8 @@ impl ValidatorNamespaceDef {
 
         // Convert the type defs, actions and entity types from the schema file
         // into the representation used by the validator.
-        let type_defs =
-            TypeDefs::from_raw_typedefs(namespace_def.common_types, namespace.as_ref())?;
+        let common_types =
+            CommonTypeDefs::from_raw_typedefs(namespace_def.common_types, namespace.as_ref())?;
         let actions =
             ActionsDef::from_raw_actions(namespace_def.actions, namespace.as_ref(), extensions)?;
         let entity_types = EntityTypesDef::from_raw_entity_types(
@@ -112,7 +112,7 @@ impl ValidatorNamespaceDef {
 
         Ok(ValidatorNamespaceDef {
             namespace,
-            type_defs,
+            common_types,
             entity_types,
             actions,
         })
@@ -170,18 +170,18 @@ impl ValidatorNamespaceDef {
 /// map) are fully qualified, and inside the [`SchemaType`]s (values in the
 /// map), all entity/common type references are also fully qualified.
 #[derive(Debug)]
-pub struct TypeDefs {
-    pub(super) type_defs: HashMap<Name, SchemaType<Name>>,
+pub struct CommonTypeDefs {
+    pub(super) defs: HashMap<Name, SchemaType<Name>>,
 }
 
-impl TypeDefs {
-    /// Construct a [`TypeDefs`] by converting the structures used by the schema
-    /// format to those used internally by the validator.
+impl CommonTypeDefs {
+    /// Construct a [`CommonTypeDefs`] by converting the structures used by the
+    /// schema format to those used internally by the validator.
     pub(crate) fn from_raw_typedefs(
         schema_file_type_def: HashMap<Id, SchemaType<RawName>>,
         schema_namespace: Option<&Name>,
     ) -> Result<Self> {
-        let mut type_defs = HashMap::with_capacity(schema_file_type_def.len());
+        let mut defs = HashMap::with_capacity(schema_file_type_def.len());
         for (id, schema_ty) in schema_file_type_def {
             if is_primitive_type_name(id.as_ref()) {
                 return Err(SchemaError::CommonTypeNameConflict(
@@ -189,7 +189,7 @@ impl TypeDefs {
                 ));
             }
             let name = RawName::new(id).qualify_with(schema_namespace);
-            match type_defs.entry(name) {
+            match defs.entry(name) {
                 Entry::Vacant(ventry) => {
                     ventry.insert(schema_ty.qualify_type_references(schema_namespace));
                 }
@@ -200,7 +200,7 @@ impl TypeDefs {
                 }
             }
         }
-        Ok(Self { type_defs })
+        Ok(Self { defs })
     }
 }
 
@@ -216,7 +216,7 @@ impl TypeDefs {
 /// All [`EntityType`] keys in this map are declared in this schema fragment.
 #[derive(Debug)]
 pub struct EntityTypesDef {
-    pub(super) entity_types: HashMap<EntityType, EntityTypeFragment>,
+    pub(super) defs: HashMap<EntityType, EntityTypeFragment>,
 }
 
 impl EntityTypesDef {
@@ -227,13 +227,13 @@ impl EntityTypesDef {
         schema_namespace: Option<&Name>,
         extensions: Extensions<'_>,
     ) -> Result<Self> {
-        let mut entity_types: HashMap<EntityType, _> =
+        let mut defs: HashMap<EntityType, _> =
             HashMap::with_capacity(schema_files_types.len());
         for (id, entity_type) in schema_files_types {
             let ety = cedar_policy_core::ast::EntityType::from(
                 RawName::new(id.clone()).qualify_with(schema_namespace),
             );
-            match entity_types.entry(ety) {
+            match defs.entry(ety) {
                 Entry::Vacant(ventry) => {
                     ventry.insert(EntityTypeFragment::from_raw_entity_type(
                         entity_type,
@@ -246,7 +246,7 @@ impl EntityTypesDef {
                 }
             }
         }
-        Ok(EntityTypesDef { entity_types })
+        Ok(EntityTypesDef { defs })
     }
 }
 
@@ -259,10 +259,10 @@ impl EntityTypesDef {
 #[derive(Debug)]
 pub struct EntityTypeFragment {
     /// The attributes record type for this entity type. The type is wrapped in
-    /// a `WithUnresolvedTypeDefs` because it may refer to common types which
-    /// have not yet been resolved/inlined (e.g., because they are not defined
-    /// in this schema fragment).
-    pub(super) attributes: WithUnresolvedTypeDefs<Type>,
+    /// a `WithUnresolvedCommonTypeRefs` because it may refer to common types
+    /// which have not yet been resolved/inlined (e.g., because they are not
+    /// defined in this schema fragment).
+    pub(super) attributes: WithUnresolvedCommonTypeRefs<Type>,
     /// Direct parent entity types for this entity type.
     /// These are fully qualified entity types, but may be entity types declared
     /// in a different namespace or schema fragment.
@@ -358,10 +358,10 @@ impl ActionsDef {
 #[derive(Debug)]
 pub struct ActionFragment {
     /// The type of the context record for this action. The type is wrapped in
-    /// a `WithUnresolvedTypeDefs` because it may refer to common types which
-    /// have not yet been resolved/inlined (e.g., because they are not defined
-    /// in this schema fragment).
-    pub(super) context: WithUnresolvedTypeDefs<Type>,
+    /// a `WithUnresolvedCommonTypeRefs` because it may refer to common types
+    /// which have not yet been resolved/inlined (e.g., because they are not
+    /// defined in this schema fragment).
+    pub(super) context: WithUnresolvedCommonTypeRefs<Type>,
     /// The principals and resources that an action can be applied to.
     pub(super) applies_to: ValidatorApplySpec,
     /// The direct parent action entities for this action.
@@ -551,48 +551,53 @@ impl ActionFragment {
 }
 
 type ResolveFunc<T> = dyn FnOnce(&HashMap<&Name, Type>) -> Result<T>;
-/// Represent a type that might be defined in terms of some type definitions
-/// which are not necessarily available in the current namespace.
-pub(crate) enum WithUnresolvedTypeDefs<T> {
+/// Represent a type that might be defined in terms of some common-type
+/// definitions which are not necessarily available in the current namespace.
+pub(crate) enum WithUnresolvedCommonTypeRefs<T> {
     WithUnresolved(Box<ResolveFunc<T>>),
     WithoutUnresolved(T),
 }
 
-impl<T: 'static> WithUnresolvedTypeDefs<T> {
+impl<T: 'static> WithUnresolvedCommonTypeRefs<T> {
     pub fn new(f: impl FnOnce(&HashMap<&Name, Type>) -> Result<T> + 'static) -> Self {
         Self::WithUnresolved(Box::new(f))
     }
 
-    pub fn map<U: 'static>(self, f: impl FnOnce(T) -> U + 'static) -> WithUnresolvedTypeDefs<U> {
+    pub fn map<U: 'static>(
+        self,
+        f: impl FnOnce(T) -> U + 'static,
+    ) -> WithUnresolvedCommonTypeRefs<U> {
         match self {
-            Self::WithUnresolved(_) => {
-                WithUnresolvedTypeDefs::new(|type_defs| self.resolve_type_defs(type_defs).map(f))
-            }
-            Self::WithoutUnresolved(v) => WithUnresolvedTypeDefs::WithoutUnresolved(f(v)),
+            Self::WithUnresolved(_) => WithUnresolvedCommonTypeRefs::new(|common_type_defs| {
+                self.resolve_common_type_refs(common_type_defs).map(f)
+            }),
+            Self::WithoutUnresolved(v) => WithUnresolvedCommonTypeRefs::WithoutUnresolved(f(v)),
         }
     }
 
-    /// Instantiate any names referencing types with the definition of the type
-    /// from the input `HashMap`.
-    pub fn resolve_type_defs(self, type_defs: &HashMap<&Name, Type>) -> Result<T> {
+    /// Resolve references to common types by inlining their definitions from
+    /// the given `HashMap`.
+    pub fn resolve_common_type_refs(self, common_type_defs: &HashMap<&Name, Type>) -> Result<T> {
         match self {
-            WithUnresolvedTypeDefs::WithUnresolved(f) => f(type_defs),
-            WithUnresolvedTypeDefs::WithoutUnresolved(v) => Ok(v),
+            WithUnresolvedCommonTypeRefs::WithUnresolved(f) => f(common_type_defs),
+            WithUnresolvedCommonTypeRefs::WithoutUnresolved(v) => Ok(v),
         }
     }
 }
 
-impl<T: 'static> From<T> for WithUnresolvedTypeDefs<T> {
+impl<T: 'static> From<T> for WithUnresolvedCommonTypeRefs<T> {
     fn from(value: T) -> Self {
         Self::WithoutUnresolved(value)
     }
 }
 
-impl<T: std::fmt::Debug> std::fmt::Debug for WithUnresolvedTypeDefs<T> {
+impl<T: std::fmt::Debug> std::fmt::Debug for WithUnresolvedCommonTypeRefs<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            WithUnresolvedTypeDefs::WithUnresolved(_) => f.debug_tuple("WithUnresolved").finish(),
-            WithUnresolvedTypeDefs::WithoutUnresolved(v) => {
+            WithUnresolvedCommonTypeRefs::WithUnresolved(_) => {
+                f.debug_tuple("WithUnresolved").finish()
+            }
+            WithUnresolvedCommonTypeRefs::WithoutUnresolved(v) => {
                 f.debug_tuple("WithoutUnresolved").field(v).finish()
             }
         }
@@ -648,7 +653,7 @@ fn parse_action_id_with_namespace(
 pub(crate) fn try_schema_type_into_validator_type(
     schema_ty: SchemaType<Name>,
     extensions: Extensions<'_>,
-) -> Result<WithUnresolvedTypeDefs<Type>> {
+) -> Result<WithUnresolvedCommonTypeRefs<Type>> {
     match schema_ty {
         SchemaType::Type(SchemaTypeVariant::String) => Ok(Type::primitive_string().into()),
         SchemaType::Type(SchemaTypeVariant::Long) => Ok(Type::primitive_long().into()),
@@ -701,8 +706,8 @@ pub(crate) fn try_schema_type_into_validator_type(
             }
         }
         SchemaType::CommonTypeRef { type_name } => {
-            Ok(WithUnresolvedTypeDefs::new(move |typ_defs| {
-                typ_defs
+            Ok(WithUnresolvedCommonTypeRefs::new(move |common_type_defs| {
+                common_type_defs
                     .get(&type_name)
                     .cloned()
                     .ok_or(UndeclaredCommonTypesError(type_name).into())
@@ -718,8 +723,8 @@ pub(crate) fn try_schema_type_into_validator_type(
 pub(crate) fn parse_record_attributes(
     attrs: impl IntoIterator<Item = (SmolStr, TypeOfAttribute<Name>)>,
     extensions: Extensions<'_>,
-) -> Result<WithUnresolvedTypeDefs<Attributes>> {
-    let attrs_with_type_defs = attrs
+) -> Result<WithUnresolvedCommonTypeRefs<Attributes>> {
+    let attrs_with_common_type_refs = attrs
         .into_iter()
         .map(|(attr, ty)| -> Result<_> {
             Ok((
@@ -731,12 +736,12 @@ pub(crate) fn parse_record_attributes(
             ))
         })
         .collect::<Result<Vec<_>>>()?;
-    Ok(WithUnresolvedTypeDefs::new(|typ_defs| {
-        attrs_with_type_defs
+    Ok(WithUnresolvedCommonTypeRefs::new(|common_type_defs| {
+        attrs_with_common_type_refs
             .into_iter()
             .map(|(s, (attr_ty, is_req))| {
                 attr_ty
-                    .resolve_type_defs(typ_defs)
+                    .resolve_common_type_refs(common_type_defs)
                     .map(|ty| (s, AttributeType::new(ty, is_req)))
             })
             .collect::<Result<Vec<_>>>()

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -227,8 +227,7 @@ impl EntityTypesDef {
         schema_namespace: Option<&Name>,
         extensions: Extensions<'_>,
     ) -> Result<Self> {
-        let mut defs: HashMap<EntityType, _> =
-            HashMap::with_capacity(schema_files_types.len());
+        let mut defs: HashMap<EntityType, _> = HashMap::with_capacity(schema_files_types.len());
         for (id, entity_type) in schema_files_types {
             let ety = cedar_policy_core::ast::EntityType::from(
                 RawName::new(id.clone()).qualify_with(schema_namespace),

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -2125,7 +2125,7 @@ mod test {
             Extensions::all_available(),
         )
         .expect("Schema type should have converted to type.")
-        .resolve_type_defs(&HashMap::new())
+        .resolve_common_type_refs(&HashMap::new())
         .unwrap();
         assert_eq!(ty, type_from_schema_type);
     }


### PR DESCRIPTION
## Description of changes

On the heels of #1059, and following [this comment](https://github.com/cedar-policy/cedar/pull/1060#discussion_r1674561634) on #1060, this PR renames a bunch of other types, fields, functions, and variables related to common types.

* Explicitly use "common type" instead of "typedef" where it makes sense, following our docs
* Distinguish between "type_defs" (definitions of common types) and "type_refs" (references to common types)
* Make a couple field names more concise (to change e.g. `self.type_defs.type_defs` into `self.common_types.defs`)

I believe that none of the changes here are breaking, or even visible outside the `cedar-policy-validator` crate.  The field renames are in structs that don't impl `Serialize` or `Deserialize`, and the types and functions are crate-private.  Happy to be corrected if I'm wrong.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


