### PR TITLE
Rename `Effect` to `Capability` in validator to match Lean and paper

### DIFF
--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -726,7 +726,7 @@ impl<'a> Typechecker<'a> {
                             match (ty_expr_left.data(), ty_expr_right.data()) {
                                 // Now the right operand is always `true`, so we can
                                 // use its capability as the result capability. The left
-                                // operand might have been `true` of `false`, but it
+                                // operand might have been `true` or `false`, but it
                                 // does not affect the value of the `||` if the
                                 // right is always `true`.
                                 (Some(_), Some(Type::True)) => {
@@ -760,7 +760,7 @@ impl<'a> Typechecker<'a> {
                                 }
                                 // When neither has a constant value, the `||`
                                 // evaluates to true if one or both is `true`. This
-                                // means we can only keep capability in the
+                                // means we can only keep capabilities in the
                                 // intersection of their capability sets.
                                 (Some(_), Some(_)) => TypecheckAnswer::success_with_capability(
                                     ExprBuilder::with_data(Some(Type::primitive_boolean()))

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -574,7 +574,7 @@ impl<'a> Typechecker<'a> {
                                     .ite(typ_test, typ_then, typ_else);
                                 if has_lub {
                                     // Capabilities are not handled in the LUB computation,
-                                    // so we need to compute resulting capability here. When
+                                    // so we need to compute the resulting capability here. When
                                     // the `||` evaluates to `true`, we know that
                                     // one operand evaluated to true, but we don't
                                     // know which. This is handled by returning a

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -702,7 +702,7 @@ impl<'a> Typechecker<'a> {
                 );
                 ans_left.then_typecheck(|ty_expr_left, capability_left| match ty_expr_left.data() {
                     // Contrary to `&&` where short circuiting did not permit
-                    // any capability, an capability can be maintained when short
+                    // any capability, a capability can be maintained when short
                     // circuiting `||`. We know the left operand is `true`, so
                     // its capability is maintained. The right operand is not
                     // evaluated, so its capability does not need to be considered.

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -35,7 +35,8 @@ use crate::{
     fuzzy_match::fuzzy_search,
     schema::ValidatorSchema,
     types::{
-        AttributeType, Effect, EffectSet, EntityRecordKind, OpenTag, Primitive, RequestEnv, Type,
+        AttributeType, Capability, CapabilitySet, EntityRecordKind, OpenTag, Primitive, RequestEnv,
+        Type,
     },
     validation_errors::{AttributeAccess, LubContext, UnexpectedTypeHelp},
     ValidationError, ValidationMode, ValidationWarning,
@@ -146,10 +147,10 @@ impl<'a> Typechecker<'a> {
     ) -> Vec<(RequestEnv<'_>, PolicyCheck)> {
         self.apply_typecheck_fn_by_request_env(t, |request, expr| {
             let mut type_errors = Vec::new();
-            let empty_prior_eff = EffectSet::new();
+            let empty_prior_capability = CapabilitySet::new();
             let ty = self.expect_type(
                 request,
-                &empty_prior_eff,
+                &empty_prior_capability,
                 expr,
                 Type::primitive_boolean(),
                 &mut type_errors,
@@ -209,10 +210,10 @@ impl<'a> Typechecker<'a> {
                 let condition_expr = t.condition();
                 for linked_env in self.link_request_env(request.clone(), t) {
                     let mut type_errors = Vec::new();
-                    let empty_prior_eff = EffectSet::new();
+                    let empty_prior_capability = CapabilitySet::new();
                     let ty = self.expect_type(
                         &linked_env,
-                        &empty_prior_eff,
+                        &empty_prior_capability,
                         &condition_expr,
                         Type::primitive_boolean(),
                         &mut type_errors,
@@ -361,16 +362,16 @@ impl<'a> Typechecker<'a> {
     }
 
     /// This method handles the majority of the work. Given an expression,
-    /// the type for the request, and the a prior effect context for the
+    /// the type for the request, and the a prior capability for the
     /// expression, return the result of typechecking the expression, and add
     /// any errors encountered into the `type_errors` list. The result of
-    /// typechecking contains the type of the expression, any current effect of
+    /// typechecking contains the type of the expression, any current capability of
     /// the expression, and a flag indicating whether the expression
     /// successfully typechecked.
     fn typecheck<'b>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         e: &'b Expr,
         type_errors: &mut Vec<ValidationError>,
     ) -> TypecheckAnswer<'b> {
@@ -499,60 +500,60 @@ impl<'a> Typechecker<'a> {
                 // The guard expression must be boolean.
                 let ans_test = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     test_expr,
                     Type::primitive_boolean(),
                     type_errors,
                     |_| None,
                 );
-                ans_test.then_typecheck(|typ_test, eff_test| {
+                ans_test.then_typecheck(|typ_test, capability_test| {
                     // If the guard has type `true` or `false`, we short circuit,
                     // looking at only the relevant branch.
                     if typ_test.data() == &Some(Type::singleton_boolean(true)) {
                         // The `then` branch needs to be typechecked using the
-                        // prior effect of the `if` and any new effect generated
+                        // prior capability of the `if` and any new capability generated
                         // by `test`. This enables an attribute access
                         // `principal.foo` after a condition `principal has foo`.
                         let ans_then = self.typecheck(
                             request_env,
-                            &prior_eff.union(&eff_test),
+                            &prior_capability.union(&capability_test),
                             then_expr,
                             type_errors,
                         );
 
-                        ans_then.then_typecheck(|typ_then, eff_then| {
-                            TypecheckAnswer::success_with_effect(
+                        ans_then.then_typecheck(|typ_then, capability_then| {
+                            TypecheckAnswer::success_with_capability(
                                 typ_then,
-                                // The output effect of the whole `if` expression also
-                                // needs to contain the effect of the condition.
-                                eff_then.union(&eff_test),
+                                // The output capability of the whole `if` expression also
+                                // needs to contain the capability of the condition.
+                                capability_then.union(&capability_test),
                             )
                         })
                     } else if typ_test.data() == &Some(Type::singleton_boolean(false)) {
-                        // The `else` branch cannot use the `test` effect since
+                        // The `else` branch cannot use the `test` capability since
                         // we know in the `else` branch that the condition
                         // evaluated to `false`. It still can use the original
-                        // prior effect.
+                        // prior capability.
                         let ans_else =
-                            self.typecheck(request_env, prior_eff, else_expr, type_errors);
+                            self.typecheck(request_env, prior_capability, else_expr, type_errors);
 
-                        ans_else.then_typecheck(|typ_else, eff_else| {
-                            TypecheckAnswer::success_with_effect(typ_else, eff_else)
+                        ans_else.then_typecheck(|typ_else, capability_else| {
+                            TypecheckAnswer::success_with_capability(typ_else, capability_else)
                         })
                     } else {
                         // When we don't short circuit, the `then` and `else`
                         // branches are individually typechecked with the same
-                        // prior effects are in their individual cases.
+                        // prior capability are in their individual cases.
                         let ans_then = self
                             .typecheck(
                                 request_env,
-                                &prior_eff.union(&eff_test),
+                                &prior_capability.union(&capability_test),
                                 then_expr,
                                 type_errors,
                             )
-                            .map_effect(|ef| ef.union(&eff_test));
+                            .map_capability(|ef| ef.union(&capability_test));
                         let ans_else =
-                            self.typecheck(request_env, prior_eff, else_expr, type_errors);
+                            self.typecheck(request_env, prior_capability, else_expr, type_errors);
                         // The type of the if expression is then the least
                         // upper bound of the types of the then and else
                         // branches.  If either of these fails to typecheck, the
@@ -560,8 +561,8 @@ impl<'a> Typechecker<'a> {
                         // may exist in that branch. This failure, in addition
                         // to any failure that may have occurred in the test
                         // expression, will propagate to final TypecheckAnswer.
-                        ans_then.then_typecheck(|typ_then, eff_then| {
-                            ans_else.then_typecheck(|typ_else, eff_else| {
+                        ans_then.then_typecheck(|typ_then, capability_then| {
+                            ans_else.then_typecheck(|typ_else, capability_else| {
                                 let lub_ty = self.least_upper_bound_or_error(
                                     e,
                                     vec![typ_then.data().clone(), typ_else.data().clone()],
@@ -573,16 +574,16 @@ impl<'a> Typechecker<'a> {
                                     .with_same_source_loc(e)
                                     .ite(typ_test, typ_then, typ_else);
                                 if has_lub {
-                                    // Effect is not handled in the LUB computation,
-                                    // so we need to compute the effect here. When
+                                    // Capability is not handled in the LUB computation,
+                                    // so we need to compute the capability here. When
                                     // the `||` evaluates to `true`, we know that
                                     // one operand evaluated to true, but we don't
                                     // know which. This is handled by returning an
-                                    // effect set that is the intersection of the
-                                    // operand effect sets.
-                                    TypecheckAnswer::success_with_effect(
+                                    // capability set that is the intersection of the
+                                    // operand capability sets.
+                                    TypecheckAnswer::success_with_capability(
                                         annot_expr,
-                                        eff_else.intersect(&eff_then),
+                                        capability_else.intersect(&capability_then),
                                     )
                                 } else {
                                     TypecheckAnswer::fail(annot_expr)
@@ -596,28 +597,28 @@ impl<'a> Typechecker<'a> {
             ExprKind::And { left, right } => {
                 let ans_left = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     left,
                     Type::primitive_boolean(),
                     type_errors,
                     |_| None,
                 );
-                ans_left.then_typecheck(|typ_left, eff_left| {
+                ans_left.then_typecheck(|typ_left, capability_left| {
                     match typ_left.data() {
                         // First argument is false, so short circuit the `&&` to
                         // false _without_ typechecking the second argument.
                         // Since the type of the `&&` is `false`, it is known to
                         // always evaluate to `false` at run time. The `&&`
-                        // expression typechecks with an empty effect rather
-                        // than the effect of the lhs.
+                        // expression typechecks with an empty capability rather
+                        // than the capability of the lhs.
                         // The right operand is not typechecked, so it is not
                         // included in the type annotated AST.
                         Some(Type::False) => TypecheckAnswer::success(typ_left),
                         _ => {
                             // Similar to the `then` branch of an `if`
                             // expression, the rhs of an `&&` is typechecked
-                            // using an updated prior effect that includes
-                            // effect learned from the lhs to enable
+                            // using an updated prior capability that includes
+                            // capability learned from the lhs to enable
                             // typechecking expressions like
                             // `principal has foo && principal.foo`. This is
                             // valid because `&&` short circuits at run time, so
@@ -625,16 +626,16 @@ impl<'a> Typechecker<'a> {
                             // evaluated to `true`.
                             let ans_right = self.expect_type(
                                 request_env,
-                                &prior_eff.union(&eff_left),
+                                &prior_capability.union(&capability_left),
                                 right,
                                 Type::primitive_boolean(),
                                 type_errors,
                                 |_| None,
                             );
-                            ans_right.then_typecheck(|typ_right, eff_right| {
+                            ans_right.then_typecheck(|typ_right, capability_right| {
                                 match (typ_left.data(), typ_right.data()) {
                                     // The second argument is false, so the `&&`
-                                    // is false. The effect is empty for the
+                                    // is false. The capability is empty for the
                                     // same reason as when the first argument
                                     // was false.
                                     (Some(_), Some(Type::False)) => TypecheckAnswer::success(
@@ -646,33 +647,33 @@ impl<'a> Typechecker<'a> {
                                     // When either argument is true, the result type is
                                     // the type of the other argument. Here, and
                                     // in the remaining successful cases, the
-                                    // effect of the `&&` is the union of the
+                                    // capability of the `&&` is the union of the
                                     // lhs and rhs because both operands must be
                                     // true for the whole `&&` to be true.
                                     (Some(_), Some(Type::True)) => {
-                                        TypecheckAnswer::success_with_effect(
+                                        TypecheckAnswer::success_with_capability(
                                             ExprBuilder::with_data(typ_left.data().clone())
                                                 .with_same_source_loc(e)
                                                 .and(typ_left, typ_right),
-                                            eff_left.union(&eff_right),
+                                            capability_left.union(&capability_right),
                                         )
                                     }
                                     (Some(Type::True), Some(_)) => {
-                                        TypecheckAnswer::success_with_effect(
+                                        TypecheckAnswer::success_with_capability(
                                             ExprBuilder::with_data(typ_right.data().clone())
                                                 .with_same_source_loc(e)
                                                 .and(typ_left, typ_right),
-                                            eff_right.union(&eff_right),
+                                            capability_right.union(&capability_right),
                                         )
                                     }
 
                                     // Neither argument was true or false, so we only
                                     // know the result type is boolean.
-                                    (Some(_), Some(_)) => TypecheckAnswer::success_with_effect(
+                                    (Some(_), Some(_)) => TypecheckAnswer::success_with_capability(
                                         ExprBuilder::with_data(Some(Type::primitive_boolean()))
                                             .with_same_source_loc(e)
                                             .and(typ_left, typ_right),
-                                        eff_left.union(&eff_right),
+                                        capability_left.union(&capability_right),
                                     ),
 
                                     // One or both of the left and the right failed to
@@ -690,83 +691,83 @@ impl<'a> Typechecker<'a> {
             }
 
             // `||` follows the same pattern as `&&`, but with short circuiting
-            // effect propagation adjusted as necessary.
+            // capability propagation adjusted as necessary.
             ExprKind::Or { left, right } => {
                 let ans_left = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     left,
                     Type::primitive_boolean(),
                     type_errors,
                     |_| None,
                 );
-                ans_left.then_typecheck(|ty_expr_left, eff_left| match ty_expr_left.data() {
+                ans_left.then_typecheck(|ty_expr_left, capability_left| match ty_expr_left.data() {
                     // Contrary to `&&` where short circuiting did not permit
-                    // any effect, an effect can be maintained when short
+                    // any capability, an capability can be maintained when short
                     // circuiting `||`. We know the left operand is `true`, so
-                    // its effect is maintained. The right operand is not
-                    // evaluated, so its effect does not need to be considered.
+                    // its capability is maintained. The right operand is not
+                    // evaluated, so its capability does not need to be considered.
                     // The right operand is not typechecked, so it is not
                     // included in the type annotated AST.
                     Some(Type::True) => TypecheckAnswer::success(ty_expr_left),
                     _ => {
                         // The right operand of an `||` cannot be typechecked
-                        // using the effect learned from the left because the
+                        // using the capability learned from the left because the
                         // left could have evaluated to either `true` or `false`
                         // when the left is evaluated.
                         let ans_right = self.expect_type(
                             request_env,
-                            prior_eff,
+                            prior_capability,
                             right,
                             Type::primitive_boolean(),
                             type_errors,
                             |_| None,
                         );
-                        ans_right.then_typecheck(|ty_expr_right, eff_right| {
+                        ans_right.then_typecheck(|ty_expr_right, capability_right| {
                             match (ty_expr_left.data(), ty_expr_right.data()) {
                                 // Now the right operand is always `true`, so we can
-                                // use its effect as the result effect. The left
+                                // use its capability as the result capability. The left
                                 // operand might have been `true` of `false`, but it
                                 // does not affect the value of the `||` if the
                                 // right is always `true`.
                                 (Some(_), Some(Type::True)) => {
-                                    TypecheckAnswer::success_with_effect(
+                                    TypecheckAnswer::success_with_capability(
                                         ExprBuilder::with_data(Some(Type::True))
                                             .with_same_source_loc(e)
                                             .or(ty_expr_left, ty_expr_right),
-                                        eff_right,
+                                        capability_right,
                                     )
                                 }
                                 // If the right or left operand is always `false`,
                                 // then the only way the `||` expression can be
                                 // `true` is if the other operand is `true`. This
-                                // lets us pass the effect of the other operand
-                                // through to the effect of the `||`.
+                                // lets us pass the capability of the other operand
+                                // through to the capability of the `||`.
                                 (Some(typ_left), Some(Type::False)) => {
-                                    TypecheckAnswer::success_with_effect(
+                                    TypecheckAnswer::success_with_capability(
                                         ExprBuilder::with_data(Some(typ_left.clone()))
                                             .with_same_source_loc(e)
                                             .or(ty_expr_left, ty_expr_right),
-                                        eff_left,
+                                        capability_left,
                                     )
                                 }
                                 (Some(Type::False), Some(typ_right)) => {
-                                    TypecheckAnswer::success_with_effect(
+                                    TypecheckAnswer::success_with_capability(
                                         ExprBuilder::with_data(Some(typ_right.clone()))
                                             .with_same_source_loc(e)
                                             .or(ty_expr_left, ty_expr_right),
-                                        eff_right,
+                                        capability_right,
                                     )
                                 }
                                 // When neither has a constant value, the `||`
                                 // evaluates to true if one or both is `true`. This
-                                // means we can only keep effects in the
-                                // intersection of their effect sets.
-                                (Some(_), Some(_)) => TypecheckAnswer::success_with_effect(
+                                // means we can only keep capability in the
+                                // intersection of their capability sets.
+                                (Some(_), Some(_)) => TypecheckAnswer::success_with_capability(
                                     ExprBuilder::with_data(Some(Type::primitive_boolean()))
                                         .with_same_source_loc(e)
                                         .or(ty_expr_left, ty_expr_right),
-                                    eff_right.intersect(&eff_left),
+                                    capability_right.intersect(&capability_left),
                                 ),
                                 _ => TypecheckAnswer::fail(
                                     ExprBuilder::with_data(Some(Type::primitive_boolean()))
@@ -781,15 +782,15 @@ impl<'a> Typechecker<'a> {
 
             ExprKind::UnaryApp { .. } => {
                 // INVARIANT: typecheck_unary requires a `UnaryApp`, we've just ensured this
-                self.typecheck_unary(request_env, prior_eff, e, type_errors)
+                self.typecheck_unary(request_env, prior_capability, e, type_errors)
             }
             ExprKind::BinaryApp { .. } => {
                 // INVARIANT: typecheck_binary requires a `BinaryApp`, we've just ensured this
-                self.typecheck_binary(request_env, prior_eff, e, type_errors)
+                self.typecheck_binary(request_env, prior_capability, e, type_errors)
             }
             ExprKind::ExtensionFunctionApp { .. } => {
                 // INVARIANT: typecheck_extension requires a `ExtensionFunctionApp`, we've just ensured this
-                self.typecheck_extension(request_env, prior_eff, e, type_errors)
+                self.typecheck_extension(request_env, prior_capability, e, type_errors)
             }
 
             ExprKind::GetAttr { expr, attr } => {
@@ -797,7 +798,7 @@ impl<'a> Typechecker<'a> {
                 // that has the attribute.
                 let actual = self.expect_one_of_types(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     expr,
                     &[Type::any_entity_reference(), Type::any_record()],
                     type_errors,
@@ -818,11 +819,13 @@ impl<'a> Typechecker<'a> {
                                 // A safe access to an attribute requires either
                                 // that the attribute is required (always
                                 // present), or that the attribute is in the
-                                // prior effect set (the current expression is
+                                // prior capability set (the current expression is
                                 // guarded by a condition that will only
                                 // evaluate to `true` when the attribute is
                                 // present).
-                                if ty.is_required || prior_eff.contains(&Effect::new(expr, attr)) {
+                                if ty.is_required
+                                    || prior_capability.contains(&Capability::new(expr, attr))
+                                {
                                     TypecheckAnswer::success(annot_expr)
                                 } else {
                                     type_errors.push(
@@ -883,7 +886,7 @@ impl<'a> Typechecker<'a> {
                 // `has` applies to an entity or a record
                 let actual = self.expect_one_of_types(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     expr,
                     &[Type::any_entity_reference(), Type::any_record()],
                     type_errors,
@@ -912,36 +915,37 @@ impl<'a> Typechecker<'a> {
                                     Type::EntityOrRecord(EntityRecordKind::Record { .. })
                                 );
                                 // However, we can make an exception when the attribute
-                                // access of the expression is already in the prior effect,
+                                // access of the expression is already in the prior capability,
                                 // which means the entity must exist.
-                                let in_prior_effs = prior_eff.contains(&Effect::new(expr, attr));
-                                let type_of_has = if exists_in_store || in_prior_effs {
+                                let in_prior_capability =
+                                    prior_capability.contains(&Capability::new(expr, attr));
+                                let type_of_has = if exists_in_store || in_prior_capability {
                                     Type::singleton_boolean(true)
                                 } else {
                                     Type::primitive_boolean()
                                 };
-                                TypecheckAnswer::success_with_effect(
+                                TypecheckAnswer::success_with_capability(
                                     ExprBuilder::with_data(Some(type_of_has))
                                         .with_same_source_loc(e)
                                         .has_attr(typ_expr_actual, attr.clone()),
-                                    EffectSet::singleton(Effect::new(expr, attr)),
+                                    CapabilitySet::singleton(Capability::new(expr, attr)),
                                 )
                             }
-                            // This is where effect information is generated. If
+                            // This is where capability information is generated. If
                             // the `HasAttr` for an optional attribute evaluates
                             // to `true`, then we know that it is safe to access
-                            // that attribute, so we add an entry to the effect
+                            // that attribute, so we add an entry to the capability
                             // set.
                             Some(AttributeType {
                                 attr_type: _,
                                 is_required: false,
-                            }) => TypecheckAnswer::success_with_effect(
+                            }) => TypecheckAnswer::success_with_capability(
                                 ExprBuilder::with_data(Some(
                                     // The optional attribute `HasAttr` can have
                                     // type `true` if it occurs after the attribute
                                     // access of the expression is already in the
-                                    // prior effect.
-                                    if prior_eff.contains(&Effect::new(expr, attr)) {
+                                    // prior capability.
+                                    if prior_capability.contains(&Capability::new(expr, attr)) {
                                         Type::singleton_boolean(true)
                                     } else {
                                         Type::primitive_boolean()
@@ -949,7 +953,7 @@ impl<'a> Typechecker<'a> {
                                 ))
                                 .with_same_source_loc(e)
                                 .has_attr(typ_expr_actual, attr.clone()),
-                                EffectSet::singleton(Effect::new(expr, attr)),
+                                CapabilitySet::singleton(Capability::new(expr, attr)),
                             ),
                             None => TypecheckAnswer::success(
                                 ExprBuilder::with_data(Some(
@@ -986,7 +990,7 @@ impl<'a> Typechecker<'a> {
                 // `like` applies to a string
                 let actual = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     expr,
                     Type::primitive_string(),
                     type_errors,
@@ -1014,7 +1018,7 @@ impl<'a> Typechecker<'a> {
             ExprKind::Is { expr, entity_type } => {
                 self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     expr,
                     Type::any_entity_reference(),
                     type_errors,
@@ -1087,7 +1091,7 @@ impl<'a> Typechecker<'a> {
             ExprKind::Set(exprs) => {
                 let elem_types = exprs
                     .iter()
-                    .map(|elem| self.typecheck(request_env, prior_eff, elem, type_errors))
+                    .map(|elem| self.typecheck(request_env, prior_capability, elem, type_errors))
                     .collect::<Vec<_>>();
 
                 // If we cannot compute a least upper bound for the element
@@ -1095,9 +1099,9 @@ impl<'a> Typechecker<'a> {
                 // `least_upper_bound_or_error` and TypecheckFail will be
                 // returned. It will also return TypecheckFail if any of the
                 // individual element failed to typecheck (were TypecheckFail).
-                TypecheckAnswer::sequence_all_then_typecheck(elem_types, |elem_types_and_effects| {
+                TypecheckAnswer::sequence_all_then_typecheck(elem_types, |types_and_capabilities| {
                     let (elem_expr_types, _): (Vec<Expr<Option<Type>>>, Vec<_>) =
-                        elem_types_and_effects.into_iter().unzip();
+                        types_and_capabilities.into_iter().unzip();
                     let elem_lub = self.least_upper_bound_or_error(
                         e,
                         elem_expr_types.iter().map(|ety| ety.data().clone()),
@@ -1136,14 +1140,14 @@ impl<'a> Typechecker<'a> {
                 // Typecheck each attribute initializer expression individually.
                 let record_attr_tys = map
                     .values()
-                    .map(|value| self.typecheck(request_env, prior_eff, value, type_errors));
+                    .map(|value| self.typecheck(request_env, prior_capability, value, type_errors));
                 // This will cause the return value to be `TypecheckFail` if any
                 // of the attributes did not typecheck.
                 TypecheckAnswer::sequence_all_then_typecheck(
                     record_attr_tys,
-                    |record_attr_tys_and_effects| {
+                    |record_attr_tys_and_capabilities| {
                         let (record_attr_expr_tys, _): (Vec<Expr<Option<Type>>>, Vec<_>) =
-                            record_attr_tys_and_effects.into_iter().unzip();
+                            record_attr_tys_and_capabilities.into_iter().unzip();
                         // If any of the attributes could not be assigned a type
                         // (recall that a expression can fail to typecheck but still
                         // be assigned a type), then we cannot assign any type to
@@ -1187,7 +1191,7 @@ impl<'a> Typechecker<'a> {
     fn typecheck_binary<'b>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         bin_expr: &'b Expr,
         type_errors: &mut Vec<ValidationError>,
     ) -> TypecheckAnswer<'b> {
@@ -1201,8 +1205,8 @@ impl<'a> Typechecker<'a> {
             // The arguments to `==` may typecheck with any type, but we will
             // return false if the types are disjoint.
             BinaryOp::Eq => {
-                let lhs_ty = self.typecheck(request_env, prior_eff, arg1, type_errors);
-                let rhs_ty = self.typecheck(request_env, prior_eff, arg2, type_errors);
+                let lhs_ty = self.typecheck(request_env, prior_capability, arg1, type_errors);
+                let rhs_ty = self.typecheck(request_env, prior_capability, arg2, type_errors);
                 lhs_ty.then_typecheck(|lhs_ty, _| {
                     rhs_ty.then_typecheck(|rhs_ty, _| {
                         let type_of_eq = self.type_of_equality(
@@ -1239,7 +1243,7 @@ impl<'a> Typechecker<'a> {
             BinaryOp::Less | BinaryOp::LessEq => {
                 let ans_arg1 = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     arg1,
                     Type::primitive_long(),
                     type_errors,
@@ -1248,7 +1252,7 @@ impl<'a> Typechecker<'a> {
                 ans_arg1.then_typecheck(|expr_ty_arg1, _| {
                     let ans_arg2 = self.expect_type(
                         request_env,
-                        prior_eff,
+                        prior_capability,
                         arg2,
                         Type::primitive_long(),
                         type_errors,
@@ -1277,7 +1281,7 @@ impl<'a> Typechecker<'a> {
                 };
                 let ans_arg1 = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     arg1,
                     Type::primitive_long(),
                     type_errors,
@@ -1286,7 +1290,7 @@ impl<'a> Typechecker<'a> {
                 ans_arg1.then_typecheck(|expr_ty_arg1, _| {
                     let ans_arg2 = self.expect_type(
                         request_env,
-                        prior_eff,
+                        prior_capability,
                         arg2,
                         Type::primitive_long(),
                         type_errors,
@@ -1302,15 +1306,20 @@ impl<'a> Typechecker<'a> {
                 })
             }
 
-            BinaryOp::In => {
-                self.typecheck_in(request_env, prior_eff, bin_expr, arg1, arg2, type_errors)
-            }
+            BinaryOp::In => self.typecheck_in(
+                request_env,
+                prior_capability,
+                bin_expr,
+                arg1,
+                arg2,
+                type_errors,
+            ),
 
             BinaryOp::Contains => {
                 // The first argument must be a set.
                 self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     arg1,
                     Type::any_set(),
                     type_errors,
@@ -1331,7 +1340,7 @@ impl<'a> Typechecker<'a> {
                 )
                 .then_typecheck(|expr_ty_arg1, _| {
                     // The second argument may be any type. We do not care if the element type cannot be in the set.
-                    self.typecheck(request_env, prior_eff, arg2, type_errors)
+                    self.typecheck(request_env, prior_capability, arg2, type_errors)
                         .then_typecheck(|expr_ty_arg2, _| {
                             if self.mode.is_strict() {
                                 let annotated_expr =
@@ -1370,7 +1379,7 @@ impl<'a> Typechecker<'a> {
                 // Both arguments to a `containsAll` or `containsAny` must be sets.
                 self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     arg1,
                     Type::any_set(),
                     type_errors,
@@ -1392,7 +1401,7 @@ impl<'a> Typechecker<'a> {
                 .then_typecheck(|expr_ty_arg1, _| {
                     self.expect_type(
                         request_env,
-                        prior_eff,
+                        prior_capability,
                         arg2,
                         Type::any_set(),
                         type_errors,
@@ -1519,7 +1528,7 @@ impl<'a> Typechecker<'a> {
     fn typecheck_in<'b>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         in_expr: &Expr,
         lhs: &'b Expr,
         rhs: &'b Expr,
@@ -1529,7 +1538,7 @@ impl<'a> Typechecker<'a> {
         // the syntactic special cases that follow.
         let ty_lhs = self.expect_type(
             request_env,
-            prior_eff,
+            prior_capability,
             lhs,
             Type::any_entity_reference(),
             type_errors,
@@ -1537,7 +1546,7 @@ impl<'a> Typechecker<'a> {
         );
         let ty_rhs = self.expect_one_of_types(
             request_env,
-            prior_eff,
+            prior_capability,
             rhs,
             &[
                 Type::set(Type::any_entity_reference()),
@@ -1556,8 +1565,8 @@ impl<'a> Typechecker<'a> {
         let lhs_typechecked = ty_lhs.typechecked();
         let rhs_typechecked = ty_rhs.typechecked();
 
-        ty_lhs.then_typecheck(|lhs_expr, _lhs_effects| {
-            ty_rhs.then_typecheck(|rhs_expr, _rhs_effects| {
+        ty_lhs.then_typecheck(|lhs_expr, _lhs_capabilities| {
+            ty_rhs.then_typecheck(|rhs_expr, _rhs_capabilities| {
                 // If either failed to typecheck, then the whole expression fails to
                 // typecheck.
                 if !lhs_typechecked || !rhs_typechecked {
@@ -1984,7 +1993,7 @@ impl<'a> Typechecker<'a> {
     fn typecheck_unary<'b>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         unary_expr: &'b Expr,
         type_errors: &mut Vec<ValidationError>,
     ) -> TypecheckAnswer<'b> {
@@ -1997,7 +2006,7 @@ impl<'a> Typechecker<'a> {
             UnaryOp::Not => {
                 let ans_arg = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     arg,
                     Type::primitive_boolean(),
                     type_errors,
@@ -2029,7 +2038,7 @@ impl<'a> Typechecker<'a> {
             UnaryOp::Neg => {
                 let ans_arg = self.expect_type(
                     request_env,
-                    prior_eff,
+                    prior_capability,
                     arg,
                     Type::primitive_long(),
                     type_errors,
@@ -2052,7 +2061,7 @@ impl<'a> Typechecker<'a> {
     fn expect_one_of_types<'b, F>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         expr: &'b Expr,
         expected: &[Type],
         type_errors: &mut Vec<ValidationError>,
@@ -2061,8 +2070,8 @@ impl<'a> Typechecker<'a> {
     where
         F: FnOnce(&Type) -> Option<UnexpectedTypeHelp>,
     {
-        let actual = self.typecheck(request_env, prior_eff, expr, type_errors);
-        actual.then_typecheck(|mut typ_actual, eff_actual| match typ_actual.data() {
+        let actual = self.typecheck(request_env, prior_capability, expr, type_errors);
+        actual.then_typecheck(|mut typ_actual, capability| match typ_actual.data() {
             Some(actual_ty) => {
                 if !expected.iter().any(|expected_ty| {
                     // This check uses `ValidationMode::Permissive` even in
@@ -2096,7 +2105,7 @@ impl<'a> Typechecker<'a> {
                     typ_actual.set_data(None);
                     TypecheckAnswer::fail(typ_actual)
                 } else {
-                    TypecheckAnswer::success_with_effect(typ_actual, eff_actual)
+                    TypecheckAnswer::success_with_capability(typ_actual, capability)
                 }
             }
             None => {
@@ -2112,7 +2121,7 @@ impl<'a> Typechecker<'a> {
     fn expect_type<'b, F>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         expr: &'b Expr,
         expected: Type,
         type_errors: &mut Vec<ValidationError>,
@@ -2123,7 +2132,7 @@ impl<'a> Typechecker<'a> {
     {
         self.expect_one_of_types(
             request_env,
-            prior_eff,
+            prior_capability,
             expr,
             &[expected],
             type_errors,
@@ -2134,7 +2143,7 @@ impl<'a> Typechecker<'a> {
     /// Return the least upper bound of all types is the `types` vector. If
     /// there isn't a least upper bound, then a type error is reported and
     /// `TypecheckFail` is returned. Note that this function does not preserve the
-    /// effects of the input [`TypecheckAnswers`].
+    /// capabilities of the input [`TypecheckAnswers`].
     fn least_upper_bound_or_error(
         &self,
         expr: &Expr,
@@ -2226,7 +2235,7 @@ impl<'a> Typechecker<'a> {
     fn typecheck_extension<'b>(
         &self,
         request_env: &RequestEnv<'_>,
-        prior_eff: &EffectSet<'b>,
+        prior_capability: &CapabilitySet<'b>,
         ext_expr: &'b Expr,
         type_errors: &mut Vec<ValidationError>,
     ) -> TypecheckAnswer<'b> {
@@ -2239,7 +2248,7 @@ impl<'a> Typechecker<'a> {
         let typed_arg_exprs = |type_errors: &mut Vec<ValidationError>| {
             args.iter()
                 .map(|arg| {
-                    self.typecheck(request_env, prior_eff, arg, type_errors)
+                    self.typecheck(request_env, prior_capability, arg, type_errors)
                         .into_typed_expr()
                 })
                 .collect::<Option<Vec<_>>>()
@@ -2294,7 +2303,7 @@ impl<'a> Typechecker<'a> {
                     let typechecked_args = zip(args.as_ref(), arg_tys).map(|(arg, ty)| {
                         self.expect_type(
                             request_env,
-                            prior_eff,
+                            prior_capability,
                             arg,
                             ty.clone(),
                             type_errors,
@@ -2303,9 +2312,9 @@ impl<'a> Typechecker<'a> {
                     });
                     TypecheckAnswer::sequence_all_then_typecheck(
                         typechecked_args,
-                        |arg_exprs_effects| {
+                        |arg_exprs_capabilities| {
                             let (typed_arg_exprs, _): (Vec<Expr<Option<Type>>>, Vec<_>) =
-                                arg_exprs_effects.into_iter().unzip();
+                                arg_exprs_capabilities.into_iter().unzip();
                             TypecheckAnswer::success(
                                 ExprBuilder::with_data(Some(ret_ty.clone()))
                                     .with_same_source_loc(ext_expr)

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -362,12 +362,11 @@ impl<'a> Typechecker<'a> {
     }
 
     /// This method handles the majority of the work. Given an expression,
-    /// the type for the request, and the a prior capability for the
-    /// expression, return the result of typechecking the expression, and add
-    /// any errors encountered into the `type_errors` list. The result of
-    /// typechecking contains the type of the expression, any current capability of
-    /// the expression, and a flag indicating whether the expression
-    /// successfully typechecked.
+    /// the type for the request, and the prior capability, return the result of
+    /// typechecking the expression, and add any errors encountered into the
+    /// `type_errors` list. The result of typechecking contains the type of the
+    /// expression, any resulting capability after the expression, and a flag
+    /// indicating whether the expression successfully typechecked.
     fn typecheck<'b>(
         &self,
         request_env: &RequestEnv<'_>,
@@ -574,11 +573,11 @@ impl<'a> Typechecker<'a> {
                                     .with_same_source_loc(e)
                                     .ite(typ_test, typ_then, typ_else);
                                 if has_lub {
-                                    // Capability is not handled in the LUB computation,
-                                    // so we need to compute the capability here. When
+                                    // Capabilities are not handled in the LUB computation,
+                                    // so we need to compute resulting capability here. When
                                     // the `||` evaluates to `true`, we know that
                                     // one operand evaluated to true, but we don't
-                                    // know which. This is handled by returning an
+                                    // know which. This is handled by returning a
                                     // capability set that is the intersection of the
                                     // operand capability sets.
                                     TypecheckAnswer::success_with_capability(
@@ -618,7 +617,7 @@ impl<'a> Typechecker<'a> {
                             // Similar to the `then` branch of an `if`
                             // expression, the rhs of an `&&` is typechecked
                             // using an updated prior capability that includes
-                            // capability learned from the lhs to enable
+                            // the capability from the lhs to enable
                             // typechecking expressions like
                             // `principal has foo && principal.foo`. This is
                             // valid because `&&` short circuits at run time, so

--- a/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
@@ -15,7 +15,7 @@
  */
 
 //! Contains tests for defining optional attributes and typechecking their
-//! access using the ability added by contextual effects.
+//! access using the ability added by capabilities.
 // GRCOV_STOP_COVERAGE
 
 use cedar_policy_core::{
@@ -96,7 +96,7 @@ fn simple_and_guard_resource() {
 }
 
 #[test]
-fn principal_and_resource_in_effect() {
+fn principal_and_resource_in_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { resource has name && principal has age && resource.name == "foo" && principal.age == 1};"#,
@@ -116,7 +116,7 @@ fn and_branches_union() {
 }
 
 #[test]
-fn and_rhs_true_has_lhs_effect() {
+fn and_rhs_true_has_lhs_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name && true) && principal.name == "foo" };"#,
@@ -126,7 +126,7 @@ fn and_rhs_true_has_lhs_effect() {
 }
 
 #[test]
-fn and_lhs_true_has_rhs_effect() {
+fn and_lhs_true_has_rhs_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (true && principal has name) && principal.name == "foo" };"#,
@@ -136,7 +136,7 @@ fn and_lhs_true_has_rhs_effect() {
 }
 
 #[test]
-fn and_branches_use_prior_effect() {
+fn and_branches_use_prior_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name) && (principal.name == "foo" && principal.name == "foo") };"#,
@@ -166,7 +166,7 @@ fn or_branches_intersect() {
 }
 
 #[test]
-fn or_lhs_false_has_rhs_effect() {
+fn or_lhs_false_has_rhs_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (false || principal has name) && principal.name == "foo" };"#,
@@ -176,7 +176,7 @@ fn or_lhs_false_has_rhs_effect() {
 }
 
 #[test]
-fn or_rhs_false_has_lhs_effect() {
+fn or_rhs_false_has_lhs_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name || false) && principal.name == "foo" };"#,
@@ -186,7 +186,7 @@ fn or_rhs_false_has_lhs_effect() {
 }
 
 #[test]
-fn or_branches_use_prior_effect() {
+fn or_branches_use_prior_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { (principal has name) && (principal.name == "foo" || principal.name == "foo") };"#,
@@ -206,7 +206,7 @@ fn then_guarded_access_by_test() {
 }
 
 #[test]
-fn then_guarded_access_by_prior_effect() {
+fn then_guarded_access_by_prior_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && (if principal has age then principal.name == "foo" else false) };"#,
@@ -216,7 +216,7 @@ fn then_guarded_access_by_prior_effect() {
 }
 
 #[test]
-fn else_guarded_access_by_prior_effect() {
+fn else_guarded_access_by_prior_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal has name && (if principal has age then false else principal.name == "foo") };"#,
@@ -265,7 +265,7 @@ fn if_then_else_then_else_same() {
 }
 
 #[test]
-fn if_then_else_can_use_guard_effect() {
+fn if_then_else_can_use_guard_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"
@@ -428,7 +428,7 @@ fn if_then_else_as_guard_empty_intersect_fails() {
 }
 
 #[test]
-fn resource_effect_access_principal_fails() {
+fn resource_capability_access_principal_fails() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { resource has name && principal.name == "foo" };"#,
@@ -438,7 +438,7 @@ fn resource_effect_access_principal_fails() {
 }
 
 #[test]
-fn not_no_effect() {
+fn not_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { !(principal has name) && principal.name == "foo" };"#,
@@ -448,7 +448,7 @@ fn not_no_effect() {
 }
 
 #[test]
-fn true_no_effect() {
+fn true_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { true && principal.name == "foo" };"#,
@@ -458,7 +458,7 @@ fn true_no_effect() {
 }
 
 #[test]
-fn set_contains_no_effect() {
+fn set_contains_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { [principal has name].contains(principal has name) && principal.name == "foo" };"#,
@@ -468,7 +468,7 @@ fn set_contains_no_effect() {
 }
 
 #[test]
-fn contains_all_no_effect() {
+fn contains_all_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { [principal has name].containsAll([principal has name]) && principal.name == "foo" };"#,
@@ -478,7 +478,7 @@ fn contains_all_no_effect() {
 }
 
 #[test]
-fn contains_any_no_effect() {
+fn contains_any_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { [principal has name].containsAny([principal has name]) && principal.name == "foo" };"#,
@@ -488,7 +488,7 @@ fn contains_any_no_effect() {
 }
 
 #[test]
-fn like_no_effect() {
+fn like_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { "foo" like "bar" && principal.name == "foo" };"#,
@@ -498,7 +498,7 @@ fn like_no_effect() {
 }
 
 #[test]
-fn record_attr_no_effect() {
+fn record_attr_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { {name: true}.name && principal.name == "foo" };"#,
@@ -508,7 +508,7 @@ fn record_attr_no_effect() {
 }
 
 #[test]
-fn record_attr_has_no_effect() {
+fn record_attr_has_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { {name: true} has name && principal.name == "foo" };"#,
@@ -518,7 +518,7 @@ fn record_attr_has_no_effect() {
 }
 
 #[test]
-fn in_no_effect() {
+fn in_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in resource && principal.name == "foo" };"#,
@@ -528,7 +528,7 @@ fn in_no_effect() {
 }
 
 #[test]
-fn in_list_no_effect() {
+fn in_list_no_capability() {
     let policy = parse_policy(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action, resource) when { principal in [resource] && principal.name == "foo" };"#,

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -30,7 +30,7 @@ use cedar_policy_core::{
 
 use crate::{
     typecheck::Typechecker,
-    types::{AttributeType, EffectSet, OpenTag, RequestEnv, Type},
+    types::{AttributeType, CapabilitySet, OpenTag, RequestEnv, Type},
     validation_errors::LubContext,
     validation_errors::LubHelp,
     RawName, SchemaFragment, ValidationError, ValidationMode,
@@ -48,10 +48,14 @@ fn assert_typechecks_strict(
     let schema = schema.try_into().expect("Failed to construct schema.");
     let typechecker = Typechecker::new(&schema, ValidationMode::Strict, expr_id_placeholder());
     let mut errs = Vec::new();
-    let answer =
-        typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs, |_| {
-            None
-        });
+    let answer = typechecker.expect_type(
+        env,
+        &CapabilitySet::new(),
+        &e,
+        expected_type,
+        &mut errs,
+        |_| None,
+    );
 
     assert_eq!(errs, vec![], "Expression should not contain any errors.");
     assert_matches!(
@@ -71,10 +75,14 @@ fn assert_strict_type_error(
     let schema = schema.try_into().expect("Failed to construct schema.");
     let typechecker = Typechecker::new(&schema, ValidationMode::Strict, expr_id_placeholder());
     let mut errs = Vec::new();
-    let answer =
-        typechecker.expect_type(env, &EffectSet::new(), &e, expected_type, &mut errs, |_| {
-            None
-        });
+    let answer = typechecker.expect_type(
+        env,
+        &CapabilitySet::new(),
+        &e,
+        expected_type,
+        &mut errs,
+        |_| None,
+    );
 
     assert_eq!(errs.into_iter().collect::<Vec<_>>(), vec![expected_error]);
     assert_matches!(
@@ -160,7 +168,7 @@ fn strict_typecheck_catches_regular_type_error() {
         let mut errs = Vec::new();
         typechecker.expect_type(
             &q,
-            &EffectSet::new(),
+            &CapabilitySet::new(),
             &Expr::from_str("1 + false").unwrap(),
             Type::primitive_long(),
             &mut errs,

--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -25,7 +25,7 @@ use cedar_policy_core::ast::{EntityUID, Expr, PolicyID, Template, ACTION_ENTITY_
 
 use crate::typecheck::{TypecheckAnswer, Typechecker};
 use crate::{
-    types::{EffectSet, OpenTag, RequestEnv, Type},
+    types::{CapabilitySet, OpenTag, RequestEnv, Type},
     validation_errors::UnexpectedTypeHelp,
     NamespaceDefinition, RawName, ValidationError, ValidationMode, ValidationWarning,
     ValidatorSchema,
@@ -85,7 +85,7 @@ impl Typechecker<'_> {
             resource_slot: None,
         };
         let mut type_errors = Vec::new();
-        let ans = self.typecheck(&request_env, &EffectSet::new(), e, &mut type_errors);
+        let ans = self.typecheck(&request_env, &CapabilitySet::new(), e, &mut type_errors);
         unique_type_errors.extend(type_errors);
         ans
     }

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -16,18 +16,18 @@
 
 use cedar_policy_core::ast::Expr;
 
-use crate::types::{EffectSet, Type};
+use crate::types::{CapabilitySet, Type};
 
 /// [`TypecheckAnswer`] holds the result of typechecking an expression.
 #[derive(Debug, Eq, PartialEq)]
 pub(crate) enum TypecheckAnswer<'a> {
-    /// Typechecking succeeded, and we know the type and a possibly empty effect
-    /// set for the expression. The effect set is the set of
+    /// Typechecking succeeded, and we know the type and a possibly empty capability
+    /// set for the expression. The capability set is the set of
     /// (expression, attribute) pairs that are known as safe to access under the
     /// assumption that the expression evaluates to true.
     TypecheckSuccess {
         expr_type: Expr<Option<Type>>,
-        expr_effect: EffectSet<'a>,
+        expr_capability: CapabilitySet<'a>,
     },
     /// Typechecking failed. We might still be able to know the type of the
     /// overall expression, but not always. For instance, an `&&` expression
@@ -43,19 +43,22 @@ pub(crate) enum TypecheckAnswer<'a> {
 
 impl<'a> TypecheckAnswer<'a> {
     /// Construct a successful [`TypecheckAnswer`] with a type but with an empty
-    /// effect set.
+    /// capability set.
     pub fn success(expr_type: Expr<Option<Type>>) -> Self {
         Self::TypecheckSuccess {
             expr_type,
-            expr_effect: EffectSet::new(),
+            expr_capability: CapabilitySet::new(),
         }
     }
 
-    /// Construct a successful [`TypecheckAnswer`] with a type and an effect.
-    pub fn success_with_effect(expr_type: Expr<Option<Type>>, expr_effect: EffectSet<'a>) -> Self {
+    /// Construct a successful [`TypecheckAnswer`] with a type and an capability.
+    pub fn success_with_capability(
+        expr_type: Expr<Option<Type>>,
+        expr_capability: CapabilitySet<'a>,
+    ) -> Self {
         Self::TypecheckSuccess {
             expr_type,
-            expr_effect,
+            expr_capability,
         }
     }
 
@@ -96,19 +99,19 @@ impl<'a> TypecheckAnswer<'a> {
         }
     }
 
-    /// Transform the effect of this [`TypecheckAnswer`] without modifying the
+    /// Transform the capability of this [`TypecheckAnswer`] without modifying the
     /// success or type.
-    pub fn map_effect<F>(self, f: F) -> Self
+    pub fn map_capability<F>(self, f: F) -> Self
     where
-        F: FnOnce(EffectSet<'a>) -> EffectSet<'a>,
+        F: FnOnce(CapabilitySet<'a>) -> CapabilitySet<'a>,
     {
         match self {
             TypecheckAnswer::TypecheckSuccess {
                 expr_type,
-                expr_effect,
+                expr_capability,
             } => TypecheckAnswer::TypecheckSuccess {
                 expr_type,
-                expr_effect: f(expr_effect),
+                expr_capability: f(expr_capability),
             },
             TypecheckAnswer::TypecheckFail { .. } => self,
             TypecheckAnswer::RecursionLimit => self,
@@ -132,15 +135,15 @@ impl<'a> TypecheckAnswer<'a> {
     /// `TypecheckFail`, otherwise it will be returned unaltered.
     pub fn then_typecheck<F>(self, f: F) -> Self
     where
-        F: FnOnce(Expr<Option<Type>>, EffectSet<'a>) -> TypecheckAnswer<'a>,
+        F: FnOnce(Expr<Option<Type>>, CapabilitySet<'a>) -> TypecheckAnswer<'a>,
     {
         match self {
             TypecheckAnswer::TypecheckSuccess {
                 expr_type,
-                expr_effect,
-            } => f(expr_type, expr_effect),
+                expr_capability,
+            } => f(expr_type, expr_capability),
             TypecheckAnswer::TypecheckFail { expr_recovery_type } => {
-                f(expr_recovery_type, EffectSet::new()).into_fail()
+                f(expr_recovery_type, CapabilitySet::new()).into_fail()
             }
             TypecheckAnswer::RecursionLimit => self,
         }
@@ -155,7 +158,7 @@ impl<'a> TypecheckAnswer<'a> {
         f: F,
     ) -> TypecheckAnswer<'a>
     where
-        F: FnOnce(Vec<(Expr<Option<Type>>, EffectSet<'a>)>) -> TypecheckAnswer<'a>,
+        F: FnOnce(Vec<(Expr<Option<Type>>, CapabilitySet<'a>)>) -> TypecheckAnswer<'a>,
     {
         let mut unwrapped = Vec::new();
         let mut any_failed = false;
@@ -165,10 +168,10 @@ impl<'a> TypecheckAnswer<'a> {
             unwrapped.push(match ans {
                 TypecheckAnswer::TypecheckSuccess {
                     expr_type,
-                    expr_effect,
-                } => (expr_type, expr_effect),
+                    expr_capability,
+                } => (expr_type, expr_capability),
                 TypecheckAnswer::TypecheckFail { expr_recovery_type } => {
-                    (expr_recovery_type, EffectSet::new())
+                    (expr_recovery_type, CapabilitySet::new())
                 }
                 TypecheckAnswer::RecursionLimit => {
                     recusion_limit_reached = true;

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -51,7 +51,7 @@ impl<'a> TypecheckAnswer<'a> {
         }
     }
 
-    /// Construct a successful [`TypecheckAnswer`] with a type and an capability.
+    /// Construct a successful [`TypecheckAnswer`] with a type and a capability.
     pub fn success_with_capability(
         expr_type: Expr<Option<Type>>,
         expr_capability: CapabilitySet<'a>,

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -17,8 +17,8 @@
 //! Defines the type structure for typechecking and various utilities for
 //! constructing and manipulating types.
 
-mod effect;
-pub use effect::*;
+mod capability;
+pub use capability::*;
 mod request_env;
 pub use request_env::*;
 

--- a/cedar-policy-validator/src/types/capability.rs
+++ b/cedar-policy-validator/src/types/capability.rs
@@ -29,7 +29,7 @@ impl<'a> CapabilitySet<'a> {
         CapabilitySet(HashSet::new())
     }
 
-    /// An capability set with a single [`Capability`]
+    /// A capability set with a single [`Capability`]
     pub fn singleton(e: Capability<'a>) -> Self {
         let mut set = Self::new();
         set.0.insert(e);

--- a/cedar-policy-validator/src/types/capability.rs
+++ b/cedar-policy-validator/src/types/capability.rs
@@ -18,19 +18,19 @@ use std::collections::HashSet;
 
 use cedar_policy_core::ast::{Expr, ExprShapeOnly};
 
-/// A set of effects. Used to represent knowledge about attribute existence
+/// A set of capabilities. Used to represent knowledge about attribute existence
 /// before and after evaluating an expression.
 #[derive(Eq, PartialEq, Debug, Clone, Default)]
-pub struct EffectSet<'a>(HashSet<Effect<'a>>);
+pub struct CapabilitySet<'a>(HashSet<Capability<'a>>);
 
-impl<'a> EffectSet<'a> {
-    /// An empty effect set
+impl<'a> CapabilitySet<'a> {
+    /// An empty capability set
     pub fn new() -> Self {
-        EffectSet(HashSet::new())
+        CapabilitySet(HashSet::new())
     }
 
-    /// An effect set with a single [`Effect`]
-    pub fn singleton(e: Effect<'a>) -> Self {
+    /// An capability set with a single [`Capability`]
+    pub fn singleton(e: Capability<'a>) -> Self {
         let mut set = Self::new();
         set.0.insert(e);
         set
@@ -38,32 +38,32 @@ impl<'a> EffectSet<'a> {
 
     /// Construct the union of `self` and `other`
     pub fn union(&self, other: &Self) -> Self {
-        EffectSet(self.0.union(&other.0).cloned().collect())
+        CapabilitySet(self.0.union(&other.0).cloned().collect())
     }
 
     /// Construct the intersection of `self` and `other`
     pub fn intersect(&self, other: &Self) -> Self {
-        EffectSet(self.0.intersection(&other.0).cloned().collect())
+        CapabilitySet(self.0.intersection(&other.0).cloned().collect())
     }
 
-    /// Does this effect set contain the given [`Effect`]
-    pub fn contains(&self, e: &Effect<'_>) -> bool {
+    /// Does this capability set contain the given [`Capability`]
+    pub fn contains(&self, e: &Capability<'_>) -> bool {
         self.0.contains(e)
     }
 }
 
-/// Represent a single effect, which is an expression and some attribute that is
+/// Represent a single capability, which is an expression and some attribute that is
 /// known to exist for that expression.
 #[derive(Hash, Eq, PartialEq, Debug, Clone)]
-pub struct Effect<'a> {
+pub struct Capability<'a> {
     /// For this expression
     on_expr: ExprShapeOnly<'a>,
     /// This attribute is known to exist on that expression
     attribute: &'a str,
 }
 
-impl<'a> Effect<'a> {
-    /// Construct a new [`Effect`] stating that the attribute `attribute` is
+impl<'a> Capability<'a> {
+    /// Construct a new [`Capability`] stating that the attribute `attribute` is
     /// known to exist for the expression `on_expr`
     pub fn new(on_expr: &'a Expr, attribute: &'a str) -> Self {
         Self {


### PR DESCRIPTION
## Description of changes

Purely internal renaming so that terminology matches in Rust and Lean.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

