### PR TITLE
bugfix in ffi policy set parsing

### DIFF
--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -1126,7 +1126,8 @@ pub mod test {
             },
             "entities": []
         });
-        assert_is_not_authorized_json(call);
+        let errs = assert_is_authorized_json_is_failure(call);
+        assert_exactly_one_error(&errs, "static policy set includes a template", None);
     }
 
     #[test]

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -16,6 +16,7 @@
 
 //! Utility functions and types for JSON interface
 use crate::{PolicyId, SchemaWarning, SlotId};
+use miette::miette;
 use miette::WrapErr;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, str::FromStr};
@@ -280,7 +281,7 @@ pub enum Policy {
 impl Policy {
     /// Parse a [`Policy`] into a [`crate::Policy`]. Takes an optional id
     /// argument that sets the policy id. If the argument is `None` then a
-    /// default id will be assigned.
+    /// default id will be assigned. Will return an error if passed a template.
     pub(super) fn parse(self, id: Option<PolicyId>) -> Result<crate::Policy, miette::Report> {
         let msg = id
             .clone()
@@ -294,7 +295,9 @@ impl Policy {
     }
 }
 
-/// Represents a policy template in either the Cedar or JSON policy format
+/// Represents a policy template in either the Cedar or JSON policy format.
+/// This format can also be used to represent static policies (which can be
+/// thought of as templates with zero slots).
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
@@ -367,9 +370,17 @@ impl StaticPolicySet {
     /// Parse a [`StaticPolicySet`] into a [`crate::PolicySet`]
     pub(super) fn parse(self) -> Result<crate::PolicySet, Vec<miette::Report>> {
         match self {
-            Self::Concatenated(str) => crate::PolicySet::from_str(&str)
-                .wrap_err("failed to parse policies from string")
-                .map_err(|e| vec![e]),
+            Self::Concatenated(str) => {
+                let policies = crate::PolicySet::from_str(&str)
+                    .wrap_err("failed to parse policies from string")
+                    .map_err(|e| vec![e])?;
+                // make sure the parsed policies are all static policies
+                if policies.templates().count() > 0 {
+                    Err(vec![miette!("static policy set includes a template")])
+                } else {
+                    Ok(policies)
+                }
+            }
             Self::Set(set) => {
                 let mut errs = Vec::new();
                 let policies = set
@@ -814,6 +825,25 @@ mod test {
             .exactly_one_underline("permit(principal == ?principal, action, resource);")
             .help("try removing the template slot(s) from this policy")
             .build(),
+        );
+
+        // Invalid static policy set - the second policy is a template
+        let policies_json = json!(
+            "
+            permit(principal == User::\"alice\", action, resource); 
+            permit(principal == ?principal, action, resource);
+        "
+        );
+        let policies: StaticPolicySet =
+            serde_json::from_value(policies_json).expect("failed to parse from JSON");
+        let errs = policies
+            .parse()
+            .expect_err("should have failed to convert to static policy set");
+        assert_length_matches(&errs, 1);
+        expect_err(
+            "permit(principal == ?principal, action, resource);",
+            &errs[0],
+            &ExpectedErrorMessageBuilder::error("static policy set includes a template").build(),
         );
 
         // Invalid static policy set - `policy1` is actually multiple policies


### PR DESCRIPTION
## Description of changes

Quick fix in the FFI function `StaticPolicySet::parse`. In the `Concatenated` case, we use `PolicySet::from_str`, which accepts both static policies & templates. Prior to this PR, this allowed some templates to be added to the "static" policy set.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
