### PR TITLE
fix TryFrom<Name> for UnreservedId

### DIFF
--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -406,10 +406,10 @@ impl From<UnreservedId> for Name {
 impl TryFrom<Name> for UnreservedId {
     type Error = ();
     fn try_from(value: Name) -> Result<Self, Self::Error> {
-        if value.0.path.is_empty() {
-            Err(())
-        } else {
+        if value.0.is_unqualified() {
             Ok(value.basename())
+        } else {
+            Err(())
         }
     }
 }


### PR DESCRIPTION
## Description of changes

I think #969 had the `TryFrom<Name> for UnreservedId` impl backwards, that is, `Ok` when it should be `Err` and vice versa.  This PR, reversing it, does not fail any tests, so I suspect this impl is unused.

Also uses `is_unqualified()` instead of manually checking `path`. This matches how the similar `TryFrom<UncheckedName> for Id` impl works.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

