### PR TITLE
Fix benchmark; better CI for benchmarks; comments

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -25,7 +25,7 @@ jobs:
       # All targets are run with the same `RUSTFLAGS
       - run: cargo build --verbose
       - run: cargo test --verbose
-      - run: cargo bench --no-run --profile=dev
+      - run: cargo test --verbose --benches
       - run: cargo test --verbose --no-default-features
       - run: cargo build --verbose --features "experimental"
       - run: cargo test --verbose --features "experimental"

--- a/cedar-policy/benches/attr_errors.rs
+++ b/cedar-policy/benches/attr_errors.rs
@@ -1,4 +1,19 @@
-// PANIC SAFETY: testing code
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// PANIC SAFETY: benchmarking
 #![allow(clippy::unwrap_used)]
 use cedar_policy::EntityUid;
 use cedar_policy::{Authorizer, Context, Entities, PolicySet, Request, RestrictedExpression};

--- a/cedar-policy/benches/cedar_benchmarks.rs
+++ b/cedar-policy/benches/cedar_benchmarks.rs
@@ -13,9 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// PANIC SAFETY unit tests
+// PANIC SAFETY benchmarking
 #![allow(clippy::unwrap_used)]
-// PANIC SAFETY unit tests
+// PANIC SAFETY benchmarking
 #![allow(clippy::expect_used)]
 
 use std::str::FromStr;

--- a/cedar-policy/benches/entity_attr_errors.rs
+++ b/cedar-policy/benches/entity_attr_errors.rs
@@ -1,6 +1,21 @@
-// PANIC SAFETY: testing code
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// PANIC SAFETY: benchmarking
 #![allow(clippy::unwrap_used)]
-// PANIC SAFETY: testing code
+// PANIC SAFETY: benchmarking
 #![allow(clippy::indexing_slicing)]
 
 use cedar_policy::{

--- a/cedar-policy/benches/extension_fn_validation.rs
+++ b/cedar-policy/benches/extension_fn_validation.rs
@@ -23,7 +23,10 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 // PANIC SAFETY: benchmarking
 #[allow(clippy::unwrap_used)]
 pub fn extension_fn_validation(c: &mut Criterion) {
-    let (schema, _) = Schema::from_str_natural("action Act appliesTo { context: {}};").unwrap();
+    let (schema, _) = Schema::from_str_natural(
+        "entity E; action Act appliesTo { principal: E, resource: E, context: {}};",
+    )
+    .unwrap();
     let validator = Validator::new(schema);
 
     let policy_set = PolicySet::from_policies([Policy::from_str(


### PR DESCRIPTION
One benchmark was broken after #983 because it  used a schema that wasn't updated. Fix that benchmark and update CI to run benchmarks once instead of just compiling. Add standard copyright header to benchmarks where it was missing.