### PR TITLE
Remove or refactor validation extension function errors

### DIFF
--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -350,6 +350,34 @@ pub mod extension_function_lookup_errors {
 /// Type alias for convenience
 pub type Result<T> = std::result::Result<T, ExtensionFunctionLookupError>;
 
+/// Utilities shared with the `cedar-policy-validator` extensions module.
+pub mod util {
+    use std::collections::{hash_map::Entry, HashMap};
+
+    /// Utility to build a `HashMap` of key value pairs from an iterator,
+    /// returning an `Err` result if there are any duplicate keys in the
+    /// iterator.
+    pub fn collect_no_duplicates<K, V>(
+        i: impl Iterator<Item = (K, V)>,
+    ) -> std::result::Result<HashMap<K, V>, K>
+    where
+        K: Clone + std::hash::Hash + Eq,
+    {
+        let mut map = HashMap::with_capacity(i.size_hint().0);
+        for (k, v) in i {
+            match map.entry(k) {
+                Entry::Occupied(occupied) => {
+                    return Err(occupied.key().clone());
+                }
+                Entry::Vacant(vacant) => {
+                    vacant.insert(v);
+                }
+            }
+        }
+        Ok(map)
+    }
+}
+
 #[cfg(test)]
 pub mod test {
     use super::*;

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -126,10 +126,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UndefinedFunction(#[from] validation_errors::UndefinedFunction),
-    /// Multiply defined extension function.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    MultiplyDefinedFunction(#[from] validation_errors::MultiplyDefinedFunction),
     /// Incorrect number of arguments in an extension function application.
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -275,19 +271,6 @@ impl ValidationError {
 
     pub(crate) fn undefined_extension(on_expr: Expr, policy_id: PolicyID, name: String) -> Self {
         validation_errors::UndefinedFunction {
-            on_expr,
-            policy_id,
-            name,
-        }
-        .into()
-    }
-
-    pub(crate) fn multiply_defined_extension(
-        on_expr: Expr,
-        policy_id: PolicyID,
-        name: String,
-    ) -> Self {
-        validation_errors::MultiplyDefinedFunction {
             on_expr,
             policy_id,
             name,

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -131,9 +131,6 @@ pub enum ValidationError {
     #[diagnostic(transparent)]
     WrongNumberArguments(#[from] validation_errors::WrongNumberArguments),
     /// Incorrect call style in an extension function application.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    WrongCallStyle(#[from] validation_errors::WrongCallStyle),
     /// Error returned by custom extension function argument validation
     #[diagnostic(transparent)]
     #[error(transparent)]

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -26,9 +26,7 @@ use cedar_policy_core::parser::Loc;
 
 use std::collections::BTreeSet;
 
-use cedar_policy_core::ast::{
-    CallStyle, EntityType, EntityUID, Expr, ExprKind, ExprShapeOnly, PolicyID, Var,
-};
+use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprKind, ExprShapeOnly, PolicyID, Var};
 use cedar_policy_core::parser::join_with_conjunction;
 
 use crate::types::{EntityLUB, EntityRecordKind, RequestEnv, Type};
@@ -467,40 +465,6 @@ impl PartialEq for WrongNumberArguments {
 }
 
 impl Diagnostic for WrongNumberArguments {
-    impl_diagnostic_from_on_expr_field!();
-}
-
-/// Structure containing details about a wrong call style error.
-#[derive(Error, Debug, Clone, Eq)]
-#[error("for policy `{policy_id}`, wrong call style in extension function application. Expected {expected}, got {actual}")]
-pub struct WrongCallStyle {
-    /// [`Expr`] containing a call in the wrong style
-    pub on_expr: Expr,
-    /// Policy ID where the error occurred
-    pub policy_id: PolicyID,
-    /// Expected call style
-    pub expected: CallStyle,
-    /// Actual call style
-    pub actual: CallStyle,
-}
-
-impl std::hash::Hash for WrongCallStyle {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.expected.hash(state);
-        self.actual.hash(state);
-    }
-}
-
-impl PartialEq for WrongCallStyle {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.expected == other.expected
-            && self.actual == other.actual
-    }
-}
-
-impl Diagnostic for WrongCallStyle {
     impl_diagnostic_from_on_expr_field!();
 }
 

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -436,35 +436,6 @@ impl Diagnostic for UndefinedFunction {
     impl_diagnostic_from_on_expr_field!();
 }
 
-/// Structure containing details about a multiply defined function error.
-#[derive(Error, Debug, Clone, Eq)]
-#[error("for policy `{policy_id}`, extension function defined multiple times: {name}")]
-pub struct MultiplyDefinedFunction {
-    /// [`Expr`] containing a call to a multiply defined function
-    pub on_expr: Expr,
-    /// Policy ID where the error occurred
-    pub policy_id: PolicyID,
-    /// Name of the multiply defined function
-    pub name: String,
-}
-
-impl std::hash::Hash for MultiplyDefinedFunction {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.name.hash(state);
-    }
-}
-impl PartialEq for MultiplyDefinedFunction {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.name == other.name
-    }
-}
-
-impl Diagnostic for MultiplyDefinedFunction {
-    impl_diagnostic_from_on_expr_field!();
-}
-
 /// Structure containing details about a wrong number of arguments error.
 #[derive(Error, Debug, Clone, Eq)]
 #[error("for policy `{policy_id}`, wrong number of arguments in extension function application. Expected {expected}, got {actual}")]

--- a/cedar-policy-validator/src/extension_schema.rs
+++ b/cedar-policy-validator/src/extension_schema.rs
@@ -16,14 +16,13 @@
 
 use crate::types::Type;
 use cedar_policy_core::ast::{Expr, Name};
-use std::collections::HashMap;
 
 /// Type information for a Cedar extension.
 pub struct ExtensionSchema {
     /// Name of the extension
     name: Name,
     /// Type information for extension functions
-    function_types: HashMap<Name, ExtensionFunctionType>,
+    function_types: Vec<ExtensionFunctionType>,
 }
 
 impl std::fmt::Debug for ExtensionSchema {
@@ -40,10 +39,7 @@ impl ExtensionSchema {
     ) -> Self {
         Self {
             name,
-            function_types: function_types
-                .into_iter()
-                .map(|f| (f.name.clone(), f))
-                .collect(),
+            function_types: function_types.into_iter().collect(),
         }
     }
 
@@ -52,8 +48,8 @@ impl ExtensionSchema {
         &self.name
     }
 
-    pub fn get_function_type(&self, name: &Name) -> Option<&ExtensionFunctionType> {
-        self.function_types.get(name)
+    pub fn function_types(&self) -> impl Iterator<Item = &ExtensionFunctionType> {
+        self.function_types.iter()
     }
 }
 
@@ -61,7 +57,8 @@ impl ExtensionSchema {
 /// extension function application. An `ArgumentCheckFn` is passed a slice
 /// containing the arguments to the extension function call and returns `Err` if
 /// it can statically determine that the arguments are invalid.
-pub(crate) type ArgumentCheckFn = Box<dyn Fn(&[Expr]) -> Result<(), String>>;
+pub(crate) type ArgumentCheckFn =
+    Box<dyn Fn(&[Expr]) -> Result<(), String> + Sync + Send + 'static>;
 
 /// Type information for a single extension function.
 pub struct ExtensionFunctionType {

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -67,7 +67,7 @@ pub struct ExtensionSchemas<'a> {
 
 impl<'a> ExtensionSchemas<'a> {
     fn build_all_available() -> ExtensionSchemas<'static> {
-        // PANIC SAFETY: Builtin extensions define functions. Also tested by many different test cases.
+        // PANIC SAFETY: Builtin extension function definitions never conflict. Also tested by many different test cases.
         #[allow(clippy::expect_used)]
         ExtensionSchemas::specific_extension_schemas(&ALL_AVAILABLE_EXTENSION_SCHEMA_OBJECTS)
             .expect("Default extension schemas should never error on initialization")

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -16,14 +16,20 @@
 
 //! This module contains type information for all of the standard Cedar extensions.
 
+use std::collections::HashMap;
+
 use cedar_policy_core::{
     ast::{Name, RestrictedExpr, Value},
     evaluator::{EvaluationError, RestrictedEvaluator},
-    extensions::Extensions,
+    extensions::{util, Extensions},
 };
+use miette::Diagnostic;
 use smol_str::SmolStr;
+use thiserror::Error;
 
-use crate::extension_schema::ExtensionSchema;
+use crate::extension_schema::{ExtensionFunctionType, ExtensionSchema};
+
+use self::extension_initialization_errors::FuncMultiplyDefinedError;
 
 #[cfg(feature = "ipaddr")]
 pub mod ipaddr;
@@ -33,15 +39,67 @@ pub mod decimal;
 
 pub mod partial_evaluation;
 
-/// Get schemas for all the available extensions.
-pub fn all_available_extension_schemas() -> Vec<ExtensionSchema> {
-    vec![
+lazy_static::lazy_static! {
+    static ref ALL_AVAILABLE_EXTENSION_SCHEMA_OBJECTS : Vec<ExtensionSchema> = vec![
         #[cfg(feature = "ipaddr")]
         ipaddr::extension_schema(),
         #[cfg(feature = "decimal")]
         decimal::extension_schema(),
         partial_evaluation::extension_schema(),
-    ]
+    ];
+
+    static ref ALL_AVAILABLE_EXTENSION_SCHEMAS : ExtensionSchemas<'static> = ExtensionSchemas::build_all_available();
+}
+
+/// Aggregate structure containing function signature for multiple [`ExtensionSchema`].
+/// Ensures that no function name is defined mode than once.
+// Intentionally not deriving `Clone` to avoid clones of the `HashMap`. For the
+// moment, it's easy to pass this around by reference. We could make this
+// `Arc<..>` if that becomes annoying.
+#[derive(Debug)]
+pub struct ExtensionSchemas<'a> {
+    /// Types for all extension functions, collected from every extension used
+    /// to construct this object.  Built ahead of time so that we know during
+    /// extension function lookup that at most one extension functions exists
+    /// for a name.
+    function_types: HashMap<&'a Name, &'a ExtensionFunctionType>,
+}
+
+impl<'a> ExtensionSchemas<'a> {
+    fn build_all_available() -> ExtensionSchemas<'static> {
+        // PANIC SAFETY: Builtin extensions define functions. Also tested by many different test cases.
+        #[allow(clippy::expect_used)]
+        ExtensionSchemas::specific_extension_schemas(&ALL_AVAILABLE_EXTENSION_SCHEMA_OBJECTS)
+            .expect("Default extension schemas should never error on initialization")
+    }
+
+    /// Get schemas for all the available extensions.
+    pub fn all_available() -> &'static ExtensionSchemas<'static> {
+        &ALL_AVAILABLE_EXTENSION_SCHEMAS
+    }
+
+    /// Get a new `ExtensionsSchemas` with these specific extensions enabled. No
+    /// two extensions may declare functions with the same name.
+    pub fn specific_extension_schemas(
+        extension_schemas: &'a [ExtensionSchema],
+    ) -> Result<ExtensionSchemas<'a>, ExtensionInitializationError> {
+        // Build function type map, ensuring that no functions share the same name.
+        let function_types = util::collect_no_duplicates(
+            extension_schemas
+                .iter()
+                .flat_map(|ext| ext.function_types())
+                .map(|f| (f.name(), f)),
+        )
+        .map_err(|name| FuncMultiplyDefinedError { name: name.clone() })?;
+
+        Ok(Self { function_types })
+    }
+
+    /// Get the [`ExtensionFunctionType`] for a function with this [`Name`].
+    /// Return `None` if no such function exists.
+    pub fn func_type(&self, name: &Name) -> Option<&ExtensionFunctionType> {
+        self.function_types.get(name).copied()
+    }
 }
 
 /// Evaluates ane extension function on a single string literal argument. Used
@@ -55,4 +113,30 @@ fn eval_extension_constructor(
     let constructor_call_expr =
         RestrictedExpr::call_extension_fn(constructor_name, [RestrictedExpr::val(lit_str_arg)]);
     evaluator.interpret(constructor_call_expr.as_borrowed())
+}
+
+/// Errors occurring while initializing extensions. There are internal errors, so
+/// this enum should not become part of the public API unless we publicly expose
+/// user-defined extension function.
+#[derive(Diagnostic, Debug, Error)]
+pub enum ExtensionInitializationError {
+    /// An extension function was defined by multiple extensions.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    FuncMultiplyDefined(#[from] extension_initialization_errors::FuncMultiplyDefinedError),
+}
+
+/// Error subtypes for [`ExtensionInitializationError`]
+mod extension_initialization_errors {
+    use cedar_policy_core::ast::Name;
+    use miette::Diagnostic;
+    use thiserror::Error;
+
+    /// An extension function was defined by multiple extensions.
+    #[derive(Diagnostic, Debug, Error)]
+    #[error("extension function `{name}` is defined multiple times")]
+    pub struct FuncMultiplyDefinedError {
+        /// Name of the function that was multiply defined
+        pub(crate) name: Name,
+    }
 }

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -53,9 +53,9 @@ lazy_static::lazy_static! {
 
 /// Aggregate structure containing function signatures for multiple [`ExtensionSchema`].
 /// Ensures that no function name is defined mode than once.
-// Intentionally not deriving `Clone` to avoid clones of the `HashMap`. For the
-// moment, it's easy to pass this around by reference. We could make this
-// `Arc<..>` if that becomes annoying.
+/// Intentionally does not derive `Clone` to avoid clones of the `HashMap`. For the
+/// moment, it's easy to pass this around by reference. We could make this
+/// `Arc<..>` if that becomes annoying.
 #[derive(Debug)]
 pub struct ExtensionSchemas<'a> {
     /// Types for all extension functions, collected from every extension used

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -117,7 +117,7 @@ fn eval_extension_constructor(
 
 /// Errors occurring while initializing extensions. These are internal errors, so
 /// this enum should not become part of the public API unless we publicly expose
-/// user-defined extension function.
+/// user-defined extension functions.
 #[derive(Diagnostic, Debug, Error)]
 pub enum ExtensionInitializationError {
     /// An extension function was defined by multiple extensions.

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -51,7 +51,7 @@ lazy_static::lazy_static! {
     static ref ALL_AVAILABLE_EXTENSION_SCHEMAS : ExtensionSchemas<'static> = ExtensionSchemas::build_all_available();
 }
 
-/// Aggregate structure containing function signature for multiple [`ExtensionSchema`].
+/// Aggregate structure containing function signatures for multiple [`ExtensionSchema`].
 /// Ensures that no function name is defined mode than once.
 // Intentionally not deriving `Clone` to avoid clones of the `HashMap`. For the
 // moment, it's easy to pass this around by reference. We could make this
@@ -115,7 +115,7 @@ fn eval_extension_constructor(
     evaluator.interpret(constructor_call_expr.as_borrowed())
 }
 
-/// Errors occurring while initializing extensions. There are internal errors, so
+/// Errors occurring while initializing extensions. These are internal errors, so
 /// this enum should not become part of the public API unless we publicly expose
 /// user-defined extension function.
 #[derive(Diagnostic, Debug, Error)]

--- a/cedar-policy-validator/src/extensions/decimal.rs
+++ b/cedar-policy-validator/src/extensions/decimal.rs
@@ -84,22 +84,19 @@ pub fn extension_schema() -> ExtensionSchema {
     let decimal_ext = decimal::extension();
     let decimal_ty = Type::extension(decimal_ext.name().clone());
 
-    let fun_tys: Vec<ExtensionFunctionType> = decimal_ext
-        .funcs()
-        .map(|f| {
-            let return_type = get_return_type(f.name(), &decimal_ty);
-            debug_assert!(f
-                .return_type()
-                .map(|ty| return_type.is_consistent_with(ty))
-                .unwrap_or_else(|| return_type == Type::Never));
-            ExtensionFunctionType::new(
-                f.name().clone(),
-                get_argument_types(f.name(), &decimal_ty),
-                return_type,
-                get_argument_check(f.name()),
-            )
-        })
-        .collect();
+    let fun_tys = decimal_ext.funcs().map(|f| {
+        let return_type = get_return_type(f.name(), &decimal_ty);
+        debug_assert!(f
+            .return_type()
+            .map(|ty| return_type.is_consistent_with(ty))
+            .unwrap_or_else(|| return_type == Type::Never));
+        ExtensionFunctionType::new(
+            f.name().clone(),
+            get_argument_types(f.name(), &decimal_ty),
+            return_type,
+            get_argument_check(f.name()),
+        )
+    });
     ExtensionSchema::new(decimal_ext.name().clone(), fun_tys)
 }
 

--- a/cedar-policy-validator/src/extensions/ipaddr.rs
+++ b/cedar-policy-validator/src/extensions/ipaddr.rs
@@ -83,22 +83,19 @@ pub fn extension_schema() -> ExtensionSchema {
     let ipaddr_ext = ipaddr::extension();
     let ipaddr_ty = Type::extension(ipaddr_ext.name().clone());
 
-    let fun_tys: Vec<ExtensionFunctionType> = ipaddr_ext
-        .funcs()
-        .map(|f| {
-            let return_type = get_return_type(f.name(), &ipaddr_ty);
-            debug_assert!(f
-                .return_type()
-                .map(|ty| return_type.is_consistent_with(ty))
-                .unwrap_or_else(|| return_type == Type::Never));
-            ExtensionFunctionType::new(
-                f.name().clone(),
-                get_argument_types(f.name(), &ipaddr_ty),
-                return_type,
-                get_argument_check(f.name()),
-            )
-        })
-        .collect();
+    let fun_tys = ipaddr_ext.funcs().map(|f| {
+        let return_type = get_return_type(f.name(), &ipaddr_ty);
+        debug_assert!(f
+            .return_type()
+            .map(|ty| return_type.is_consistent_with(ty))
+            .unwrap_or_else(|| return_type == Type::Never));
+        ExtensionFunctionType::new(
+            f.name().clone(),
+            get_argument_types(f.name(), &ipaddr_ty),
+            return_type,
+            get_argument_check(f.name()),
+        )
+    });
     ExtensionSchema::new(ipaddr_ext.name().clone(), fun_tys)
 }
 

--- a/cedar-policy-validator/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-validator/src/extensions/partial_evaluation.rs
@@ -51,24 +51,21 @@ fn get_return_type(fname: &str) -> Type {
 pub fn extension_schema() -> ExtensionSchema {
     let pe_ext = partial_evaluation::extension();
 
-    let fun_tys: Vec<ExtensionFunctionType> = pe_ext
-        .funcs()
-        .map(|f| {
-            let fname = f.name();
-            let fstring = fname.to_string();
-            let return_type = get_return_type(&fstring);
-            debug_assert!(f
-                .return_type()
-                .map(|ty| return_type.is_consistent_with(ty))
-                .unwrap_or_else(|| return_type == Type::Never));
-            ExtensionFunctionType::new(
-                fname.clone(),
-                get_argument_types(&fstring),
-                return_type,
-                None,
-            )
-        })
-        .collect();
+    let fun_tys = pe_ext.funcs().map(|f| {
+        let fname = f.name();
+        let fstring = fname.to_string();
+        let return_type = get_return_type(&fstring);
+        debug_assert!(f
+            .return_type()
+            .map(|ty| return_type.is_consistent_with(ty))
+            .unwrap_or_else(|| return_type == Type::Never));
+        ExtensionFunctionType::new(
+            fname.clone(),
+            get_argument_types(&fstring),
+            return_type,
+            None,
+        )
+    });
     ExtensionSchema::new(pe_ext.name().clone(), fun_tys)
 }
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -381,10 +381,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     WrongNumberArguments(#[from] validation_errors::WrongNumberArguments),
-    /// Incorrect call style in an extension function application.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    WrongCallStyle(#[from] validation_errors::WrongCallStyle),
     /// Error returned by custom extension function argument validation
     #[diagnostic(transparent)]
     #[error(transparent)]
@@ -418,7 +414,6 @@ impl ValidationError {
             Self::UnsafeOptionalAttributeAccess(e) => e.policy_id(),
             Self::UndefinedFunction(e) => e.policy_id(),
             Self::WrongNumberArguments(e) => e.policy_id(),
-            Self::WrongCallStyle(e) => e.policy_id(),
             Self::FunctionArgumentValidation(e) => e.policy_id(),
             Self::EmptySetForbidden(e) => e.policy_id(),
             Self::NonLitExtConstructor(e) => e.policy_id(),
@@ -457,9 +452,6 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
             }
             cedar_policy_validator::ValidationError::WrongNumberArguments(e) => {
                 Self::WrongNumberArguments(e.into())
-            }
-            cedar_policy_validator::ValidationError::WrongCallStyle(e) => {
-                Self::WrongCallStyle(e.into())
             }
             cedar_policy_validator::ValidationError::FunctionArgumentValidation(e) => {
                 Self::FunctionArgumentValidation(e.into())

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -377,10 +377,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UndefinedFunction(#[from] validation_errors::UndefinedFunction),
-    /// Multiply defined extension function.
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    MultiplyDefinedFunction(#[from] validation_errors::MultiplyDefinedFunction),
     /// Incorrect number of arguments in an extension function application.
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -421,7 +417,6 @@ impl ValidationError {
             Self::UnsafeAttributeAccess(e) => e.policy_id(),
             Self::UnsafeOptionalAttributeAccess(e) => e.policy_id(),
             Self::UndefinedFunction(e) => e.policy_id(),
-            Self::MultiplyDefinedFunction(e) => e.policy_id(),
             Self::WrongNumberArguments(e) => e.policy_id(),
             Self::WrongCallStyle(e) => e.policy_id(),
             Self::FunctionArgumentValidation(e) => e.policy_id(),
@@ -459,9 +454,6 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
             }
             cedar_policy_validator::ValidationError::UndefinedFunction(e) => {
                 Self::UndefinedFunction(e.into())
-            }
-            cedar_policy_validator::ValidationError::MultiplyDefinedFunction(e) => {
-                Self::MultiplyDefinedFunction(e.into())
             }
             cedar_policy_validator::ValidationError::WrongNumberArguments(e) => {
                 Self::WrongNumberArguments(e.into())

--- a/cedar-policy/src/api/err/validation_errors.rs
+++ b/cedar-policy/src/api/err/validation_errors.rs
@@ -65,7 +65,6 @@ wrap_core_error!(UnsafeAttributeAccess);
 wrap_core_error!(UnsafeOptionalAttributeAccess);
 wrap_core_error!(UndefinedFunction);
 wrap_core_error!(WrongNumberArguments);
-wrap_core_error!(WrongCallStyle);
 wrap_core_error!(FunctionArgumentValidation);
 wrap_core_error!(HierarchyNotRespected);
 wrap_core_error!(EmptySetForbidden);

--- a/cedar-policy/src/api/err/validation_errors.rs
+++ b/cedar-policy/src/api/err/validation_errors.rs
@@ -64,7 +64,6 @@ wrap_core_error!(IncompatibleTypes);
 wrap_core_error!(UnsafeAttributeAccess);
 wrap_core_error!(UnsafeOptionalAttributeAccess);
 wrap_core_error!(UndefinedFunction);
-wrap_core_error!(MultiplyDefinedFunction);
 wrap_core_error!(WrongNumberArguments);
 wrap_core_error!(WrongCallStyle);
 wrap_core_error!(FunctionArgumentValidation);


### PR DESCRIPTION
## Description of changes

Fix #193.

* Remove `WrongCallStyle` error. The corresponding eval error was refactored out a while ago, but the validation error stuck around.
* Remove `MultiplyDefinedFunctionError`. Report this error only once when constructing extension schema.

## Issue #, if available


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

