### PR TITLE
Carry only `Loc` and not `Expr` on validator errors

### DIFF
--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -49,6 +49,7 @@ partial-validate = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [dev-dependencies]
+similar-asserts = "1.5.0"
 cool_asserts = "2.0"
 cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core", features = ["test-util"] }
 

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -22,7 +22,7 @@ use thiserror::Error;
 
 use std::collections::BTreeSet;
 
-use cedar_policy_core::ast::{EntityType, Expr, PolicyID};
+use cedar_policy_core::ast::{EntityType, PolicyID};
 use cedar_policy_core::parser::Loc;
 
 use crate::types::Type;
@@ -201,14 +201,14 @@ impl ValidationError {
 
     /// Construct a type error for when an unexpected type occurs in an expression.
     pub(crate) fn expected_one_of_types(
-        on_expr: Expr,
+        source_loc: Option<Loc>,
         policy_id: PolicyID,
         expected: impl IntoIterator<Item = Type>,
         actual: Type,
         help: Option<validation_errors::UnexpectedTypeHelp>,
     ) -> Self {
         validation_errors::UnexpectedType {
-            on_expr,
+            source_loc,
             policy_id,
             expected: expected.into_iter().collect::<BTreeSet<_>>(),
             actual,
@@ -220,14 +220,14 @@ impl ValidationError {
     /// Construct a type error for when a least upper bound cannot be found for
     /// a collection of types.
     pub(crate) fn incompatible_types(
-        on_expr: Expr,
+        source_loc: Option<Loc>,
         policy_id: PolicyID,
         types: impl IntoIterator<Item = Type>,
         hint: validation_errors::LubHelp,
         context: validation_errors::LubContext,
     ) -> Self {
         validation_errors::IncompatibleTypes {
-            on_expr,
+            source_loc,
             policy_id,
             types: types.into_iter().collect::<BTreeSet<_>>(),
             hint,
@@ -237,14 +237,14 @@ impl ValidationError {
     }
 
     pub(crate) fn unsafe_attribute_access(
-        on_expr: Expr,
+        source_loc: Option<Loc>,
         policy_id: PolicyID,
         attribute_access: validation_errors::AttributeAccess,
         suggestion: Option<String>,
         may_exist: bool,
     ) -> Self {
         validation_errors::UnsafeAttributeAccess {
-            on_expr,
+            source_loc,
             policy_id,
             attribute_access,
             suggestion,
@@ -254,21 +254,25 @@ impl ValidationError {
     }
 
     pub(crate) fn unsafe_optional_attribute_access(
-        on_expr: Expr,
+        source_loc: Option<Loc>,
         policy_id: PolicyID,
         attribute_access: validation_errors::AttributeAccess,
     ) -> Self {
         validation_errors::UnsafeOptionalAttributeAccess {
-            on_expr,
+            source_loc,
             policy_id,
             attribute_access,
         }
         .into()
     }
 
-    pub(crate) fn undefined_extension(on_expr: Expr, policy_id: PolicyID, name: String) -> Self {
+    pub(crate) fn undefined_extension(
+        source_loc: Option<Loc>,
+        policy_id: PolicyID,
+        name: String,
+    ) -> Self {
         validation_errors::UndefinedFunction {
-            on_expr,
+            source_loc,
             policy_id,
             name,
         }
@@ -276,14 +280,14 @@ impl ValidationError {
     }
 
     pub(crate) fn wrong_number_args(
-        on_expr: Expr,
+        source_loc: Option<Loc>,
 
         policy_id: PolicyID,
         expected: usize,
         actual: usize,
     ) -> Self {
         validation_errors::WrongNumberArguments {
-            on_expr,
+            source_loc,
             policy_id,
             expected,
             actual,
@@ -292,12 +296,12 @@ impl ValidationError {
     }
 
     pub(crate) fn function_argument_validation(
-        on_expr: Expr,
+        source_loc: Option<Loc>,
         policy_id: PolicyID,
         msg: String,
     ) -> Self {
         validation_errors::FunctionArgumentValidation {
-            on_expr,
+            source_loc,
             policy_id,
             msg,
         }

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -21,28 +21,17 @@ use thiserror::Error;
 
 use std::fmt::Display;
 
+use cedar_policy_core::impl_diagnostic_from_source_loc_field;
 use cedar_policy_core::parser::Loc;
-use cedar_policy_core::{impl_diagnostic_from_expr_field, impl_diagnostic_from_source_loc_field};
 
 use std::collections::BTreeSet;
 
-use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprKind, ExprShapeOnly, PolicyID, Var};
+use cedar_policy_core::ast::{EntityType, EntityUID, Expr, ExprKind, PolicyID, Var};
 use cedar_policy_core::parser::join_with_conjunction;
 
 use crate::types::{EntityLUB, EntityRecordKind, RequestEnv, Type};
 use itertools::Itertools;
 use smol_str::SmolStr;
-
-// Specialize `impl_diagnostics_from_expr_field` to `on_expr`.
-// Storing the `Expr` should not be required because we only
-// care about the source location emended in the expression.  To avoid cloning
-// expressions when constructing errors, we should remove `on_expr` and rewrite
-// the affected tests to only check for the correct `source_loc`.
-macro_rules! impl_diagnostic_from_on_expr_field {
-    () => {
-        impl_diagnostic_from_expr_field!(on_expr);
-    };
-}
 
 /// Structure containing details about an unrecognized entity type error.
 #[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
@@ -131,7 +120,7 @@ impl Diagnostic for InvalidActionApplication {
 }
 
 /// Structure containing details about an unexpected type error.
-#[derive(Error, Debug, Clone, Eq)]
+#[derive(Error, Debug, Clone, Hash, PartialEq, Eq)]
 #[error("for policy `{policy_id}`, unexpected type: expected {} but saw {}",
     match .expected.iter().next() {
         Some(single) if .expected.len() == 1 => format!("{}", single),
@@ -139,8 +128,8 @@ impl Diagnostic for InvalidActionApplication {
     },
     .actual)]
 pub struct UnexpectedType {
-    /// [`Expr`] which had the unexpected type
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// Type(s) which were expected
@@ -151,31 +140,8 @@ pub struct UnexpectedType {
     pub help: Option<UnexpectedTypeHelp>,
 }
 
-impl std::hash::Hash for UnexpectedType {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.expected.hash(state);
-        self.actual.hash(state);
-        self.help.hash(state);
-    }
-}
-
-// Manual `PartialEq` implementations are so that we do not need to have the
-// same source location for on errors when asserting error equality in tests
-// cases. We can remove this impls if we replace `on_expr` with a `Loc` and
-// update tests cases with the correct value for this loc check source
-// locations.
-impl PartialEq for UnexpectedType {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.expected == other.expected
-            && self.actual == other.actual
-            && self.help == other.help
-    }
-}
-
 impl Diagnostic for UnexpectedType {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.help.as_ref().map(|h| Box::new(h) as Box<dyn Display>)
@@ -217,10 +183,10 @@ pub enum UnexpectedTypeHelp {
 }
 
 /// Structure containing details about an incompatible type error.
-#[derive(Error, Debug, Clone, Eq)]
+#[derive(Error, Debug, Clone, Hash, PartialEq, Eq)]
 pub struct IncompatibleTypes {
-    /// [`Expr`] that had the incompatible type
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// Types which are incompatible
@@ -231,25 +197,8 @@ pub struct IncompatibleTypes {
     pub context: LubContext,
 }
 
-impl std::hash::Hash for IncompatibleTypes {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.types.hash(state);
-        self.hint.hash(state);
-        self.context.hash(state);
-    }
-}
-impl PartialEq for IncompatibleTypes {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.types == other.types
-            && self.hint == other.hint
-            && self.context == other.context
-    }
-}
-
 impl Diagnostic for IncompatibleTypes {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(format!(
@@ -308,11 +257,11 @@ pub enum LubContext {
 }
 
 /// Structure containing details about a missing attribute error.
-#[derive(Debug, Clone, Eq, Error)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Error)]
 #[error("for policy `{policy_id}`, attribute {attribute_access} not found")]
 pub struct UnsafeAttributeAccess {
-    /// [`Expr`] that was missing an attribute
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// More details about the missing-attribute error
@@ -324,25 +273,8 @@ pub struct UnsafeAttributeAccess {
     pub may_exist: bool,
 }
 
-impl std::hash::Hash for UnsafeAttributeAccess {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.attribute_access.hash(state);
-        self.suggestion.hash(state);
-        self.may_exist.hash(state);
-    }
-}
-impl PartialEq for UnsafeAttributeAccess {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.attribute_access == other.attribute_access
-            && self.suggestion == other.suggestion
-            && self.may_exist == other.may_exist
-    }
-}
-
 impl Diagnostic for UnsafeAttributeAccess {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         match (&self.suggestion, self.may_exist) {
@@ -355,32 +287,19 @@ impl Diagnostic for UnsafeAttributeAccess {
 }
 
 /// Structure containing details about an unsafe optional attribute error.
-#[derive(Error, Debug, Clone, Eq)]
+#[derive(Error, Debug, Clone, Hash, PartialEq, Eq)]
 #[error("unable to guarantee safety of access to optional attribute {attribute_access}")]
 pub struct UnsafeOptionalAttributeAccess {
-    /// [`Expr`] that contains unsafe optional attribute access
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// More details about the attribute-access error
     pub attribute_access: AttributeAccess,
 }
 
-impl std::hash::Hash for UnsafeOptionalAttributeAccess {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.attribute_access.hash(state);
-    }
-}
-impl PartialEq for UnsafeOptionalAttributeAccess {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.attribute_access == other.attribute_access
-    }
-}
-
 impl Diagnostic for UnsafeOptionalAttributeAccess {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(format!(
@@ -391,40 +310,27 @@ impl Diagnostic for UnsafeOptionalAttributeAccess {
 }
 
 /// Structure containing details about an undefined function error.
-#[derive(Error, Debug, Clone, Eq)]
+#[derive(Error, Debug, Clone, Hash, PartialEq, Eq)]
 #[error("for policy `{policy_id}`, undefined extension function: {name}")]
 pub struct UndefinedFunction {
-    /// [`Expr`] that contains a call to an undefined function
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// Name of the undefined function
     pub name: String,
 }
 
-impl std::hash::Hash for UndefinedFunction {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.name.hash(state);
-    }
-}
-impl PartialEq for UndefinedFunction {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.name == other.name
-    }
-}
-
 impl Diagnostic for UndefinedFunction {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 }
 
 /// Structure containing details about a wrong number of arguments error.
-#[derive(Error, Debug, Clone, Eq)]
+#[derive(Error, Debug, Clone, Hash, PartialEq, Eq)]
 #[error("for policy `{policy_id}`, wrong number of arguments in extension function application. Expected {expected}, got {actual}")]
 pub struct WrongNumberArguments {
-    /// [`Expr`] containing a call with the wrong number of arguments
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// Expected number of arguments
@@ -433,54 +339,24 @@ pub struct WrongNumberArguments {
     pub actual: usize,
 }
 
-impl std::hash::Hash for WrongNumberArguments {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.expected.hash(state);
-        self.actual.hash(state);
-    }
-}
-
-impl PartialEq for WrongNumberArguments {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.expected == other.expected
-            && self.actual == other.actual
-    }
-}
-
 impl Diagnostic for WrongNumberArguments {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 }
 
 /// Structure containing details about a function argument validation error.
-#[derive(Debug, Clone, Eq, Error)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Error)]
 #[error("for policy `{policy_id}`, error during extension function argument validation: {msg}")]
 pub struct FunctionArgumentValidation {
-    /// [`Expr`] containing the problematic function argument
-    pub on_expr: Expr,
+    /// Source location
+    pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// Error message
     pub msg: String,
 }
 
-impl std::hash::Hash for FunctionArgumentValidation {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        ExprShapeOnly::new(&self.on_expr).hash(state);
-        self.msg.hash(state);
-    }
-}
-
-impl PartialEq for FunctionArgumentValidation {
-    fn eq(&self, other: &Self) -> bool {
-        ExprShapeOnly::new(&self.on_expr) == ExprShapeOnly::new(&other.on_expr)
-            && self.msg == other.msg
-    }
-}
-
 impl Diagnostic for FunctionArgumentValidation {
-    impl_diagnostic_from_on_expr_field!();
+    impl_diagnostic_from_source_loc_field!();
 }
 
 /// Structure containing details about a hierarchy not respected error

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -217,7 +217,7 @@ mod test {
 
     use super::*;
     use cedar_policy_core::{
-        ast::{self, Expr, PolicyID},
+        ast::{self, PolicyID},
         parser::{self, Loc},
     };
 
@@ -491,7 +491,7 @@ mod test {
         assert_eq!(
             result.validation_errors().collect::<Vec<_>>(),
             vec![&ValidationError::expected_type(
-                Expr::val(true),
+                typecheck::test::test_utils::get_loc(src, "true"),
                 PolicyID::from_string("policy0"),
                 Type::primitive_long(),
                 Type::singleton_boolean(true),

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -18,7 +18,7 @@
 //! the `Typechecker` struct by calling the `typecheck_policy` method given a
 //! policy.
 
-mod test;
+pub(crate) mod test;
 
 mod typecheck_answer;
 pub(crate) use typecheck_answer::TypecheckAnswer;
@@ -818,7 +818,7 @@ impl<'a> Typechecker<'a> {
                                 } else {
                                     type_errors.push(
                                         ValidationError::unsafe_optional_attribute_access(
-                                            e.clone(),
+                                            e.source_loc().cloned(),
                                             self.policy_id.clone(),
                                             AttributeAccess::from_expr(
                                                 request_env,
@@ -848,7 +848,7 @@ impl<'a> Typechecker<'a> {
                                     all_attrs.iter().map(|s| s.as_str()).collect::<Vec<_>>();
                                 let suggestion = fuzzy_search(attr, &borrowed);
                                 type_errors.push(ValidationError::unsafe_attribute_access(
-                                    e.clone(),
+                                    e.source_loc().cloned(),
                                     self.policy_id.clone(),
                                     AttributeAccess::from_expr(
                                         request_env,
@@ -1444,7 +1444,7 @@ impl<'a> Typechecker<'a> {
                         Type::least_upper_bound(self.schema, lhs_ty, rhs_ty, self.mode)
                     {
                         type_errors.push(ValidationError::incompatible_types(
-                            unannotated_expr.clone(),
+                            unannotated_expr.source_loc().cloned(),
                             self.policy_id.clone(),
                             [lhs_ty.clone(), rhs_ty.clone()],
                             lub_hint,
@@ -2078,7 +2078,7 @@ impl<'a> Typechecker<'a> {
                     )
                 }) {
                     type_errors.push(ValidationError::expected_one_of_types(
-                        expr.clone(),
+                        expr.source_loc().cloned(),
                         self.policy_id.clone(),
                         expected.to_vec(),
                         actual_ty.clone(),
@@ -2155,7 +2155,7 @@ impl<'a> Typechecker<'a> {
                         // will be None, so this function will correctly report this
                         // as a failure.
                         type_errors.push(ValidationError::incompatible_types(
-                            expr.clone(),
+                            expr.source_loc().cloned(),
                             self.policy_id.clone(),
                             typechecked_types,
                             lub_hint,
@@ -2191,7 +2191,11 @@ impl<'a> Typechecker<'a> {
         e: &Expr,
     ) -> Result<&ExtensionFunctionType, ValidationError> {
         self.extensions.func_type(f).ok_or_else(|| {
-            ValidationError::undefined_extension(e.clone(), self.policy_id.clone(), f.to_string())
+            ValidationError::undefined_extension(
+                e.source_loc().cloned(),
+                self.policy_id.clone(),
+                f.to_string(),
+            )
         })
     }
 
@@ -2227,7 +2231,7 @@ impl<'a> Typechecker<'a> {
                 let mut failed = false;
                 if args.len() != arg_tys.len() {
                     type_errors.push(ValidationError::wrong_number_args(
-                        ext_expr.clone(),
+                        ext_expr.source_loc().cloned(),
                         self.policy_id.clone(),
                         arg_tys.len(),
                         args.len(),
@@ -2236,7 +2240,7 @@ impl<'a> Typechecker<'a> {
                 }
                 if let Err(msg) = efunc.check_arguments(args) {
                     type_errors.push(ValidationError::function_argument_validation(
-                        ext_expr.clone(),
+                        ext_expr.source_loc().cloned(),
                         self.policy_id.clone(),
                         msg,
                     ));

--- a/cedar-policy-validator/src/typecheck/test.rs
+++ b/cedar-policy-validator/src/typecheck/test.rs
@@ -20,7 +20,7 @@
 // PANIC SAFETY unit tests
 #![allow(clippy::indexing_slicing)]
 
-mod test_utils;
+pub(crate) mod test_utils;
 
 mod expr;
 mod extensions;

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -249,7 +249,7 @@ fn or_left_true_ignores_right() {
 
 #[test]
 fn or_right_true_fails_left() {
-    let src = "1 || false";
+    let src = "1 || true";
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),

--- a/cedar-policy-validator/src/typecheck/test/extensions.rs
+++ b/cedar-policy-validator/src/typecheck/test/extensions.rs
@@ -23,6 +23,7 @@ use std::str::FromStr;
 
 use super::test_utils::{
     assert_typecheck_fails_empty_schema, assert_typechecks_empty_schema, expr_id_placeholder,
+    get_loc,
 };
 
 #[test]
@@ -46,45 +47,49 @@ fn ip_extension_typecheck_fails() {
     use cedar_policy_core::ast::Name;
 
     let ipaddr_name = Name::parse_unqualified_name("ipaddr").expect("should be a valid identifier");
-    let expr = Expr::from_str("ip(3)").expect("parsing should succeed");
+    let src = "ip(3)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(ipaddr_name.clone()),
         vec![ValidationError::expected_type(
-            Expr::val(3),
+            get_loc(src, "3"),
             expr_id_placeholder(),
             Type::primitive_string(),
             Type::primitive_long(),
             None,
         )],
     );
-    let expr = Expr::from_str("ip(\"foo\")").expect("parsing should succeed");
+    let src = "ip(\"foo\")";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
-        expr.clone(),
+        expr,
         Type::extension(ipaddr_name.clone()),
         vec![ValidationError::function_argument_validation(
-            expr,
+            get_loc(src, src),
             expr_id_placeholder(),
             "Failed to parse as IP address: `\"foo\"`".into(),
         )],
     );
-    let expr = Expr::from_str("ip(\"127.0.0.1\").isIpv4(3)").expect("parsing should succeed");
+    let src = "ip(\"127.0.0.1\").isIpv4(3)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::primitive_boolean(),
         vec![ValidationError::wrong_number_args(
-            expr,
+            get_loc(src, src),
             expr_id_placeholder(),
             1,
             2,
         )],
     );
-    let expr = Expr::from_str("ip(\"127.0.0.1\").isInRange(3)").expect("parsing should succeed");
+    let src = "ip(\"127.0.0.1\").isInRange(3)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::primitive_boolean(),
         vec![ValidationError::expected_type(
-            Expr::val(3),
+            get_loc(src, "3"),
             expr_id_placeholder(),
             Type::extension(ipaddr_name),
             Type::primitive_long(),
@@ -123,45 +128,49 @@ fn decimal_extension_typecheck_fails() {
 
     let decimal_name =
         Name::parse_unqualified_name("decimal").expect("should be a valid identifier");
-    let expr = Expr::from_str("decimal(3)").expect("parsing should succeed");
+    let src = "decimal(3)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(decimal_name.clone()),
         vec![ValidationError::expected_type(
-            Expr::val(3),
+            get_loc(src, "3"),
             expr_id_placeholder(),
             Type::primitive_string(),
             Type::primitive_long(),
             None,
         )],
     );
-    let expr = Expr::from_str("decimal(\"foo\")").expect("parsing should succeed");
+    let src = "decimal(\"foo\")";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::extension(decimal_name.clone()),
         vec![ValidationError::function_argument_validation(
-            expr,
+            get_loc(src, src),
             expr_id_placeholder(),
             "Failed to parse as a decimal value: `\"foo\"`".into(),
         )],
     );
-    let expr = Expr::from_str("decimal(\"1.23\").lessThan(3, 4)").expect("parsing should succeed");
+    let src = "decimal(\"1.23\").lessThan(3, 4)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::primitive_boolean(),
         vec![ValidationError::wrong_number_args(
-            expr,
+            get_loc(src, src),
             expr_id_placeholder(),
             2,
             3,
         )],
     );
-    let expr = Expr::from_str("decimal(\"1.23\").lessThan(3)").expect("parsing should succeed");
+    let src = "decimal(\"1.23\").lessThan(4)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
     assert_typecheck_fails_empty_schema(
         expr,
         Type::primitive_boolean(),
         vec![ValidationError::expected_type(
-            Expr::val(3),
+            get_loc(src, "4"),
             expr_id_placeholder(),
             Type::extension(decimal_name),
             Type::primitive_long(),

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -36,7 +36,7 @@ use crate::{
     RawName, SchemaFragment, ValidationError, ValidationMode,
 };
 
-use super::test_utils::{assert_policy_typecheck_fails, expr_id_placeholder};
+use super::test_utils::{assert_policy_typecheck_fails, expr_id_placeholder, get_loc};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
@@ -96,19 +96,20 @@ fn assert_types_must_match(
     schema: SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
-    on_expr: Expr,
+    snippet: impl AsRef<str>,
     expected_type: Type,
     unequal_types: impl IntoIterator<Item = Type>,
     hint: LubHelp,
     context: LubContext,
 ) {
+    let loc = get_loc(e.source_loc().unwrap().src.clone(), snippet);
     assert_strict_type_error(
         schema,
         env,
         e,
         expected_type,
         ValidationError::incompatible_types(
-            on_expr,
+            loc,
             expr_id_placeholder(),
             unequal_types,
             hint,
@@ -226,7 +227,7 @@ fn eq_strict_types_mismatch() {
             s,
             &q,
             Expr::from_str(r#"1 == "foo""#).unwrap(),
-            Expr::from_str(r#"1 == "foo""#).unwrap(),
+            r#"1 == "foo""#,
             Type::primitive_boolean(),
             [Type::primitive_string(), Type::primitive_long()],
             LubHelp::None,
@@ -242,7 +243,7 @@ fn contains_strict_types_mismatch() {
             s,
             &q,
             Expr::from_str(r#"[1].contains("test")"#).unwrap(),
-            Expr::from_str(r#"[1].contains("test")"#).unwrap(),
+            r#"[1].contains("test")"#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
@@ -258,7 +259,7 @@ fn contains_any_strict_types_mismatch() {
             s,
             &q,
             Expr::from_str(r#"[principal].containsAny([1])"#).unwrap(),
-            Expr::from_str(r#"[principal].containsAny([1])"#).unwrap(),
+            r#"[principal].containsAny([1])"#,
             Type::primitive_boolean(),
             [
                 Type::set(Type::named_entity_reference_from_str("User")),
@@ -277,7 +278,7 @@ fn contains_all_strict_types_mismatch() {
             s,
             &q,
             Expr::from_str(r#"[principal].containsAll([1])"#).unwrap(),
-            Expr::from_str(r#"[principal].containsAll([1])"#).unwrap(),
+            r#"[principal].containsAll([1])"#,
             Type::primitive_boolean(),
             [
                 Type::set(Type::named_entity_reference_from_str("User")),
@@ -335,10 +336,7 @@ fn if_bool_strict_type_mismatch() {
                 r#"if principal == User::"alice" then User::"alice" else Photo::"pie.jpg""#,
             )
             .unwrap(),
-            Expr::from_str(
-                r#"if principal == User::"alice" then User::"alice" else Photo::"pie.jpg""#,
-            )
-            .unwrap(),
+            r#"if principal == User::"alice" then User::"alice" else Photo::"pie.jpg""#,
             Type::any_entity_reference(),
             [
                 Type::named_entity_reference_from_str("User"),
@@ -357,7 +355,7 @@ fn set_strict_types_mismatch() {
             s,
             &q,
             Expr::from_str(r#"[User::"alice", Photo::"foo.jpg"]"#).unwrap(),
-            Expr::from_str(r#"[User::"alice", Photo::"foo.jpg"]"#).unwrap(),
+            r#"[User::"alice", Photo::"foo.jpg"]"#,
             Type::set(Type::entity_lub(["User", "Photo"])),
             [
                 Type::named_entity_reference_from_str("User"),
@@ -432,7 +430,7 @@ fn entity_in_lub() {
                 r#"User::"alice" in (if 1 > 0 then User::"alice" else Photo::"pie.jpg")"#,
             )
             .unwrap(),
-            Expr::from_str(r#"if 1 > 0 then User::"alice" else Photo::"pie.jpg""#).unwrap(),
+            r#"if 1 > 0 then User::"alice" else Photo::"pie.jpg""#,
             Type::primitive_boolean(),
             [
                 Type::named_entity_reference_from_str("User"),
@@ -461,7 +459,7 @@ fn test_and() {
             s.clone(),
             &q,
             Expr::from_str(r#"(1 == (2 > 0)) && true"#).unwrap(),
-            Expr::from_str(r#"1 == (2 > 0)"#).unwrap(),
+            r#"1 == (2 > 0)"#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
             LubHelp::None,
@@ -471,7 +469,7 @@ fn test_and() {
             s,
             &q,
             Expr::from_str(r#"true && (1 == (2 > 0))"#).unwrap(),
-            Expr::from_str(r#"1 == (2 > 0)"#).unwrap(),
+            r#"1 == (2 > 0)"#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_boolean()],
             LubHelp::None,
@@ -493,7 +491,7 @@ fn test_or() {
             s.clone(),
             &q,
             Expr::from_str(r#"(1 == (2 > 0)) || false"#).unwrap(),
-            Expr::from_str(r#"1 == (2 > 0)"#).unwrap(),
+            r#"1 == (2 > 0)"#,
             Type::primitive_boolean(),
             [Type::primitive_boolean(), Type::primitive_long()],
             LubHelp::None,
@@ -503,7 +501,7 @@ fn test_or() {
             s,
             &q,
             Expr::from_str(r#"false || (1 == (2 > 0))"#).unwrap(),
-            Expr::from_str(r#"1 == (2 > 0)"#).unwrap(),
+            r#"1 == (2 > 0)"#,
             Type::primitive_boolean(),
             [Type::primitive_boolean(), Type::primitive_long()],
             LubHelp::None,
@@ -525,7 +523,7 @@ fn test_unary() {
             s,
             &q,
             Expr::from_str(r#"!(1 == "foo")"#).unwrap(),
-            Expr::from_str(r#"1 == "foo""#).unwrap(),
+            r#"1 == "foo""#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
@@ -547,7 +545,7 @@ fn test_mul() {
             s,
             &q,
             Expr::from_str(r#"2*(if 1 == false then 3 else 4)"#).unwrap(),
-            Expr::from_str(r#"1 == false"#).unwrap(),
+            "1 == false",
             Type::primitive_long(),
             [Type::primitive_long(), Type::singleton_boolean(false)],
             LubHelp::None,
@@ -569,7 +567,7 @@ fn test_like() {
             s,
             &q,
             Expr::from_str(r#"(if 1 == false then "foo" else "bar") like "bar""#).unwrap(),
-            Expr::from_str(r#"1 == false"#).unwrap(),
+            r#"1 == false"#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::singleton_boolean(false)],
             LubHelp::None,
@@ -591,7 +589,7 @@ fn test_get_attr() {
             s,
             &q,
             Expr::from_str(r#"{name: 1 == "foo"}.name"#).unwrap(),
-            Expr::from_str(r#"1 == "foo""#).unwrap(),
+            r#"1 == "foo""#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
@@ -619,7 +617,7 @@ fn test_has_attr() {
             s,
             &q,
             Expr::from_str(r#"(if 1 == 2 then {name: 1} else {bar: 2}) has bar"#).unwrap(),
-            Expr::from_str("if 1 == 2 then {name: 1} else {bar: 2}").unwrap(),
+            "if 1 == 2 then {name: 1} else {bar: 2}",
             Type::primitive_boolean(),
             [
                 Type::closed_record_with_required_attributes([(
@@ -651,7 +649,7 @@ fn test_extension() {
             s,
             &q,
             Expr::from_str(r#"ip("192.168.1.0/8").isInRange(if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
-            Expr::from_str(r#"1 == false"#).unwrap(),
+            r#"1 == false"#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::singleton_boolean(false)],
             LubHelp::None,
@@ -717,16 +715,14 @@ fn qualified_record_attr() {
         Extensions::all_available(),
     )
     .unwrap();
-    let p = parse_policy_template(
-        None,
-        "permit(principal, action, resource) when { context == {num_of_things: 1}};",
-    )
-    .unwrap();
+
+    let src = "permit(principal, action, resource) when { context == {num_of_things: 1}};";
+    let p = parse_policy_template(None, src).unwrap();
     assert_policy_typecheck_fails(
         schema,
         p.clone(),
         vec![ValidationError::incompatible_types(
-            "context == {num_of_things: 1}".parse().unwrap(),
+            get_loc(src, "context == {num_of_things: 1}"),
             PolicyID::from_string("policy0"),
             [
                 Type::record_with_attributes(


### PR DESCRIPTION
## Description of changes

Cleanup validation errors a bit by always carrying `Loc` on validation errors instead of sometimes storing an `Expr`. A lot of lines touched but mostly trivial test updates. I didn't go all the way to rewriting these tests to using `ExpectedErrorMessage` since that's a much larger test update for marginal benefit.

Shouldn't conflict with type resolution change, but this can wait a little bit in the interest of merging that.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

