### PR TITLE
Always pass `Extensions` struct as a reference

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -111,7 +111,7 @@ impl Request {
         resource: (EntityUID, Option<Loc>),
         context: Context,
         schema: Option<&S>,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<Self, S::Error> {
         let req = Self {
             principal: EntityUIDEntry::known(principal.0, principal.1),
@@ -136,7 +136,7 @@ impl Request {
         resource: EntityUIDEntry,
         context: Option<Context>,
         schema: Option<&S>,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<Self, S::Error> {
         let req = Self {
             principal,
@@ -267,11 +267,11 @@ impl Context {
     /// evaluating the `RestrictedExpr`.
     pub fn from_expr(
         expr: BorrowedRestrictedExpr<'_>,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<Self, ContextCreationError> {
         match expr.expr_kind() {
             ExprKind::Record { .. } => {
-                let evaluator = RestrictedEvaluator::new(&extensions);
+                let evaluator = RestrictedEvaluator::new(extensions);
                 let pval = evaluator.partial_interpret(expr)?;
                 // The invariant on `from_restricted_partial_val_unchecked`
                 // is satisfied because `expr` is a restricted expression,
@@ -296,7 +296,7 @@ impl Context {
     /// evaluating the `RestrictedExpr`.
     pub fn from_pairs(
         pairs: impl IntoIterator<Item = (SmolStr, RestrictedExpr)>,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<Self, ContextCreationError> {
         match RestrictedExpr::record(pairs) {
             Ok(record) => Self::from_expr(record.as_borrowed(), extensions),
@@ -377,7 +377,7 @@ impl Context {
                 let expr = BorrowedRestrictedExpr::new_unchecked(&expr);
 
                 let extns = Extensions::all_available();
-                let eval = RestrictedEvaluator::new(&extns);
+                let eval = RestrictedEvaluator::new(extns);
                 let partial_value = eval.partial_interpret(expr)?;
 
                 // The invariant on `from_restricted_partial_val_unchecked`
@@ -541,7 +541,7 @@ pub trait RequestSchema {
     fn validate_request(
         &self,
         request: &Request,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<(), Self::Error>;
 }
 
@@ -553,7 +553,7 @@ impl RequestSchema for RequestSchemaAllPass {
     fn validate_request(
         &self,
         _request: &Request,
-        _extensions: Extensions<'_>,
+        _extensions: &Extensions<'_>,
     ) -> Result<(), Self::Error> {
         Ok(())
     }

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -42,7 +42,7 @@ pub use partial_response::PartialResponse;
 /// Authorizer
 pub struct Authorizer {
     /// Cedar `Extension`s which will be used during requests to this `Authorizer`
-    extensions: Extensions<'static>,
+    extensions: &'static Extensions<'static>,
     /// Error-handling behavior of this `Authorizer`
     error_handling: ErrorHandling,
 }
@@ -68,7 +68,7 @@ impl Authorizer {
     /// Create a new `Authorizer`
     pub fn new() -> Self {
         Self {
-            extensions: Extensions::all_available(), // set at compile time
+            extensions: crate::extensions::Extensions::all_available(), // set at compile time
             error_handling: Default::default(),
         }
     }
@@ -90,7 +90,7 @@ impl Authorizer {
         pset: &PolicySet,
         entities: &Entities,
     ) -> PartialResponse {
-        let eval = Evaluator::new(q.clone(), entities, &self.extensions);
+        let eval = Evaluator::new(q.clone(), entities, self.extensions);
         let mut true_permits = vec![];
         let mut true_forbids = vec![];
         let mut false_permits = vec![];

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -68,7 +68,7 @@ impl Authorizer {
     /// Create a new `Authorizer`
     pub fn new() -> Self {
         Self {
-            extensions: crate::extensions::Extensions::all_available(), // set at compile time
+            extensions: Extensions::all_available(), // set at compile time
             error_handling: Default::default(),
         }
     }

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -129,7 +129,7 @@ impl Entities {
         collection: impl IntoIterator<Item = Entity>,
         schema: Option<&impl Schema>,
         tc_computation: TCComputation,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<Self> {
         let checker = schema.map(|schema| EntitySchemaConformanceChecker::new(schema, extensions));
         for entity in collection.into_iter() {
@@ -166,7 +166,7 @@ impl Entities {
         entities: impl IntoIterator<Item = Entity>,
         schema: Option<&impl Schema>,
         tc_computation: TCComputation,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<Self> {
         let mut entity_map = create_entity_map(entities.into_iter())?;
         if let Some(schema) = schema {
@@ -174,7 +174,7 @@ impl Entities {
             // We do this before adding the actions, because we trust the
             // actions were already validated as part of constructing the
             // `Schema`
-            let checker = EntitySchemaConformanceChecker::new(schema, extensions.clone());
+            let checker = EntitySchemaConformanceChecker::new(schema, extensions);
             for entity in entity_map.values() {
                 if !entity.uid().entity_type().is_action() {
                     checker.validate_entity(entity)?;
@@ -196,7 +196,7 @@ impl Entities {
         // schema already satisfies TC, and action and non-action entities
         // can never be in the same hierarchy when using schema-based parsing.
         if let Some(schema) = schema {
-            let checker = EntitySchemaConformanceChecker::new(schema, extensions.clone());
+            let checker = EntitySchemaConformanceChecker::new(schema, extensions);
             for entity in entity_map.values() {
                 if entity.uid().entity_type().is_action() {
                     checker.validate_entity(entity)?;
@@ -1695,7 +1695,7 @@ mod json_parsing_tests {
             ]
             .into_iter()
             .collect(),
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
         .unwrap();
         let entities = Entities::from_entities(
@@ -1729,7 +1729,7 @@ mod json_parsing_tests {
             ]
             .into_iter()
             .collect(),
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
         .unwrap();
         let entities = Entities::from_entities(

--- a/cedar-policy-core/src/entities/json/context.rs
+++ b/cedar-policy-core/src/entities/json/context.rs
@@ -54,7 +54,7 @@ pub struct ContextJsonParser<'e, 's, S: ContextSchema = NullContextSchema> {
     schema: Option<&'s S>,
 
     /// Extensions which are active for the JSON parsing.
-    extensions: Extensions<'e>,
+    extensions: &'e Extensions<'e>,
 }
 
 impl<'e, 's, S: ContextSchema> ContextJsonParser<'e, 's, S> {
@@ -66,7 +66,7 @@ impl<'e, 's, S: ContextSchema> ContextJsonParser<'e, 's, S> {
     /// `schema` -- for instance, it will error if attributes have the wrong
     /// types (e.g., string instead of integer), or if required attributes are
     /// missing or superfluous attributes are provided.
-    pub fn new(schema: Option<&'s S>, extensions: Extensions<'e>) -> Self {
+    pub fn new(schema: Option<&'s S>, extensions: &'e Extensions<'e>) -> Self {
         Self { schema, extensions }
     }
 
@@ -82,12 +82,12 @@ impl<'e, 's, S: ContextSchema> ContextJsonParser<'e, 's, S> {
         &self,
         json: serde_json::Value,
     ) -> Result<Context, ContextJsonDeserializationError> {
-        let vparser = ValueParser::new(self.extensions.clone());
+        let vparser = ValueParser::new(self.extensions);
         let expected_ty = self.schema.map(|s| s.context_type());
         let rexpr = vparser.val_into_restricted_expr(json, expected_ty.as_ref(), || {
             JsonDeserializationErrorContext::Context
         })?;
-        Context::from_expr(rexpr.as_borrowed(), self.extensions.clone())
+        Context::from_expr(rexpr.as_borrowed(), self.extensions)
             .map_err(ContextJsonDeserializationError::ContextCreation)
     }
 

--- a/cedar-policy-core/src/entities/json/schema_types.rs
+++ b/cedar-policy-core/src/entities/json/schema_types.rs
@@ -518,12 +518,12 @@ fn schematype_of_set_elements<E: From<HeterogeneousSetError>>(
 /// See notes on [`schematype_of_value()`].
 pub fn schematype_of_partialvalue(
     pvalue: &PartialValue,
-    extensions: Extensions<'_>,
+    extensions: &Extensions<'_>,
 ) -> Result<SchemaType, GetSchemaTypeError> {
     match pvalue {
         PartialValue::Value(v) => schematype_of_value(v).map_err(Into::into),
         PartialValue::Residual(expr) => match BorrowedRestrictedExpr::new(expr) {
-            Ok(expr) => schematype_of_restricted_expr(expr, &extensions),
+            Ok(expr) => schematype_of_restricted_expr(expr, extensions),
             Err(_) => {
                 // the PartialValue is a residual that isn't a valid restricted expression.
                 // For now we don't try to determine the type in this case.

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -431,12 +431,12 @@ impl FnAndArg {
 #[derive(Debug, Clone)]
 pub struct ValueParser<'e> {
     /// Extensions which are active for the JSON parsing.
-    extensions: Extensions<'e>,
+    extensions: &'e Extensions<'e>,
 }
 
 impl<'e> ValueParser<'e> {
     /// Create a new `ValueParser`.
-    pub fn new(extensions: Extensions<'e>) -> Self {
+    pub fn new(extensions: &'e Extensions<'e>) -> Self {
         Self { extensions }
     }
 
@@ -506,7 +506,7 @@ impl<'e> ValueParser<'e> {
                         expected: Box::new(expected_ty.clone()),
                         actual_ty: match schematype_of_restricted_expr(
                             actual_val.as_borrowed(),
-                            &self.extensions,
+                            self.extensions,
                         ) {
                             Ok(actual_ty) => Some(Box::new(actual_ty)),
                             Err(_) => None, // just don't report the type if there was an error computing it
@@ -581,7 +581,7 @@ impl<'e> ValueParser<'e> {
                         expected: Box::new(expected_ty.clone()),
                         actual_ty: match schematype_of_restricted_expr(
                             actual_val.as_borrowed(),
-                            &self.extensions,
+                            self.extensions,
                         ) {
                             Ok(actual_ty) => Some(Box::new(actual_ty)),
                             Err(_) => None, // just don't report the type if there was an error computing it
@@ -638,7 +638,7 @@ impl<'e> ValueParser<'e> {
             }
             ExtnValueJson::ImplicitConstructor(val) => {
                 let arg = val.into_expr(ctx.clone())?;
-                let argty = schematype_of_restricted_expr(arg.as_borrowed(), &self.extensions)
+                let argty = schematype_of_restricted_expr(arg.as_borrowed(), self.extensions)
                     .map_err(|e| match e {
                         GetSchemaTypeError::HeterogeneousSet(err) => match ctx() {
                             JsonDeserializationErrorContext::EntityAttribute { uid, attr } => {

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1030,7 +1030,7 @@ pub mod test {
         let second = EntityUID::with_eid("joseph");
         let missing = EntityUID::with_eid("non-present");
         let parent = EntityUID::with_eid("parent");
-        let eval = Evaluator::new(q, &entities, &exts);
+        let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let e = Expr::binary_app(
             BinaryOp::In,
@@ -1079,7 +1079,7 @@ pub mod test {
         let child = EntityUID::with_eid("child");
         let missing = EntityUID::with_eid("non-present");
         let parent = EntityUID::with_eid("parent");
-        let eval = Evaluator::new(q, &entities, &exts);
+        let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let e = Expr::binary_app(BinaryOp::In, Expr::val(child), Expr::val(parent.clone()));
         let r = eval.partial_eval_expr(&e).unwrap();
@@ -1111,7 +1111,7 @@ pub mod test {
         let entities = rich_entities().partial();
         let has_attr = EntityUID::with_eid("entity_with_attrs");
         let missing = EntityUID::with_eid("missing");
-        let eval = Evaluator::new(q, &entities, &exts);
+        let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let e = Expr::has_attr(Expr::val(has_attr), "spoon".into());
         let r = eval.partial_eval_expr(&e).unwrap();
@@ -1138,7 +1138,7 @@ pub mod test {
         let entities = rich_entities().partial();
         let has_attr = EntityUID::with_eid("entity_with_attrs");
         let missing = EntityUID::with_eid("missing");
-        let eval = Evaluator::new(q, &entities, &exts);
+        let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let e = Expr::get_attr(Expr::val(has_attr), "spoon".into());
         let r = eval.partial_eval_expr(&e).unwrap();

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1026,7 +1026,6 @@ pub mod test {
     fn partial_entity_stores_in_set() {
         let q = basic_request();
         let entities = rich_entities().partial();
-        let exts = Extensions::none();
         let child = EntityUID::with_eid("child");
         let second = EntityUID::with_eid("joseph");
         let missing = EntityUID::with_eid("non-present");
@@ -1077,7 +1076,6 @@ pub mod test {
     fn partial_entity_stores_in() {
         let q = basic_request();
         let entities = rich_entities().partial();
-        let exts = Extensions::none();
         let child = EntityUID::with_eid("child");
         let missing = EntityUID::with_eid("non-present");
         let parent = EntityUID::with_eid("parent");
@@ -1111,7 +1109,6 @@ pub mod test {
     fn partial_entity_stores_hasattr() {
         let q = basic_request();
         let entities = rich_entities().partial();
-        let exts = Extensions::none();
         let has_attr = EntityUID::with_eid("entity_with_attrs");
         let missing = EntityUID::with_eid("missing");
         let eval = Evaluator::new(q, &entities, &exts);
@@ -1139,7 +1136,6 @@ pub mod test {
     fn partial_entity_stores_getattr() {
         let q = basic_request();
         let entities = rich_entities().partial();
-        let exts = Extensions::none();
         let has_attr = EntityUID::with_eid("entity_with_attrs");
         let missing = EntityUID::with_eid("missing");
         let eval = Evaluator::new(q, &entities, &exts);
@@ -1166,8 +1162,7 @@ pub mod test {
     fn interpret_primitives() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // The below `assert_eq`s don't actually check the value's source location,
         // because `PartialEq` and `Eq` for `Value` don't compare source locations,
         // but checking the value's source location would not be an interesting
@@ -1221,8 +1216,7 @@ pub mod test {
     fn interpret_entities() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // The below `assert_eq`s don't actually check the value's source location,
         // because `PartialEq` and `Eq` for `Value` don't compare source locations,
         // but checking the value's source location would not be an interesting
@@ -1252,8 +1246,7 @@ pub mod test {
     fn interpret_builtin_vars() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         assert_eq!(
             eval.interpret_inline_policy(&Expr::var(Var::Principal)),
             Ok(Value::from(EntityUID::with_eid("test_principal")))
@@ -1272,8 +1265,7 @@ pub mod test {
     fn interpret_entity_attrs() {
         let request = basic_request();
         let entities = rich_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // has_attr on an entity with no attrs
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(
@@ -1358,8 +1350,7 @@ pub mod test {
     fn interpret_ternaries() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // if true then 3 else 8
         assert_eq!(
             eval.interpret_inline_policy(&Expr::ite(Expr::val(true), Expr::val(3), Expr::val(8))),
@@ -1540,8 +1531,7 @@ pub mod test {
     fn interpret_sets() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // The below `assert_eq`s don't actually check the value's source location,
         // because `PartialEq` and `Eq` for `Value` don't compare source locations,
         // but checking the value's source location would not be an interesting
@@ -1760,8 +1750,7 @@ pub mod test {
     fn interpret_records() {
         let request = basic_request();
         let entities = rich_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // {"key": 3}["key"] or {"key": 3}.key
         let string_key = Expr::record(vec![("key".into(), Expr::val(3))]).unwrap();
         assert_eq!(
@@ -2085,7 +2074,6 @@ pub mod test {
         let attrs = (1..=7)
             .map(|id| (format!("{id}").into(), RestrictedExpr::val(true)))
             .collect::<HashMap<SmolStr, _>>();
-        let exts = Extensions::none();
         let entity = Entity::new(
             r#"Foo::"bar""#.parse().unwrap(),
             attrs.clone(),
@@ -2101,7 +2089,7 @@ pub mod test {
             Extensions::none(),
         )
         .unwrap();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         let result = eval.interpret_inline_policy(&expr).unwrap_err();
         // These are arbitrarily determined by BTreeMap ordering, but are deterministic
         let expected_keys = ["1", "2", "3", "4", "5"]
@@ -2126,8 +2114,7 @@ pub mod test {
         );
         let request = basic_request();
         let entities = rich_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         let result = eval.interpret_inline_policy(&expr).unwrap_err();
         let first_five = (1..=5)
             .map(|id| format!("{id}").into())
@@ -2141,8 +2128,7 @@ pub mod test {
     fn interpret_nots() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // not(true)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::not(Expr::val(true))),
@@ -2202,8 +2188,7 @@ pub mod test {
     fn interpret_negs() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // neg(101)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::neg(Expr::val(101))),
@@ -2271,8 +2256,7 @@ pub mod test {
     fn interpret_eqs() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // eq(33, 33)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_eq(Expr::val(33), Expr::val(33))),
@@ -2502,8 +2486,7 @@ pub mod test {
     fn interpret_compares() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // 3 < 303
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(3), Expr::val(303))),
@@ -2831,8 +2814,7 @@ pub mod test {
         // fix for incorrect evaluation order in `>` and `>=`.
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
 
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(
@@ -2887,8 +2869,7 @@ pub mod test {
     fn interpret_arithmetic() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // 11 + 22
         assert_eq!(
             eval.interpret_inline_policy(&Expr::add(Expr::val(11), Expr::val(22))),
@@ -2990,8 +2971,7 @@ pub mod test {
     fn interpret_set_and_map_membership() {
         let request = basic_request();
         let entities = rich_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
 
         // [2, 3, 4] contains 2
         assert_eq!(
@@ -3167,8 +3147,7 @@ pub mod test {
     fn interpret_hierarchy_membership() {
         let request = basic_request();
         let entities = rich_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // A in B, where A and B are unrelated (but same type)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_in(
@@ -3491,8 +3470,7 @@ pub mod test {
             Extensions::all_available(),
         )
         .expect("failed to create basic entities");
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_in(
                 Expr::val(EntityUID::with_eid("Alice")),
@@ -3533,8 +3511,7 @@ pub mod test {
     fn interpret_string_like() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // "eggs" vs "ham"
         assert_eq!(
             eval.interpret_inline_policy(
@@ -3711,8 +3688,7 @@ pub mod test {
     fn interpret_string_like_escaped_chars() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         // testing like wth escaped characters -- similar tests are also in parser/convert.rs
         assert_eq!(
             eval.interpret_inline_policy(
@@ -3751,8 +3727,7 @@ pub mod test {
     fn interpret_is() {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         assert_eq!(
             eval.interpret_inline_policy(
                 &parse_expr(&format!(
@@ -3811,8 +3786,7 @@ pub mod test {
     fn interpret_contains_all_and_contains_any() -> Result<()> {
         let request = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, exts);
+        let eval = Evaluator::new(request, &entities, Extensions::none());
         //  [1, -22, 34] containsall of [1, -22]?
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains_all(
@@ -4077,12 +4051,10 @@ pub mod test {
     fn eval_and_or() -> Result<()> {
         use crate::parser;
         let request = basic_request();
-        let exts = Extensions::none();
         let eparser: EntityJsonParser<'_, '_> =
-            EntityJsonParser::new(None, exts, TCComputation::ComputeNow);
+            EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
-        let exts = Extensions::none();
-        let evaluator = Evaluator::new(request, &entities, exts);
+        let evaluator = Evaluator::new(request, &entities, Extensions::none());
 
         // short-circuit allows these to pass without error
         let raw_expr = "(false && 3)";
@@ -4194,8 +4166,7 @@ pub mod test {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
-        let exts = Extensions::none();
-        let evaluator = Evaluator::new(request, &entities, exts);
+        let evaluator = Evaluator::new(request, &entities, Extensions::none());
         let e = Expr::slot(SlotId::principal());
 
         let slots = HashMap::new();
@@ -4247,8 +4218,7 @@ pub mod test {
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
-        let exts = Extensions::none();
-        let eval = Evaluator::new(q, &entities, exts);
+        let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let ir = pset.policies().next().expect("No linked policies");
         assert_matches!(eval.partial_evaluate(ir), Ok(Either::Left(b)) => {
@@ -4401,8 +4371,7 @@ pub mod test {
         )
         .unwrap();
         let es = Entities::new();
-        let exts = Extensions::none();
-        let e = Evaluator::new(q, &es, exts);
+        let e = Evaluator::new(q, &es, Extensions::none());
         match e.partial_evaluate(p).expect("eval error") {
             Either::Left(_) => panic!("Evalled to a value"),
             Either::Right(expr) => {
@@ -4436,8 +4405,7 @@ pub mod test {
         )
         .unwrap();
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(q, &es, exts);
+        let eval = Evaluator::new(q, &es, Extensions::none());
         eval.partial_eval_expr(&e).unwrap()
     }
 
@@ -4592,8 +4560,7 @@ pub mod test {
         )
         .unwrap();
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(q, &es, exts);
+        let eval = Evaluator::new(q, &es, Extensions::none());
         let e = Expr::get_attr(Expr::var(Var::Context), "foo".into());
         assert_matches!(eval.partial_eval_expr(&e), Err(_))
     }
@@ -4637,8 +4604,7 @@ pub mod test {
             Extensions::none(),
         )
         .unwrap();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(q, &es, exts);
+        let eval = Evaluator::new(q, &es, Extensions::none());
 
         let result = eval.partial_evaluate(policy).expect("Eval error");
         match result {
@@ -4675,8 +4641,7 @@ pub mod test {
 
         let es = Entities::new();
 
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4704,7 +4669,6 @@ pub mod test {
 
         let es = Entities::new();
 
-        let exts = Extensions::none();
         let q = Request::new(
             (EntityUID::with_eid("p"), None),
             (EntityUID::with_eid("a"), None),
@@ -4725,7 +4689,7 @@ pub mod test {
             Extensions::none(),
         )
         .unwrap();
-        let eval = Evaluator::new(q, &es, exts);
+        let eval = Evaluator::new(q, &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4753,8 +4717,7 @@ pub mod test {
 
         let es = Entities::new();
 
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_eq!(
             eval.partial_interpret(&e, &HashMap::new()).unwrap(),
@@ -4775,8 +4738,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4792,8 +4754,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4815,8 +4776,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -4834,8 +4794,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Ok(_));
     }
@@ -4850,8 +4809,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4867,8 +4825,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4890,8 +4847,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -4909,8 +4865,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Ok(_));
     }
@@ -4923,8 +4878,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&a, &HashMap::new()), Err(_));
     }
@@ -4937,8 +4891,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&a, &HashMap::new()).unwrap();
 
@@ -4959,8 +4912,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&a, &HashMap::new()), Err(_));
     }
@@ -4977,8 +4929,7 @@ pub mod test {
         );
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&a, &HashMap::new()).unwrap();
 
@@ -4995,8 +4946,7 @@ pub mod test {
         let e = Expr::ite(guard.clone(), cons, alt);
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5013,8 +4963,7 @@ pub mod test {
         let e = Expr::ite(guard.clone(), cons.clone(), alt);
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5031,8 +4980,7 @@ pub mod test {
         let e = Expr::ite(guard.clone(), cons, alt.clone());
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5048,8 +4996,7 @@ pub mod test {
         let e = Expr::ite(guard.clone(), cons.clone(), alt.clone());
 
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_eq!(
             eval.partial_interpret(&e, &HashMap::new()).unwrap(),
@@ -5064,8 +5011,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -5077,8 +5023,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -5090,8 +5035,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5109,8 +5053,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(r, PartialValue::Value(Value::from(false)));
@@ -5123,8 +5066,7 @@ pub mod test {
         let rhs = Expr::binary_app(BinaryOp::Eq, Expr::val(2), Expr::val(2));
         let e = Expr::and(lhs.clone(), rhs.clone());
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::and(lhs, rhs);
@@ -5137,8 +5079,7 @@ pub mod test {
         let rhs = Expr::binary_app(BinaryOp::Eq, Expr::val(2), Expr::val(1));
         let e = Expr::and(lhs.clone(), rhs.clone());
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::and(lhs, rhs);
@@ -5152,8 +5093,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5171,8 +5111,7 @@ pub mod test {
         let rhs = Expr::binary_app(BinaryOp::Add, Expr::val(1), Expr::val("oops"));
         let e = Expr::and(lhs, rhs.clone());
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5190,8 +5129,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(r, PartialValue::Value(Value::from(true)));
@@ -5204,8 +5142,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::or(
@@ -5222,8 +5159,7 @@ pub mod test {
         let rhs = Expr::binary_app(BinaryOp::Eq, Expr::val(2), Expr::val(2));
         let e = Expr::or(lhs.clone(), rhs.clone());
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::or(lhs, rhs);
@@ -5236,8 +5172,7 @@ pub mod test {
         let rhs = Expr::binary_app(BinaryOp::Eq, Expr::val(2), Expr::val(1));
         let e = Expr::or(lhs.clone(), rhs.clone());
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::or(lhs, rhs);
@@ -5251,8 +5186,7 @@ pub mod test {
         let rhs = Expr::get_attr(Expr::unknown(Unknown::new_untyped("test")), "field".into());
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5270,8 +5204,7 @@ pub mod test {
         let rhs = Expr::binary_app(BinaryOp::Add, Expr::val(1), Expr::val("oops"));
         let e = Expr::or(lhs, rhs.clone());
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5285,8 +5218,7 @@ pub mod test {
     #[test]
     fn partial_unop() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::unary_app(UnaryOp::Neg, Expr::unknown(Unknown::new_untyped("a")));
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
@@ -5300,8 +5232,7 @@ pub mod test {
     #[test]
     fn partial_binop() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let binops = [
             BinaryOp::Add,
@@ -5375,8 +5306,7 @@ pub mod test {
     #[test]
     fn partial_mul() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::mul(Expr::unknown(Unknown::new_untyped("a")), Expr::val(32));
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
@@ -5386,8 +5316,7 @@ pub mod test {
     #[test]
     fn partial_ext_constructors() {
         let es = Entities::new();
-        let exts = Extensions::all_available();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::call_extension_fn(
             "ip".parse().unwrap(),
@@ -5431,8 +5360,7 @@ pub mod test {
     #[test]
     fn partial_like() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::like(Expr::unknown(Unknown::new_untyped("a")), []);
 
@@ -5444,8 +5372,7 @@ pub mod test {
     #[test]
     fn partial_is() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::is_entity_type(
             Expr::unknown(Unknown::new_untyped("a")),
@@ -5460,8 +5387,7 @@ pub mod test {
     #[test]
     fn partial_hasattr() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::has_attr(Expr::unknown(Unknown::new_untyped("a")), "test".into());
 
@@ -5473,8 +5399,7 @@ pub mod test {
     #[test]
     fn partial_set() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::set([
             Expr::val(1),
@@ -5510,8 +5435,7 @@ pub mod test {
     #[test]
     fn partial_record() {
         let es = Entities::new();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::none());
 
         let e = Expr::record([
             ("a".into(), Expr::val(1)),
@@ -5586,8 +5510,7 @@ pub mod test {
     fn small() {
         let e = parser::parse_expr("[[1]]").unwrap();
         let re = RestrictedExpr::new(e).unwrap();
-        let exts = Extensions::none();
-        let eval = RestrictedEvaluator::new(exts);
+        let eval = RestrictedEvaluator::new(Extensions::none());
         let r = eval.partial_interpret(re.as_borrowed()).unwrap();
         assert_matches!(r, PartialValue::Value(Value { value: ValueKind::Set(set), .. }) => {
             assert_eq!(set.len(), 1);
@@ -5598,8 +5521,7 @@ pub mod test {
     fn unprojectable_residual() {
         let q = basic_request();
         let entities = basic_entities();
-        let exts = Extensions::none();
-        let eval = Evaluator::new(q, &entities, exts);
+        let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let e = Expr::get_attr(
             Expr::record([

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -964,11 +964,7 @@ pub mod test {
             Entity::with_uid(EntityUID::with_eid("entity_no_attrs_no_parents"));
         let mut entity_with_attrs = Entity::with_uid(EntityUID::with_eid("entity_with_attrs"));
         entity_with_attrs
-            .set_attr(
-                "spoon".into(),
-                RestrictedExpr::val(787),
-                &Extensions::none(),
-            )
+            .set_attr("spoon".into(), RestrictedExpr::val(787), Extensions::none())
             .unwrap();
         entity_with_attrs
             .set_attr(
@@ -978,7 +974,7 @@ pub mod test {
                     RestrictedExpr::val("good"),
                     RestrictedExpr::val("useful"),
                 ]),
-                &Extensions::none(),
+                Extensions::none(),
             )
             .unwrap();
         entity_with_attrs
@@ -990,7 +986,7 @@ pub mod test {
                     ("country".into(), RestrictedExpr::val("amazonia")),
                 ])
                 .unwrap(),
-                &Extensions::none(),
+                Extensions::none(),
             )
             .unwrap();
         let mut child = Entity::with_uid(EntityUID::with_eid("child"));
@@ -1171,7 +1167,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // The below `assert_eq`s don't actually check the value's source location,
         // because `PartialEq` and `Eq` for `Value` don't compare source locations,
         // but checking the value's source location would not be an interesting
@@ -1226,7 +1222,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // The below `assert_eq`s don't actually check the value's source location,
         // because `PartialEq` and `Eq` for `Value` don't compare source locations,
         // but checking the value's source location would not be an interesting
@@ -1257,7 +1253,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         assert_eq!(
             eval.interpret_inline_policy(&Expr::var(Var::Principal)),
             Ok(Value::from(EntityUID::with_eid("test_principal")))
@@ -1277,7 +1273,7 @@ pub mod test {
         let request = basic_request();
         let entities = rich_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // has_attr on an entity with no attrs
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_attr(
@@ -1363,7 +1359,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // if true then 3 else 8
         assert_eq!(
             eval.interpret_inline_policy(&Expr::ite(Expr::val(true), Expr::val(3), Expr::val(8))),
@@ -1545,7 +1541,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // The below `assert_eq`s don't actually check the value's source location,
         // because `PartialEq` and `Eq` for `Value` don't compare source locations,
         // but checking the value's source location would not be an interesting
@@ -1765,7 +1761,7 @@ pub mod test {
         let request = basic_request();
         let entities = rich_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // {"key": 3}["key"] or {"key": 3}.key
         let string_key = Expr::record(vec![("key".into(), Expr::val(3))]).unwrap();
         assert_eq!(
@@ -2094,7 +2090,7 @@ pub mod test {
             r#"Foo::"bar""#.parse().unwrap(),
             attrs.clone(),
             HashSet::new(),
-            &Extensions::none(),
+            Extensions::none(),
         )
         .unwrap();
         let request = basic_request();
@@ -2105,7 +2101,7 @@ pub mod test {
             Extensions::none(),
         )
         .unwrap();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         let result = eval.interpret_inline_policy(&expr).unwrap_err();
         // These are arbitrarily determined by BTreeMap ordering, but are deterministic
         let expected_keys = ["1", "2", "3", "4", "5"]
@@ -2131,7 +2127,7 @@ pub mod test {
         let request = basic_request();
         let entities = rich_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         let result = eval.interpret_inline_policy(&expr).unwrap_err();
         let first_five = (1..=5)
             .map(|id| format!("{id}").into())
@@ -2146,7 +2142,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // not(true)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::not(Expr::val(true))),
@@ -2207,7 +2203,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // neg(101)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::neg(Expr::val(101))),
@@ -2276,7 +2272,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // eq(33, 33)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_eq(Expr::val(33), Expr::val(33))),
@@ -2507,7 +2503,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // 3 < 303
         assert_eq!(
             eval.interpret_inline_policy(&Expr::less(Expr::val(3), Expr::val(303))),
@@ -2836,7 +2832,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
 
         assert_matches!(
             eval.interpret_inline_policy(&Expr::greatereq(
@@ -2892,7 +2888,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // 11 + 22
         assert_eq!(
             eval.interpret_inline_policy(&Expr::add(Expr::val(11), Expr::val(22))),
@@ -2995,7 +2991,7 @@ pub mod test {
         let request = basic_request();
         let entities = rich_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
 
         // [2, 3, 4] contains 2
         assert_eq!(
@@ -3172,7 +3168,7 @@ pub mod test {
         let request = basic_request();
         let entities = rich_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // A in B, where A and B are unrelated (but same type)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_in(
@@ -3496,7 +3492,7 @@ pub mod test {
         )
         .expect("failed to create basic entities");
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         assert_eq!(
             eval.interpret_inline_policy(&Expr::is_in(
                 Expr::val(EntityUID::with_eid("Alice")),
@@ -3538,7 +3534,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // "eggs" vs "ham"
         assert_eq!(
             eval.interpret_inline_policy(
@@ -3716,7 +3712,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         // testing like wth escaped characters -- similar tests are also in parser/convert.rs
         assert_eq!(
             eval.interpret_inline_policy(
@@ -3756,7 +3752,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         assert_eq!(
             eval.interpret_inline_policy(
                 &parse_expr(&format!(
@@ -3816,7 +3812,7 @@ pub mod test {
         let request = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(request, &entities, &exts);
+        let eval = Evaluator::new(request, &entities, exts);
         //  [1, -22, 34] containsall of [1, -22]?
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains_all(
@@ -4081,11 +4077,12 @@ pub mod test {
     fn eval_and_or() -> Result<()> {
         use crate::parser;
         let request = basic_request();
+        let exts = Extensions::none();
         let eparser: EntityJsonParser<'_, '_> =
-            EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
+            EntityJsonParser::new(None, exts, TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
-        let evaluator = Evaluator::new(request, &entities, &exts);
+        let evaluator = Evaluator::new(request, &entities, exts);
 
         // short-circuit allows these to pass without error
         let raw_expr = "(false && 3)";
@@ -4198,7 +4195,7 @@ pub mod test {
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
-        let evaluator = Evaluator::new(request, &entities, &exts);
+        let evaluator = Evaluator::new(request, &entities, exts);
         let e = Expr::slot(SlotId::principal());
 
         let slots = HashMap::new();
@@ -4251,7 +4248,7 @@ pub mod test {
             EntityJsonParser::new(None, Extensions::none(), TCComputation::ComputeNow);
         let entities = eparser.from_json_str("[]").expect("empty slice");
         let exts = Extensions::none();
-        let eval = Evaluator::new(q, &entities, &exts);
+        let eval = Evaluator::new(q, &entities, exts);
 
         let ir = pset.policies().next().expect("No linked policies");
         assert_matches!(eval.partial_evaluate(ir), Ok(Either::Left(b)) => {
@@ -4269,8 +4266,7 @@ pub mod test {
 
     #[test]
     fn restricted_expressions() {
-        let exts = Extensions::all_available();
-        let evaluator = RestrictedEvaluator::new(&exts);
+        let evaluator = RestrictedEvaluator::new(Extensions::all_available());
 
         // simple expressions
         assert_eq!(
@@ -4406,7 +4402,7 @@ pub mod test {
         .unwrap();
         let es = Entities::new();
         let exts = Extensions::none();
-        let e = Evaluator::new(q, &es, &exts);
+        let e = Evaluator::new(q, &es, exts);
         match e.partial_evaluate(p).expect("eval error") {
             Either::Left(_) => panic!("Evalled to a value"),
             Either::Right(expr) => {
@@ -4441,7 +4437,7 @@ pub mod test {
         .unwrap();
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(q, &es, &exts);
+        let eval = Evaluator::new(q, &es, exts);
         eval.partial_eval_expr(&e).unwrap()
     }
 
@@ -4597,7 +4593,7 @@ pub mod test {
         .unwrap();
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(q, &es, &exts);
+        let eval = Evaluator::new(q, &es, exts);
         let e = Expr::get_attr(Expr::var(Var::Context), "foo".into());
         assert_matches!(eval.partial_eval_expr(&e), Err(_))
     }
@@ -4642,7 +4638,7 @@ pub mod test {
         )
         .unwrap();
         let exts = Extensions::none();
-        let eval = Evaluator::new(q, &es, &exts);
+        let eval = Evaluator::new(q, &es, exts);
 
         let result = eval.partial_evaluate(policy).expect("Eval error");
         match result {
@@ -4680,7 +4676,7 @@ pub mod test {
         let es = Entities::new();
 
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4729,7 +4725,7 @@ pub mod test {
             Extensions::none(),
         )
         .unwrap();
-        let eval = Evaluator::new(q, &es, &exts);
+        let eval = Evaluator::new(q, &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4758,7 +4754,7 @@ pub mod test {
         let es = Entities::new();
 
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_eq!(
             eval.partial_interpret(&e, &HashMap::new()).unwrap(),
@@ -4780,7 +4776,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4797,7 +4793,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4820,7 +4816,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -4839,7 +4835,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Ok(_));
     }
@@ -4855,7 +4851,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4872,7 +4868,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -4895,7 +4891,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -4914,7 +4910,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Ok(_));
     }
@@ -4928,7 +4924,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&a, &HashMap::new()), Err(_));
     }
@@ -4942,7 +4938,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&a, &HashMap::new()).unwrap();
 
@@ -4964,7 +4960,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&a, &HashMap::new()), Err(_));
     }
@@ -4982,7 +4978,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&a, &HashMap::new()).unwrap();
 
@@ -5000,7 +4996,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5018,7 +5014,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5036,7 +5032,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5053,7 +5049,7 @@ pub mod test {
 
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_eq!(
             eval.partial_interpret(&e, &HashMap::new()).unwrap(),
@@ -5069,7 +5065,7 @@ pub mod test {
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -5082,7 +5078,7 @@ pub mod test {
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         assert_matches!(eval.partial_interpret(&e, &HashMap::new()), Err(_));
     }
@@ -5095,7 +5091,7 @@ pub mod test {
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5114,7 +5110,7 @@ pub mod test {
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(r, PartialValue::Value(Value::from(false)));
@@ -5128,7 +5124,7 @@ pub mod test {
         let e = Expr::and(lhs.clone(), rhs.clone());
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::and(lhs, rhs);
@@ -5142,7 +5138,7 @@ pub mod test {
         let e = Expr::and(lhs.clone(), rhs.clone());
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::and(lhs, rhs);
@@ -5157,7 +5153,7 @@ pub mod test {
         let e = Expr::and(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5176,7 +5172,7 @@ pub mod test {
         let e = Expr::and(lhs, rhs.clone());
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5195,7 +5191,7 @@ pub mod test {
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         assert_eq!(r, PartialValue::Value(Value::from(true)));
@@ -5209,7 +5205,7 @@ pub mod test {
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::or(
@@ -5227,7 +5223,7 @@ pub mod test {
         let e = Expr::or(lhs.clone(), rhs.clone());
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::or(lhs, rhs);
@@ -5241,7 +5237,7 @@ pub mod test {
         let e = Expr::or(lhs.clone(), rhs.clone());
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
         let expected = Expr::or(lhs, rhs);
@@ -5256,7 +5252,7 @@ pub mod test {
         let e = Expr::or(lhs, rhs);
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5275,7 +5271,7 @@ pub mod test {
         let e = Expr::or(lhs, rhs.clone());
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
 
@@ -5290,7 +5286,7 @@ pub mod test {
     fn partial_unop() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::unary_app(UnaryOp::Neg, Expr::unknown(Unknown::new_untyped("a")));
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
@@ -5305,7 +5301,7 @@ pub mod test {
     fn partial_binop() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let binops = [
             BinaryOp::Add,
@@ -5380,7 +5376,7 @@ pub mod test {
     fn partial_mul() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::mul(Expr::unknown(Unknown::new_untyped("a")), Expr::val(32));
         let r = eval.partial_interpret(&e, &HashMap::new()).unwrap();
@@ -5391,7 +5387,7 @@ pub mod test {
     fn partial_ext_constructors() {
         let es = Entities::new();
         let exts = Extensions::all_available();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::call_extension_fn(
             "ip".parse().unwrap(),
@@ -5407,8 +5403,7 @@ pub mod test {
     #[test]
     fn partial_ext_unfold() {
         let es = Entities::new();
-        let exts = Extensions::all_available();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, Extensions::all_available());
 
         let a = Expr::call_extension_fn("ip".parse().unwrap(), vec![Expr::val("127.0.0.1")]);
         let b = Expr::unknown(Unknown::new_untyped("a"));
@@ -5437,7 +5432,7 @@ pub mod test {
     fn partial_like() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::like(Expr::unknown(Unknown::new_untyped("a")), []);
 
@@ -5450,7 +5445,7 @@ pub mod test {
     fn partial_is() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::is_entity_type(
             Expr::unknown(Unknown::new_untyped("a")),
@@ -5466,7 +5461,7 @@ pub mod test {
     fn partial_hasattr() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::has_attr(Expr::unknown(Unknown::new_untyped("a")), "test".into());
 
@@ -5479,7 +5474,7 @@ pub mod test {
     fn partial_set() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::set([
             Expr::val(1),
@@ -5516,7 +5511,7 @@ pub mod test {
     fn partial_record() {
         let es = Entities::new();
         let exts = Extensions::none();
-        let eval = Evaluator::new(empty_request(), &es, &exts);
+        let eval = Evaluator::new(empty_request(), &es, exts);
 
         let e = Expr::record([
             ("a".into(), Expr::val(1)),
@@ -5592,7 +5587,7 @@ pub mod test {
         let e = parser::parse_expr("[[1]]").unwrap();
         let re = RestrictedExpr::new(e).unwrap();
         let exts = Extensions::none();
-        let eval = RestrictedEvaluator::new(&exts);
+        let eval = RestrictedEvaluator::new(exts);
         let r = eval.partial_interpret(re.as_borrowed()).unwrap();
         assert_matches!(r, PartialValue::Value(Value { value: ValueKind::Set(set), .. }) => {
             assert_eq!(set.len(), 1);
@@ -5604,7 +5599,7 @@ pub mod test {
         let q = basic_request();
         let entities = basic_entities();
         let exts = Extensions::none();
-        let eval = Evaluator::new(q, &entities, &exts);
+        let eval = Evaluator::new(q, &entities, exts);
 
         let e = Expr::get_attr(
             Expr::record([

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -94,13 +94,13 @@ impl Extensions<'static> {
     }
 
     /// An [`Extensions`] object with static lifetime contain all available extensions.
-    pub fn all_available() -> Extensions<'static> {
-        ALL_AVAILABLE_EXTENSIONS.clone()
+    pub fn all_available() -> &'static Extensions<'static> {
+        &ALL_AVAILABLE_EXTENSIONS
     }
 
     /// Get a new `Extensions` with no extensions enabled.
-    pub fn none() -> Extensions<'static> {
-        EXTENSIONS_NONE.clone()
+    pub fn none() -> &'static Extensions<'static> {
+        &EXTENSIONS_NONE
     }
 }
 

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -24,7 +24,6 @@ pub mod decimal;
 pub mod partial_evaluation;
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use crate::ast::{Extension, ExtensionFunction, Name};
 use crate::entities::SchemaType;
@@ -51,8 +50,8 @@ lazy_static::lazy_static! {
 
     static ref EXTENSIONS_NONE : Extensions<'static> = Extensions {
         extensions: &[],
-        functions: Arc::new(HashMap::new()),
-        single_arg_constructors: Arc::new(HashMap::new()),
+        functions: HashMap::new(),
+        single_arg_constructors: HashMap::new(),
     };
 }
 
@@ -68,8 +67,9 @@ pub(crate) struct ExtensionConstructorSignature<'a> {
 
 /// Holds data on all the Extensions which are active for a given evaluation.
 ///
-/// Clone is cheap for this type.
-#[derive(Debug, Clone)]
+/// This structure is intentionally not `Clone` because we can use it entirely
+/// by reference.
+#[derive(Debug)]
 pub struct Extensions<'a> {
     /// the actual extensions
     extensions: &'a [Extension],
@@ -77,11 +77,11 @@ pub struct Extensions<'a> {
     /// construct this object.  Built ahead of time so that we know during
     /// extension function lookup that at most one extension function exists
     /// for a name. This should also make the lookup more efficient.
-    functions: Arc<HashMap<&'a Name, &'a ExtensionFunction>>,
+    functions: HashMap<&'a Name, &'a ExtensionFunction>,
     /// All single argument extension function constructors, indexed by their
     /// type signature. Built ahead of time so that we know each constructor has
     /// a unique type signature.
-    single_arg_constructors: Arc<HashMap<ExtensionConstructorSignature<'a>, &'a ExtensionFunction>>,
+    single_arg_constructors: HashMap<ExtensionConstructorSignature<'a>, &'a ExtensionFunction>,
 }
 
 impl Extensions<'static> {
@@ -144,8 +144,8 @@ impl<'a> Extensions<'a> {
 
         Ok(Extensions {
             extensions,
-            functions: Arc::new(functions),
-            single_arg_constructors: Arc::new(single_arg_constructors),
+            functions,
+            single_arg_constructors,
         })
     }
 

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -423,7 +423,7 @@ mod tests {
         let request = eval::test::basic_request();
         let entities = eval::test::basic_entities();
         let exts = Extensions::none();
-        let evaluator = eval::Evaluator::new(request, &entities, &exts);
+        let evaluator = eval::Evaluator::new(request, &entities, exts);
         // The below tests check not only that we get the expected `Value`, but
         // that it has the expected source location.
         // We have to check that separately because the `PartialEq` and `Eq`
@@ -476,7 +476,7 @@ mod tests {
         let request = eval::test::basic_request();
         let entities = eval::test::rich_entities();
         let exts = Extensions::none();
-        let evaluator = eval::Evaluator::new(request, &entities, &exts);
+        let evaluator = eval::Evaluator::new(request, &entities, exts);
         // The below tests check not only that we get the expected `Value`, but
         // that it has the expected source location.
         // See note on this in the above test.
@@ -560,7 +560,7 @@ mod tests {
         let request = eval::test::basic_request();
         let entities = eval::test::basic_entities();
         let exts = Extensions::none();
-        let evaluator = eval::Evaluator::new(request, &entities, &exts);
+        let evaluator = eval::Evaluator::new(request, &entities, exts);
         // The below tests check not only that we get the expected `Value`, but
         // that it has the expected source location.
         // See note on this in the above test.

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -160,7 +160,7 @@ impl ast::RequestSchema for ValidatorSchema {
     fn validate_request(
         &self,
         request: &ast::Request,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> std::result::Result<(), Self::Error> {
         use ast::EntityUIDEntry;
         // first check that principal and resource are of types that exist in
@@ -246,7 +246,7 @@ impl<'a> ast::RequestSchema for CoreSchema<'a> {
     fn validate_request(
         &self,
         request: &ast::Request,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<(), Self::Error> {
         self.schema.validate_request(request, extensions)
     }

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -110,7 +110,7 @@ fn eval_extension_constructor(
     lit_str_arg: SmolStr,
 ) -> Result<Value, EvaluationError> {
     let exts = Extensions::all_available();
-    let evaluator = RestrictedEvaluator::new(&exts);
+    let evaluator = RestrictedEvaluator::new(exts);
     let constructor_call_expr =
         RestrictedExpr::call_extension_fn(constructor_name, [RestrictedExpr::val(lit_str_arg)]);
     evaluator.interpret(constructor_call_expr.as_borrowed())

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -99,7 +99,7 @@ pub enum HumanSyntaxParseErrors {
 /// possibly generating warnings
 pub fn parse_natural_schema_fragment<'a>(
     src: &str,
-    extensions: Extensions<'a>,
+    extensions: &Extensions<'a>,
 ) -> Result<
     (
         crate::SchemaFragment<crate::RawName>,
@@ -108,7 +108,7 @@ pub fn parse_natural_schema_fragment<'a>(
     HumanSyntaxParseErrors,
 > {
     let ast: Schema = parse_collect_errors(&*SCHEMA_PARSER, grammar::SchemaParser::parse, src)?;
-    let tuple = custom_schema_to_json_schema(ast, extensions.clone())?;
+    let tuple = custom_schema_to_json_schema(ast, extensions)?;
     Ok(tuple)
 }
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -251,10 +251,10 @@ impl ValidatorSchema {
     /// "natural" schema syntax.
     pub fn from_file_natural<'a>(
         r: impl std::io::Read,
-        extensions: &'_ Extensions<'a>,
+        extensions: &'a Extensions<'a>,
     ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
     {
-        let (fragment, warnings) = SchemaFragment::from_file_natural(r, extensions.clone())?;
+        let (fragment, warnings) = SchemaFragment::from_file_natural(r, extensions)?;
         let schema_and_warnings =
             Self::from_schema_frag(fragment, ActionBehavior::default(), extensions)
                 .map(|schema| (schema, warnings))?;
@@ -268,7 +268,7 @@ impl ValidatorSchema {
         extensions: &Extensions<'a>,
     ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
     {
-        let (fragment, warnings) = SchemaFragment::from_str_natural(src, extensions.clone())?;
+        let (fragment, warnings) = SchemaFragment::from_str_natural(src, extensions)?;
         let schema_and_warnings =
             Self::from_schema_frag(fragment, ActionBehavior::default(), extensions)
                 .map(|schema| (schema, warnings))?;
@@ -2317,7 +2317,7 @@ mod test {
                 action_uid,
                 HashMap::from([("attr".into(), RestrictedExpr::val("foo"))]),
                 HashSet::new(),
-                &&Extensions::none(),
+                Extensions::none(),
             )
             .unwrap(),
         );

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -768,7 +768,7 @@ impl ActionFragment<ConditionalName, ConditionalName> {
     ) -> crate::err::Result<(Attributes, BTreeMap<SmolStr, PartialValueSerializedAsExpr>)> {
         let mut attr_types: HashMap<SmolStr, Type> = HashMap::with_capacity(m.len());
         let mut attr_values: BTreeMap<SmolStr, PartialValueSerializedAsExpr> = BTreeMap::new();
-        let evaluator = RestrictedEvaluator::new(&extensions);
+        let evaluator = RestrictedEvaluator::new(extensions);
 
         for (k, v) in m {
             let t = Self::jsonval_to_type_helper(&v, action_id);

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -143,7 +143,7 @@ impl SchemaFragment<RawName> {
     /// Parse the schema (in natural schema syntax) from a string
     pub fn from_str_natural<'a>(
         src: &str,
-        extensions: Extensions<'a>,
+        extensions: &Extensions<'a>,
     ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
     {
         parse_natural_schema_fragment(src, extensions)
@@ -151,10 +151,10 @@ impl SchemaFragment<RawName> {
     }
 
     /// Parse the schema (in natural schema syntax) from a reader
-    pub fn from_file_natural(
+    pub fn from_file_natural<'a>(
         mut file: impl std::io::Read,
-        extensions: Extensions<'_>,
-    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + '_), HumanSchemaError>
+        extensions: &'a Extensions<'_>,
+    ) -> std::result::Result<(Self, impl Iterator<Item = SchemaWarning> + 'a), HumanSchemaError>
     {
         let mut src = String::new();
         file.read_to_string(&mut src)?;

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -501,7 +501,7 @@ impl Type {
     pub(crate) fn typecheck_partial_value(
         &self,
         value: &PartialValue,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<bool, GetSchemaTypeError> {
         match value {
             PartialValue::Value(value) => self.typecheck_value(value, extensions),
@@ -516,7 +516,7 @@ impl Type {
     pub(crate) fn typecheck_value(
         &self,
         value: &Value,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<bool, GetSchemaTypeError> {
         // we accept the overhead of cloning the `Value` and converting to
         // `RestrictedExpr` in order to improve code reuse and maintainability
@@ -531,7 +531,7 @@ impl Type {
     pub(crate) fn typecheck_restricted_expr(
         &self,
         restricted_expr: BorrowedRestrictedExpr<'_>,
-        extensions: Extensions<'_>,
+        extensions: &Extensions<'_>,
     ) -> Result<bool, GetSchemaTypeError> {
         match self {
             Type::Never => Ok(false), // no expr has type Never
@@ -552,7 +552,7 @@ impl Type {
             } => match restricted_expr.as_set_elements() {
                 Some(elts) => {
                     for elt in elts {
-                        if !el_type.typecheck_restricted_expr(elt, extensions.clone())? {
+                        if !el_type.typecheck_restricted_expr(elt, extensions)? {
                             return Ok(false);
                         }
                     }
@@ -584,10 +584,10 @@ impl Type {
                     for (k, attr_val) in &record {
                         match attrs.get_attr(k) {
                             Some(attr_ty) => {
-                                if !attr_ty.attr_type.typecheck_restricted_expr(
-                                    attr_val.to_owned(),
-                                    extensions.clone(),
-                                )? {
+                                if !attr_ty
+                                    .attr_type
+                                    .typecheck_restricted_expr(attr_val.to_owned(), extensions)?
+                                {
                                     return Ok(false);
                                 }
                             }
@@ -629,7 +629,7 @@ impl Type {
                         if typecheck_restricted_expr_against_schematype(
                             actual_arg,
                             expected_arg_ty,
-                            extensions.clone(),
+                            extensions,
                         )
                         .is_err()
                         {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -92,7 +92,7 @@ impl Entity {
                 .map(|(k, v)| (SmolStr::from(k), v.0))
                 .collect(),
             parents.into_iter().map(EntityUid::into).collect(),
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )?))
     }
 
@@ -3622,7 +3622,7 @@ pub fn eval_expression(
     expr: &Expression,
 ) -> Result<EvalResult, EvaluationError> {
     let all_ext = Extensions::all_available();
-    let eval = Evaluator::new(request.0.clone(), &entities.0, &all_ext);
+    let eval = Evaluator::new(request.0.clone(), &entities.0, all_ext);
     Ok(EvalResult::from(
         // Evaluate under the empty slot map, as an expression should not have slots
         eval.interpret(&expr.0, &ast::SlotEnv::new())?,

--- a/cedar-policy/src/ffi/check_parse.rs
+++ b/cedar-policy/src/ffi/check_parse.rs
@@ -261,7 +261,7 @@ mod test {
 
     #[track_caller]
     fn assert_check_parse_is_ok(parse_result: CheckParseAnswer) {
-        assert_matches!(parse_result, CheckParseAnswer::Success)
+        assert_matches!(parse_result, CheckParseAnswer::Success);
     }
 
     #[track_caller]
@@ -331,7 +331,7 @@ mod test {
           }
         });
         let answer = serde_json::from_value(check_parse_schema_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer)
+        assert_check_parse_is_ok(answer);
     }
 
     #[test]
@@ -389,7 +389,7 @@ mod test {
             }
         });
         let answer = serde_json::from_value(check_parse_entities_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer)
+        assert_check_parse_is_ok(answer);
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod test {
             ]
         });
         let answer = serde_json::from_value(check_parse_entities_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer)
+        assert_check_parse_is_ok(answer);
     }
 
     #[test]
@@ -491,7 +491,7 @@ mod test {
 
         });
         let answer = serde_json::from_value(check_parse_context_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer)
+        assert_check_parse_is_ok(answer);
     }
 
     #[test]

--- a/cedar-policy/src/ffi/check_parse.rs
+++ b/cedar-policy/src/ffi/check_parse.rs
@@ -261,7 +261,7 @@ mod test {
 
     #[track_caller]
     fn assert_check_parse_is_ok(parse_result: CheckParseAnswer) {
-        assert_matches!(parse_result, CheckParseAnswer::Success);
+        assert_matches!(parse_result, CheckParseAnswer::Success)
     }
 
     #[track_caller]
@@ -331,7 +331,7 @@ mod test {
           }
         });
         let answer = serde_json::from_value(check_parse_schema_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer);
+        assert_check_parse_is_ok(answer)
     }
 
     #[test]
@@ -389,7 +389,7 @@ mod test {
             }
         });
         let answer = serde_json::from_value(check_parse_entities_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer);
+        assert_check_parse_is_ok(answer)
     }
 
     #[test]
@@ -410,7 +410,7 @@ mod test {
             ]
         });
         let answer = serde_json::from_value(check_parse_entities_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer);
+        assert_check_parse_is_ok(answer)
     }
 
     #[test]
@@ -491,7 +491,7 @@ mod test {
 
         });
         let answer = serde_json::from_value(check_parse_context_json(call).unwrap()).unwrap();
-        assert_check_parse_is_ok(answer);
+        assert_check_parse_is_ok(answer)
     }
 
     #[test]

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -342,7 +342,7 @@ impl CedarTestImplementation for RustEngine {
         } else {
             Extensions::none()
         };
-        let e = Evaluator::new(request.clone(), entities, &exts);
+        let e = Evaluator::new(request.clone(), entities, exts);
         let result = e.partial_interpret(expr, &HashMap::default());
         match (result, expected) {
             (Ok(PartialValue::Residual(r)), Some(ExprOrValue::Expr(e))) => {
@@ -371,7 +371,7 @@ impl CedarTestImplementation for RustEngine {
         } else {
             Extensions::none()
         };
-        let evaluator = Evaluator::new(request.clone(), entities, &exts);
+        let evaluator = Evaluator::new(request.clone(), entities, exts);
         let result = evaluator.interpret(expr, &HashMap::default());
         let response = result.ok() == expected;
         TestResult::Success(response)


### PR DESCRIPTION
## Description of changes

Follow on to #1090.
Always pass `Extensions` struct as a reference. Avoids a few clones.

I expect this will conflict with #1060, so merging it should wait until that's done.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

