### PR TITLE
Feature flags set

### DIFF
--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -309,6 +309,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "partial-eval")]
     fn authorizer_sanity_check_partial_deny() {
         let context = Context::from_expr(
             RestrictedExpr::record([(
@@ -401,6 +402,40 @@ mod test {
             false
         };
         "#;
+
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("1")), src1).unwrap())
+            .unwrap();
+        pset.add_static(parser::parse_policy(Some(PolicyID::from_string("2")), src2).unwrap())
+            .unwrap();
+
+        let r = a.is_authorized_core(q.clone(), &pset, &es).decision();
+        assert_eq!(r, Some(Decision::Allow));
+    }
+
+    #[test]
+    #[cfg(feature = "partial-eval")]
+    fn satisfied_permit_no_forbids_unknown() {
+        let q = Request::new(
+            (EntityUID::with_eid("p"), None),
+            (EntityUID::with_eid("a"), None),
+            (EntityUID::with_eid("r"), None),
+            Context::empty(),
+            None::<&RequestSchemaAllPass>,
+            Extensions::none(),
+        )
+        .unwrap();
+        let a = Authorizer::new();
+        let mut pset = PolicySet::new();
+        let es = Entities::new();
+
+        let src1 = r#"
+        permit(principal == test_entity_type::"p",action,resource);
+        "#;
+        let src2 = r#"
+        forbid(principal == test_entity_type::"p",action,resource) when {
+            false
+        };
+        "#;
         let src3 = r#"
         permit(principal == test_entity_type::"p",action,resource) when {
             unknown("test")
@@ -432,6 +467,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "partial-eval")]
     fn satisfied_permit_residual_forbid() {
         let q = Request::new(
             (EntityUID::with_eid("p"), None),
@@ -480,6 +516,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "partial-eval")]
     fn no_permits() {
         let q = Request::new(
             (EntityUID::with_eid("p"), None),
@@ -542,6 +579,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "partial-eval")]
     fn residual_permits() {
         let q = Request::new(
             (EntityUID::with_eid("p"), None),

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -273,6 +273,7 @@ mod test {
         .expect("Policy Creation Failed")
     }
 
+    #[cfg(feature = "partial-eval")]
     fn context_pol(id: &str, effect: Effect) -> StaticPolicy {
         let pid = PolicyID::from_string(id);
         StaticPolicy::new(

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -4441,13 +4441,13 @@ mod issue_994 {
     }
 }
 
+#[cfg(feature = "partial-eval")]
 #[cfg(test)]
 mod issue_1061 {
     use crate::{est, parser};
     use serde_json::json;
 
     #[test]
-    #[cfg(feature = "partial-eval")]
     fn function_with_name_unknown() {
         let src = json!(
             {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -4447,6 +4447,7 @@ mod issue_1061 {
     use serde_json::json;
 
     #[test]
+    #[cfg(feature = "partial-eval")]
     fn function_with_name_unknown() {
         let src = json!(
             {

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -43,6 +43,7 @@ lazy_static::lazy_static! {
         ipaddr::extension(),
         #[cfg(feature = "decimal")]
         decimal::extension(),
+        #[cfg(feature = "partial-eval")]
         partial_evaluation::extension(),
     ];
 

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -31,6 +31,7 @@ fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
 /// Construct the extension
 // PANIC SAFETY: all uses of `unwrap` here on parsing extension names are correct names
 #[allow(clippy::unwrap_used)]
+#[cfg(feature = "partial-eval")]
 pub fn extension() -> Extension {
     Extension::new(
         "partial_evaluation".parse().unwrap(),

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#![cfg(feature = "partial-eval")]
 
 //! This module contains the extension for including unknown values
 use crate::{
@@ -31,7 +32,6 @@ fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
 /// Construct the extension
 // PANIC SAFETY: all uses of `unwrap` here on parsing extension names are correct names
 #[allow(clippy::unwrap_used)]
-#[cfg(feature = "partial-eval")]
 pub fn extension() -> Extension {
     Extension::new(
         "partial_evaluation".parse().unwrap(),

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -38,6 +38,7 @@ default = ["ipaddr", "decimal"]
 # when enabling a feature, make sure that the Core feature is also enabled
 ipaddr = ["cedar-policy-core/ipaddr"]
 decimal = ["cedar-policy-core/decimal"]
+partial-eval = ["cedar-policy-core/partial-eval"]
 
 # Enables `Arbitrary` implementations for several types in this crate
 arbitrary = ["dep:arbitrary", "cedar-policy-core/arbitrary"]

--- a/cedar-policy-validator/src/extensions.rs
+++ b/cedar-policy-validator/src/extensions.rs
@@ -45,6 +45,7 @@ lazy_static::lazy_static! {
         ipaddr::extension_schema(),
         #[cfg(feature = "decimal")]
         decimal::extension_schema(),
+        #[cfg(feature = "partial-eval")]
         partial_evaluation::extension_schema(),
     ];
 

--- a/cedar-policy-validator/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-validator/src/extensions/partial_evaluation.rs
@@ -18,6 +18,7 @@
 //! out-of-date with the decimal extension definition in Core.
 //! This is tested by the `extension_schema_correctness()` test
 
+#![cfg(feature = "partial-eval")]
 use crate::extension_schema::{ExtensionFunctionType, ExtensionSchema};
 use crate::types::{self, Type};
 use cedar_policy_core::extensions::partial_evaluation;

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -26,6 +26,8 @@ Cedar Language Version: 4.0
 
 ### Changed
 
+- `unknown()` is no longer a valid extension function if `partial-eval`
+  is not enabled as a feature.
 - The API around `Request::new` has changed to remove the `Option`s
   around the entity type arguments. See [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md).
 - Significantly reworked all public-facing error types to address some issues

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -47,7 +47,7 @@ corpus-timing = []
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
 experimental = ["partial-eval", "permissive-validate", "partial-validate"]
-partial-eval = ["cedar-policy-core/partial-eval"]
+partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []
 partial-validate = ["cedar-policy-validator/partial-validate"]
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -495,6 +495,25 @@ mod policy_set_tests {
     use cool_asserts::assert_matches;
 
     #[test]
+    fn no_unknown_feature() {
+        let src = r#"
+        permit(principal,action,resource) when {
+            unknown("foo")
+        };
+        "#;
+        let pset: Result<PolicySet, _> = src.parse();
+        #[cfg(not(feature = "partial-eval"))]
+        {
+            let err_string = pset.unwrap_err().to_string();
+            assert!(err_string.contains("`unknown` is not a valid function"));
+        }
+        #[cfg(feature = "partial-eval")]
+        {
+            assert!(pset.is_ok());
+        }
+    }
+
+    #[test]
     fn template_link_lookup() {
         let mut pset = PolicySet::new();
         let p = Policy::parse(


### PR DESCRIPTION
## Description of changes
Sets feature flags so that `unknown` is not a valid extension function unless `partial-eval` is enabled.
## Issue #, if available
#1096 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).


I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


