### PR TITLE
require templates in the `Template` constructors

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -517,7 +517,7 @@ mod test {
         )
         .expect("Failed to parse");
         pset.add_static(p1).expect("Failed to add!");
-        let template = parser::parse_policy_template(
+        let template = parser::parse_policy_or_template(
             Some(PolicyID::from_string("t")),
             "permit(principal == ?principal, action, resource);",
         )
@@ -557,7 +557,7 @@ mod test {
             .expect("Adding static policy in Policy form should succeed");
 
         let template = Arc::new(
-            parser::parse_policy_template(
+            parser::parse_policy_or_template(
                 Some(PolicyID::from_string("t")),
                 "permit(principal == ?principal, action, resource);",
             )
@@ -605,7 +605,7 @@ mod test {
         );
 
         let template2 = Arc::new(
-            parser::parse_policy_template(
+            parser::parse_policy_or_template(
                 Some(PolicyID::from_string("t")),
                 "forbid(principal, action, resource == ?resource);",
             )
@@ -654,7 +654,7 @@ mod test {
 
     #[test]
     fn template_filtering() {
-        let template = parser::parse_policy_template(
+        let template = parser::parse_policy_or_template(
             Some(PolicyID::from_string("template")),
             "permit(principal == ?principal, action, resource);",
         )

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -198,7 +198,9 @@ impl Policy {
     ) -> Result<ast::Template, FromJsonError> {
         let template: ast::Template = self.try_into_ast_policy_or_template(id)?;
         if template.slots().count() == 0 {
-            Err(FromJsonError::PolicyToTemplate)
+            Err(FromJsonError::PolicyToTemplate(
+                parse_errors::ExpectedTemplate {},
+            ))
         } else {
             Ok(template)
         }
@@ -3215,8 +3217,8 @@ mod test {
                 expect_err(
                     "",
                     &miette::Report::new(e),
-                    &ExpectedErrorMessageBuilder::error(r#"tried to convert JSON representing a template to a static policy"#)
-                        .source("found slot `?principal` where slots are not allowed")
+                    &ExpectedErrorMessageBuilder::error(r#"expected a static policy, got a template containing the slot ?principal"#)
+                        .help("try removing the template slot(s) from this policy")
                         .build()
                 );
             }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -199,7 +199,7 @@ impl Policy {
         let template: ast::Template = self.try_into_ast_policy_or_template(id)?;
         if template.slots().count() == 0 {
             Err(FromJsonError::PolicyToTemplate(
-                parse_errors::ExpectedTemplate {},
+                parse_errors::ExpectedTemplate::new(),
             ))
         } else {
             Ok(template)

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -173,7 +173,7 @@ impl TryFrom<cst::Cond> for Clause {
 }
 
 impl Policy {
-    /// Try to convert EST Policy into AST Policy.
+    /// Try to convert a [`Policy`] into a [`ast::Policy`].
     ///
     /// This process requires a policy ID. If not supplied, this method will
     /// fill it in as "JSON policy".
@@ -181,17 +181,35 @@ impl Policy {
         self,
         id: Option<ast::PolicyID>,
     ) -> Result<ast::Policy, FromJsonError> {
-        let template: ast::Template = self.try_into_ast_template(id)?;
+        let template: ast::Template = self.try_into_ast_policy_or_template(id)?;
         ast::StaticPolicy::try_from(template)
             .map(Into::into)
             .map_err(Into::into)
     }
 
-    /// Try to convert EST Policy into AST Template.
+    /// Try to convert a [`Policy`] into a [`ast::Template`]. Returns an error
+    /// if the input is a static policy.
     ///
     /// This process requires a policy ID. If not supplied, this method will
     /// fill it in as "JSON policy".
     pub fn try_into_ast_template(
+        self,
+        id: Option<ast::PolicyID>,
+    ) -> Result<ast::Template, FromJsonError> {
+        let template: ast::Template = self.try_into_ast_policy_or_template(id)?;
+        if template.slots().count() == 0 {
+            Err(FromJsonError::PolicyToTemplate)
+        } else {
+            Ok(template)
+        }
+    }
+
+    /// Try to convert a [`Policy`] into a [`ast::Template`]. The `Template` may
+    /// represent a template or static policy (which is a template with zero slots).
+    ///
+    /// This process requires a policy ID. If not supplied, this method will
+    /// fill it in as "JSON policy".
+    pub fn try_into_ast_policy_or_template(
         self,
         id: Option<ast::PolicyID>,
     ) -> Result<ast::Template, FromJsonError> {
@@ -363,7 +381,7 @@ mod test {
     #[track_caller]
     fn ast_roundtrip_template(est: Policy) -> Policy {
         let ast = est
-            .try_into_ast_template(None)
+            .try_into_ast_policy_or_template(None)
             .expect("Failed to convert to AST");
         ast.into()
     }
@@ -388,7 +406,7 @@ mod test {
     #[track_caller]
     fn circular_roundtrip_template(est: Policy) -> Policy {
         let ast = est
-            .try_into_ast_template(None)
+            .try_into_ast_policy_or_template(None)
             .expect("Failed to convert to AST");
         let text = ast.to_string();
         let cst = parser::text_to_cst::parse_policy(&text)
@@ -4478,7 +4496,7 @@ mod issue_1061 {
         let ast_from_est = est
             .try_into_ast_policy(None)
             .expect("Failed to convert EST to AST");
-        let ast_from_cedar = parser::parse_policy_template(None, &ast_from_est.to_string())
+        let ast_from_cedar = parser::parse_policy_or_template(None, &ast_from_est.to_string())
             .expect("Failed to parse policy template");
 
         assert!(ast_from_est

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -34,6 +34,9 @@ pub enum FromJsonError {
     #[error("tried to convert JSON representing a template to a static policy")]
     #[diagnostic(transparent)]
     TemplateToPolicy(#[from] ast::UnexpectedSlotError),
+    /// Tried to convert an EST representing a static policy to an AST representing a template
+    #[error("tried to convert JSON representing a static policy to a template")]
+    PolicyToTemplate,
     /// Slot name was not valid for the position it was used in. (Currently, principal slots must
     /// be named `?principal`, and resource slots must be named `?resource`.)
     #[error("invalid slot name or slot used in wrong position")]

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -31,12 +31,13 @@ pub enum FromJsonError {
     #[diagnostic(transparent)]
     JsonDeserializationError(#[from] JsonDeserializationError),
     /// Tried to convert an EST representing a template to an AST representing a static policy
-    #[error("tried to convert JSON representing a template to a static policy")]
+    #[error(transparent)]
     #[diagnostic(transparent)]
-    TemplateToPolicy(#[from] ast::UnexpectedSlotError),
+    TemplateToPolicy(#[from] parse_errors::ExpectedStaticPolicy),
     /// Tried to convert an EST representing a static policy to an AST representing a template
-    #[error("tried to convert JSON representing a static policy to a template")]
-    PolicyToTemplate,
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    PolicyToTemplate(#[from] parse_errors::ExpectedTemplate),
     /// Slot name was not valid for the position it was used in. (Currently, principal slots must
     /// be named `?principal`, and resource slots must be named `?resource`.)
     #[error("invalid slot name or slot used in wrong position")]
@@ -105,4 +106,10 @@ pub enum LinkingError {
         /// Slot which didn't have a value provided for it
         slot: ast::SlotId,
     },
+}
+
+impl From<ast::UnexpectedSlotError> for FromJsonError {
+    fn from(err: ast::UnexpectedSlotError) -> Self {
+        Self::TemplateToPolicy(err.into())
+    }
 }

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -106,7 +106,7 @@ impl TryFrom<PolicySet> for ast::PolicySet {
         let mut ast_pset = ast::PolicySet::default();
 
         for (id, policy) in value.templates {
-            let ast = policy.try_into_ast_template(Some(id))?;
+            let ast = policy.try_into_ast_policy_or_template(Some(id))?;
             ast_pset.add_template(ast)?;
         }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -910,7 +910,7 @@ pub mod test {
 
     use crate::{
         entities::{EntityJsonParser, NoEntitiesSchema, TCComputation},
-        parser::{self, parse_expr, parse_policy_template, parse_policyset},
+        parser::{self, parse_expr, parse_policy_or_template, parse_policyset},
     };
 
     use cool_asserts::assert_matches;
@@ -4222,7 +4222,7 @@ pub mod test {
 
     #[test]
     fn template_interp() {
-        let t = parse_policy_template(
+        let t = parse_policy_or_template(
             Some(PolicyID::from_string("template")),
             r#"permit(principal == ?principal, action, resource);"#,
         )

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -100,10 +100,11 @@ pub fn parse_policyset_to_ests_and_pset(
     Ok((ests, pset))
 }
 
-/// Simple main function for parsing a policy template.
+/// Main function for parsing a policy _or_ template. In either case, the
+/// returned value will be a [`Template`].
 /// If `id` is Some, then the resulting template will have that `id`.
 /// If the `id` is None, the parser will use "policy0".
-pub fn parse_policy_template(
+pub fn parse_policy_or_template(
     id: Option<ast::PolicyID>,
     text: &str,
 ) -> Result<ast::Template, err::ParseErrors> {
@@ -112,24 +113,40 @@ pub fn parse_policy_template(
     cst.to_policy_template(id)
 }
 
-/// Like `parse_policy_template()`, but also returns the (lossless) EST -- that
+/// Like `parse_policy_or_template()`, but also returns the (lossless) EST -- that
 /// is, the EST of the original template without any of the lossy transforms
 /// involved in converting to AST.
-pub fn parse_policy_template_to_est_and_ast(
-    id: Option<String>,
+pub fn parse_policy_or_template_to_est_and_ast(
+    id: Option<ast::PolicyID>,
     text: &str,
 ) -> Result<(est::Policy, ast::Template), err::ParseErrors> {
-    let id = match id {
-        Some(id) => ast::PolicyID::from_string(id),
-        None => ast::PolicyID::from_string("policy0"),
-    };
+    let id = id.unwrap_or(ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
     let ast = cst.to_policy_template(id)?;
     let est = cst.try_into_inner()?.try_into()?;
     Ok((est, ast))
 }
 
-/// simple main function for parsing a policy.
+/// Main function for parsing a template.
+/// Will return an error if provided with a static policy.
+/// If `id` is Some, then the resulting policy will have that `id`.
+/// If the `id` is None, the parser will use "policy0".
+pub fn parse_template(
+    id: Option<ast::PolicyID>,
+    text: &str,
+) -> Result<ast::Template, err::ParseErrors> {
+    let id = id.unwrap_or(ast::PolicyID::from_string("policy0"));
+    let cst = text_to_cst::parse_policy(text)?;
+    let template = cst.to_policy_template(id)?;
+    if template.slots().count() == 0 {
+        Err(err::ToASTError::new(err::ToASTErrorKind::ExpectedTemplate, cst.loc.clone()).into())
+    } else {
+        Ok(template)
+    }
+}
+
+/// Main function for parsing a (static) policy.
+/// Will return an error if provided with a template.
 /// If `id` is Some, then the resulting policy will have that `id`.
 /// If the `id` is None, the parser will use "policy0".
 pub fn parse_policy(
@@ -161,7 +178,7 @@ pub fn parse_policy_or_template_to_est(text: &str) -> Result<est::Policy, err::P
     // checks are applied by the CST-to-AST conversion and not CST-to-EST, and
     // we do not want to return any EST if the policy text would not parse
     // normally.
-    parse_policy_template_to_est_and_ast(None, text).map(|(est, _ast)| est)
+    parse_policy_or_template_to_est_and_ast(None, text).map(|(est, _ast)| est)
 }
 
 /// parse an Expr
@@ -332,7 +349,8 @@ mod tests {
         for template in all_templates().map(Template::from) {
             let id = template.id();
             let src = format!("{template}");
-            let parsed = parse_policy_template(Some(ast::PolicyID::from_string(id)), &src).unwrap();
+            let parsed =
+                parse_policy_or_template(Some(ast::PolicyID::from_string(id)), &src).unwrap();
             assert_eq!(
                 parsed.slots().collect::<HashSet<_>>(),
                 template.slots().collect::<HashSet<_>>()
@@ -689,7 +707,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_when_clause);
         });
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
@@ -697,7 +715,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_when_clause);
         });
         assert_matches!(parse_policyset(src), Err(e) => {
@@ -728,7 +746,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_when_clause);
         });
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
@@ -736,7 +754,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_when_clause);
         });
         assert_matches!(parse_policyset(src), Err(e) => {
@@ -758,13 +776,13 @@ mod tests {
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
         assert_matches!(parse_policyset(src), Err(e) => {
@@ -796,7 +814,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_unless_clause);
         });
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
@@ -804,7 +822,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_unless_clause);
         });
         assert_matches!(parse_policyset(src), Err(e) => {
@@ -836,7 +854,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_unless_clause);
         });
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
@@ -844,7 +862,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template);
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &slot_in_unless_clause);
         });
         assert_matches!(parse_policyset(src), Err(e) => {
@@ -866,13 +884,13 @@ mod tests {
         assert_matches!(parse_policy(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
         assert_matches!(parse_policy_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_exactly_one_error(src, &e, &error);
         });
         assert_matches!(parse_policyset(src), Err(e) => {
@@ -912,7 +930,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template); // 2 copies of this error
         });
-        assert_matches!(parse_policy_template(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template(None, src), Err(e) => {
             expect_n_errors(src, &e, 2);
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
@@ -923,7 +941,7 @@ mod tests {
             expect_some_error_matches(src, &e, &slot_in_unless_clause);
             expect_some_error_matches(src, &e, &unexpected_template); // 2 copies of this error
         });
-        assert_matches!(parse_policy_template_to_est_and_ast(None, src), Err(e) => {
+        assert_matches!(parse_policy_or_template_to_est_and_ast(None, src), Err(e) => {
             expect_n_errors(src, &e, 2);
             expect_some_error_matches(src, &e, &slot_in_when_clause);
             expect_some_error_matches(src, &e, &slot_in_unless_clause);

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -139,7 +139,7 @@ pub fn parse_template(
     let cst = text_to_cst::parse_policy(text)?;
     let template = cst.to_policy_template(id)?;
     if template.slots().count() == 0 {
-        Err(err::ToASTError::new(err::ToASTErrorKind::ExpectedTemplate, cst.loc.clone()).into())
+        Err(err::ToASTError::new(err::ToASTErrorKind::expected_template(), cst.loc.clone()).into())
     } else {
         Ok(template)
     }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -114,7 +114,7 @@ pub fn parse_policy_or_template(
 }
 
 /// Like `parse_policy_or_template()`, but also returns the (lossless) EST -- that
-/// is, the EST of the original template without any of the lossy transforms
+/// is, the EST of the original policy/template without any of the lossy transforms
 /// involved in converting to AST.
 pub fn parse_policy_or_template_to_est_and_ast(
     id: Option<ast::PolicyID>,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -169,7 +169,7 @@ impl Node<Option<cst::Policy>> {
             Ok(Ok(p)) => Ok(p),
             // The source parsed as a template, but not a static policy
             Ok(Err(ast::UnexpectedSlotError::FoundSlot(slot))) => Err(ToASTError::new(
-                ToASTErrorKind::ExpectedStaticPolicy { slot: slot.clone() },
+                ToASTErrorKind::expected_static_policy(slot.clone()),
                 slot.loc.unwrap_or_else(|| self.loc.clone()),
             )
             .into()),
@@ -181,9 +181,7 @@ impl Node<Option<cst::Policy>> {
                     .filter_map(|err| match err {
                         ParseError::ToAST(err) => match err.kind() {
                             ToASTErrorKind::SlotsInConditionClause(inner) => Some(ToASTError::new(
-                                ToASTErrorKind::ExpectedStaticPolicy {
-                                    slot: inner.slot.clone(),
-                                },
+                                ToASTErrorKind::expected_static_policy(inner.slot.clone()),
                                 err.source_loc().clone(),
                             )),
                             _ => None,

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -139,16 +139,13 @@ pub enum ToASTErrorKind {
     #[error("a policy with id `{0}` already exists in the policy set")]
     DuplicatePolicyId(ast::PolicyID),
     /// Returned when a template is encountered but a static policy is expected
-    #[error("expected a static policy, got a template containing the slot {}", slot.id)]
-    #[diagnostic(help("try removing the template slot(s) from this policy"))]
-    ExpectedStaticPolicy {
-        /// Slot that was found (which is not valid in a static policy)
-        slot: ast::Slot,
-    },
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ExpectedStaticPolicy(#[from] parse_errors::ExpectedStaticPolicy),
     /// Returned when a static policy is encountered but a template is expected
-    #[error("expected a template, got a static policy")]
-    #[diagnostic(help("a template should include slot(s) `?principal` or `?resource`"))]
-    ExpectedTemplate,
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ExpectedTemplate(#[from] parse_errors::ExpectedTemplate),
     /// Returned when we attempt to parse a policy or template with duplicate or
     /// conflicting annotations
     #[error("duplicate annotation: @{0}")]
@@ -410,6 +407,16 @@ impl ToASTErrorKind {
         parse_errors::SlotsInConditionClause { slot, clause_type }.into()
     }
 
+    /// Constructor for the [`ToASTErrorKind::ExpectedStaticPolicy`] error
+    pub fn expected_static_policy(slot: ast::Slot) -> Self {
+        parse_errors::ExpectedStaticPolicy { slot }.into()
+    }
+
+    /// Constructor for the [`ToASTErrorKind::ExpectedTemplate`] error
+    pub fn expected_template() -> Self {
+        parse_errors::ExpectedTemplate {}.into()
+    }
+
     /// Constructor for the [`ToASTErrorKind::WrongEntityArgument`] error when
     /// one kind of entity argument was expected
     pub fn wrong_entity_argument_one_expected(
@@ -441,6 +448,29 @@ pub mod parse_errors {
     use std::sync::Arc;
 
     use super::*;
+
+    /// Details about a `ExpectedStaticPolicy` error.
+    #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]
+    #[error("expected a static policy, got a template containing the slot {}", slot.id)]
+    #[diagnostic(help("try removing the template slot(s) from this policy"))]
+    pub struct ExpectedStaticPolicy {
+        /// Slot that was found (which is not valid in a static policy)
+        pub(crate) slot: ast::Slot,
+    }
+
+    impl From<ast::UnexpectedSlotError> for ExpectedStaticPolicy {
+        fn from(err: ast::UnexpectedSlotError) -> Self {
+            match err {
+                ast::UnexpectedSlotError::FoundSlot(slot) => Self { slot },
+            }
+        }
+    }
+
+    /// Details about a `ExpectedTemplate` error.
+    #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]
+    #[error("expected a template, got a static policy")]
+    #[diagnostic(help("a template should include slot(s) `?principal` or `?resource`"))]
+    pub struct ExpectedTemplate {}
 
     /// Details about a `SlotsInConditionClause` error.
     #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -141,10 +141,14 @@ pub enum ToASTErrorKind {
     /// Returned when a template is encountered but a static policy is expected
     #[error("expected a static policy, got a template containing the slot {}", slot.id)]
     #[diagnostic(help("try removing the template slot(s) from this policy"))]
-    UnexpectedTemplate {
+    ExpectedStaticPolicy {
         /// Slot that was found (which is not valid in a static policy)
         slot: ast::Slot,
     },
+    /// Returned when a static policy is encountered but a template is expected
+    #[error("expected a template, got a static policy")]
+    #[diagnostic(help("a template should include slot(s) `?principal` or `?resource`"))]
+    ExpectedTemplate,
     /// Returned when we attempt to parse a policy or template with duplicate or
     /// conflicting annotations
     #[error("duplicate annotation: @{0}")]

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -414,7 +414,7 @@ impl ToASTErrorKind {
 
     /// Constructor for the [`ToASTErrorKind::ExpectedTemplate`] error
     pub fn expected_template() -> Self {
-        parse_errors::ExpectedTemplate {}.into()
+        parse_errors::ExpectedTemplate::new().into()
     }
 
     /// Constructor for the [`ToASTErrorKind::WrongEntityArgument`] error when
@@ -470,7 +470,19 @@ pub mod parse_errors {
     #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]
     #[error("expected a template, got a static policy")]
     #[diagnostic(help("a template should include slot(s) `?principal` or `?resource`"))]
-    pub struct ExpectedTemplate {}
+    pub struct ExpectedTemplate {
+        /// A private field, just so the public interface notes this as a
+        /// private-fields struct and not a empty-fields struct for semver
+        /// purposes (e.g., consumers cannot construct this type with
+        /// `ExpectedTemplate {}`)
+        _dummy: (),
+    }
+
+    impl ExpectedTemplate {
+        pub(crate) fn new() -> Self {
+            Self { _dummy: () }
+        }
+    }
 
     /// Details about a `SlotsInConditionClause` error.
     #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -356,7 +356,7 @@ mod test {
         .expect("Expected valid schema.");
         let validator = Validator::new(schema);
 
-        let t = parser::parse_policy_template(
+        let t = parser::parse_policy_or_template(
             Some(PolicyID::from_string("template")),
             r#"permit(principal == some_namespace::User::"Alice", action, resource in ?resource);"#,
         )

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -402,7 +402,7 @@ mod test {
             Annotations, Effect, Eid, EntityUID, Expr, PolicyID, PrincipalConstraint,
             ResourceConstraint,
         },
-        parser::{parse_policy, parse_policy_template},
+        parser::{parse_policy, parse_policy_or_template},
         test_utils::{expect_err, ExpectedErrorMessageBuilder},
     };
     use miette::Report;
@@ -417,7 +417,7 @@ mod test {
     #[test]
     fn validate_entity_type_empty_schema() {
         let src = r#"permit(principal, action, resource == foo_type::"foo_name");"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
         let validate = Validator::new(ValidatorSchema::empty());
         let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
         expect_err(
@@ -460,7 +460,7 @@ mod test {
         let schema = schema_file.try_into().unwrap();
 
         let src = r#"permit(principal == admins::"admin1", action == Action::"act", resource == bin::"bin");"#;
-        let p = parse_policy_template(None, src).unwrap();
+        let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> =
@@ -529,7 +529,7 @@ mod test {
         let singleton_schema = schema_file.try_into().unwrap();
 
         let src = r#"permit(principal, action, resource == bar_type::"bar_name");"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
         let validate = Validator::new(singleton_schema);
         let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
         expect_err(
@@ -548,7 +548,7 @@ mod test {
     #[test]
     fn validate_action_id_empty_schema() {
         let src = r#"permit(principal, action == Action::"foo_name", resource);"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
         let validate = Validator::new(ValidatorSchema::empty());
         let notes: Vec<ValidationError> = validate.validate_action_ids(&policy).collect();
         expect_err(
@@ -706,7 +706,7 @@ mod test {
         let singleton_schema = schema_file.try_into().unwrap();
 
         let src = r#"permit(principal, action == Action::"bar_name", resource);"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
         let validate = Validator::new(singleton_schema);
         let notes: Vec<ValidationError> = validate.validate_action_ids(&policy).collect();
         expect_err(
@@ -769,7 +769,7 @@ mod test {
         let schema = descriptors.try_into().unwrap();
 
         let src = r#"permit(principal, action == Bogus::Action::"foo_name", resource);"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> = validate.validate_action_ids(&policy).collect();
         expect_err(
@@ -835,7 +835,7 @@ mod test {
         let schema = descriptors.try_into().unwrap();
 
         let src = r#"permit(principal == Bogus::Foo::"bar", action, resource);"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> = validate.validate_entity_types(&policy).collect();
         expect_err(
@@ -1082,7 +1082,7 @@ mod test {
 
         let src =
             r#"permit(principal == baz::"p", action == Action::"foo", resource == baz::"r");"#;
-        let p = parse_policy_template(None, src).unwrap();
+        let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> =
@@ -1106,7 +1106,7 @@ mod test {
 
         let src =
             r#"permit(principal == bar::"p", action == Action::"foo", resource == bar::"r");"#;
-        let p = parse_policy_template(None, src).unwrap();
+        let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> =
@@ -1130,7 +1130,7 @@ mod test {
 
         let src =
             r#"permit(principal == baz::"p", action == Action::"foo", resource == bar::"r");"#;
-        let p = parse_policy_template(None, src).unwrap();
+        let p = parse_policy_or_template(None, src).unwrap();
 
         let validate = Validator::new(schema);
         let notes: Vec<ValidationError> =
@@ -1153,12 +1153,12 @@ mod test {
         let (_, _, _, schema) = schema_with_single_principal_action_resource();
 
         let policy =
-            parse_policy_template(None, "permit(principal is bar, action, resource);").unwrap();
+            parse_policy_or_template(None, "permit(principal is bar, action, resource);").unwrap();
 
         let validator = Validator::new(schema);
         assert_validate_policy_succeeds(&validator, &policy);
 
-        let policy = parse_policy_template(
+        let policy = parse_policy_or_template(
             None,
             r#"permit(principal is bar in bar::"baz", action, resource);"#,
         )
@@ -1172,7 +1172,7 @@ mod test {
         let (_, _, _, schema) = schema_with_single_principal_action_resource();
 
         let src = "permit(principal is baz, action, resource);";
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
         assert_validate_policy_fails(
@@ -1188,7 +1188,7 @@ mod test {
         assert_validate_policy_flags_impossible_policy(&validator, &policy);
 
         let src = r#"permit(principal is biz in faz::"a", action, resource);"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         assert_validate_policy_fails(
             &validator,
@@ -1217,7 +1217,7 @@ mod test {
         assert_validate_policy_flags_impossible_policy(&validator, &policy);
 
         let src = r#"permit(principal is bar in baz::"buz", action, resource);"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         assert_validate_policy_fails(
             &validator,
@@ -1237,12 +1237,12 @@ mod test {
         let (_, _, _, schema) = schema_with_single_principal_action_resource();
 
         let policy =
-            parse_policy_template(None, "permit(principal, action, resource is baz);").unwrap();
+            parse_policy_or_template(None, "permit(principal, action, resource is baz);").unwrap();
 
         let validator = Validator::new(schema);
         assert_validate_policy_succeeds(&validator, &policy);
 
-        let policy = parse_policy_template(
+        let policy = parse_policy_or_template(
             None,
             r#"permit(principal, action, resource is baz in baz::"bar");"#,
         )
@@ -1256,7 +1256,7 @@ mod test {
         let (_, _, _, schema) = schema_with_single_principal_action_resource();
 
         let src = "permit(principal, action, resource is bar);";
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
         assert_validate_policy_fails(
@@ -1272,7 +1272,7 @@ mod test {
         assert_validate_policy_flags_impossible_policy(&validator, &policy);
 
         let src = r#"permit(principal, action, resource is baz in bar::"buz");"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         assert_validate_policy_fails(
             &validator,
@@ -1287,7 +1287,7 @@ mod test {
         assert_validate_policy_flags_impossible_policy(&validator, &policy);
 
         let src = r#"permit(principal, action, resource is biz in faz::"a");"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         assert_validate_policy_fails(
             &validator,
@@ -1320,7 +1320,7 @@ mod test {
     fn is_unknown_entity_condition() {
         let (_, _, _, schema) = schema_with_single_principal_action_resource();
         let src = r#"permit(principal, action, resource) when { resource is biz };"#;
-        let policy = parse_policy_template(None, src).unwrap();
+        let policy = parse_policy_or_template(None, src).unwrap();
 
         let validator = Validator::new(schema);
         let err = validator

--- a/cedar-policy-validator/src/typecheck/test/policy.rs
+++ b/cedar-policy-validator/src/typecheck/test/policy.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use cedar_policy_core::{
     ast::{EntityUID, Expr, PolicyID, Template, Var},
-    parser::{parse_policy, parse_policy_template},
+    parser::{parse_policy, parse_policy_or_template},
 };
 use smol_str::SmolStr;
 
@@ -177,7 +177,7 @@ fn entity_literal_typechecks() {
 
 #[test]
 fn policy_checked_in_multiple_envs() {
-    let t = parse_policy_template(
+    let t = parse_policy_or_template(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"view_photo", resource) when { resource.file_type == "jpg" };"#
     ).expect("Policy should parse.");
@@ -205,7 +205,7 @@ fn policy_checked_in_multiple_envs() {
             == 1
     );
 
-    let t = parse_policy_template(
+    let t = parse_policy_or_template(
         Some(PolicyID::from_string("0")),
         r#"permit(principal, action == Action::"delete_group", resource) when { resource.file_type == "jpg" };"#
     ).expect("Policy should parse.");
@@ -1085,7 +1085,7 @@ mod templates {
     #[test]
     fn principal_eq_slot() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal == ?principal, action, resource);"#,
             )
@@ -1096,7 +1096,7 @@ mod templates {
     #[test]
     fn resource_eq_slot() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(None, r#"permit(principal, action, resource == ?resource);"#)
+            parse_policy_or_template(None, r#"permit(principal, action, resource == ?resource);"#)
                 .unwrap(),
         );
     }
@@ -1104,7 +1104,7 @@ mod templates {
     #[test]
     fn principal_resource_eq_slot() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal == ?principal, action, resource == ?resource);"#,
             )
@@ -1115,7 +1115,7 @@ mod templates {
     #[test]
     fn principal_in_slot() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal in ?principal, action, resource);"#,
             )
@@ -1126,7 +1126,7 @@ mod templates {
     #[test]
     fn resource_in_slot() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(None, r#"permit(principal, action, resource in ?resource);"#)
+            parse_policy_or_template(None, r#"permit(principal, action, resource in ?resource);"#)
                 .unwrap(),
         );
     }
@@ -1134,7 +1134,7 @@ mod templates {
     #[test]
     fn principal_resource_in_slot() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal in ?principal, action, resource in ?resource);"#,
             )
@@ -1145,7 +1145,7 @@ mod templates {
     #[test]
     fn resource_slot_safe_body() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal, action, resource in ?resource) when { resource in Group::"Friends" && resource.name like "*" };"#,
             )
@@ -1156,7 +1156,7 @@ mod templates {
     #[test]
     fn resource_slot_error_body() {
         assert_policy_typecheck_fails_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal, action, resource in ?resource) when { resource in Group::"Friends" && resource.bogus };"#,
             )
@@ -1174,7 +1174,7 @@ mod templates {
     #[test]
     fn principal_slot_safe_body() {
         assert_policy_typechecks_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal == ?principal, action, resource in ?resource) when { principal has age && principal.age > 0};"#,
             )
@@ -1185,7 +1185,7 @@ mod templates {
     #[test]
     fn principal_slot_error_body() {
         assert_policy_typecheck_fails_simple_schema(
-            parse_policy_template(
+            parse_policy_or_template(
                 None,
                 r#"permit(principal == ?principal, action, resource) when { principal has age && principal.bogus > 0 };"#,
             )
@@ -1202,7 +1202,7 @@ mod templates {
 
     #[test]
     fn template_all_false() {
-        let template = parse_policy_template(
+        let template = parse_policy_or_template(
             None,
             r#"permit(principal == ?principal, action, resource) when { false };"#,
         )

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use cedar_policy_core::{
     ast::{EntityUID, Expr, PolicyID},
     extensions::Extensions,
-    parser::{parse_policy_template, Loc},
+    parser::{parse_policy_or_template, Loc},
 };
 
 use crate::{
@@ -717,7 +717,7 @@ fn qualified_record_attr() {
         Extensions::all_available(),
     )
     .unwrap();
-    let p = parse_policy_template(
+    let p = parse_policy_or_template(
         None,
         "permit(principal, action, resource) when { context == {num_of_things: 1}};",
     )

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -81,6 +81,9 @@ Cedar Language Version: 4.0
   human-readable Cedar policies. (#943, resolving #925)
 - (*) JSON format Cedar policies will now fail to parse if any annotations are not
   valid Cedar identifiers. (#1004, resolving #994)
+- `Template` parsing functions (e.g., `Template::parse()`) will now fail when
+  passed a static policy as input. Use the `Policy` parsing functions instead.
+  (#??, resolving #1095)
 
 ## [3.2.1] - 2024-05-31
 Cedar Language Version: 3.3

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -89,7 +89,7 @@ Cedar Language Version: 4.0
   even in contexts occurring in a non-empty namespace. (#1060, resolving #579)
 - `Template` parsing functions (e.g., `Template::parse()`) will now fail when
   passed a static policy as input. Use the `Policy` parsing functions instead.
-  (#??, resolving #1095)
+  (#1108, resolving #1095)
 
 ## [3.2.1] - 2024-05-31
 Cedar Language Version: 3.3

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2069,6 +2069,10 @@ pub(crate) fn fold_partition<T, A, B, E>(
 }
 
 /// Policy template datatype
+//
+// NOTE: Unlike the internal type [`ast::Template`], this type only supports
+// templates. The `Template` constructors will return an error if provided with
+// a static policy.
 #[derive(Debug, Clone)]
 pub struct Template {
     /// AST representation of the template, used for most operations.
@@ -2097,12 +2101,13 @@ impl PartialEq for Template {
 impl Eq for Template {}
 
 impl Template {
-    /// Attempt to parse a `Template` from source.
+    /// Attempt to parse a [`Template`] from source.
+    /// Returns an error if the input is a static policy (i.e., has no slots).
     /// If `id` is Some, then the resulting template will have that `id`.
     /// If the `id` is None, the parser will use the default "policy0".
     /// The behavior around None may change in the future.
     pub fn parse(id: Option<PolicyId>, src: impl AsRef<str>) -> Result<Self, ParseErrors> {
-        let ast = parser::parse_policy_template(id.map(Into::into), src.as_ref())?;
+        let ast = parser::parse_template(id.map(Into::into), src.as_ref())?;
         Ok(Self {
             ast,
             lossless: LosslessPolicy::policy_or_template_text(src.as_ref()),
@@ -2221,7 +2226,8 @@ impl Template {
         }
     }
 
-    /// Create a `Template` from its JSON representation.
+    /// Create a [`Template`] from its JSON representation.
+    /// Returns an error if the input is a static policy (i.e., has no slots).
     /// If `id` is Some, the policy will be given that Policy Id.
     /// If `id` is None, then "JSON policy" will be used.
     /// The behavior around None may change in the future.

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -414,8 +414,8 @@ mod test {
         assert_matches!(result, PolicyToTextAnswer::Failure { errors } => {
             assert_exactly_one_error(
                 &errors,
-                "failed to parse template from JSON: error deserializing a policy/template from JSON: tried to convert JSON representing a static policy to a template",
-                None,
+                "failed to parse template from JSON: error deserializing a policy/template from JSON: expected a template, got a static policy",
+                Some("a template should include slot(s) `?principal` or `?resource`"),
             );
         });
     }

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -70,7 +70,7 @@ pub fn policy_to_json(policy: Policy) -> PolicyToJsonAnswer {
 }
 
 /// Return the JSON representation of a template.
-#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policyToJson"))]
+#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "templateToJson"))]
 pub fn template_to_json(template: Template) -> PolicyToJsonAnswer {
     match template.parse(None) {
         Ok(template) => match template.to_json() {

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -296,8 +296,6 @@ impl Policy {
 }
 
 /// Represents a policy template in either the Cedar or JSON policy format.
-/// This format can also be used to represent static policies (which can be
-/// thought of as templates with zero slots).
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
@@ -754,11 +752,22 @@ mod test {
                 .build(),
         );
 
-        // Static policies can also be parsed as templates
-        let template_json = json!("permit(principal == User::\"alice\", action, resource);");
+        // Static policies cannot be parsed as templates
+        let src = "permit(principal == User::\"alice\", action, resource);";
         let template: Template =
-            serde_json::from_value(template_json).expect("failed to parse from JSON");
-        template.parse(None).expect("failed to convert to template");
+            serde_json::from_value(json!(src)).expect("failed to parse from JSON");
+        let err = template
+            .parse(None)
+            .expect_err("should have failed to convert to template");
+        expect_err(
+            src,
+            &err,
+            &ExpectedErrorMessageBuilder::error("failed to parse template from string")
+                .source("expected a template, got a static policy")
+                .help("a template should include slot(s) `?principal` or `?resource`")
+                .exactly_one_underline(src)
+                .build(),
+        );
     }
 
     #[test]

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -391,9 +391,10 @@ fn policy_annotations() {
     assert_eq!(p.annotations().next(), Some(("anno", "good annotation")));
 
     // and on templates
-    let t: Template = r#"@tanno("good annotation")permit(principal, action, resource);"#
-        .parse()
-        .unwrap();
+    let t: Template =
+        r#"@tanno("good annotation")permit(principal == ?principal, action, resource);"#
+            .parse()
+            .unwrap();
     // need a new id to include in set
     let t = t.new_id(PolicyId::new("new_template_id"));
     assert_eq!(t.annotation("tanno"), Some("good annotation"));


### PR DESCRIPTION
## Description of changes

* The public-facing `Template` constructors will now return an error if passed a static policy.
* The internal `Template` type will continue to support both templates and static policies. There are several places in the parser and validator where we want a single type to represent both options because we use the same logic for both. I added comments & did some renaming in places where I felt this was unclear.
* Added new error variants to `FromJsonError` (`PolicyToTemplate`) and `ParseError` (`ExpectedTemplate`) to return in the case where a static policy is being used as a template.
* Made corresponding changes to the FFI code and test cases.

## Issue #, if available

Resolves #1095 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
