### PR TITLE
Get rid of unnecessary vecs in validator tests

### DIFF
--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -142,10 +142,10 @@ fn heterogeneous_set() {
     let src = "[true, 1]";
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![ValidationError::incompatible_types(
+        [ValidationError::incompatible_types(
             get_loc(src, src),
             expr_id_placeholder(),
-            vec![Type::singleton_boolean(true), Type::primitive_long()],
+            [Type::singleton_boolean(true), Type::primitive_long()],
             LubHelp::None,
             LubContext::Set,
         )],
@@ -174,7 +174,7 @@ fn and_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::primitive_boolean(),
@@ -187,7 +187,7 @@ fn and_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "2"),
             expr_id_placeholder(),
             Type::primitive_boolean(),
@@ -200,7 +200,7 @@ fn and_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "false"),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -213,7 +213,7 @@ fn and_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "false"),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -253,7 +253,7 @@ fn or_right_true_fails_left() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::primitive_boolean(),
@@ -304,7 +304,7 @@ fn or_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::primitive_boolean(),
@@ -317,7 +317,7 @@ fn or_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::primitive_boolean(),
@@ -330,7 +330,7 @@ fn or_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "true"),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -343,7 +343,7 @@ fn or_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::singleton_boolean(true),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "false"),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -356,7 +356,7 @@ fn or_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "true"),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -615,10 +615,10 @@ fn has_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_one_of_types(
+        [ValidationError::expected_one_of_types(
             get_loc(src, "true"),
             expr_id_placeholder(),
-            vec![Type::any_entity_reference(), Type::any_record()],
+            [Type::any_entity_reference(), Type::any_record()],
             Type::singleton_boolean(true),
             None,
         )],
@@ -641,7 +641,7 @@ fn record_get_attr_incompatible() {
         empty_schema_file(),
         src.parse().unwrap(),
         None,
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, src),
             expr_id_placeholder(),
             AttributeAccess::Other(vec!["foo".into()]),
@@ -657,10 +657,10 @@ fn record_get_attr_typecheck_fails() {
     let src = "2.foo";
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![ValidationError::expected_one_of_types(
+        [ValidationError::expected_one_of_types(
             get_loc(src, "2"),
             expr_id_placeholder(),
-            vec![Type::any_entity_reference(), Type::any_record()],
+            [Type::any_entity_reference(), Type::any_record()],
             Type::primitive_long(),
             None,
         )],
@@ -672,10 +672,10 @@ fn record_get_attr_lub_typecheck_fails() {
     let src = "(if (0 < 1) then {foo: true} else 1).foo";
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![ValidationError::incompatible_types(
+        [ValidationError::incompatible_types(
             get_loc(src, "if (0 < 1) then {foo: true} else 1"),
             expr_id_placeholder(),
-            vec![
+            [
                 Type::closed_record_with_required_attributes([(
                     "foo".into(),
                     Type::singleton_boolean(true),
@@ -693,7 +693,7 @@ fn record_get_attr_does_not_exist() {
     let src = "{}.foo";
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, src),
             expr_id_placeholder(),
             AttributeAccess::Other(vec!["foo".into()]),
@@ -708,7 +708,7 @@ fn record_get_attr_lub_does_not_exist() {
     let src = "(if true then {} else {foo: 1}).foo";
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, src),
             expr_id_placeholder(),
             AttributeAccess::Other(vec!["foo".into()]),
@@ -762,7 +762,7 @@ fn in_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![
+        [
             ValidationError::expected_type(
                 get_loc(src, "0"),
                 expr_id_placeholder(),
@@ -773,7 +773,7 @@ fn in_typecheck_fails() {
             ValidationError::expected_one_of_types(
                 get_loc(src, "true"),
                 expr_id_placeholder(),
-                vec![
+                [
                     Type::set(Type::any_entity_reference()),
                     Type::any_entity_reference(),
                 ],
@@ -799,7 +799,7 @@ fn contains_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#""foo""#),
             expr_id_placeholder(),
             Type::any_set(),
@@ -812,7 +812,7 @@ fn contains_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::any_set(),
@@ -825,7 +825,7 @@ fn contains_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "{foo: 1}"),
             expr_id_placeholder(),
             Type::any_set(),
@@ -881,7 +881,7 @@ fn contains_all_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![
+        [
             ValidationError::expected_type(
                 get_loc(src, "1"),
                 expr_id_placeholder(),
@@ -934,7 +934,7 @@ fn like_typechecks() {
     assert_typechecks_empty_schema(
         Expr::like(
             Expr::val("foo"),
-            vec![
+            [
                 PatternElem::Char('b'),
                 PatternElem::Char('a'),
                 PatternElem::Char('r'),
@@ -950,7 +950,7 @@ fn like_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::primitive_string(),
@@ -974,7 +974,7 @@ fn less_than_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![
+        [
             ValidationError::expected_type(
                 get_loc(src, "true"),
                 expr_id_placeholder(),
@@ -1005,7 +1005,7 @@ fn not_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::primitive_boolean(),
@@ -1044,10 +1044,10 @@ fn if_no_lub_error() {
     let src = r#"if (1 < 2) then 1 else "test""#;
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![ValidationError::incompatible_types(
+        [ValidationError::incompatible_types(
             get_loc(src, src),
             expr_id_placeholder(),
-            vec![Type::primitive_long(), Type::primitive_string()],
+            [Type::primitive_long(), Type::primitive_string()],
             LubHelp::None,
             LubContext::Conditional,
         )],
@@ -1059,11 +1059,11 @@ fn if_typecheck_fails() {
     let src = r#"if "fail" then 1 else "test""#;
     assert_typecheck_fails_empty_schema_without_type(
         src.parse().unwrap(),
-        vec![
+        [
             ValidationError::incompatible_types(
                 get_loc(src, src),
                 expr_id_placeholder(),
-                vec![Type::primitive_long(), Type::primitive_string()],
+                [Type::primitive_long(), Type::primitive_string()],
                 LubHelp::None,
                 LubContext::Conditional,
             ),
@@ -1090,7 +1090,7 @@ fn neg_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_long(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#""foo""#),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -1112,7 +1112,7 @@ fn mul_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_long(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#""foo""#),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -1136,7 +1136,7 @@ fn add_sub_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_long(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#""foo""#),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -1149,7 +1149,7 @@ fn add_sub_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),
         Type::primitive_long(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#""bar""#),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -1168,7 +1168,7 @@ fn is_typecheck_fails() {
         schema,
         src.parse().unwrap(),
         Some(Type::primitive_boolean()),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "1"),
             expr_id_placeholder(),
             Type::any_entity_reference(),

--- a/cedar-policy-validator/src/typecheck/test/extensions.rs
+++ b/cedar-policy-validator/src/typecheck/test/extensions.rs
@@ -52,7 +52,7 @@ fn ip_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(ipaddr_name.clone()),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "3"),
             expr_id_placeholder(),
             Type::primitive_string(),
@@ -65,7 +65,7 @@ fn ip_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(ipaddr_name.clone()),
-        vec![ValidationError::function_argument_validation(
+        [ValidationError::function_argument_validation(
             get_loc(src, src),
             expr_id_placeholder(),
             "Failed to parse as IP address: `\"foo\"`".into(),
@@ -76,7 +76,7 @@ fn ip_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::primitive_boolean(),
-        vec![ValidationError::wrong_number_args(
+        [ValidationError::wrong_number_args(
             get_loc(src, src),
             expr_id_placeholder(),
             1,
@@ -88,7 +88,7 @@ fn ip_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr,
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "3"),
             expr_id_placeholder(),
             Type::extension(ipaddr_name),
@@ -133,7 +133,7 @@ fn decimal_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr,
         Type::extension(decimal_name.clone()),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "3"),
             expr_id_placeholder(),
             Type::primitive_string(),
@@ -146,7 +146,7 @@ fn decimal_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::extension(decimal_name.clone()),
-        vec![ValidationError::function_argument_validation(
+        [ValidationError::function_argument_validation(
             get_loc(src, src),
             expr_id_placeholder(),
             "Failed to parse as a decimal value: `\"foo\"`".into(),
@@ -157,7 +157,7 @@ fn decimal_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr.clone(),
         Type::primitive_boolean(),
-        vec![ValidationError::wrong_number_args(
+        [ValidationError::wrong_number_args(
             get_loc(src, src),
             expr_id_placeholder(),
             2,
@@ -169,7 +169,7 @@ fn decimal_extension_typecheck_fails() {
     assert_typecheck_fails_empty_schema(
         expr,
         Type::primitive_boolean(),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "4"),
             expr_id_placeholder(),
             Type::extension(decimal_name),

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -78,7 +78,7 @@ fn assert_expr_typechecks_namespace_schema(e: Expr, t: Type) {
 fn assert_expr_typecheck_fails_namespace_schema(
     e: Expr,
     t: Option<Type>,
-    errs: Vec<ValidationError>,
+    errs: impl IntoIterator<Item = ValidationError>,
 ) {
     assert_typecheck_fails(namespaced_entity_type_schema(), e, t, errs)
 }
@@ -142,7 +142,7 @@ fn namespaced_entity_can_type_error() {
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(src).expect("Expr should parse."),
         Some(Type::primitive_boolean()),
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#"N::S::Foo::"alice""#),
             expr_id_placeholder(),
             Type::primitive_long(),
@@ -157,32 +157,32 @@ fn namespaced_entity_wrong_namespace() {
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(r#"N::S::T::Foo::"alice""#).expect("Expr should parse."),
         None,
-        vec![],
+        [],
     );
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(r#"N::Foo::"alice""#).expect("Expr should parse."),
         None,
-        vec![],
+        [],
     );
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(r#"Foo::"alice""#).expect("Expr should parse."),
         None,
-        vec![],
+        [],
     );
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(r#"N::Action::"baz""#).expect("Expr should parse."),
         None,
-        vec![],
+        [],
     );
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(r#"Action::N::S::"baz""#).expect("Expr should parse."),
         None,
-        vec![],
+        [],
     );
     assert_expr_typecheck_fails_namespace_schema(
         Expr::from_str(r#"Action::"baz""#).expect("Expr should parse."),
         None,
-        vec![],
+        [],
     );
 }
 
@@ -367,7 +367,7 @@ fn multiple_namespaces_attributes() {
         schema,
         Expr::from_str(src).unwrap(),
         None,
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, src),
             PolicyID::from_string("expr"),
             AttributeAccess::EntityLUB(
@@ -490,7 +490,7 @@ fn multiple_namespaces_applies_to() {
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails_namespace_schema(
     p: StaticPolicy,
-    expected_type_errors: Vec<ValidationError>,
+    expected_type_errors: impl IntoIterator<Item = ValidationError>,
 ) {
     assert_policy_typecheck_fails(namespaced_entity_type_schema(), p, expected_type_errors);
 }
@@ -506,7 +506,7 @@ fn namespaced_entity_is_wrong_type_and() {
     let policy = parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse.");
     assert_policy_typecheck_fails_namespace_schema(
         policy,
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#"N::S::Foo::"alice""#),
             PolicyID::from_string("0"),
             Type::primitive_boolean(),
@@ -527,7 +527,7 @@ fn namespaced_entity_is_wrong_type_when() {
     let policy = parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse.");
     assert_policy_typecheck_fails_namespace_schema(
         policy,
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, r#"N::S::Foo::"alice""#),
             PolicyID::from_string("0"),
             Type::primitive_boolean(),
@@ -581,7 +581,7 @@ fn multi_namespace_action_eq() {
     assert_policy_typecheck_warns(
         schema.clone(),
         policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             policy.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
@@ -647,7 +647,7 @@ fn multi_namespace_action_in() {
     assert_policy_typecheck_warns(
         schema.clone(),
         policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             policy.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],

--- a/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
@@ -69,7 +69,7 @@ fn assert_policy_typechecks_optional_schema(p: StaticPolicy) {
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails_optional_schema(
     p: StaticPolicy,
-    expected_type_errors: Vec<ValidationError>,
+    expected_type_errors: impl IntoIterator<Item = ValidationError>,
 ) {
     assert_policy_typecheck_fails(schema_with_optionals(), p, expected_type_errors);
 }
@@ -321,7 +321,7 @@ fn assert_name_access_fails(policy: StaticPolicy) {
     let loc = get_loc(policy.loc().unwrap().src.clone(), "principal.name");
     assert_policy_typecheck_fails_optional_schema(
         policy,
-        vec![ValidationError::unsafe_optional_attribute_access(
+        [ValidationError::unsafe_optional_attribute_access(
             loc,
             id,
             AttributeAccess::EntityLUB(
@@ -585,7 +585,7 @@ fn record_optional_attrs() {
     assert_policy_typecheck_fails(
         schema.clone(),
         failing_policy,
-        vec![ValidationError::unsafe_optional_attribute_access(
+        [ValidationError::unsafe_optional_attribute_access(
             get_loc(src, "principal.record.name"),
             PolicyID::from_string("0"),
             AttributeAccess::EntityLUB(
@@ -601,7 +601,7 @@ fn record_optional_attrs() {
     assert_policy_typecheck_fails(
         schema,
         failing_policy2,
-        vec![ValidationError::unsafe_optional_attribute_access(
+        [ValidationError::unsafe_optional_attribute_access(
             get_loc(src, "principal.name"),
             PolicyID::from_string("0"),
             AttributeAccess::EntityLUB(
@@ -764,7 +764,7 @@ fn action_attrs_failing() {
     assert_policy_typecheck_fails(
         schema.clone(),
         failing_policy,
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, "action.canUndo"),
             PolicyID::from_string("0"),
             AttributeAccess::Other(vec!["canUndo".into()]),
@@ -783,7 +783,7 @@ fn action_attrs_failing() {
     assert_policy_typecheck_warns(
         schema.clone(),
         failing_policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             failing_policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -805,5 +805,5 @@ fn action_attrs_failing() {
         "#,
     )
     .expect("Policy should parse.");
-    assert_policy_typecheck_fails(schema, failing_policy, vec![]);
+    assert_policy_typecheck_fails(schema, failing_policy, []);
 }

--- a/cedar-policy-validator/src/typecheck/test/policy.rs
+++ b/cedar-policy-validator/src/typecheck/test/policy.rs
@@ -123,7 +123,7 @@ fn assert_policy_typechecks_permissive_simple_schema(p: impl Into<Arc<Template>>
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_fails_simple_schema(
     p: impl Into<Arc<Template>>,
-    expected_type_errors: Vec<ValidationError>,
+    expected_type_errors: impl IntoIterator<Item = ValidationError>,
 ) {
     assert_policy_typecheck_fails(simple_schema_file(), p, expected_type_errors)
 }
@@ -131,7 +131,7 @@ fn assert_policy_typecheck_fails_simple_schema(
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_warns_simple_schema(
     p: impl Into<Arc<Template>>,
-    expected_warnings: Vec<ValidationWarning>,
+    expected_warnings: impl IntoIterator<Item = ValidationWarning>,
 ) {
     assert_policy_typecheck_warns(simple_schema_file(), p, expected_warnings)
 }
@@ -139,7 +139,7 @@ fn assert_policy_typecheck_warns_simple_schema(
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_permissive_fails_simple_schema(
     p: impl Into<Arc<Template>>,
-    expected_type_errors: Vec<ValidationError>,
+    expected_type_errors: impl IntoIterator<Item = ValidationError>,
 ) {
     assert_policy_typecheck_fails_for_mode(
         simple_schema_file(),
@@ -152,7 +152,7 @@ fn assert_policy_typecheck_permissive_fails_simple_schema(
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_policy_typecheck_permissive_warns_simple_schema(
     p: impl Into<Arc<Template>>,
-    expected_warnings: Vec<ValidationWarning>,
+    expected_warnings: impl IntoIterator<Item = ValidationWarning>,
 ) {
     assert_policy_typecheck_warns_for_mode(
         simple_schema_file(),
@@ -299,7 +299,7 @@ fn policy_invalid_attribute() {
     let src = r#"permit(principal, action in [Action::"delete_group", Action::"view_photo"], resource) when { resource.file_type == "jpg" };"#;
     assert_policy_typecheck_fails_simple_schema(
         parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse."),
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, "resource.file_type"),
             PolicyID::from_string("0"),
             AttributeAccess::EntityLUB(
@@ -317,7 +317,7 @@ fn policy_invalid_attribute_2() {
     let src = r#"permit(principal, action == Action::"view_photo", resource) when { principal.age > 21 };"#;
     assert_policy_typecheck_fails_simple_schema(
         parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse."),
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, "principal.age"),
             PolicyID::from_string("0"),
             AttributeAccess::EntityLUB(
@@ -336,7 +336,7 @@ fn policy_context_invalid_attribute() {
         r#"permit(principal, action == Action::"view_photo", resource) when { context.fake };"#;
     assert_policy_typecheck_fails_simple_schema(
         parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse."),
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(src, "context.fake"),
             PolicyID::from_string("0"),
             AttributeAccess::Context(
@@ -414,7 +414,7 @@ fn policy_impossible_scope() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -430,7 +430,7 @@ fn policy_impossible_literal_euids() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -446,7 +446,7 @@ fn policy_impossible_not_has() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -470,7 +470,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -483,7 +483,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -496,7 +496,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -509,7 +509,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -522,7 +522,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -535,7 +535,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -548,7 +548,7 @@ fn policy_in_action_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_permissive_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -564,7 +564,7 @@ fn policy_action_in_impossible() {
     .expect("Policy should parse.");
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -609,7 +609,7 @@ fn entity_lub_cant_access_attribute_not_shared() {
     let p = parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse.");
     assert_policy_typecheck_permissive_fails_simple_schema(
         p,
-        vec![ValidationError::unsafe_attribute_access(
+        [ValidationError::unsafe_attribute_access(
             get_loc(
                 src,
                 r#"(if 1 > 0 then User::"alice" else Photo::"vacation.jpg").name"#,
@@ -640,7 +640,7 @@ fn entity_attribute_recommendation() {
         Some("file_type".into()),
         false,
     );
-    assert_policy_typecheck_fails_simple_schema(p, vec![expected]);
+    assert_policy_typecheck_fails_simple_schema(p, [expected]);
 }
 
 #[test]
@@ -660,7 +660,7 @@ fn entity_lub_cant_have_undeclared_attribute() {
     .expect("Policy should parse.");
     assert_policy_typecheck_permissive_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -688,7 +688,7 @@ fn is_impossible() {
     let p = parse_policy(None, r#"permit(principal is Photo, action, resource);"#).unwrap();
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
@@ -696,7 +696,7 @@ fn is_impossible() {
     let p = parse_policy(None, r#"permit(principal, action, resource is User);"#).unwrap();
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
@@ -727,7 +727,7 @@ fn is_entity_lub() {
     .unwrap();
     assert_policy_typecheck_permissive_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
@@ -754,7 +754,7 @@ fn is_action() {
     .unwrap();
     assert_policy_typecheck_warns_simple_schema(
         p.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             p.loc().cloned(),
             PolicyID::from_string("policy0"),
         )],
@@ -766,7 +766,7 @@ fn entity_record_lub_is_none() {
     let src = r#"permit(principal, action, resource) when { (if 1 > 0 then User::"alice" else {name: "bob"}).name == "jane" };"#;
     assert_policy_typecheck_fails_simple_schema(
         parse_policy(Some(PolicyID::from_string("0")), src).expect("Policy should parse."),
-        vec![ValidationError::incompatible_types(
+        [ValidationError::incompatible_types(
             get_loc(src, r#"if 1 > 0 then User::"alice" else {name: "bob"}"#),
             PolicyID::from_string("0"),
             [
@@ -821,7 +821,7 @@ fn optional_attr_fail() {
     assert_policy_typecheck_fails(
         schema,
         policy,
-        vec![ValidationError::unsafe_optional_attribute_access(
+        [ValidationError::unsafe_optional_attribute_access(
             get_loc(src, "principal.name"),
             PolicyID::from_string("0"),
             AttributeAccess::EntityLUB(
@@ -859,7 +859,7 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
     assert_policy_typecheck_fails(
         schema,
         policy,
-        vec![ValidationError::expected_type(
+        [ValidationError::expected_type(
             get_loc(src, "true"),
             PolicyID::from_string("0"),
             Type::primitive_long(),
@@ -916,7 +916,7 @@ fn action_groups() {
     assert_policy_typecheck_warns(
         schema.clone(),
         policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -930,7 +930,7 @@ fn action_groups() {
     assert_policy_typecheck_warns(
         schema.clone(),
         policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -944,7 +944,7 @@ fn action_groups() {
     assert_policy_typecheck_warns(
         schema.clone(),
         policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -958,7 +958,7 @@ fn action_groups() {
     assert_policy_typecheck_warns(
         schema,
         policy.clone(),
-        vec![ValidationWarning::impossible_policy(
+        [ValidationWarning::impossible_policy(
             policy.loc().cloned(),
             PolicyID::from_string("0"),
         )],
@@ -1008,7 +1008,7 @@ fn record_entity_lub_non_term() {
     assert_policy_typecheck_fails(
         schema,
         policy,
-        vec![ValidationError::incompatible_types(
+        [ValidationError::incompatible_types(
             get_loc(src, r#"if principal.bar then principal.foo else U::"b""#),
             PolicyID::from_string("policy0"),
             [
@@ -1143,7 +1143,7 @@ mod templates {
         let src = r#"permit(principal, action, resource in ?resource) when { resource in Group::"Friends" && resource.bogus };"#;
         assert_policy_typecheck_fails_simple_schema(
             parse_policy_template(None, src).unwrap(),
-            vec![ValidationError::unsafe_attribute_access(
+            [ValidationError::unsafe_attribute_access(
                 get_loc(src, "resource.bogus"),
                 PolicyID::from_string("policy0"),
                 AttributeAccess::EntityLUB(
@@ -1172,7 +1172,7 @@ mod templates {
         let src = r#"permit(principal == ?principal, action, resource) when { principal has age && principal.bogus > 0 };"#;
         assert_policy_typecheck_fails_simple_schema(
             parse_policy_template(None, src).unwrap(),
-            vec![ValidationError::unsafe_attribute_access(
+            [ValidationError::unsafe_attribute_access(
                 get_loc(src, "principal.bogus"),
                 PolicyID::from_string("policy0"),
                 AttributeAccess::EntityLUB(
@@ -1194,7 +1194,7 @@ mod templates {
         .unwrap();
         assert_policy_typecheck_warns_simple_schema(
             template.clone(),
-            vec![ValidationWarning::impossible_policy(
+            [ValidationWarning::impossible_policy(
                 template.loc().cloned(),
                 PolicyID::from_string("policy0"),
             )],

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -721,7 +721,7 @@ fn qualified_record_attr() {
     assert_policy_typecheck_fails(
         schema,
         p.clone(),
-        vec![ValidationError::incompatible_types(
+        [ValidationError::incompatible_types(
             get_loc(src, "context == {num_of_things: 1}"),
             PolicyID::from_string("policy0"),
             [


### PR DESCRIPTION
## Description of changes

Slight change to the test utils I noticed I could make while doing some other refactoring

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

