### PR TITLE
rename `schema_file_format` to `json_schema`

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -386,7 +386,7 @@ pub mod schema_errors {
     #[derive(Debug, Diagnostic, Error)]
     #[diagnostic(help("any actions appearing as parents need to be declared as actions"))]
     pub struct ActionResolutionError(
-        pub(crate) NonEmpty<crate::schema_file_format::ActionEntityUID<crate::ConditionalName>>,
+        pub(crate) NonEmpty<crate::json_schema::ActionEntityUID<crate::ConditionalName>>,
     );
 
     impl ActionResolutionError {

--- a/cedar-policy-validator/src/human_schema.rs
+++ b/cedar-policy-validator/src/human_schema.rs
@@ -17,6 +17,7 @@
 //! The Cedar human/natural syntax for schemas
 
 mod ast;
+pub use ast::Path;
 mod err;
 pub mod fmt;
 pub mod parser;

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -27,7 +27,7 @@ use smol_str::SmolStr;
 #[allow(unused_imports)]
 use smol_str::ToSmolStr;
 
-use crate::SchemaTypeVariant;
+use crate::json_schema;
 
 pub const BUILTIN_TYPES: [&str; 3] = ["Long", "String", "Bool"];
 
@@ -240,12 +240,12 @@ pub enum PrimitiveType {
     Bool,
 }
 
-impl<N> From<PrimitiveType> for SchemaTypeVariant<N> {
+impl<N> From<PrimitiveType> for json_schema::SchemaTypeVariant<N> {
     fn from(value: PrimitiveType) -> Self {
         match value {
-            PrimitiveType::Long => SchemaTypeVariant::Long,
-            PrimitiveType::String => SchemaTypeVariant::String,
-            PrimitiveType::Bool => SchemaTypeVariant::Boolean,
+            PrimitiveType::Long => json_schema::SchemaTypeVariant::Long,
+            PrimitiveType::String => json_schema::SchemaTypeVariant::String,
+            PrimitiveType::Bool => json_schema::SchemaTypeVariant::Boolean,
         }
     }
 }

--- a/cedar-policy-validator/src/human_schema/ast.rs
+++ b/cedar-policy-validator/src/human_schema/ast.rs
@@ -240,12 +240,12 @@ pub enum PrimitiveType {
     Bool,
 }
 
-impl<N> From<PrimitiveType> for json_schema::SchemaTypeVariant<N> {
+impl<N> From<PrimitiveType> for json_schema::TypeVariant<N> {
     fn from(value: PrimitiveType) -> Self {
         match value {
-            PrimitiveType::Long => json_schema::SchemaTypeVariant::Long,
-            PrimitiveType::String => json_schema::SchemaTypeVariant::String,
-            PrimitiveType::Bool => json_schema::SchemaTypeVariant::Boolean,
+            PrimitiveType::Long => json_schema::TypeVariant::Long,
+            PrimitiveType::String => json_schema::TypeVariant::String,
+            PrimitiveType::Bool => json_schema::TypeVariant::Boolean,
         }
     }
 }

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -24,12 +24,9 @@ use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
 use thiserror::Error;
 
-use crate::{
-    ActionType, EntityType, NamespaceDefinition, RawName, SchemaFragment, SchemaType,
-    SchemaTypeVariant,
-};
+use crate::{json_schema, RawName};
 
-impl<N: Display> Display for SchemaFragment<N> {
+impl<N: Display> Display for json_schema::SchemaFragment<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (ns, def) in &self.0 {
             match ns {
@@ -41,7 +38,7 @@ impl<N: Display> Display for SchemaFragment<N> {
     }
 }
 
-impl<N: Display> Display for NamespaceDefinition<N> {
+impl<N: Display> Display for json_schema::NamespaceDefinition<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (n, ty) in &self.common_types {
             writeln!(f, "type {n} = {ty};")?
@@ -56,16 +53,18 @@ impl<N: Display> Display for NamespaceDefinition<N> {
     }
 }
 
-impl<N: Display> Display for SchemaType<N> {
+impl<N: Display> Display for json_schema::SchemaType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            SchemaType::Type(ty) => match ty {
-                SchemaTypeVariant::Boolean => write!(f, "__cedar::Bool"),
-                SchemaTypeVariant::Entity { name } => write!(f, "{name}"),
-                SchemaTypeVariant::EntityOrCommon { type_name } => write!(f, "{type_name}"),
-                SchemaTypeVariant::Extension { name } => write!(f, "__cedar::{name}"),
-                SchemaTypeVariant::Long => write!(f, "__cedar::Long"),
-                SchemaTypeVariant::Record {
+            json_schema::SchemaType::Type(ty) => match ty {
+                json_schema::SchemaTypeVariant::Boolean => write!(f, "__cedar::Bool"),
+                json_schema::SchemaTypeVariant::Entity { name } => write!(f, "{name}"),
+                json_schema::SchemaTypeVariant::EntityOrCommon { type_name } => {
+                    write!(f, "{type_name}")
+                }
+                json_schema::SchemaTypeVariant::Extension { name } => write!(f, "__cedar::{name}"),
+                json_schema::SchemaTypeVariant::Long => write!(f, "__cedar::Long"),
+                json_schema::SchemaTypeVariant::Record {
                     attributes,
                     additional_attributes: _,
                 } => {
@@ -85,10 +84,10 @@ impl<N: Display> Display for SchemaType<N> {
                     write!(f, "}}")?;
                     Ok(())
                 }
-                SchemaTypeVariant::Set { element } => write!(f, "Set < {element} >"),
-                SchemaTypeVariant::String => write!(f, "__cedar::String"),
+                json_schema::SchemaTypeVariant::Set { element } => write!(f, "Set < {element} >"),
+                json_schema::SchemaTypeVariant::String => write!(f, "__cedar::String"),
             },
-            SchemaType::CommonTypeRef { type_name } => write!(f, "{type_name}"),
+            json_schema::SchemaType::CommonTypeRef { type_name } => write!(f, "{type_name}"),
         }
     }
 }
@@ -104,7 +103,7 @@ fn fmt_vec<T: Display>(f: &mut std::fmt::Formatter<'_>, ets: NonEmpty<T>) -> std
     write!(f, "[{contents}]")
 }
 
-impl<N: Display> Display for EntityType<N> {
+impl<N: Display> Display for json_schema::EntityType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(non_empty) = non_empty_slice(&self.member_of_types) {
             write!(f, " in ")?;
@@ -121,7 +120,7 @@ impl<N: Display> Display for EntityType<N> {
     }
 }
 
-impl<N: Display> Display for ActionType<N> {
+impl<N: Display> Display for json_schema::ActionType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(parents) = self
             .member_of
@@ -199,7 +198,7 @@ impl NameCollisionsError {
 // less conservative in the future without breaking people.
 // 2) This code is also likely the cause of #1063; see that issue
 pub fn json_schema_to_custom_schema_str<N: Display>(
-    json_schema: &SchemaFragment<N>,
+    json_schema: &json_schema::SchemaFragment<N>,
 ) -> Result<String, ToHumanSchemaSyntaxError> {
     let mut name_collisions: Vec<SmolStr> = Vec::new();
     for (name, ns) in json_schema.0.iter().filter(|(name, _)| !name.is_none()) {

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -26,7 +26,7 @@ use thiserror::Error;
 
 use crate::{json_schema, RawName};
 
-impl<N: Display> Display for json_schema::SchemaFragment<N> {
+impl<N: Display> Display for json_schema::Fragment<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (ns, def) in &self.0 {
             match ns {
@@ -182,7 +182,7 @@ impl NameCollisionsError {
     }
 }
 
-/// Convert a [`SchemaFragment`] to a string containing human schema syntax
+/// Convert a [`json_schema::Fragment`] to a string containing human schema syntax
 ///
 /// As of this writing, this existing code throws an error if any
 /// fully-qualified name in a non-empty namespace is a valid common type and
@@ -198,7 +198,7 @@ impl NameCollisionsError {
 // less conservative in the future without breaking people.
 // 2) This code is also likely the cause of #1063; see that issue
 pub fn json_schema_to_custom_schema_str<N: Display>(
-    json_schema: &json_schema::SchemaFragment<N>,
+    json_schema: &json_schema::Fragment<N>,
 ) -> Result<String, ToHumanSchemaSyntaxError> {
     let mut name_collisions: Vec<SmolStr> = Vec::new();
     for (name, ns) in json_schema.0.iter().filter(|(name, _)| !name.is_none()) {

--- a/cedar-policy-validator/src/human_schema/fmt.rs
+++ b/cedar-policy-validator/src/human_schema/fmt.rs
@@ -53,18 +53,18 @@ impl<N: Display> Display for json_schema::NamespaceDefinition<N> {
     }
 }
 
-impl<N: Display> Display for json_schema::SchemaType<N> {
+impl<N: Display> Display for json_schema::Type<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            json_schema::SchemaType::Type(ty) => match ty {
-                json_schema::SchemaTypeVariant::Boolean => write!(f, "__cedar::Bool"),
-                json_schema::SchemaTypeVariant::Entity { name } => write!(f, "{name}"),
-                json_schema::SchemaTypeVariant::EntityOrCommon { type_name } => {
+            json_schema::Type::Type(ty) => match ty {
+                json_schema::TypeVariant::Boolean => write!(f, "__cedar::Bool"),
+                json_schema::TypeVariant::Entity { name } => write!(f, "{name}"),
+                json_schema::TypeVariant::EntityOrCommon { type_name } => {
                     write!(f, "{type_name}")
                 }
-                json_schema::SchemaTypeVariant::Extension { name } => write!(f, "__cedar::{name}"),
-                json_schema::SchemaTypeVariant::Long => write!(f, "__cedar::Long"),
-                json_schema::SchemaTypeVariant::Record {
+                json_schema::TypeVariant::Extension { name } => write!(f, "__cedar::{name}"),
+                json_schema::TypeVariant::Long => write!(f, "__cedar::Long"),
+                json_schema::TypeVariant::Record {
                     attributes,
                     additional_attributes: _,
                 } => {
@@ -84,10 +84,10 @@ impl<N: Display> Display for json_schema::SchemaType<N> {
                     write!(f, "}}")?;
                     Ok(())
                 }
-                json_schema::SchemaTypeVariant::Set { element } => write!(f, "Set < {element} >"),
-                json_schema::SchemaTypeVariant::String => write!(f, "__cedar::String"),
+                json_schema::TypeVariant::Set { element } => write!(f, "Set < {element} >"),
+                json_schema::TypeVariant::String => write!(f, "__cedar::String"),
             },
-            json_schema::SchemaType::CommonTypeRef { type_name } => write!(f, "{type_name}"),
+            json_schema::Type::CommonTypeRef { type_name } => write!(f, "{type_name}"),
         }
     }
 }

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -96,14 +96,14 @@ pub enum HumanSyntaxParseErrors {
     JsonError(#[from] ToJsonSchemaErrors),
 }
 
-/// Parse a schema fragment, in human syntax, into a [`crate::SchemaFragment`],
+/// Parse a schema fragment, in human syntax, into a [`json_schema::Fragment`],
 /// possibly generating warnings
 pub fn parse_natural_schema_fragment<'a>(
     src: &str,
     extensions: &Extensions<'a>,
 ) -> Result<
     (
-        json_schema::SchemaFragment<crate::RawName>,
+        json_schema::Fragment<crate::RawName>,
         impl Iterator<Item = SchemaWarning> + 'a,
     ),
     HumanSyntaxParseErrors,

--- a/cedar-policy-validator/src/human_schema/parser.rs
+++ b/cedar-policy-validator/src/human_schema/parser.rs
@@ -27,6 +27,7 @@ use super::{
     err::{self, ParseError, ParseErrors, SchemaWarning, ToJsonSchemaErrors},
     to_json_schema::custom_schema_to_json_schema,
 };
+use crate::json_schema;
 use cedar_policy_core::extensions::Extensions;
 
 lalrpop_mod!(
@@ -102,7 +103,7 @@ pub fn parse_natural_schema_fragment<'a>(
     extensions: &Extensions<'a>,
 ) -> Result<
     (
-        crate::SchemaFragment<crate::RawName>,
+        json_schema::SchemaFragment<crate::RawName>,
         impl Iterator<Item = SchemaWarning> + 'a,
     ),
     HumanSyntaxParseErrors,

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -564,15 +564,14 @@ namespace Baz {action "Foo" appliesTo {
         let groups = ["readers", "writers", "triagers", "admins", "maintainers"];
         for group in groups {
             match &repo.shape.0 {
-                json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+                json_schema::Type::Type(json_schema::TypeVariant::Record {
                     attributes,
                     additional_attributes: false,
                 }) => {
-                    let expected = json_schema::SchemaType::Type(
-                        json_schema::SchemaTypeVariant::EntityOrCommon {
+                    let expected =
+                        json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                             type_name: "UserGroup".parse().unwrap(),
-                        },
-                    );
+                        });
                     let attribute = attributes.get(group).expect("No attribute `{group}`");
                     assert_has_type(attribute, expected);
                 }
@@ -585,21 +584,21 @@ namespace Baz {action "Foo" appliesTo {
             .expect("No `Issue`");
         assert!(issue.member_of_types.is_empty());
         match &issue.shape.0 {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+            json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 let attribute = attributes.get("repo").expect("No `repo`");
                 assert_has_type(
                     attribute,
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "Repository".parse().unwrap(),
                     }),
                 );
                 let attribute = attributes.get("reporter").expect("No `repo`");
                 assert_has_type(
                     attribute,
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     }),
                 );
@@ -614,15 +613,14 @@ namespace Baz {action "Foo" appliesTo {
         let groups = ["members", "owners", "memberOfTypes"];
         for group in groups {
             match &org.shape.0 {
-                json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+                json_schema::Type::Type(json_schema::TypeVariant::Record {
                     attributes,
                     additional_attributes: false,
                 }) => {
-                    let expected = json_schema::SchemaType::Type(
-                        json_schema::SchemaTypeVariant::EntityOrCommon {
+                    let expected =
+                        json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                             type_name: "UserGroup".parse().unwrap(),
-                        },
-                    );
+                        });
                     let attribute = attributes.get(group).expect("No attribute `{group}`");
                     assert_has_type(attribute, expected);
                 }
@@ -634,7 +632,7 @@ namespace Baz {action "Foo" appliesTo {
     #[track_caller]
     fn assert_has_type<N: std::fmt::Debug + PartialEq>(
         e: &json_schema::TypeOfAttribute<N>,
-        expected: json_schema::SchemaType<N>,
+        expected: json_schema::Type<N>,
     ) {
         assert!(e.required);
         assert_eq!(&e.ty, &expected);
@@ -643,7 +641,7 @@ namespace Baz {action "Foo" appliesTo {
     #[track_caller]
     fn assert_empty_record<N: std::fmt::Debug>(etyp: &json_schema::EntityType<N>) {
         assert_matches!(&etyp.shape.0,
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+            json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => assert!(attributes.is_empty(), "Record should be empty")
@@ -687,21 +685,21 @@ namespace Baz {action "Foo" appliesTo {
             .expect("No `User`");
         assert_eq!(&user.member_of_types, &vec!["Group".parse().unwrap()]);
         match &user.shape.0 {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+            json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 assert_has_type(
                     attributes.get("personalGroup").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "Group".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("blocked").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Set {
-                        element: Box::new(json_schema::SchemaType::Type(
-                            json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::Set {
+                        element: Box::new(json_schema::Type::Type(
+                            json_schema::TypeVariant::EntityOrCommon {
                                 type_name: "User".parse().unwrap(),
                             },
                         )),
@@ -719,13 +717,13 @@ namespace Baz {action "Foo" appliesTo {
             &vec!["DocumentShare".parse().unwrap()]
         );
         match &group.shape.0 {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+            json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 assert_has_type(
                     attributes.get("owner").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     }),
                 );
@@ -738,43 +736,43 @@ namespace Baz {action "Foo" appliesTo {
             .expect("No `Group`");
         assert!(document.member_of_types.is_empty());
         match &document.shape.0 {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+            json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 assert_has_type(
                     attributes.get("owner").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("isPrivate").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "Bool".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("publicAccess").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "String".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("viewACL").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "DocumentShare".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("modifyACL").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "DocumentShare".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("manageACL").unwrap(),
-                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "DocumentShare".parse().unwrap(),
                     }),
                 );
@@ -912,14 +910,14 @@ namespace Baz {action "Foo" appliesTo {
             .entity_types
             .get(&"Resource".parse().unwrap())
             .unwrap();
-        assert_matches!(&resource.shape.0, json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+        assert_matches!(&resource.shape.0, json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes,
             }) => {
                 assert!(!additional_attributes);
                 let json_schema::TypeOfAttribute { ty, required } = attributes.get("tag").unwrap();
                 assert!(required);
-                assert_matches!(ty, json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon { type_name }) => {
+                assert_matches!(ty, json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name }) => {
                     assert_eq!(type_name, &"AWS::Tag".parse().unwrap());
                 });
             }
@@ -1454,7 +1452,7 @@ mod translator_tests {
         .unwrap();
         let demo = schema.0.get(&Some("Demo".parse().unwrap())).unwrap();
         let user = demo.entity_types.get(&"User".parse().unwrap()).unwrap();
-        assert_matches!(&user.shape.0, json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+        assert_matches!(&user.shape.0, json_schema::Type::Type(json_schema::TypeVariant::Record {
                 attributes,
                 additional_attributes,
             }) => {
@@ -1462,7 +1460,7 @@ mod translator_tests {
                 let json_schema::TypeOfAttribute { ty, required } = attributes.get("name").unwrap();
                 {
                     assert!(required);
-                    let expected = json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "id".parse().unwrap(),
                     });
                     assert_eq!(ty, &expected);
@@ -1470,7 +1468,7 @@ mod translator_tests {
                 let json_schema::TypeOfAttribute { ty, required } = attributes.get("email").unwrap();
                 {
                     assert!(required);
-                    let expected = json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                    let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "email_address".parse().unwrap(),
                     });
                     assert_eq!(ty, &expected);

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -42,8 +42,7 @@ mod demo_tests {
         let src = r#"
             action "Foo";
         "#;
-        let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::none()).unwrap();
+        let (schema, _) = json_schema::Fragment::from_str_natural(src, Extensions::none()).unwrap();
         let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
             json_schema::ActionType {
@@ -61,7 +60,7 @@ mod demo_tests {
         let src = r#"
         action "Foo" appliesTo { context: {} };
         "#;
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::none()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -80,7 +79,7 @@ mod demo_tests {
         action "Foo" appliesTo { principal: a, context: {}  };
         "#;
 
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::none()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -98,7 +97,7 @@ mod demo_tests {
         entity a;
         action "Foo" appliesTo { resource: a, context: {}  };
         "#;
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::none()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -118,7 +117,7 @@ mod demo_tests {
                 resource : [a]
             };
         "#;
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -139,7 +138,7 @@ mod demo_tests {
                 resource : [a, b]
             };
         "#;
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -159,7 +158,7 @@ mod demo_tests {
                 principal: [a]
             };
         "#;
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -180,7 +179,7 @@ mod demo_tests {
                 principal: [a, b]
             };
         "#;
-        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::Fragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -205,8 +204,7 @@ mod demo_tests {
             };
         "#;
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
@@ -246,8 +244,7 @@ mod demo_tests {
             };
         "#;
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
@@ -287,11 +284,10 @@ mod demo_tests {
             };
         "#;
         // Can't unwrap here as impl iter doesn't implement debug
-        let err =
-            match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
-                Err(e) => e,
-                _ => panic!("Should have failed to parse"),
-            };
+        let err = match json_schema::Fragment::from_str_natural(src, Extensions::all_available()) {
+            Err(e) => e,
+            _ => panic!("Should have failed to parse"),
+        };
         assert_matches!(err, crate::HumanSchemaError::Parsing(err) => {
             assert_matches!(err.inner(), human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
                 assert!(json_errs
@@ -323,11 +319,10 @@ mod demo_tests {
             };
         "#;
         // Can't unwrap here as impl iter doesn't implement debug
-        let err =
-            match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
-                Err(e) => e,
-                _ => panic!("Should have failed to parse"),
-            };
+        let err = match json_schema::Fragment::from_str_natural(src, Extensions::all_available()) {
+            Err(e) => e,
+            _ => panic!("Should have failed to parse"),
+        };
         assert_matches!(err,
         crate::HumanSchemaError::Parsing(err) => assert_matches!(err.inner(),
             human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
@@ -355,7 +350,7 @@ mod demo_tests {
         let namespace =
             json_schema::NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
         let fragment =
-            json_schema::SchemaFragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
+            json_schema::Fragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
         let as_src = fragment.as_natural_schema().unwrap();
         let expected = r#"action "foo";"#;
         assert!(as_src.contains(expected), "src was:\n`{as_src}`");
@@ -363,7 +358,7 @@ mod demo_tests {
 
     #[test]
     fn context_is_common_type() {
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
         type empty = {};
         entity E;
@@ -376,7 +371,7 @@ mod demo_tests {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
     type flag = { value: __cedar::Bool };
     action "Foo" appliesTo {
@@ -388,7 +383,7 @@ mod demo_tests {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
 namespace Bar { type empty = {}; }
 action "Foo" appliesTo {
@@ -400,7 +395,7 @@ action "Foo" appliesTo {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
 namespace Bar { type flag = { value: Bool }; }
 namespace Baz {action "Foo" appliesTo {
@@ -412,7 +407,7 @@ namespace Baz {action "Foo" appliesTo {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
         type authcontext = {
             ip: ipaddr,
@@ -456,14 +451,14 @@ namespace Baz {action "Foo" appliesTo {
                 },
             )]),
         };
-        let fragment = json_schema::SchemaFragment(HashMap::from([(None, namespace)]));
+        let fragment = json_schema::Fragment(HashMap::from([(None, namespace)]));
         let src = fragment.as_natural_schema().unwrap();
         assert!(src.contains(r#"action "j";"#), "schema was: `{src}`")
     }
 
     #[test]
     fn fully_qualified_actions() {
-        let (_, _) = json_schema::SchemaFragment::from_str_natural(
+        let (_, _) = json_schema::Fragment::from_str_natural(
             r#"namespace NS1 {entity PrincipalEntity  = {  };
         entity SystemEntity1  = {  };
         entity SystemEntity2 in [SystemEntity1] = {  };
@@ -483,7 +478,7 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn action_eid_invalid_escape() {
-        match json_schema::SchemaFragment::from_str_natural(
+        match json_schema::Fragment::from_str_natural(
             r#"namespace NS1 {entity PrincipalEntity  = {  };
         entity SystemEntity1  = {  };
         entity SystemEntity2 in [SystemEntity1] = {  };
@@ -511,7 +506,7 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn test_github() {
-        let (fragment, warnings) = json_schema::SchemaFragment::from_str_natural(
+        let (fragment, warnings) = json_schema::Fragment::from_str_natural(
             r#"namespace GitHub {
             entity User in [UserGroup,Team];
             entity UserGroup in [UserGroup];
@@ -657,7 +652,7 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn test_doc_cloud() {
-        let (fragment, warnings) = json_schema::SchemaFragment::from_str_natural(
+        let (fragment, warnings) = json_schema::Fragment::from_str_natural(
             r#"namespace DocCloud {
             entity User in [Group] {
                 personalGroup: Group,
@@ -819,8 +814,7 @@ namespace Baz {action "Foo" appliesTo {
         action Foo appliesTo { principal : A, resource : B  };
         "#;
         let (_, warnings) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
     }
 
@@ -890,8 +884,7 @@ namespace Baz {action "Foo" appliesTo {
         "#;
 
         let (_, warnings) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
     }
 
@@ -912,8 +905,7 @@ namespace Baz {action "Foo" appliesTo {
         }
         "#;
         let (fragment, warnings) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
         let service = fragment.0.get(&Some("Service".parse().unwrap())).unwrap();
         let resource = service
@@ -938,7 +930,7 @@ namespace Baz {action "Foo" appliesTo {
     fn expected_tokens() {
         #[track_caller]
         fn assert_labeled_span(src: &str, label: impl Into<String>) {
-            assert_matches!(json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()).map(|(s, _)| s), Err(e) => {
+            assert_matches!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).map(|(s, _)| s), Err(e) => {
                 let actual_label = e.labels().and_then(|l| {
                     l.exactly_one()
                         .ok()
@@ -1207,12 +1199,11 @@ mod translator_tests {
         ValidatorSchema,
     };
 
-    // We allow translating schemas that violate RFC 52 to `SchemaFragment`.
-    // The violations are reported during further translation to
-    // `ValidatorSchema`
+    // We allow translating schemas that violate RFC 52 to `json_schema::Fragment`.
+    // The violations are reported during further translation to `ValidatorSchema`
     #[test]
     fn use_reserved_namespace() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           namespace __cedar {}
         "#,
@@ -1220,7 +1211,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           namespace __cedar::Foo {}
         "#,
@@ -1231,7 +1222,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_namespace() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           namespace A {}
           namespace A {}
@@ -1243,7 +1234,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_action_types() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           action A;
           action A appliesTo { context: {}};
@@ -1254,7 +1245,7 @@ mod translator_tests {
             schema.is_err(),
             "duplicate action type names shouldn't be allowed: "
         );
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           action A;
           action "A";
@@ -1266,7 +1257,7 @@ mod translator_tests {
             "duplicate action type names shouldn't be allowed"
         );
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
             namespace Foo {
           action A;
@@ -1280,7 +1271,7 @@ mod translator_tests {
             "duplicate action type names shouldn't be allowed"
         );
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           namespace X { action A; }
           action A;
@@ -1292,7 +1283,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_entity_types() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           entity A;
           entity A {};
@@ -1303,14 +1294,14 @@ mod translator_tests {
             schema.is_err(),
             "duplicate entity type names shouldn't be allowed"
         );
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
           entity A,A {};
         "#,
             Extensions::all_available(),
         )
         .is_err());
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
           namespace X { entity A; }
           entity A {};
@@ -1322,7 +1313,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_common_types() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
           type A = Bool;
           type A = Long;
@@ -1333,7 +1324,7 @@ mod translator_tests {
             schema.is_err(),
             "duplicate common type names shouldn't be allowed"
         );
-        assert!(json_schema::SchemaFragment::from_str_natural(
+        assert!(json_schema::Fragment::from_str_natural(
             r#"
           namespace X { type A = Bool; }
           type A = Long;
@@ -1345,7 +1336,7 @@ mod translator_tests {
 
     #[test]
     fn type_name_resolution_basic() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         namespace Demo {
             entity Host {
@@ -1409,7 +1400,7 @@ mod translator_tests {
 
     #[test]
     fn type_name_cross_namespace() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
                 entity B in [X::Y, A::C];
                 entity C;
@@ -1436,7 +1427,7 @@ mod translator_tests {
 
     #[test]
     fn type_name_resolution_empty_namespace() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
           type id = {
             group: String,
@@ -1496,7 +1487,7 @@ mod translator_tests {
     #[allow(clippy::indexing_slicing)]
     #[test]
     fn type_name_resolution_cross_namespace() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
                 entity B in [A::C] = {
                     foo?: X::Y,
@@ -1523,7 +1514,7 @@ mod translator_tests {
             matches!(&attr.attr_type, crate::types::Type::Primitive { primitive_type } if matches!(primitive_type, crate::types::Primitive::Bool))
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
                 entity B in [A::C] = {
                     foo?: X::Y,
@@ -1560,8 +1551,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["namespace".parse().unwrap()]);
@@ -1575,10 +1565,7 @@ mod translator_tests {
         entity Foo in [in] = {};
         "#;
 
-        assert!(
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .is_err()
-        );
+        assert!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1589,8 +1576,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Set".parse().unwrap()]);
@@ -1604,8 +1590,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["appliesTo".parse().unwrap()]);
@@ -1619,8 +1604,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["principal".parse().unwrap()]);
@@ -1634,8 +1618,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["resource".parse().unwrap()]);
@@ -1649,8 +1632,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["action".parse().unwrap()]);
@@ -1664,8 +1646,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["context".parse().unwrap()]);
@@ -1679,8 +1660,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["attributes".parse().unwrap()]);
@@ -1694,8 +1674,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Bool".parse().unwrap()]);
@@ -1709,8 +1688,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Long".parse().unwrap()]);
@@ -1724,8 +1702,7 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .unwrap();
+            json_schema::Fragment::from_str_natural(src, Extensions::all_available()).unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["String".parse().unwrap()]);
@@ -1738,10 +1715,7 @@ mod translator_tests {
         entity Foo in [if] = {};
         "#;
 
-        assert!(
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .is_err()
-        );
+        assert!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1751,10 +1725,7 @@ mod translator_tests {
         entity Foo in [like] = {};
         "#;
 
-        assert!(
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .is_err()
-        );
+        assert!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1764,10 +1735,7 @@ mod translator_tests {
         entity Foo in [true] = {};
         "#;
 
-        assert!(
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .is_err()
-        );
+        assert!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1777,10 +1745,7 @@ mod translator_tests {
         entity Foo in [false] = {};
         "#;
 
-        assert!(
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .is_err()
-        );
+        assert!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
@@ -1790,15 +1755,12 @@ mod translator_tests {
         entity Foo in [has] = {};
         "#;
 
-        assert!(
-            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
-                .is_err()
-        );
+        assert!(json_schema::Fragment::from_str_natural(src, Extensions::all_available()).is_err());
     }
 
     #[test]
     fn multiple_principal_decls() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { principal: A, principal: A };
@@ -1807,7 +1769,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { principal: A, resource: B, principal: A };
@@ -1819,7 +1781,7 @@ mod translator_tests {
 
     #[test]
     fn multiple_resource_decls() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { resource: A, resource: A };
@@ -1828,7 +1790,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { resource: A, principal: B, resource: A };
@@ -1840,7 +1802,7 @@ mod translator_tests {
 
     #[test]
     fn multiple_context_decls() {
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { context: A, context: A };
@@ -1849,7 +1811,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { principal: C, context: A, context: A };
@@ -1858,7 +1820,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = json_schema::SchemaFragment::from_str_natural(
+        let schema = json_schema::Fragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { resource: C, context: A, context: A };
@@ -1923,7 +1885,7 @@ mod common_type_references {
 
     #[test]
     fn basic() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         type a = b;
         type b = Long;
@@ -1944,7 +1906,7 @@ mod common_type_references {
             &AttributeType::new(Type::primitive_long(), true)
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         type a = b;
         type b = c;
@@ -1966,7 +1928,7 @@ mod common_type_references {
             &AttributeType::new(Type::primitive_long(), true)
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
             type a = b;
             type b = c;
@@ -1995,7 +1957,7 @@ mod common_type_references {
 
     #[test]
     fn set() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         type a = Set<b>;
         type b = Long;
@@ -2015,7 +1977,7 @@ mod common_type_references {
                 .unwrap(),
             &AttributeType::new(Type::set(Type::primitive_long()), true)
         );
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         type a = Set<b>;
         type b = c;
@@ -2037,7 +1999,7 @@ mod common_type_references {
             &AttributeType::new(Type::set(Type::primitive_long()), true)
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
             type a = Set<b>;
             type b = c;
@@ -2066,7 +2028,7 @@ mod common_type_references {
 
     #[test]
     fn record() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         type a = {a: b};
         type b = Long;
@@ -2087,7 +2049,7 @@ mod common_type_references {
             AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::primitive_long()
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"
         type a = {a: b};
         type b = c;
@@ -2109,7 +2071,7 @@ mod common_type_references {
             AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::primitive_long()
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
             type a = {a: b};
             type b = c;
@@ -2138,7 +2100,7 @@ mod common_type_references {
 
     #[test]
     fn cycles() {
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
             type a = {a: b};
             type b = c;
@@ -2160,7 +2122,7 @@ mod common_type_references {
             Err(SchemaError::CycleInCommonTypeReferences(_))
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
             type a = {a: b};
             type b = c;
@@ -2182,7 +2144,7 @@ mod common_type_references {
             Err(SchemaError::CycleInCommonTypeReferences(_))
         );
 
-        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::Fragment::from_str_natural(
             r#"namespace A {
             type a = B::a;
             entity foo {

--- a/cedar-policy-validator/src/human_schema/test.rs
+++ b/cedar-policy-validator/src/human_schema/test.rs
@@ -31,9 +31,7 @@ mod demo_tests {
 
     use crate::{
         human_schema::{self, ast::PR, err::ToJsonSchemaError},
-        ActionType, ApplySpec, AttributesOrContext, EntityType, HumanSchemaError,
-        NamespaceDefinition, RawName, SchemaFragment, SchemaType, SchemaTypeVariant,
-        TypeOfAttribute,
+        json_schema, HumanSchemaError, RawName,
     };
 
     use itertools::Itertools;
@@ -44,11 +42,12 @@ mod demo_tests {
         let src = r#"
             action "Foo";
         "#;
-        let (schema, _) = SchemaFragment::from_str_natural(src, Extensions::none()).unwrap();
+        let (schema, _) =
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::none()).unwrap();
         let foo = schema.0.get(&None).unwrap().actions.get("Foo").unwrap();
         assert_matches!(foo,
-            ActionType {
-                applies_to : Some(ApplySpec {
+            json_schema::ActionType {
+                applies_to : Some(json_schema::ApplySpec {
                     resource_types : resources,
                     principal_types : principals, ..
                 }),
@@ -62,7 +61,7 @@ mod demo_tests {
         let src = r#"
         action "Foo" appliesTo { context: {} };
         "#;
-        match SchemaFragment::from_str_natural(src, Extensions::none()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -81,7 +80,7 @@ mod demo_tests {
         action "Foo" appliesTo { principal: a, context: {}  };
         "#;
 
-        match SchemaFragment::from_str_natural(src, Extensions::none()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -99,7 +98,7 @@ mod demo_tests {
         entity a;
         action "Foo" appliesTo { resource: a, context: {}  };
         "#;
-        match SchemaFragment::from_str_natural(src, Extensions::none()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::none()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -119,7 +118,7 @@ mod demo_tests {
                 resource : [a]
             };
         "#;
-        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -140,7 +139,7 @@ mod demo_tests {
                 resource : [a, b]
             };
         "#;
-        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -160,7 +159,7 @@ mod demo_tests {
                 principal: [a]
             };
         "#;
-        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -181,7 +180,7 @@ mod demo_tests {
                 principal: [a, b]
             };
         "#;
-        match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+        match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
             Ok(_) => panic!("Should have failed to parse!"),
             Err(e) => expect_err(
                 src,
@@ -206,12 +205,13 @@ mod demo_tests {
             };
         "#;
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
-                ActionType {
-                    applies_to : Some(ApplySpec {
+                json_schema::ActionType {
+                    applies_to : Some(json_schema::ApplySpec {
                         resource_types,
                         principal_types,
                         ..
@@ -246,12 +246,13 @@ mod demo_tests {
             };
         "#;
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let unqual = schema.0.get(&None).unwrap();
         let foo = unqual.actions.get("Foo").unwrap();
         assert_matches!(foo,
-                ActionType {
-                    applies_to : Some(ApplySpec {
+                json_schema::ActionType {
+                    applies_to : Some(json_schema::ApplySpec {
                         resource_types,
                         principal_types,
                         ..
@@ -286,10 +287,11 @@ mod demo_tests {
             };
         "#;
         // Can't unwrap here as impl iter doesn't implement debug
-        let err = match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
-            Err(e) => e,
-            _ => panic!("Should have failed to parse"),
-        };
+        let err =
+            match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+                Err(e) => e,
+                _ => panic!("Should have failed to parse"),
+            };
         assert_matches!(err, crate::HumanSchemaError::Parsing(err) => {
             assert_matches!(err.inner(), human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
                 assert!(json_errs
@@ -321,10 +323,11 @@ mod demo_tests {
             };
         "#;
         // Can't unwrap here as impl iter doesn't implement debug
-        let err = match SchemaFragment::from_str_natural(src, Extensions::all_available()) {
-            Err(e) => e,
-            _ => panic!("Should have failed to parse"),
-        };
+        let err =
+            match json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()) {
+                Err(e) => e,
+                _ => panic!("Should have failed to parse"),
+            };
         assert_matches!(err,
         crate::HumanSchemaError::Parsing(err) => assert_matches!(err.inner(),
             human_schema::parser::HumanSyntaxParseErrors::JsonError(json_errs) => {
@@ -344,13 +347,15 @@ mod demo_tests {
 
     #[test]
     fn empty_appliesto() {
-        let action = ActionType::<RawName> {
+        let action = json_schema::ActionType::<RawName> {
             attributes: None,
             applies_to: None,
             member_of: None,
         };
-        let namespace = NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
-        let fragment = SchemaFragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
+        let namespace =
+            json_schema::NamespaceDefinition::new(empty(), once(("foo".to_smolstr(), action)));
+        let fragment =
+            json_schema::SchemaFragment(HashMap::from([(Some("bar".parse().unwrap()), namespace)]));
         let as_src = fragment.as_natural_schema().unwrap();
         let expected = r#"action "foo";"#;
         assert!(as_src.contains(expected), "src was:\n`{as_src}`");
@@ -358,7 +363,7 @@ mod demo_tests {
 
     #[test]
     fn context_is_common_type() {
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
         type empty = {};
         entity E;
@@ -371,7 +376,7 @@ mod demo_tests {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
     type flag = { value: __cedar::Bool };
     action "Foo" appliesTo {
@@ -383,7 +388,7 @@ mod demo_tests {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
 namespace Bar { type empty = {}; }
 action "Foo" appliesTo {
@@ -395,7 +400,7 @@ action "Foo" appliesTo {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
 namespace Bar { type flag = { value: Bool }; }
 namespace Baz {action "Foo" appliesTo {
@@ -407,7 +412,7 @@ namespace Baz {action "Foo" appliesTo {
             Extensions::all_available(),
         )
         .is_ok());
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
         type authcontext = {
             ip: ipaddr,
@@ -429,36 +434,36 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn print_actions() {
-        let namespace = NamespaceDefinition {
+        let namespace = json_schema::NamespaceDefinition {
             common_types: HashMap::new(),
             entity_types: HashMap::from([(
                 "a".parse().unwrap(),
-                EntityType::<RawName> {
+                json_schema::EntityType::<RawName> {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::<RawName>::default(),
+                    shape: json_schema::AttributesOrContext::<RawName>::default(),
                 },
             )]),
             actions: HashMap::from([(
                 "j".to_smolstr(),
-                ActionType::<RawName> {
+                json_schema::ActionType::<RawName> {
                     attributes: None,
-                    applies_to: Some(ApplySpec::<RawName> {
+                    applies_to: Some(json_schema::ApplySpec::<RawName> {
                         resource_types: vec![],
                         principal_types: vec!["a".parse().unwrap()],
-                        context: AttributesOrContext::<RawName>::default(),
+                        context: json_schema::AttributesOrContext::<RawName>::default(),
                     }),
                     member_of: None,
                 },
             )]),
         };
-        let fragment = SchemaFragment(HashMap::from([(None, namespace)]));
+        let fragment = json_schema::SchemaFragment(HashMap::from([(None, namespace)]));
         let src = fragment.as_natural_schema().unwrap();
         assert!(src.contains(r#"action "j";"#), "schema was: `{src}`")
     }
 
     #[test]
     fn fully_qualified_actions() {
-        let (_, _) = SchemaFragment::from_str_natural(
+        let (_, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace NS1 {entity PrincipalEntity  = {  };
         entity SystemEntity1  = {  };
         entity SystemEntity2 in [SystemEntity1] = {  };
@@ -478,7 +483,7 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn action_eid_invalid_escape() {
-        match SchemaFragment::from_str_natural(
+        match json_schema::SchemaFragment::from_str_natural(
             r#"namespace NS1 {entity PrincipalEntity  = {  };
         entity SystemEntity1  = {  };
         entity SystemEntity2 in [SystemEntity1] = {  };
@@ -506,7 +511,7 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn test_github() {
-        let (fragment, warnings) = SchemaFragment::from_str_natural(
+        let (fragment, warnings) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace GitHub {
             entity User in [UserGroup,Team];
             entity UserGroup in [UserGroup];
@@ -564,13 +569,15 @@ namespace Baz {action "Foo" appliesTo {
         let groups = ["readers", "writers", "triagers", "admins", "maintainers"];
         for group in groups {
             match &repo.shape.0 {
-                SchemaType::Type(SchemaTypeVariant::Record {
+                json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                     attributes,
                     additional_attributes: false,
                 }) => {
-                    let expected = SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
-                        type_name: "UserGroup".parse().unwrap(),
-                    });
+                    let expected = json_schema::SchemaType::Type(
+                        json_schema::SchemaTypeVariant::EntityOrCommon {
+                            type_name: "UserGroup".parse().unwrap(),
+                        },
+                    );
                     let attribute = attributes.get(group).expect("No attribute `{group}`");
                     assert_has_type(attribute, expected);
                 }
@@ -583,21 +590,21 @@ namespace Baz {action "Foo" appliesTo {
             .expect("No `Issue`");
         assert!(issue.member_of_types.is_empty());
         match &issue.shape.0 {
-            SchemaType::Type(SchemaTypeVariant::Record {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 let attribute = attributes.get("repo").expect("No `repo`");
                 assert_has_type(
                     attribute,
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "Repository".parse().unwrap(),
                     }),
                 );
                 let attribute = attributes.get("reporter").expect("No `repo`");
                 assert_has_type(
                     attribute,
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     }),
                 );
@@ -612,13 +619,15 @@ namespace Baz {action "Foo" appliesTo {
         let groups = ["members", "owners", "memberOfTypes"];
         for group in groups {
             match &org.shape.0 {
-                SchemaType::Type(SchemaTypeVariant::Record {
+                json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                     attributes,
                     additional_attributes: false,
                 }) => {
-                    let expected = SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
-                        type_name: "UserGroup".parse().unwrap(),
-                    });
+                    let expected = json_schema::SchemaType::Type(
+                        json_schema::SchemaTypeVariant::EntityOrCommon {
+                            type_name: "UserGroup".parse().unwrap(),
+                        },
+                    );
                     let attribute = attributes.get(group).expect("No attribute `{group}`");
                     assert_has_type(attribute, expected);
                 }
@@ -629,17 +638,17 @@ namespace Baz {action "Foo" appliesTo {
 
     #[track_caller]
     fn assert_has_type<N: std::fmt::Debug + PartialEq>(
-        e: &TypeOfAttribute<N>,
-        expected: SchemaType<N>,
+        e: &json_schema::TypeOfAttribute<N>,
+        expected: json_schema::SchemaType<N>,
     ) {
         assert!(e.required);
         assert_eq!(&e.ty, &expected);
     }
 
     #[track_caller]
-    fn assert_empty_record<N: std::fmt::Debug>(etyp: &EntityType<N>) {
+    fn assert_empty_record<N: std::fmt::Debug>(etyp: &json_schema::EntityType<N>) {
         assert_matches!(&etyp.shape.0,
-            SchemaType::Type(SchemaTypeVariant::Record {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => assert!(attributes.is_empty(), "Record should be empty")
@@ -648,7 +657,7 @@ namespace Baz {action "Foo" appliesTo {
 
     #[test]
     fn test_doc_cloud() {
-        let (fragment, warnings) = SchemaFragment::from_str_natural(
+        let (fragment, warnings) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace DocCloud {
             entity User in [Group] {
                 personalGroup: Group,
@@ -683,22 +692,24 @@ namespace Baz {action "Foo" appliesTo {
             .expect("No `User`");
         assert_eq!(&user.member_of_types, &vec!["Group".parse().unwrap()]);
         match &user.shape.0 {
-            SchemaType::Type(SchemaTypeVariant::Record {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 assert_has_type(
                     attributes.get("personalGroup").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "Group".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("blocked").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::Set {
-                        element: Box::new(SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
-                            type_name: "User".parse().unwrap(),
-                        })),
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Set {
+                        element: Box::new(json_schema::SchemaType::Type(
+                            json_schema::SchemaTypeVariant::EntityOrCommon {
+                                type_name: "User".parse().unwrap(),
+                            },
+                        )),
                     }),
                 );
             }
@@ -713,13 +724,13 @@ namespace Baz {action "Foo" appliesTo {
             &vec!["DocumentShare".parse().unwrap()]
         );
         match &group.shape.0 {
-            SchemaType::Type(SchemaTypeVariant::Record {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 assert_has_type(
                     attributes.get("owner").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     }),
                 );
@@ -732,43 +743,43 @@ namespace Baz {action "Foo" appliesTo {
             .expect("No `Group`");
         assert!(document.member_of_types.is_empty());
         match &document.shape.0 {
-            SchemaType::Type(SchemaTypeVariant::Record {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes: false,
             }) => {
                 assert_has_type(
                     attributes.get("owner").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("isPrivate").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "Bool".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("publicAccess").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "String".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("viewACL").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "DocumentShare".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("modifyACL").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "DocumentShare".parse().unwrap(),
                     }),
                 );
                 assert_has_type(
                     attributes.get("manageACL").unwrap(),
-                    SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "DocumentShare".parse().unwrap(),
                     }),
                 );
@@ -808,7 +819,8 @@ namespace Baz {action "Foo" appliesTo {
         action Foo appliesTo { principal : A, resource : B  };
         "#;
         let (_, warnings) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
     }
 
@@ -878,7 +890,8 @@ namespace Baz {action "Foo" appliesTo {
         "#;
 
         let (_, warnings) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
     }
 
@@ -899,21 +912,22 @@ namespace Baz {action "Foo" appliesTo {
         }
         "#;
         let (fragment, warnings) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         assert!(warnings.collect::<Vec<_>>().is_empty());
         let service = fragment.0.get(&Some("Service".parse().unwrap())).unwrap();
         let resource = service
             .entity_types
             .get(&"Resource".parse().unwrap())
             .unwrap();
-        assert_matches!(&resource.shape.0, SchemaType::Type(SchemaTypeVariant::Record {
+        assert_matches!(&resource.shape.0, json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes,
             }) => {
                 assert!(!additional_attributes);
-                let TypeOfAttribute { ty, required } = attributes.get("tag").unwrap();
+                let json_schema::TypeOfAttribute { ty, required } = attributes.get("tag").unwrap();
                 assert!(required);
-                assert_matches!(ty, SchemaType::Type(SchemaTypeVariant::EntityOrCommon { type_name }) => {
+                assert_matches!(ty, json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon { type_name }) => {
                     assert_eq!(type_name, &"AWS::Tag".parse().unwrap());
                 });
             }
@@ -924,7 +938,7 @@ namespace Baz {action "Foo" appliesTo {
     fn expected_tokens() {
         #[track_caller]
         fn assert_labeled_span(src: &str, label: impl Into<String>) {
-            assert_matches!(SchemaFragment::from_str_natural(src, Extensions::all_available()).map(|(s, _)| s), Err(e) => {
+            assert_matches!(json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available()).map(|(s, _)| s), Err(e) => {
                 let actual_label = e.labels().and_then(|l| {
                     l.exactly_one()
                         .ok()
@@ -1188,8 +1202,9 @@ mod translator_tests {
 
     use crate::{
         human_schema::{parser::parse_schema, to_json_schema::custom_schema_to_json_schema},
+        json_schema,
         types::{EntityLUB, Type},
-        SchemaFragment, SchemaType, SchemaTypeVariant, TypeOfAttribute, ValidatorSchema,
+        ValidatorSchema,
     };
 
     // We allow translating schemas that violate RFC 52 to `SchemaFragment`.
@@ -1197,7 +1212,7 @@ mod translator_tests {
     // `ValidatorSchema`
     #[test]
     fn use_reserved_namespace() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           namespace __cedar {}
         "#,
@@ -1205,7 +1220,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           namespace __cedar::Foo {}
         "#,
@@ -1216,7 +1231,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_namespace() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           namespace A {}
           namespace A {}
@@ -1228,7 +1243,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_action_types() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           action A;
           action A appliesTo { context: {}};
@@ -1239,7 +1254,7 @@ mod translator_tests {
             schema.is_err(),
             "duplicate action type names shouldn't be allowed: "
         );
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           action A;
           action "A";
@@ -1251,7 +1266,7 @@ mod translator_tests {
             "duplicate action type names shouldn't be allowed"
         );
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
             namespace Foo {
           action A;
@@ -1265,7 +1280,7 @@ mod translator_tests {
             "duplicate action type names shouldn't be allowed"
         );
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           namespace X { action A; }
           action A;
@@ -1277,7 +1292,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_entity_types() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           entity A;
           entity A {};
@@ -1288,14 +1303,14 @@ mod translator_tests {
             schema.is_err(),
             "duplicate entity type names shouldn't be allowed"
         );
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
           entity A,A {};
         "#,
             Extensions::all_available(),
         )
         .is_err());
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
           namespace X { entity A; }
           entity A {};
@@ -1307,7 +1322,7 @@ mod translator_tests {
 
     #[test]
     fn duplicate_common_types() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
           type A = Bool;
           type A = Long;
@@ -1318,7 +1333,7 @@ mod translator_tests {
             schema.is_err(),
             "duplicate common type names shouldn't be allowed"
         );
-        assert!(SchemaFragment::from_str_natural(
+        assert!(json_schema::SchemaFragment::from_str_natural(
             r#"
           namespace X { type A = Bool; }
           type A = Long;
@@ -1330,7 +1345,7 @@ mod translator_tests {
 
     #[test]
     fn type_name_resolution_basic() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         namespace Demo {
             entity Host {
@@ -1394,7 +1409,7 @@ mod translator_tests {
 
     #[test]
     fn type_name_cross_namespace() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
                 entity B in [X::Y, A::C];
                 entity C;
@@ -1421,7 +1436,7 @@ mod translator_tests {
 
     #[test]
     fn type_name_resolution_empty_namespace() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
           type id = {
             group: String,
@@ -1448,23 +1463,23 @@ mod translator_tests {
         .unwrap();
         let demo = schema.0.get(&Some("Demo".parse().unwrap())).unwrap();
         let user = demo.entity_types.get(&"User".parse().unwrap()).unwrap();
-        assert_matches!(&user.shape.0, SchemaType::Type(SchemaTypeVariant::Record {
+        assert_matches!(&user.shape.0, json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
                 attributes,
                 additional_attributes,
             }) => {
                 assert!(!additional_attributes);
-                let TypeOfAttribute { ty, required } = attributes.get("name").unwrap();
+                let json_schema::TypeOfAttribute { ty, required } = attributes.get("name").unwrap();
                 {
                     assert!(required);
-                    let expected = SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    let expected = json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "id".parse().unwrap(),
                     });
                     assert_eq!(ty, &expected);
                 }
-                let TypeOfAttribute { ty, required } = attributes.get("email").unwrap();
+                let json_schema::TypeOfAttribute { ty, required } = attributes.get("email").unwrap();
                 {
                     assert!(required);
-                    let expected = SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                    let expected = json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
                         type_name: "email_address".parse().unwrap(),
                     });
                     assert_eq!(ty, &expected);
@@ -1481,7 +1496,7 @@ mod translator_tests {
     #[allow(clippy::indexing_slicing)]
     #[test]
     fn type_name_resolution_cross_namespace() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
                 entity B in [A::C] = {
                     foo?: X::Y,
@@ -1508,7 +1523,7 @@ mod translator_tests {
             matches!(&attr.attr_type, crate::types::Type::Primitive { primitive_type } if matches!(primitive_type, crate::types::Primitive::Bool))
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
                 entity B in [A::C] = {
                     foo?: X::Y,
@@ -1545,7 +1560,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["namespace".parse().unwrap()]);
@@ -1559,7 +1575,10 @@ mod translator_tests {
         entity Foo in [in] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
+        assert!(
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .is_err()
+        );
     }
 
     #[test]
@@ -1570,7 +1589,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Set".parse().unwrap()]);
@@ -1584,7 +1604,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["appliesTo".parse().unwrap()]);
@@ -1598,7 +1619,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["principal".parse().unwrap()]);
@@ -1612,7 +1634,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["resource".parse().unwrap()]);
@@ -1626,7 +1649,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["action".parse().unwrap()]);
@@ -1640,7 +1664,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["context".parse().unwrap()]);
@@ -1654,7 +1679,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["attributes".parse().unwrap()]);
@@ -1668,7 +1694,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Bool".parse().unwrap()]);
@@ -1682,7 +1709,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["Long".parse().unwrap()]);
@@ -1696,7 +1724,8 @@ mod translator_tests {
         "#;
 
         let (schema, _) =
-            SchemaFragment::from_str_natural(src, Extensions::all_available()).unwrap();
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .unwrap();
         let ns = schema.0.get(&None).unwrap();
         let foo = ns.entity_types.get(&"Foo".parse().unwrap()).unwrap();
         assert_eq!(foo.member_of_types, vec!["String".parse().unwrap()]);
@@ -1709,7 +1738,10 @@ mod translator_tests {
         entity Foo in [if] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
+        assert!(
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .is_err()
+        );
     }
 
     #[test]
@@ -1719,7 +1751,10 @@ mod translator_tests {
         entity Foo in [like] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
+        assert!(
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .is_err()
+        );
     }
 
     #[test]
@@ -1729,7 +1764,10 @@ mod translator_tests {
         entity Foo in [true] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
+        assert!(
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .is_err()
+        );
     }
 
     #[test]
@@ -1739,7 +1777,10 @@ mod translator_tests {
         entity Foo in [false] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
+        assert!(
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .is_err()
+        );
     }
 
     #[test]
@@ -1749,12 +1790,15 @@ mod translator_tests {
         entity Foo in [has] = {};
         "#;
 
-        assert!(SchemaFragment::from_str_natural(src, Extensions::all_available()).is_err());
+        assert!(
+            json_schema::SchemaFragment::from_str_natural(src, Extensions::all_available())
+                .is_err()
+        );
     }
 
     #[test]
     fn multiple_principal_decls() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { principal: A, principal: A };
@@ -1763,7 +1807,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { principal: A, resource: B, principal: A };
@@ -1775,7 +1819,7 @@ mod translator_tests {
 
     #[test]
     fn multiple_resource_decls() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { resource: A, resource: A };
@@ -1784,7 +1828,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { resource: A, principal: B, resource: A };
@@ -1796,7 +1840,7 @@ mod translator_tests {
 
     #[test]
     fn multiple_context_decls() {
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { context: A, context: A };
@@ -1805,7 +1849,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { principal: C, context: A, context: A };
@@ -1814,7 +1858,7 @@ mod translator_tests {
         );
         assert!(schema.is_err());
 
-        let schema = SchemaFragment::from_str_natural(
+        let schema = json_schema::SchemaFragment::from_str_natural(
             r#"
         entity foo;
         action a appliesTo { resource: C, context: A, context: A };
@@ -1871,14 +1915,15 @@ mod common_type_references {
     use cool_asserts::assert_matches;
 
     use crate::{
+        json_schema,
         types::{AttributeType, EntityRecordKind, Type},
-        SchemaError, SchemaFragment, ValidatorSchema,
+        SchemaError, ValidatorSchema,
     };
     use cedar_policy_core::extensions::Extensions;
 
     #[test]
     fn basic() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         type a = b;
         type b = Long;
@@ -1899,7 +1944,7 @@ mod common_type_references {
             &AttributeType::new(Type::primitive_long(), true)
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         type a = b;
         type b = c;
@@ -1921,7 +1966,7 @@ mod common_type_references {
             &AttributeType::new(Type::primitive_long(), true)
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
             type a = b;
             type b = c;
@@ -1950,7 +1995,7 @@ mod common_type_references {
 
     #[test]
     fn set() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         type a = Set<b>;
         type b = Long;
@@ -1970,7 +2015,7 @@ mod common_type_references {
                 .unwrap(),
             &AttributeType::new(Type::set(Type::primitive_long()), true)
         );
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         type a = Set<b>;
         type b = c;
@@ -1992,7 +2037,7 @@ mod common_type_references {
             &AttributeType::new(Type::set(Type::primitive_long()), true)
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
             type a = Set<b>;
             type b = c;
@@ -2021,7 +2066,7 @@ mod common_type_references {
 
     #[test]
     fn record() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         type a = {a: b};
         type b = Long;
@@ -2042,7 +2087,7 @@ mod common_type_references {
             AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::primitive_long()
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"
         type a = {a: b};
         type b = c;
@@ -2064,7 +2109,7 @@ mod common_type_references {
             AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::primitive_long()
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
             type a = {a: b};
             type b = c;
@@ -2093,7 +2138,7 @@ mod common_type_references {
 
     #[test]
     fn cycles() {
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
             type a = {a: b};
             type b = c;
@@ -2115,7 +2160,7 @@ mod common_type_references {
             Err(SchemaError::CycleInCommonTypeReferences(_))
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
             type a = {a: b};
             type b = c;
@@ -2137,7 +2182,7 @@ mod common_type_references {
             Err(SchemaError::CycleInCommonTypeReferences(_))
         );
 
-        let (schema, _) = SchemaFragment::from_str_natural(
+        let (schema, _) = json_schema::SchemaFragment::from_str_natural(
             r#"namespace A {
             type a = B::a;
             entity foo {

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -95,25 +95,21 @@ fn is_valid_ext_type(ty: &Id, extensions: &Extensions<'_>) -> bool {
 }
 
 /// Convert a `Type` into the JSON representation of the type.
-pub fn human_type_to_json_type(ty: Node<Type>) -> json_schema::SchemaType<RawName> {
+pub fn human_type_to_json_type(ty: Node<Type>) -> json_schema::Type<RawName> {
     match ty.node {
-        Type::Set(t) => json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Set {
+        Type::Set(t) => json_schema::Type::Type(json_schema::TypeVariant::Set {
             element: Box::new(human_type_to_json_type(*t)),
         }),
-        Type::Ident(p) => {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
-                type_name: RawName::from(p),
-            })
-        }
-        Type::Record(fields) => {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
-                attributes: fields
-                    .into_iter()
-                    .map(|field| convert_attr_decl(field.node))
-                    .collect(),
-                additional_attributes: false,
-            })
-        }
+        Type::Ident(p) => json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+            type_name: RawName::from(p),
+        }),
+        Type::Record(fields) => json_schema::Type::Type(json_schema::TypeVariant::Record {
+            attributes: fields
+                .into_iter()
+                .map(|field| convert_attr_decl(field.node))
+                .collect(),
+            additional_attributes: false,
+        }),
     }
 }
 
@@ -376,15 +372,13 @@ fn convert_entity_decl(
 
 /// Create a Record Type from a vector of `AttrDecl`s
 fn convert_attr_decls(attrs: Vec<Node<AttrDecl>>) -> json_schema::AttributesOrContext<RawName> {
-    json_schema::AttributesOrContext(json_schema::SchemaType::Type(
-        json_schema::SchemaTypeVariant::Record {
-            attributes: attrs
-                .into_iter()
-                .map(|attr| convert_attr_decl(attr.node))
-                .collect(),
-            additional_attributes: false,
-        },
-    ))
+    json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record {
+        attributes: attrs
+            .into_iter()
+            .map(|attr| convert_attr_decl(attr.node))
+            .collect(),
+        additional_attributes: false,
+    }))
 }
 
 /// Create a context decl
@@ -392,18 +386,16 @@ fn convert_context_decl(
     decl: Either<Path, Vec<Node<AttrDecl>>>,
 ) -> json_schema::AttributesOrContext<RawName> {
     json_schema::AttributesOrContext(match decl {
-        Either::Left(p) => json_schema::SchemaType::CommonTypeRef {
+        Either::Left(p) => json_schema::Type::CommonTypeRef {
             type_name: p.into(),
         },
-        Either::Right(attrs) => {
-            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
-                attributes: attrs
-                    .into_iter()
-                    .map(|attr| convert_attr_decl(attr.node))
-                    .collect(),
-                additional_attributes: false,
-            })
-        }
+        Either::Right(attrs) => json_schema::Type::Type(json_schema::TypeVariant::Record {
+            attributes: attrs
+                .into_iter()
+                .map(|attr| convert_attr_decl(attr.node))
+                .collect(),
+            additional_attributes: false,
+        }),
     })
 }
 

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -47,7 +47,7 @@ impl From<human_schema::Path> for RawName {
 /// Convert a schema AST into the JSON representation.
 /// This will let you subsequently decode that into the Validator AST for Schemas ([`crate::ValidatorSchema`]).
 /// On success, this function returns a tuple containing:
-///     * The `json_schema::SchemaFragment`
+///     * The `json_schema::Fragment`
 ///     * An iterator of warnings that were generated
 ///
 /// TODO(#1085): These warnings should be generated later in the process, such
@@ -57,7 +57,7 @@ pub fn custom_schema_to_json_schema(
     extensions: &Extensions<'_>,
 ) -> Result<
     (
-        json_schema::SchemaFragment<RawName>,
+        json_schema::Fragment<RawName>,
         impl Iterator<Item = SchemaWarning>,
     ),
     ToJsonSchemaErrors,
@@ -81,7 +81,7 @@ pub fn custom_schema_to_json_schema(
     let warnings = compute_namespace_warnings(&names, extensions);
     let fragment = collect_all_errors(all_namespaces.into_iter().map(convert_namespace))?.collect();
     Ok((
-        json_schema::SchemaFragment(fragment),
+        json_schema::Fragment(fragment),
         warnings.collect::<Vec<_>>().into_iter(),
     ))
 }

--- a/cedar-policy-validator/src/human_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/human_schema/to_json_schema.rs
@@ -28,22 +28,18 @@ use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::hash_map::Entry;
 
-use crate::{
-    human_schema::ast::Path, ActionEntityUID, ActionType, ApplySpec, AttributesOrContext,
-    EntityType, NamespaceDefinition, RawName, SchemaFragment, SchemaType, SchemaTypeVariant,
-    TypeOfAttribute,
-};
+use crate::{human_schema, json_schema, RawName};
 
 use super::{
     ast::{
-        ActionDecl, AppDecl, AttrDecl, Decl, Declaration, EntityDecl, Namespace, PRAppDecl,
+        ActionDecl, AppDecl, AttrDecl, Decl, Declaration, EntityDecl, Namespace, PRAppDecl, Path,
         QualName, Schema, Type, TypeDecl, BUILTIN_TYPES, PR,
     },
     err::{schema_warnings, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors},
 };
 
-impl From<Path> for RawName {
-    fn from(p: Path) -> Self {
+impl From<human_schema::Path> for RawName {
+    fn from(p: human_schema::Path) -> Self {
         RawName::from_name(p.into())
     }
 }
@@ -51,7 +47,7 @@ impl From<Path> for RawName {
 /// Convert a schema AST into the JSON representation.
 /// This will let you subsequently decode that into the Validator AST for Schemas ([`crate::ValidatorSchema`]).
 /// On success, this function returns a tuple containing:
-///     * The `SchemaFragment`
+///     * The `json_schema::SchemaFragment`
 ///     * An iterator of warnings that were generated
 ///
 /// TODO(#1085): These warnings should be generated later in the process, such
@@ -59,7 +55,13 @@ impl From<Path> for RawName {
 pub fn custom_schema_to_json_schema(
     schema: Schema,
     extensions: &Extensions<'_>,
-) -> Result<(SchemaFragment<RawName>, impl Iterator<Item = SchemaWarning>), ToJsonSchemaErrors> {
+) -> Result<
+    (
+        json_schema::SchemaFragment<RawName>,
+        impl Iterator<Item = SchemaWarning>,
+    ),
+    ToJsonSchemaErrors,
+> {
     // combine all of the declarations in unqualified (empty) namespaces into a
     // single unqualified namespace
     //
@@ -79,7 +81,7 @@ pub fn custom_schema_to_json_schema(
     let warnings = compute_namespace_warnings(&names, extensions);
     let fragment = collect_all_errors(all_namespaces.into_iter().map(convert_namespace))?.collect();
     Ok((
-        SchemaFragment(fragment),
+        json_schema::SchemaFragment(fragment),
         warnings.collect::<Vec<_>>().into_iter(),
     ))
 }
@@ -93,21 +95,25 @@ fn is_valid_ext_type(ty: &Id, extensions: &Extensions<'_>) -> bool {
 }
 
 /// Convert a `Type` into the JSON representation of the type.
-pub fn human_type_to_json_type(ty: Node<Type>) -> SchemaType<RawName> {
+pub fn human_type_to_json_type(ty: Node<Type>) -> json_schema::SchemaType<RawName> {
     match ty.node {
-        Type::Set(t) => SchemaType::Type(SchemaTypeVariant::Set {
+        Type::Set(t) => json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Set {
             element: Box::new(human_type_to_json_type(*t)),
         }),
-        Type::Ident(p) => SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
-            type_name: RawName::from(p),
-        }),
-        Type::Record(fields) => SchemaType::Type(SchemaTypeVariant::Record {
-            attributes: fields
-                .into_iter()
-                .map(|field| convert_attr_decl(field.node))
-                .collect(),
-            additional_attributes: false,
-        }),
+        Type::Ident(p) => {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::EntityOrCommon {
+                type_name: RawName::from(p),
+            })
+        }
+        Type::Record(fields) => {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+                attributes: fields
+                    .into_iter()
+                    .map(|field| convert_attr_decl(field.node))
+                    .collect(),
+                additional_attributes: false,
+            })
+        }
     }
 }
 
@@ -140,7 +146,7 @@ fn split_unqualified_namespace(
 /// Converts a CST namespace to a JSON namespace
 fn convert_namespace(
     namespace: Namespace,
-) -> Result<(Option<Name>, NamespaceDefinition<RawName>), ToJsonSchemaErrors> {
+) -> Result<(Option<Name>, json_schema::NamespaceDefinition<RawName>), ToJsonSchemaErrors> {
     let ns_name = namespace
         .name
         .clone()
@@ -158,10 +164,10 @@ fn convert_namespace(
     Ok((ns_name, def))
 }
 
-impl TryFrom<Namespace> for NamespaceDefinition<RawName> {
+impl TryFrom<Namespace> for json_schema::NamespaceDefinition<RawName> {
     type Error = ToJsonSchemaErrors;
 
-    fn try_from(n: Namespace) -> Result<NamespaceDefinition<RawName>, Self::Error> {
+    fn try_from(n: Namespace) -> Result<json_schema::NamespaceDefinition<RawName>, Self::Error> {
         // Partition the decls into entities, actions, and common types
         let (entity_types, action, common_types) = into_partition_decls(n.decls);
 
@@ -190,7 +196,7 @@ impl TryFrom<Namespace> for NamespaceDefinition<RawName> {
             })
             .collect::<Result<_, ToJsonSchemaError>>()?;
 
-        Ok(NamespaceDefinition {
+        Ok(json_schema::NamespaceDefinition {
             common_types,
             entity_types,
             actions,
@@ -201,7 +207,7 @@ impl TryFrom<Namespace> for NamespaceDefinition<RawName> {
 /// Converts action type decls
 fn convert_action_decl(
     a: ActionDecl,
-) -> Result<impl Iterator<Item = (SmolStr, ActionType<RawName>)>, ToJsonSchemaErrors> {
+) -> Result<impl Iterator<Item = (SmolStr, json_schema::ActionType<RawName>)>, ToJsonSchemaErrors> {
     let ActionDecl {
         names,
         parents,
@@ -212,13 +218,13 @@ fn convert_action_decl(
     let applies_to = app_decls
         .map(|decls| convert_app_decls(info, decls))
         .transpose()?
-        .unwrap_or_else(|| ApplySpec {
+        .unwrap_or_else(|| json_schema::ApplySpec {
             resource_types: vec![],
             principal_types: vec![],
-            context: AttributesOrContext::default(),
+            context: json_schema::AttributesOrContext::default(),
         });
     let member_of = parents.map(|parents| parents.into_iter().map(convert_qual_name).collect());
-    let ty = ActionType {
+    let ty = json_schema::ActionType {
         attributes: None, // Action attributes are currently unsupported in the natural schema
         applies_to: Some(applies_to),
         member_of,
@@ -227,20 +233,20 @@ fn convert_action_decl(
     Ok(names.into_iter().map(move |name| (name.node, ty.clone())))
 }
 
-fn convert_qual_name(qn: Node<QualName>) -> ActionEntityUID<RawName> {
-    ActionEntityUID::new(qn.node.path.map(Into::into), qn.node.eid)
+fn convert_qual_name(qn: Node<QualName>) -> json_schema::ActionEntityUID<RawName> {
+    json_schema::ActionEntityUID::new(qn.node.path.map(Into::into), qn.node.eid)
 }
 
 // Convert the applies to decls
 fn convert_app_decls(
     action_info: (&SmolStr, &Loc),
     decls: Node<NonEmpty<Node<AppDecl>>>,
-) -> Result<ApplySpec<RawName>, ToJsonSchemaErrors> {
+) -> Result<json_schema::ApplySpec<RawName>, ToJsonSchemaErrors> {
     // Split AppDecl's into context/principal/resource decls
     let (decls, _) = decls.into_inner();
     let mut principal_types: Option<Node<Vec<RawName>>> = None;
     let mut resource_types: Option<Node<Vec<RawName>>> = None;
-    let mut context: Option<Node<AttributesOrContext<RawName>>> = None;
+    let mut context: Option<Node<json_schema::AttributesOrContext<RawName>>> = None;
 
     for decl in decls {
         match decl {
@@ -317,7 +323,7 @@ fn convert_app_decls(
             },
         }
     }
-    Ok(ApplySpec {
+    Ok(json_schema::ApplySpec {
         resource_types: resource_types.map(|node| node.node).ok_or(
             ToJsonSchemaError::NoPrincipalOrResource {
                 kind: PR::Resource,
@@ -348,9 +354,12 @@ fn convert_id(node: Node<Id>) -> Result<UnreservedId, ToJsonSchemaError> {
 /// Convert Entity declarations
 fn convert_entity_decl(
     e: EntityDecl,
-) -> Result<impl Iterator<Item = (UnreservedId, EntityType<RawName>)>, ToJsonSchemaErrors> {
+) -> Result<
+    impl Iterator<Item = (UnreservedId, json_schema::EntityType<RawName>)>,
+    ToJsonSchemaErrors,
+> {
     // First build up the defined entity type
-    let etype = EntityType {
+    let etype = json_schema::EntityType {
         member_of_types: e.member_of_types.into_iter().map(RawName::from).collect(),
         shape: convert_attr_decls(e.attrs),
     };
@@ -366,37 +375,43 @@ fn convert_entity_decl(
 }
 
 /// Create a Record Type from a vector of `AttrDecl`s
-fn convert_attr_decls(attrs: Vec<Node<AttrDecl>>) -> AttributesOrContext<RawName> {
-    AttributesOrContext(SchemaType::Type(SchemaTypeVariant::Record {
-        attributes: attrs
-            .into_iter()
-            .map(|attr| convert_attr_decl(attr.node))
-            .collect(),
-        additional_attributes: false,
-    }))
-}
-
-/// Create a context decl
-fn convert_context_decl(decl: Either<Path, Vec<Node<AttrDecl>>>) -> AttributesOrContext<RawName> {
-    AttributesOrContext(match decl {
-        Either::Left(p) => SchemaType::CommonTypeRef {
-            type_name: p.into(),
-        },
-        Either::Right(attrs) => SchemaType::Type(SchemaTypeVariant::Record {
+fn convert_attr_decls(attrs: Vec<Node<AttrDecl>>) -> json_schema::AttributesOrContext<RawName> {
+    json_schema::AttributesOrContext(json_schema::SchemaType::Type(
+        json_schema::SchemaTypeVariant::Record {
             attributes: attrs
                 .into_iter()
                 .map(|attr| convert_attr_decl(attr.node))
                 .collect(),
             additional_attributes: false,
-        }),
+        },
+    ))
+}
+
+/// Create a context decl
+fn convert_context_decl(
+    decl: Either<Path, Vec<Node<AttrDecl>>>,
+) -> json_schema::AttributesOrContext<RawName> {
+    json_schema::AttributesOrContext(match decl {
+        Either::Left(p) => json_schema::SchemaType::CommonTypeRef {
+            type_name: p.into(),
+        },
+        Either::Right(attrs) => {
+            json_schema::SchemaType::Type(json_schema::SchemaTypeVariant::Record {
+                attributes: attrs
+                    .into_iter()
+                    .map(|attr| convert_attr_decl(attr.node))
+                    .collect(),
+                additional_attributes: false,
+            })
+        }
     })
 }
 
 /// Convert an attribute type from an `AttrDecl`
-fn convert_attr_decl(attr: AttrDecl) -> (SmolStr, TypeOfAttribute<RawName>) {
+fn convert_attr_decl(attr: AttrDecl) -> (SmolStr, json_schema::TypeOfAttribute<RawName>) {
     (
         attr.name.node,
-        TypeOfAttribute {
+        json_schema::TypeOfAttribute {
             ty: human_type_to_json_type(attr.ty),
             required: attr.required,
         },

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -891,7 +891,7 @@ impl Type<RawName> {
         ns: Option<&InternalName>,
     ) -> Type<ConditionalName> {
         match self {
-            Self::Type(stv) => Type::Type(stv.conditionally_qualify_type_references(ns)),
+            Self::Type(tv) => Type::Type(tv.conditionally_qualify_type_references(ns)),
             Self::CommonTypeRef { type_name } => Type::CommonTypeRef {
                 type_name: type_name.conditionally_qualify_with(ns, ReferenceType::Common),
             },
@@ -900,7 +900,7 @@ impl Type<RawName> {
 
     fn into_n<N: From<RawName>>(self) -> Type<N> {
         match self {
-            Self::Type(stv) => Type::Type(stv.into_n()),
+            Self::Type(tv) => Type::Type(tv.into_n()),
             Self::CommonTypeRef { type_name } => Type::CommonTypeRef {
                 type_name: type_name.into(),
             },
@@ -921,8 +921,8 @@ impl Type<ConditionalName> {
         all_entity_defs: &HashSet<InternalName>,
     ) -> std::result::Result<Type<InternalName>, TypeResolutionError> {
         match self {
-            Self::Type(stv) => Ok(Type::Type(
-                stv.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            Self::Type(tv) => Ok(Type::Type(
+                tv.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
             )),
             Self::CommonTypeRef { type_name } => Ok(Type::CommonTypeRef {
                 type_name: type_name.resolve(all_common_defs, all_entity_defs)?.clone(),

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -193,7 +193,7 @@ pub struct NamespaceDefinition<N> {
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    pub common_types: HashMap<UnreservedId, SchemaType<N>>,
+    pub common_types: HashMap<UnreservedId, Type<N>>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
     pub entity_types: HashMap<UnreservedId, EntityType<N>>,
     #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
@@ -376,15 +376,14 @@ impl EntityType<ConditionalName> {
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct AttributesOrContext<N>(
-    // We use the usual `SchemaType` deserialization, but it will ultimately
-    // need to be a `Record` or common-type reference which resolves to a
-    // `Record`.
-    pub SchemaType<N>,
+    // We use the usual `Type` deserialization, but it will ultimately need to
+    // be a `Record` or common-type reference which resolves to a `Record`.
+    pub Type<N>,
 );
 
 impl<N> AttributesOrContext<N> {
-    /// Convert the `AttributesOrContext` into its `SchemaType`.
-    pub fn into_inner(self) -> SchemaType<N> {
+    /// Convert the [`AttributesOrContext`] into its [`Type`].
+    pub fn into_inner(self) -> Type<N> {
         self.0
     }
 
@@ -396,7 +395,7 @@ impl<N> AttributesOrContext<N> {
 
 impl<N> Default for AttributesOrContext<N> {
     fn default() -> Self {
-        Self(SchemaType::Type(SchemaTypeVariant::Record {
+        Self(Type::Type(TypeVariant::Record {
             attributes: BTreeMap::new(),
             additional_attributes: partial_schema_default(),
         }))
@@ -799,7 +798,7 @@ impl From<EntityUID> for ActionEntityUID<Name> {
 /// which are exposed to users.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
-/// this [`SchemaType`], including recursively.
+/// this [`Type`], including recursively.
 /// See notes on [`Fragment`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 // This enum is `untagged` with these variants as a workaround to a serde
@@ -809,16 +808,16 @@ impl From<EntityUID> for ActionEntityUID<Name> {
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum SchemaType<N> {
+pub enum Type<N> {
     /// One of the standard types exposed to users.
     ///
     /// This branch also includes the "entity-or-common-type-reference" possibility.
-    Type(SchemaTypeVariant<N>),
+    Type(TypeVariant<N>),
     /// Reference to a common type
     ///
     /// This is only used for references that _must_ resolve to common types.
     /// References that may resolve to either common or entity types can use
-    /// `SchemaType::Type(SchemaTypeVariant::EntityOrCommon)`.
+    /// `Type::Type(TypeVariant::EntityOrCommon)`.
     CommonTypeRef {
         /// Name of the common type.
         /// For the important case of `N` = [`RawName`], this is the schema JSON
@@ -829,54 +828,54 @@ pub enum SchemaType<N> {
     },
 }
 
-impl<N> SchemaType<N> {
+impl<N> Type<N> {
     /// Iterate over all references which occur in the type and (must or may)
     /// resolve to a common type
     pub(crate) fn common_type_references(&self) -> Box<dyn Iterator<Item = &N> + '_> {
         match self {
-            SchemaType::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
+            Type::Type(TypeVariant::Record { attributes, .. }) => attributes
                 .iter()
                 .map(|(_, ty)| ty.ty.common_type_references())
                 .fold(Box::new(std::iter::empty()), |it, tys| {
                     Box::new(it.chain(tys))
                 }),
-            SchemaType::Type(SchemaTypeVariant::Set { element }) => {
-                element.common_type_references()
-            }
-            SchemaType::Type(SchemaTypeVariant::EntityOrCommon { type_name }) => {
+            Type::Type(TypeVariant::Set { element }) => element.common_type_references(),
+            Type::Type(TypeVariant::EntityOrCommon { type_name }) => {
                 Box::new(std::iter::once(type_name))
             }
-            SchemaType::CommonTypeRef { type_name } => Box::new(std::iter::once(type_name)),
+            Type::CommonTypeRef { type_name } => Box::new(std::iter::once(type_name)),
             _ => Box::new(std::iter::empty()),
         }
     }
 
-    /// Is this [`SchemaType`] an extension type, or does it contain one
+    /// Is this [`Type`] an extension type, or does it contain one
     /// (recursively)? Returns `None` if this is a `CommonTypeRef` or
     /// `EntityOrCommon` because we can't easily check the type of a common type
     /// reference, accounting for namespaces, without first converting to a
     /// [`crate::types::Type`].
     pub fn is_extension(&self) -> Option<bool> {
         match self {
-            Self::Type(SchemaTypeVariant::Extension { .. }) => Some(true),
-            Self::Type(SchemaTypeVariant::Set { element }) => element.is_extension(),
-            Self::Type(SchemaTypeVariant::Record { attributes, .. }) => attributes
-                .values()
-                .try_fold(false, |a, e| match e.ty.is_extension() {
-                    Some(true) => Some(true),
-                    Some(false) => Some(a),
-                    None => None,
-                }),
+            Self::Type(TypeVariant::Extension { .. }) => Some(true),
+            Self::Type(TypeVariant::Set { element }) => element.is_extension(),
+            Self::Type(TypeVariant::Record { attributes, .. }) => {
+                attributes
+                    .values()
+                    .try_fold(false, |a, e| match e.ty.is_extension() {
+                        Some(true) => Some(true),
+                        Some(false) => Some(a),
+                        None => None,
+                    })
+            }
             Self::Type(_) => Some(false),
             Self::CommonTypeRef { .. } => None,
         }
     }
 
-    /// Is this [`SchemaType`] an empty record? This function is used by the `Display`
+    /// Is this [`Type`] an empty record? This function is used by the `Display`
     /// implementation to avoid printing unnecessary entity/action data.
     pub fn is_empty_record(&self) -> bool {
         match self {
-            Self::Type(SchemaTypeVariant::Record {
+            Self::Type(TypeVariant::Record {
                 attributes,
                 additional_attributes,
             }) => *additional_attributes == partial_schema_default() && attributes.is_empty(),
@@ -885,34 +884,33 @@ impl<N> SchemaType<N> {
     }
 }
 
-impl SchemaType<RawName> {
+impl Type<RawName> {
     /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> SchemaType<ConditionalName> {
+    ) -> Type<ConditionalName> {
         match self {
-            Self::Type(stv) => SchemaType::Type(stv.conditionally_qualify_type_references(ns)),
-            Self::CommonTypeRef { type_name } => SchemaType::CommonTypeRef {
+            Self::Type(stv) => Type::Type(stv.conditionally_qualify_type_references(ns)),
+            Self::CommonTypeRef { type_name } => Type::CommonTypeRef {
                 type_name: type_name.conditionally_qualify_with(ns, ReferenceType::Common),
             },
         }
     }
 
-    fn into_n<N: From<RawName>>(self) -> SchemaType<N> {
+    fn into_n<N: From<RawName>>(self) -> Type<N> {
         match self {
-            Self::Type(stv) => SchemaType::Type(stv.into_n()),
-            Self::CommonTypeRef { type_name } => SchemaType::CommonTypeRef {
+            Self::Type(stv) => Type::Type(stv.into_n()),
+            Self::CommonTypeRef { type_name } => Type::CommonTypeRef {
                 type_name: type_name.into(),
             },
         }
     }
 }
 
-impl SchemaType<ConditionalName> {
-    /// Convert this [`SchemaType<ConditionalName>`] into a
-    /// [`SchemaType<InternalName>`] by fully-qualifying all typenames that
-    /// appear anywhere in any definitions.
+impl Type<ConditionalName> {
+    /// Convert this [`Type<ConditionalName>`] into a [`Type<InternalName>`] by
+    /// fully-qualifying all typenames that appear anywhere in any definitions.
     ///
     /// `all_common_defs` and `all_entity_defs` need to be the full set of all
     /// fully-qualified typenames (of common and entity types respectively) that
@@ -921,30 +919,30 @@ impl SchemaType<ConditionalName> {
         self,
         all_common_defs: &HashSet<InternalName>,
         all_entity_defs: &HashSet<InternalName>,
-    ) -> std::result::Result<SchemaType<InternalName>, TypeResolutionError> {
+    ) -> std::result::Result<Type<InternalName>, TypeResolutionError> {
         match self {
-            Self::Type(stv) => Ok(SchemaType::Type(
+            Self::Type(stv) => Ok(Type::Type(
                 stv.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
             )),
-            Self::CommonTypeRef { type_name } => Ok(SchemaType::CommonTypeRef {
+            Self::CommonTypeRef { type_name } => Ok(Type::CommonTypeRef {
                 type_name: type_name.resolve(all_common_defs, all_entity_defs)?.clone(),
             }),
         }
     }
 }
 
-impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for SchemaType<N> {
+impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for Type<N> {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_any(SchemaTypeVisitor {
+        deserializer.deserialize_any(TypeVisitor {
             _phantom: PhantomData,
         })
     }
 }
 
-/// The fields for a `SchemaTypes`. Used for implementing deserialization.
+/// The fields for a `Type`. Used for implementing deserialization.
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Deserialize)]
 #[serde(field_identifier, rename_all = "camelCase")]
 enum TypeFields {
@@ -998,12 +996,12 @@ struct AttributesTypeMap(
     BTreeMap<SmolStr, TypeOfAttribute<RawName>>,
 );
 
-struct SchemaTypeVisitor<N> {
+struct TypeVisitor<N> {
     _phantom: PhantomData<N>,
 }
 
-impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for SchemaTypeVisitor<N> {
-    type Value = SchemaType<N>;
+impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for TypeVisitor<N> {
+    type Value = Type<N>;
 
     fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter.write_str("builtin type or reference to type defined in commonTypes")
@@ -1021,7 +1019,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for SchemaTypeVisito
         // field so not exist at all, so that the schema author can delete the
         // field without wasting time fixing errors in the value.
         let mut type_name: Option<std::result::Result<SmolStr, M::Error>> = None;
-        let mut element: Option<std::result::Result<SchemaType<N>, M::Error>> = None;
+        let mut element: Option<std::result::Result<Type<N>, M::Error>> = None;
         let mut attributes: Option<std::result::Result<AttributesTypeMap, M::Error>> = None;
         let mut additional_attributes: Option<std::result::Result<bool, M::Error>> = None;
         let mut name: Option<std::result::Result<SmolStr, M::Error>> = None;
@@ -1084,18 +1082,18 @@ pub(crate) mod static_names {
     }
 }
 
-impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
+impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
     /// Construct a schema type given the name of the type and its fields.
     /// Fields which were not present are `None`. It is an error for a field
     /// which is not used for a particular type to be `Some` when building that
     /// type.
     fn build_schema_type<M>(
         type_name: Option<std::result::Result<SmolStr, M::Error>>,
-        element: Option<std::result::Result<SchemaType<N>, M::Error>>,
+        element: Option<std::result::Result<Type<N>, M::Error>>,
         attributes: Option<std::result::Result<AttributesTypeMap, M::Error>>,
         additional_attributes: Option<std::result::Result<bool, M::Error>>,
         name: Option<std::result::Result<SmolStr, M::Error>>,
-    ) -> std::result::Result<SchemaType<N>, M::Error>
+    ) -> std::result::Result<Type<N>, M::Error>
     where
         M: MapAccess<'de>,
     {
@@ -1136,20 +1134,20 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                 match s.as_str() {
                     "String" => {
                         error_if_any_fields()?;
-                        Ok(SchemaType::Type(SchemaTypeVariant::String))
+                        Ok(Type::Type(TypeVariant::String))
                     }
                     "Long" => {
                         error_if_any_fields()?;
-                        Ok(SchemaType::Type(SchemaTypeVariant::Long))
+                        Ok(Type::Type(TypeVariant::Long))
                     }
                     "Boolean" => {
                         error_if_any_fields()?;
-                        Ok(SchemaType::Type(SchemaTypeVariant::Boolean))
+                        Ok(Type::Type(TypeVariant::Boolean))
                     }
                     "Set" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Set`
-                            Ok(SchemaType::CommonTypeRef {
+                            Ok(Type::CommonTypeRef {
                                 type_name: N::from(SET_NAME.clone()),
                             })
                         } else {
@@ -1158,11 +1156,11 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                                 &[type_field_name!(Element)],
                             )?;
 
-                            Ok(SchemaType::Type(SchemaTypeVariant::Set {
+                            Ok(Type::Type(TypeVariant::Set {
                                 element: {
                                     // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them, ensuring `element` exists
                                     #[allow(clippy::unwrap_used)]
-                                    let element: SchemaType<N> = element.unwrap()?;
+                                    let element: Type<N> = element.unwrap()?;
                                     Box::new(element)
                                 },
                             }))
@@ -1171,7 +1169,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "Record" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Record`
-                            Ok(SchemaType::CommonTypeRef {
+                            Ok(Type::CommonTypeRef {
                                 type_name: N::from(RECORD_NAME.clone()),
                             })
                         } else {
@@ -1186,7 +1184,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                             if let Some(attributes) = attributes {
                                 let additional_attributes =
                                     additional_attributes.unwrap_or(Ok(partial_schema_default()));
-                                Ok(SchemaType::Type(SchemaTypeVariant::Record {
+                                Ok(Type::Type(TypeVariant::Record {
                                     attributes: attributes?
                                         .0
                                         .into_iter()
@@ -1210,7 +1208,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "Entity" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Entity`
-                            Ok(SchemaType::CommonTypeRef {
+                            Ok(Type::CommonTypeRef {
                                 type_name: N::from(ENTITY_NAME.clone()),
                             })
                         } else {
@@ -1221,7 +1219,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                             // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
                             #[allow(clippy::unwrap_used)]
                             let name = name.unwrap()?;
-                            Ok(SchemaType::Type(SchemaTypeVariant::Entity {
+                            Ok(Type::Type(TypeVariant::Entity {
                                 name: RawName::from_normalized_str(&name)
                                     .map_err(|err| {
                                         serde::de::Error::custom(format!(
@@ -1235,7 +1233,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "EntityOrCommon" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `EntityOrCommon`
-                            Ok(SchemaType::CommonTypeRef {
+                            Ok(Type::CommonTypeRef {
                                 type_name: N::from(ENTITY_OR_COMMON_NAME.clone()),
                             })
                         } else {
@@ -1246,7 +1244,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                             // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
                             #[allow(clippy::unwrap_used)]
                             let name = name.unwrap()?;
-                            Ok(SchemaType::Type(SchemaTypeVariant::EntityOrCommon {
+                            Ok(Type::Type(TypeVariant::EntityOrCommon {
                                 type_name: RawName::from_normalized_str(&name)
                                     .map_err(|err| {
                                         serde::de::Error::custom(format!(
@@ -1260,7 +1258,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     "Extension" => {
                         if remaining_fields.is_empty() {
                             // must be referring to a common type named `Extension`
-                            Ok(SchemaType::CommonTypeRef {
+                            Ok(Type::CommonTypeRef {
                                 type_name: N::from(EXTENSION_NAME.clone()),
                             })
                         } else {
@@ -1272,7 +1270,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                             // PANIC SAFETY: There are four fields allowed and the previous function rules out three of them ensuring `name` exists
                             #[allow(clippy::unwrap_used)]
                             let name = name.unwrap()?;
-                            Ok(SchemaType::Type(SchemaTypeVariant::Extension {
+                            Ok(Type::Type(TypeVariant::Extension {
                                 name: UnreservedId::from_normalized_str(&name).map_err(|err| {
                                     serde::de::Error::custom(format!(
                                         "invalid extension type `{name}`: {err}"
@@ -1283,7 +1281,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
                     }
                     type_name => {
                         error_if_any_fields()?;
-                        Ok(SchemaType::CommonTypeRef {
+                        Ok(Type::CommonTypeRef {
                             type_name: N::from(RawName::from_normalized_str(type_name).map_err(
                                 |err| {
                                     serde::de::Error::custom(format!(
@@ -1300,24 +1298,24 @@ impl<'de, N: Deserialize<'de> + From<RawName>> SchemaTypeVisitor<N> {
     }
 }
 
-impl<N> From<SchemaTypeVariant<N>> for SchemaType<N> {
-    fn from(variant: SchemaTypeVariant<N>) -> Self {
+impl<N> From<TypeVariant<N>> for Type<N> {
+    fn from(variant: TypeVariant<N>) -> Self {
         Self::Type(variant)
     }
 }
 
-/// The variants of [`SchemaType`] that are exposed to users, i.e., legal to write
-/// in schemas. Does not include common types, which are handled separately.
+/// The variants of [`Type`] that are exposed to users, i.e., legal to write in
+/// schemas. Does not include common types, which are handled separately.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
-/// this [`SchemaTypeVariant`], including recursively.
+/// this [`TypeVariant`], including recursively.
 /// See notes on [`Fragment`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum SchemaTypeVariant<N> {
+pub enum TypeVariant<N> {
     /// String
     String,
     /// Long
@@ -1327,7 +1325,7 @@ pub enum SchemaTypeVariant<N> {
     /// Set
     Set {
         /// Element type
-        element: Box<SchemaType<N>>,
+        element: Box<Type<N>>,
     },
     /// Record
     Record {
@@ -1354,16 +1352,16 @@ pub enum SchemaTypeVariant<N> {
         /// may not yet be fully qualified.
         ///
         /// There is no possible ambiguity in the JSON syntax between this and
-        /// `Entity`, nor between this and `SchemaType::Common`.
+        /// `Entity`, nor between this and `Type::Common`.
         /// - To represent a must-be-entity-type reference in the JSON syntax,
         ///     use `{ "type": "Entity", "name": "foo" }`. This ser/de as
-        ///     `SchemaType::Type(SchemaTypeVariant::Entity)`.
+        ///     `Type::Type(TypeVariant::Entity)`.
         /// - To represent a must-be-common-type reference in the JSON syntax,
         ///     use `{ "type": "foo" }`. This ser/de as
-        ///     `SchemaType::CommonTypeRef`.
+        ///     `Type::CommonTypeRef`.
         /// - To represent an either-entity-or-common-type reference in the
         ///     JSON syntax, use `{ "type": "EntityOrCommon", "name": "foo" }`.
-        ///     This ser/de as `SchemaType::Type(SchemaTypeVariant::EntityOrCommon`.
+        ///     This ser/de as `Type::Type(TypeVariant::EntityOrCommon`.
         ///
         /// You can still use `{ "type": "Entity" }` alone (no `"name"` key) to
         /// indicate a common type named `Entity`, and likewise for
@@ -1378,30 +1376,30 @@ pub enum SchemaTypeVariant<N> {
     },
 }
 
-impl SchemaTypeVariant<RawName> {
+impl TypeVariant<RawName> {
     /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> SchemaTypeVariant<ConditionalName> {
+    ) -> TypeVariant<ConditionalName> {
         match self {
-            Self::Boolean => SchemaTypeVariant::Boolean,
-            Self::Long => SchemaTypeVariant::Long,
-            Self::String => SchemaTypeVariant::String,
-            Self::Extension { name } => SchemaTypeVariant::Extension { name },
-            Self::Entity { name } => SchemaTypeVariant::Entity {
+            Self::Boolean => TypeVariant::Boolean,
+            Self::Long => TypeVariant::Long,
+            Self::String => TypeVariant::String,
+            Self::Extension { name } => TypeVariant::Extension { name },
+            Self::Entity { name } => TypeVariant::Entity {
                 name: name.conditionally_qualify_with(ns, ReferenceType::Entity), // `Self::Entity` must resolve to an entity type, not a common type
             },
-            Self::EntityOrCommon { type_name } => SchemaTypeVariant::EntityOrCommon {
+            Self::EntityOrCommon { type_name } => TypeVariant::EntityOrCommon {
                 type_name: type_name.conditionally_qualify_with(ns, ReferenceType::CommonOrEntity),
             },
-            Self::Set { element } => SchemaTypeVariant::Set {
+            Self::Set { element } => TypeVariant::Set {
                 element: Box::new(element.conditionally_qualify_type_references(ns)),
             },
             Self::Record {
                 attributes,
                 additional_attributes,
-            } => SchemaTypeVariant::Record {
+            } => TypeVariant::Record {
                 attributes: BTreeMap::from_iter(attributes.into_iter().map(
                     |(attr, TypeOfAttribute { ty, required })| {
                         (
@@ -1418,37 +1416,37 @@ impl SchemaTypeVariant<RawName> {
         }
     }
 
-    fn into_n<N: From<RawName>>(self) -> SchemaTypeVariant<N> {
+    fn into_n<N: From<RawName>>(self) -> TypeVariant<N> {
         match self {
-            Self::Boolean => SchemaTypeVariant::Boolean,
-            Self::Long => SchemaTypeVariant::Long,
-            Self::String => SchemaTypeVariant::String,
-            Self::Entity { name } => SchemaTypeVariant::Entity { name: name.into() },
-            Self::EntityOrCommon { type_name } => SchemaTypeVariant::EntityOrCommon {
+            Self::Boolean => TypeVariant::Boolean,
+            Self::Long => TypeVariant::Long,
+            Self::String => TypeVariant::String,
+            Self::Entity { name } => TypeVariant::Entity { name: name.into() },
+            Self::EntityOrCommon { type_name } => TypeVariant::EntityOrCommon {
                 type_name: type_name.into(),
             },
             Self::Record {
                 attributes,
                 additional_attributes,
-            } => SchemaTypeVariant::Record {
+            } => TypeVariant::Record {
                 attributes: attributes
                     .into_iter()
                     .map(|(k, v)| (k, v.into_n()))
                     .collect(),
                 additional_attributes,
             },
-            Self::Set { element } => SchemaTypeVariant::Set {
+            Self::Set { element } => TypeVariant::Set {
                 element: Box::new(element.into_n()),
             },
-            Self::Extension { name } => SchemaTypeVariant::Extension { name },
+            Self::Extension { name } => TypeVariant::Extension { name },
         }
     }
 }
 
-impl SchemaTypeVariant<ConditionalName> {
-    /// Convert this [`SchemaTypeVariant<ConditionalName>`] into a
-    /// [`SchemaTypeVariant<InternalName>`] by fully-qualifying all typenames
-    /// that appear anywhere in any definitions.
+impl TypeVariant<ConditionalName> {
+    /// Convert this [`TypeVariant<ConditionalName>`] into a
+    /// [`TypeVariant<InternalName>`] by fully-qualifying all typenames that
+    /// appear anywhere in any definitions.
     ///
     /// `all_common_defs` and `all_entity_defs` need to be the full set of all
     /// fully-qualified typenames (of common and entity types respectively) that
@@ -1457,19 +1455,19 @@ impl SchemaTypeVariant<ConditionalName> {
         self,
         all_common_defs: &HashSet<InternalName>,
         all_entity_defs: &HashSet<InternalName>,
-    ) -> std::result::Result<SchemaTypeVariant<InternalName>, TypeResolutionError> {
+    ) -> std::result::Result<TypeVariant<InternalName>, TypeResolutionError> {
         match self {
-            Self::Boolean => Ok(SchemaTypeVariant::Boolean),
-            Self::Long => Ok(SchemaTypeVariant::Long),
-            Self::String => Ok(SchemaTypeVariant::String),
-            Self::Extension { name } => Ok(SchemaTypeVariant::Extension { name }),
-            Self::Entity { name } => Ok(SchemaTypeVariant::Entity {
+            Self::Boolean => Ok(TypeVariant::Boolean),
+            Self::Long => Ok(TypeVariant::Long),
+            Self::String => Ok(TypeVariant::String),
+            Self::Extension { name } => Ok(TypeVariant::Extension { name }),
+            Self::Entity { name } => Ok(TypeVariant::Entity {
                 name: name.resolve(all_common_defs, all_entity_defs)?.clone(),
             }),
-            Self::EntityOrCommon { type_name } => Ok(SchemaTypeVariant::EntityOrCommon {
+            Self::EntityOrCommon { type_name } => Ok(TypeVariant::EntityOrCommon {
                 type_name: type_name.resolve(all_common_defs, all_entity_defs)?.clone(),
             }),
-            Self::Set { element } => Ok(SchemaTypeVariant::Set {
+            Self::Set { element } => Ok(TypeVariant::Set {
                 element: Box::new(
                     element.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
                 ),
@@ -1477,7 +1475,7 @@ impl SchemaTypeVariant<ConditionalName> {
             Self::Record {
                 attributes,
                 additional_attributes,
-            } => Ok(SchemaTypeVariant::Record {
+            } => Ok(TypeVariant::Record {
                 attributes: attributes
                     .into_iter()
                     .map(|(attr, TypeOfAttribute { ty, required })| {
@@ -1507,15 +1505,15 @@ fn is_partial_schema_default(b: &bool) -> bool {
 #[cfg(feature = "arbitrary")]
 // PANIC SAFETY property testing code
 #[allow(clippy::panic)]
-impl<'a> arbitrary::Arbitrary<'a> for SchemaType<RawName> {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<SchemaType<RawName>> {
+impl<'a> arbitrary::Arbitrary<'a> for Type<RawName> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Type<RawName>> {
         use std::collections::BTreeSet;
 
-        Ok(SchemaType::Type(match u.int_in_range::<u8>(1..=8)? {
-            1 => SchemaTypeVariant::String,
-            2 => SchemaTypeVariant::Long,
-            3 => SchemaTypeVariant::Boolean,
-            4 => SchemaTypeVariant::Set {
+        Ok(Type::Type(match u.int_in_range::<u8>(1..=8)? {
+            1 => TypeVariant::String,
+            2 => TypeVariant::Long,
+            3 => TypeVariant::Boolean,
+            4 => TypeVariant::Set {
                 element: Box::new(u.arbitrary()?),
             },
             5 => {
@@ -1526,20 +1524,20 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType<RawName> {
                         .map(|attr_name| Ok((attr_name.into(), u.arbitrary()?)))
                         .collect::<arbitrary::Result<_>>()?
                 };
-                SchemaTypeVariant::Record {
+                TypeVariant::Record {
                     attributes,
                     additional_attributes: u.arbitrary()?,
                 }
             }
-            6 => SchemaTypeVariant::Entity {
+            6 => TypeVariant::Entity {
                 name: u.arbitrary()?,
             },
-            7 => SchemaTypeVariant::Extension {
+            7 => TypeVariant::Extension {
                 // PANIC SAFETY: `ipaddr` is a valid `UnreservedId`
                 #[allow(clippy::unwrap_used)]
                 name: "ipaddr".parse().unwrap(),
             },
-            8 => SchemaTypeVariant::Extension {
+            8 => TypeVariant::Extension {
                 // PANIC SAFETY: `decimal` is a valid `UnreservedId`
                 #[allow(clippy::unwrap_used)]
                 name: "decimal".parse().unwrap(),
@@ -1562,20 +1560,20 @@ impl<'a> arbitrary::Arbitrary<'a> for SchemaType<RawName> {
 /// See notes on [`Fragment`].
 ///
 /// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
-/// using `#[serde(tag = "type")]` in [`SchemaType`] which is flattened here.
+/// using `#[serde(tag = "type")]` in [`Type`] which is flattened here.
 /// The way `serde(flatten)` is implemented means it may be possible to access
 /// fields incorrectly if a struct contains two structs that are flattened
 /// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
 /// us as we're using `flatten` only once
 /// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
-/// unknown fields for [`TypeOfAttribute`] should be passed to [`SchemaType`] where
+/// unknown fields for [`TypeOfAttribute`] should be passed to [`Type`] where
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 pub struct TypeOfAttribute<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]
-    pub ty: SchemaType<N>,
+    pub ty: Type<N>,
     /// Whether the attribute is required
     #[serde(default = "record_attribute_required_default")]
     #[serde(skip_serializing_if = "is_record_attribute_required_default")]
@@ -1602,7 +1600,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TypeOfAttribute<RawName> {
 
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
         arbitrary::size_hint::and(
-            <SchemaType<RawName> as arbitrary::Arbitrary>::size_hint(depth),
+            <Type<RawName> as arbitrary::Arbitrary>::size_hint(depth),
             <bool as arbitrary::Arbitrary>::size_hint(depth),
         )
     }
@@ -1649,7 +1647,7 @@ mod test {
         assert_eq!(et.member_of_types, vec!["UserGroup".parse().unwrap()]);
         assert_eq!(
             et.shape.into_inner(),
-            SchemaType::Type(SchemaTypeVariant::Record {
+            Type::Type(TypeVariant::Record {
                 attributes: BTreeMap::new(),
                 additional_attributes: false
             })
@@ -1665,7 +1663,7 @@ mod test {
         assert_eq!(et.member_of_types.len(), 0);
         assert_eq!(
             et.shape.into_inner(),
-            SchemaType::Type(SchemaTypeVariant::Record {
+            Type::Type(TypeVariant::Record {
                 attributes: BTreeMap::new(),
                 additional_attributes: false
             })
@@ -1981,7 +1979,7 @@ mod strengthened_types {
     use cool_asserts::assert_matches;
 
     use super::{
-        ActionEntityUID, ApplySpec, EntityType, Fragment, NamespaceDefinition, RawName, SchemaType,
+        ActionEntityUID, ApplySpec, EntityType, Fragment, NamespaceDefinition, RawName, Type,
     };
 
     /// Assert that `result` is an `Err`, and the error message matches `msg`
@@ -2187,7 +2185,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": ""
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -2195,7 +2193,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": "*"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -2203,7 +2201,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": "::A"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type `::A`: unexpected token `::`");
 
         let src = serde_json::json!(
@@ -2211,7 +2209,7 @@ mod strengthened_types {
            "type": "Entity",
             "name": "A::"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid entity type `A::`: unexpected end of input");
     }
 
@@ -2256,28 +2254,28 @@ mod strengthened_types {
         {
            "type": ""
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type ``: unexpected end of input");
 
         let src = serde_json::json!(
         {
            "type": "*"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
         {
            "type": "::A"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type `::A`: unexpected token `::`");
 
         let src = serde_json::json!(
         {
            "type": "A::"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid common type `A::`: unexpected end of input");
     }
 
@@ -2288,7 +2286,7 @@ mod strengthened_types {
            "type": "Extension",
            "name": ""
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid extension type ``: unexpected end of input");
 
         let src = serde_json::json!(
@@ -2296,7 +2294,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "*"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(schema, "invalid extension type `*`: unexpected token `*`");
 
         let src = serde_json::json!(
@@ -2304,7 +2302,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "__cedar::decimal"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(
             schema,
             "invalid extension type `__cedar::decimal`: unexpected token `::`",
@@ -2315,7 +2313,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "__cedar::"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(
             schema,
             "invalid extension type `__cedar::`: unexpected token `::`",
@@ -2326,7 +2324,7 @@ mod strengthened_types {
             "type": "Extension",
            "name": "::__cedar"
         });
-        let schema: Result<SchemaType<RawName>, _> = serde_json::from_value(src);
+        let schema: Result<Type<RawName>, _> = serde_json::from_value(src);
         assert_error_matches(
             schema,
             "invalid extension type `::__cedar`: unexpected token `::`",
@@ -2382,7 +2380,7 @@ mod test_json_roundtrip {
                     "a".parse().unwrap(),
                     EntityType {
                         member_of_types: vec!["a".parse().unwrap()],
-                        shape: AttributesOrContext(SchemaType::Type(SchemaTypeVariant::Record {
+                        shape: AttributesOrContext(Type::Type(TypeVariant::Record {
                             attributes: BTreeMap::new(),
                             additional_attributes: false,
                         })),
@@ -2395,12 +2393,10 @@ mod test_json_roundtrip {
                         applies_to: Some(ApplySpec {
                             resource_types: vec!["a".parse().unwrap()],
                             principal_types: vec!["a".parse().unwrap()],
-                            context: AttributesOrContext(SchemaType::Type(
-                                SchemaTypeVariant::Record {
-                                    attributes: BTreeMap::new(),
-                                    additional_attributes: false,
-                                },
-                            )),
+                            context: AttributesOrContext(Type::Type(TypeVariant::Record {
+                                attributes: BTreeMap::new(),
+                                additional_attributes: false,
+                            })),
                         }),
                         member_of: None,
                     },
@@ -2421,12 +2417,10 @@ mod test_json_roundtrip {
                         "a".parse().unwrap(),
                         EntityType {
                             member_of_types: vec!["a".parse().unwrap()],
-                            shape: AttributesOrContext(SchemaType::Type(
-                                SchemaTypeVariant::Record {
-                                    attributes: BTreeMap::new(),
-                                    additional_attributes: false,
-                                },
-                            )),
+                            shape: AttributesOrContext(Type::Type(TypeVariant::Record {
+                                attributes: BTreeMap::new(),
+                                additional_attributes: false,
+                            })),
                         },
                     )]),
                     actions: HashMap::new(),
@@ -2444,12 +2438,10 @@ mod test_json_roundtrip {
                             applies_to: Some(ApplySpec {
                                 resource_types: vec!["foo::a".parse().unwrap()],
                                 principal_types: vec!["foo::a".parse().unwrap()],
-                                context: AttributesOrContext(SchemaType::Type(
-                                    SchemaTypeVariant::Record {
-                                        attributes: BTreeMap::new(),
-                                        additional_attributes: false,
-                                    },
-                                )),
+                                context: AttributesOrContext(Type::Type(TypeVariant::Record {
+                                    attributes: BTreeMap::new(),
+                                    additional_attributes: false,
+                                })),
                             }),
                             member_of: None,
                         },

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -1011,7 +1011,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for TypeVisitor<N> {
     where
         M: MapAccess<'de>,
     {
-        use TypeFields::*;
+        use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
 
         // We keep field values wrapped in a `Result` initially so that we do
         // not report errors due the contents of a field when the field is not
@@ -1029,9 +1029,9 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for TypeVisitor<N> {
         // serde already.
         while let Some(key) = map.next_key()? {
             match key {
-                Type => {
+                TypeField => {
                     if type_name.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Type.as_str()));
+                        return Err(serde::de::Error::duplicate_field(TypeField.as_str()));
                     }
                     type_name = Some(map.next_value());
                 }
@@ -1098,10 +1098,10 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
         M: MapAccess<'de>,
     {
         use static_names::*;
-        use TypeFields::*;
+        use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
         // Fields that remain to be parsed
         let mut remaining_fields = [
-            (Type, type_name.is_some()),
+            (TypeField, type_name.is_some()),
             (Element, element.is_some()),
             (Attributes, attributes.is_some()),
             (AdditionalAttributes, additional_attributes.is_some()),
@@ -1115,7 +1115,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
         match type_name.transpose()?.as_ref() {
             Some(s) => {
                 // We've concluded that type exists
-                remaining_fields.remove(&Type);
+                remaining_fields.remove(&TypeField);
                 // Used to generate the appropriate serde error if a field is present
                 // when it is not expected.
                 let error_if_fields = |fs: &[TypeFields],
@@ -1293,7 +1293,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                     }
                 }
             }
-            None => Err(serde::de::Error::missing_field(Type.as_str())),
+            None => Err(serde::de::Error::missing_field(TypeField.as_str())),
         }
     }
 }

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Structures defining the JSON syntax for Cedar schemas
+
 use cedar_policy_core::{
     ast::{Eid, EntityUID, InternalName, Name, UnreservedId},
     entities::CedarValueJson,
@@ -1979,7 +1981,7 @@ mod test {
 mod strengthened_types {
     use cool_asserts::assert_matches;
 
-    use crate::{
+    use super::{
         ActionEntityUID, ApplySpec, EntityType, NamespaceDefinition, RawName, SchemaFragment,
         SchemaType,
     };

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -310,7 +310,7 @@ mod test {
     #[test]
     fn top_level_validate_with_links() -> Result<()> {
         let mut set = PolicySet::new();
-        let schema: ValidatorSchema = serde_json::from_str::<json_schema::SchemaFragment<RawName>>(
+        let schema: ValidatorSchema = serde_json::from_str::<json_schema::Fragment<RawName>>(
             r#"
             {
                 "some_namespace": {
@@ -457,7 +457,7 @@ mod test {
 
     #[test]
     fn validate_finds_warning_and_error() {
-        let schema: ValidatorSchema = json_schema::SchemaFragment::from_json_str(
+        let schema: ValidatorSchema = json_schema::Fragment::from_json_str(
             r#"
             {
                 "": {

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -310,7 +310,7 @@ mod test {
     #[test]
     fn top_level_validate_with_links() -> Result<()> {
         let mut set = PolicySet::new();
-        let schema: ValidatorSchema = serde_json::from_str::<json_schema::Fragment<RawName>>(
+        let schema: ValidatorSchema = json_schema::Fragment::from_json_str(
             r#"
             {
                 "some_namespace": {

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -48,8 +48,7 @@ mod fuzzy_match;
 mod rbac;
 mod schema;
 pub use schema::*;
-mod schema_file_format;
-pub use schema_file_format::*;
+pub mod json_schema;
 mod str_checks;
 pub use str_checks::confusable_string_checks;
 pub mod human_schema;
@@ -227,30 +226,30 @@ mod test {
         let foo_type = "foo_type";
         let bar_type = "bar_type";
         let action_name = "action";
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [
                 (
                     foo_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     bar_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
             ],
             [(
                 action_name.into(),
-                ActionType {
-                    applies_to: Some(ApplySpec {
+                json_schema::ActionType {
+                    applies_to: Some(json_schema::ApplySpec {
                         principal_types: vec!["foo_type".parse().unwrap()],
                         resource_types: vec!["bar_type".parse().unwrap()],
-                        context: AttributesOrContext::default(),
+                        context: json_schema::AttributesOrContext::default(),
                     }),
                     member_of: None,
                     attributes: None,
@@ -311,7 +310,7 @@ mod test {
     #[test]
     fn top_level_validate_with_links() -> Result<()> {
         let mut set = PolicySet::new();
-        let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment<RawName>>(
+        let schema: ValidatorSchema = serde_json::from_str::<json_schema::SchemaFragment<RawName>>(
             r#"
             {
                 "some_namespace": {
@@ -458,7 +457,7 @@ mod test {
 
     #[test]
     fn validate_finds_warning_and_error() {
-        let schema: ValidatorSchema = serde_json::from_str::<SchemaFragment<RawName>>(
+        let schema: ValidatorSchema = json_schema::SchemaFragment::from_json_str(
             r#"
             {
                 "": {

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -409,9 +409,8 @@ mod test {
 
     use super::*;
     use crate::{
-        json_schema::{NamespaceDefinition, *},
-        validation_errors::UnrecognizedEntityType,
-        RawName, ValidationMode, ValidationWarning, Validator,
+        json_schema, validation_errors::UnrecognizedEntityType, RawName, ValidationMode,
+        ValidationWarning, Validator,
     };
 
     #[test]
@@ -434,29 +433,30 @@ mod test {
 
     #[test]
     fn validate_equals_instead_of_in() {
-        let schema_file: NamespaceDefinition<RawName> = serde_json::from_value(serde_json::json!(
-            {
-                "entityTypes": {
-                    "user": {
-                        "memberOfTypes": ["admins"]
+        let schema_file: json_schema::NamespaceDefinition<RawName> =
+            serde_json::from_value(serde_json::json!(
+                {
+                    "entityTypes": {
+                        "user": {
+                            "memberOfTypes": ["admins"]
+                        },
+                        "admins": {},
+                        "widget": {
+                            "memberOfTypes": ["bin"]
+                        },
+                        "bin": {}
                     },
-                    "admins": {},
-                    "widget": {
-                        "memberOfTypes": ["bin"]
-                    },
-                    "bin": {}
-                },
-                "actions": {
-                    "act": {
-                        "appliesTo": {
-                            "principalTypes": ["user"],
-                            "resourceTypes": ["widget"]
+                    "actions": {
+                        "act": {
+                            "appliesTo": {
+                                "principalTypes": ["user"],
+                                "resourceTypes": ["widget"]
+                            }
                         }
                     }
                 }
-            }
-        ))
-        .unwrap();
+            ))
+            .unwrap();
         let schema = schema_file.try_into().unwrap();
 
         let src = r#"permit(principal == admins::"admin1", action == Action::"act", resource == bin::"bin");"#;
@@ -482,12 +482,12 @@ mod test {
     #[test]
     fn validate_entity_type_in_singleton_schema() {
         let foo_type = "foo_type";
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [(
                 foo_type.parse().unwrap(),
-                EntityType {
+                json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -516,12 +516,12 @@ mod test {
 
     #[test]
     fn validate_entity_type_not_in_singleton_schema() {
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [(
                 "foo_type".parse().unwrap(),
-                EntityType {
+                json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -566,11 +566,11 @@ mod test {
     #[test]
     fn validate_action_id_in_singleton_schema() {
         let foo_name = "foo_name";
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [],
             [(
                 foo_name.into(),
-                ActionType {
+                json_schema::ActionType {
                     applies_to: None,
                     member_of: None,
                     attributes: None,
@@ -601,12 +601,12 @@ mod test {
     #[test]
     fn validate_principal_slot_in_singleton_schema() {
         let p_name = "User";
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [(
                 p_name.parse().unwrap(),
-                EntityType {
+                json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -625,12 +625,12 @@ mod test {
     #[test]
     fn validate_resource_slot_in_singleton_schema() {
         let p_name = "Package";
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [(
                 p_name.parse().unwrap(),
-                EntityType {
+                json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -649,12 +649,12 @@ mod test {
     #[test]
     fn undefined_entity_type_in_principal_slot() {
         let p_name = "User";
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [(
                 p_name.parse().unwrap(),
-                EntityType {
+                json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -692,11 +692,11 @@ mod test {
 
     #[test]
     fn validate_action_id_not_in_singleton_schema() {
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [],
             [(
                 "foo_name".into(),
-                ActionType {
+                json_schema::ActionType {
                     applies_to: None,
                     member_of: None,
                     attributes: None,
@@ -724,7 +724,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_action_id_in_schema() {
-        let descriptors: Fragment<RawName> = serde_json::from_str(
+        let descriptors = json_schema::Fragment::from_json_str(
             r#"
                 {
                     "NS": {
@@ -756,7 +756,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_invalid_action() {
-        let descriptors: Fragment<RawName> = serde_json::from_str(
+        let descriptors = json_schema::Fragment::from_json_str(
             r#"
                 {
                     "NS": {
@@ -787,7 +787,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_entity_type_in_schema() {
-        let descriptors: Fragment<RawName> = serde_json::from_str(
+        let descriptors = json_schema::Fragment::from_json_str(
             r#"
                 {
                     "NS": {
@@ -822,7 +822,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_invalid_entity_type() {
-        let descriptors: Fragment<RawName> = serde_json::from_str(
+        let descriptors = json_schema::Fragment::from_json_str(
             r#"
                 {
                     "NS": {
@@ -858,11 +858,11 @@ mod test {
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
         let action_constraint = ActionConstraint::is_eq(euid_foo.clone());
 
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [],
             [(
                 foo_name.into(),
-                ActionType {
+                json_schema::ActionType {
                     applies_to: None,
                     member_of: None,
                     attributes: None,
@@ -885,11 +885,11 @@ mod test {
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
         let action_constraint = ActionConstraint::is_in(vec![euid_foo.clone()]);
 
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [],
             [(
                 foo_name.into(),
-                ActionType {
+                json_schema::ActionType {
                     applies_to: None,
                     member_of: None,
                     attributes: None,
@@ -912,11 +912,11 @@ mod test {
             EntityUID::with_eid_and_type("Action", foo_name).expect("should be a valid identifier");
         let action_constraint = ActionConstraint::is_in(vec![euid_foo.clone()]);
 
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [],
             [(
                 foo_name.into(),
-                ActionType {
+                json_schema::ActionType {
                     applies_to: None,
                     member_of: None,
                     attributes: None,
@@ -939,12 +939,12 @@ mod test {
             .expect("should be a valid identifier");
         let principal_constraint = PrincipalConstraint::is_eq(Arc::new(euid_foo.clone()));
 
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [(
                 foo_type.parse().unwrap(),
-                EntityType {
+                json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: AttributesOrContext::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -971,30 +971,30 @@ mod test {
         let resource_euid = EntityUID::with_eid_and_type(resource_type, "resource")
             .expect("should be a valid identifier");
 
-        let schema = NamespaceDefinition::new(
+        let schema = json_schema::NamespaceDefinition::new(
             [
                 (
                     principal_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
             ],
             [(
                 action_name.into(),
-                ActionType {
-                    applies_to: Some(ApplySpec {
+                json_schema::ActionType {
+                    applies_to: Some(json_schema::ApplySpec {
                         resource_types: vec![resource_type.parse().unwrap()],
                         principal_types: vec![principal_type.parse().unwrap()],
-                        context: AttributesOrContext::default(),
+                        context: json_schema::AttributesOrContext::default(),
                     }),
                     member_of: Some(vec![]),
                     attributes: None,
@@ -1360,47 +1360,47 @@ mod test {
             EntityUID::with_eid_and_type(resource_parent_type, "resource")
                 .expect("should be a valid identifier");
 
-        let schema_file = NamespaceDefinition::new(
+        let schema_file = json_schema::NamespaceDefinition::new(
             [
                 (
                     principal_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![resource_parent_type.parse().unwrap()],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_parent_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![resource_grandparent_type.parse().unwrap()],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_grandparent_type.parse().unwrap(),
-                    EntityType {
+                    json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: AttributesOrContext::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
             ],
             [
                 (
                     action_name.into(),
-                    ActionType {
-                        applies_to: Some(ApplySpec {
+                    json_schema::ActionType {
+                        applies_to: Some(json_schema::ApplySpec {
                             resource_types: vec![resource_type.parse().unwrap()],
                             principal_types: vec![principal_type.parse().unwrap()],
-                            context: AttributesOrContext::default(),
+                            context: json_schema::AttributesOrContext::default(),
                         }),
-                        member_of: Some(vec![ActionEntityUID::new(
+                        member_of: Some(vec![json_schema::ActionEntityUID::new(
                             None,
                             action_parent_name.into(),
                         )]),
@@ -1409,9 +1409,9 @@ mod test {
                 ),
                 (
                     action_parent_name.into(),
-                    ActionType {
+                    json_schema::ActionType {
                         applies_to: None,
-                        member_of: Some(vec![ActionEntityUID::new(
+                        member_of: Some(vec![json_schema::ActionEntityUID::new(
                             None,
                             action_grandparent_name.into(),
                         )]),
@@ -1420,7 +1420,7 @@ mod test {
                 ),
                 (
                     action_grandparent_name.into(),
-                    ActionType {
+                    json_schema::ActionType {
                         applies_to: None,
                         member_of: Some(vec![]),
                         attributes: None,
@@ -1447,7 +1447,7 @@ mod test {
 
     #[test]
     fn unspecified_principal_resource_with_scope_conditions() {
-        let schema = serde_json::from_str::<NamespaceDefinition<RawName>>(
+        let schema = serde_json::from_str::<json_schema::NamespaceDefinition<RawName>>(
             r#"
         {
             "entityTypes": {"a": {}},

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -409,7 +409,7 @@ mod test {
 
     use super::*;
     use crate::{
-        schema_file_format::{NamespaceDefinition, *},
+        json_schema::{NamespaceDefinition, *},
         validation_errors::UnrecognizedEntityType,
         RawName, ValidationMode, ValidationWarning, Validator,
     };
@@ -1480,11 +1480,11 @@ mod partial_schema {
         parser::parse_policy,
     };
 
-    use crate::{NamespaceDefinition, RawName, Validator};
+    use crate::{json_schema, RawName, Validator};
 
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_validates_with_empty_schema(policy: StaticPolicy) {
-        let schema = serde_json::from_str::<NamespaceDefinition<RawName>>(
+        let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_str(
             r#"
         {
             "entityTypes": { },
@@ -1492,9 +1492,8 @@ mod partial_schema {
         }
         "#,
         )
-        .unwrap()
-        .try_into()
         .unwrap();
+        let schema = schema.try_into().unwrap();
 
         let (template, _) = Template::link_static_policy(policy);
         let validate = Validator::new(schema);

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -724,7 +724,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_action_id_in_schema() {
-        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
+        let descriptors: Fragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -756,7 +756,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_invalid_action() {
-        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
+        let descriptors: Fragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -787,7 +787,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_entity_type_in_schema() {
-        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
+        let descriptors: Fragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {
@@ -822,7 +822,7 @@ mod test {
 
     #[test]
     fn validate_namespaced_invalid_entity_type() {
-        let descriptors: SchemaFragment<RawName> = serde_json::from_str(
+        let descriptors: Fragment<RawName> = serde_json::from_str(
             r#"
                 {
                     "NS": {

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -49,7 +49,7 @@ pub(crate) use action::ValidatorApplySpec;
 mod entity_type;
 pub use entity_type::ValidatorEntityType;
 mod namespace_def;
-pub(crate) use namespace_def::try_schema_type_into_validator_type;
+pub(crate) use namespace_def::try_jsonschema_type_into_validator_type;
 pub use namespace_def::ValidatorNamespaceDef;
 mod raw_name;
 pub use raw_name::{ConditionalName, RawName, ReferenceType};
@@ -432,8 +432,10 @@ impl ValidatorSchema {
                 // `check_for_undeclared`.
                 let descendants = entity_children.remove(&name).unwrap_or_default();
                 let (attributes, open_attributes) = {
-                    let unresolved =
-                        try_schema_type_into_validator_type(entity_type.attributes, extensions)?;
+                    let unresolved = try_jsonschema_type_into_validator_type(
+                        entity_type.attributes,
+                        extensions,
+                    )?;
                     Self::record_attributes_or_none(
                         unresolved.resolve_common_type_refs(&common_types)?,
                     )
@@ -468,7 +470,7 @@ impl ValidatorSchema {
                 let descendants = action_children.remove(&name).unwrap_or_default();
                 let (context, open_context_attributes) = {
                     let unresolved =
-                        try_schema_type_into_validator_type(action.context, extensions)?;
+                        try_jsonschema_type_into_validator_type(action.context, extensions)?;
                     Self::record_attributes_or_none(
                         unresolved.resolve_common_type_refs(&common_types)?,
                     )
@@ -1092,7 +1094,7 @@ impl<'a> CommonTypeResolver<'a> {
             resolve_table.insert(name, substituted_ty.clone());
             tys.insert(
                 name,
-                try_schema_type_into_validator_type(substituted_ty, extensions)?
+                try_jsonschema_type_into_validator_type(substituted_ty, extensions)?
                     .resolve_common_type_refs(&HashMap::new())?,
             );
         }
@@ -1652,10 +1654,11 @@ mod test {
         let schema_ty = schema_ty
             .fully_qualify_type_references(&HashSet::new(), &all_entity_defs)
             .unwrap();
-        let ty: Type = try_schema_type_into_validator_type(schema_ty, &Extensions::all_available())
-            .expect("Error converting schema type to type.")
-            .resolve_common_type_refs(&HashMap::new())
-            .unwrap();
+        let ty: Type =
+            try_jsonschema_type_into_validator_type(schema_ty, &Extensions::all_available())
+                .expect("Error converting schema type to type.")
+                .resolve_common_type_refs(&HashMap::new())
+                .unwrap();
         assert_eq!(ty, Type::named_entity_reference_from_str("NS::Foo"));
     }
 
@@ -1679,10 +1682,11 @@ mod test {
         let schema_ty = schema_ty
             .fully_qualify_type_references(&HashSet::new(), &all_entity_defs)
             .unwrap();
-        let ty: Type = try_schema_type_into_validator_type(schema_ty, &Extensions::all_available())
-            .expect("Error converting schema type to type.")
-            .resolve_common_type_refs(&HashMap::new())
-            .unwrap();
+        let ty: Type =
+            try_jsonschema_type_into_validator_type(schema_ty, &Extensions::all_available())
+                .expect("Error converting schema type to type.")
+                .resolve_common_type_refs(&HashMap::new())
+                .unwrap();
         assert_eq!(ty, Type::named_entity_reference_from_str("NS::Foo"));
     }
 
@@ -1711,10 +1715,11 @@ mod test {
         let schema_ty = schema_ty
             .fully_qualify_type_references(&HashSet::new(), &all_entity_defs)
             .unwrap();
-        let ty: Type = try_schema_type_into_validator_type(schema_ty, &Extensions::all_available())
-            .expect("Error converting schema type to type.")
-            .resolve_common_type_refs(&HashMap::new())
-            .unwrap();
+        let ty: Type =
+            try_jsonschema_type_into_validator_type(schema_ty, &Extensions::all_available())
+                .expect("Error converting schema type to type.")
+                .resolve_common_type_refs(&HashMap::new())
+                .unwrap();
         assert_eq!(ty, Type::closed_record_with_attributes(None));
     }
 

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -947,13 +947,13 @@ impl TryInto<ValidatorNamespaceDef<ConditionalName, ConditionalName>>
     }
 }
 
-/// Convert a type as represented in the schema file format (but with
-/// fully-qualified names) into the [`Type`] type used by the validator.
+/// Convert a [`json_schema::Type`] (with fully-qualified names) into the
+/// [`Type`] type used by the validator.
 ///
 /// Conversion can fail if an entity or record attribute name is invalid. It
 /// will also fail for some types that can be written in the schema, but are
 /// not yet implemented in the typechecking logic.
-pub(crate) fn try_schema_type_into_validator_type(
+pub(crate) fn try_jsonschema_type_into_validator_type(
     schema_ty: json_schema::Type<InternalName>,
     extensions: &Extensions<'_>,
 ) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
@@ -968,7 +968,7 @@ pub(crate) fn try_schema_type_into_validator_type(
             Ok(Type::primitive_boolean().into())
         }
         json_schema::Type::Type(json_schema::TypeVariant::Set { element }) => {
-            Ok(try_schema_type_into_validator_type(*element, extensions)?.map(Type::set))
+            Ok(try_jsonschema_type_into_validator_type(*element, extensions)?.map(Type::set))
         }
         json_schema::Type::Type(json_schema::TypeVariant::Record {
             attributes,
@@ -1067,7 +1067,7 @@ fn parse_record_attributes(
             Ok((
                 attr,
                 (
-                    try_schema_type_into_validator_type(ty.ty, extensions)?,
+                    try_jsonschema_type_into_validator_type(ty.ty, extensions)?,
                     ty.required,
                 ),
             ))

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -1181,7 +1181,7 @@ fn is_typecheck_fails() {
 
 #[test]
 fn is_typechecks() {
-    let schema = json_schema::SchemaFragment::from_json_value(json!({
+    let schema = json_schema::Fragment::from_json_value(json!({
             "": { "entityTypes": { "User": {}, "Photo": {} }, "actions": {} },
             "N::S": { "entityTypes": { "User": {} }, "actions": {} }
     }))

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -26,9 +26,10 @@ use smol_str::SmolStr;
 
 use crate::{
     diagnostics::ValidationError,
+    json_schema,
     types::Type,
     validation_errors::{AttributeAccess, LubContext, LubHelp, UnexpectedTypeHelp},
-    AttributesOrContext, EntityType, NamespaceDefinition, RawName, SchemaFragment, ValidationMode,
+    RawName, ValidationMode,
 };
 
 use super::test_utils::{
@@ -57,11 +58,11 @@ fn slot_typechecks() {
 
 #[test]
 fn slot_in_typechecks() {
-    let etype = EntityType {
+    let etype = json_schema::EntityType {
         member_of_types: vec![],
-        shape: AttributesOrContext::default(),
+        shape: json_schema::AttributesOrContext::default(),
     };
-    let schema = NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
+    let schema = json_schema::NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
         schema.clone(),
         Expr::binary_app(
@@ -86,15 +87,15 @@ fn slot_in_typechecks() {
 
 #[test]
 fn slot_equals_typechecks() {
-    let etype = EntityType {
+    let etype = json_schema::EntityType {
         member_of_types: vec![],
-        shape: AttributesOrContext::default(),
+        shape: json_schema::AttributesOrContext::default(),
     };
     // These don't typecheck in strict mode because the test_util expression
     // typechecker doesn't have access to a schema, so it can't link
     // the template slots with appropriate types. Similar policies that pass
     // strict typechecking are in the test_policy file.
-    let schema = NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
+    let schema = json_schema::NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
         schema.clone(),
         Expr::binary_app(
@@ -376,7 +377,7 @@ fn eq_typechecks() {
 
 #[test]
 fn entity_eq_is_false() {
-    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {
@@ -424,7 +425,7 @@ fn entity_eq_is_false() {
 
 #[test]
 fn set_eq_is_not_false() {
-    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {
@@ -477,7 +478,7 @@ fn set_eq_is_not_false() {
 
 #[test]
 fn eq_typecheck_action_literals_false() {
-    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {},
@@ -506,7 +507,7 @@ fn eq_typecheck_action_literals_false() {
 
 #[test]
 fn eq_typecheck_entity_literals_false() {
-    let schema: NamespaceDefinition<RawName> = serde_json::from_str(
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_str(
         r#"
     {
         "entityTypes": {
@@ -840,7 +841,7 @@ fn contains_typecheck_fails() {
 
 #[test]
 fn contains_typecheck_literals_false() {
-    let schema: NamespaceDefinition<RawName> = serde_json::from_value(json!(
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_value(json!(
     {
         "entityTypes": {},
         "actions": {
@@ -902,7 +903,7 @@ fn contains_all_typecheck_fails() {
 
 #[test]
 fn contains_all_typecheck_literals_false() {
-    let schema: NamespaceDefinition<RawName> = serde_json::from_value(json!(
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_value(json!(
     {
         "entityTypes": {},
         "actions": {
@@ -1161,7 +1162,7 @@ fn add_sub_typecheck_fails() {
 
 #[test]
 fn is_typecheck_fails() {
-    let schema: NamespaceDefinition<RawName> =
+    let schema: json_schema::NamespaceDefinition<RawName> =
         serde_json::from_value(json!({ "entityTypes": { "User": {}, }, "actions": {} })).unwrap();
     let src = r#"1 is User"#;
     assert_typecheck_fails(
@@ -1180,7 +1181,7 @@ fn is_typecheck_fails() {
 
 #[test]
 fn is_typechecks() {
-    let schema: SchemaFragment<RawName> = serde_json::from_value(json!({
+    let schema = json_schema::SchemaFragment::from_json_value(json!({
             "": { "entityTypes": { "User": {}, "Photo": {} }, "actions": {} },
             "N::S": { "entityTypes": { "User": {} }, "actions": {} }
     }))

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -41,7 +41,7 @@ use crate::{
     RawName, SchemaError, ValidationWarning, ValidatorSchema,
 };
 
-fn namespaced_entity_type_schema() -> json_schema::SchemaFragment<RawName> {
+fn namespaced_entity_type_schema() -> json_schema::Fragment<RawName> {
     serde_json::from_str(
         r#"
             { "N::S": {
@@ -189,7 +189,7 @@ fn namespaced_entity_wrong_namespace() {
 
 #[test]
 fn namespaced_entity_type_in_attribute() {
-    let schema = json_schema::SchemaFragment::from_json_str(
+    let schema = json_schema::Fragment::from_json_str(
         r#"{ "N::S":
             {
                 "entityTypes": {
@@ -237,7 +237,7 @@ fn namespaced_entity_type_in_attribute() {
 
 #[test]
 fn namespaced_entity_type_member_of() {
-    let schema = json_schema::SchemaFragment::from_json_value(serde_json::json!(
+    let schema = json_schema::Fragment::from_json_value(serde_json::json!(
     {"N::S": {
         "entityTypes": {
             "Foo": {
@@ -270,7 +270,7 @@ fn namespaced_entity_type_member_of() {
 
 #[test]
 fn namespaced_entity_type_applies_to() {
-    let schema = json_schema::SchemaFragment::from_json_value(serde_json::json!(
+    let schema = json_schema::Fragment::from_json_value(serde_json::json!(
     {"N::S": {
         "entityTypes": {
             "Foo": { },
@@ -296,7 +296,7 @@ fn namespaced_entity_type_applies_to() {
 
 #[test]
 fn multiple_namespaces_literals() {
-    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
+    let authorization_model = json_schema::Fragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {"Foo": {}},
@@ -334,7 +334,7 @@ fn multiple_namespaces_literals() {
 
 #[test]
 fn multiple_namespaces_attributes() {
-    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
+    let authorization_model = json_schema::Fragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -383,7 +383,7 @@ fn multiple_namespaces_attributes() {
 
 #[test]
 fn multiple_namespaces_member_of() {
-    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
+    let authorization_model = json_schema::Fragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -422,7 +422,7 @@ fn multiple_namespaces_member_of() {
 
 #[test]
 fn multiple_namespaces_applies_to() {
-    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
+    let authorization_model = json_schema::Fragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -540,7 +540,7 @@ fn namespaced_entity_is_wrong_type_when() {
 
 #[test]
 fn multi_namespace_action_eq() {
-    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::Fragment::from_str_natural(
         r#"
             entity E;
             action "Action" appliesTo { context: {}, principal : [E], resource : [E] };
@@ -591,7 +591,7 @@ fn multi_namespace_action_eq() {
 
 #[test]
 fn multi_namespace_action_in() {
-    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::Fragment::from_str_natural(
         r#"
             entity E;
             namespace NS1 { action "Group"; }
@@ -657,7 +657,7 @@ fn multi_namespace_action_in() {
 
 #[test]
 fn test_cedar_policy_642() {
-    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::Fragment::from_str_natural(
         r#"
         namespace NS1 {
             entity SystemEntity2 in SystemEntity1;
@@ -694,7 +694,7 @@ fn test_cedar_policy_642() {
 
 #[test]
 fn multi_namespace_action_group_cycle() {
-    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::Fragment::from_str_natural(
         r#"
             namespace A { action "Act" in C::Action::"Act"; }
             namespace B { action "Act" in A::Action::"Act"; }

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -35,12 +35,13 @@ use super::test_utils::{
 };
 use crate::{
     diagnostics::ValidationError,
+    json_schema,
     types::{EntityLUB, Type},
     validation_errors::AttributeAccess,
-    RawName, SchemaError, SchemaFragment, ValidationWarning, ValidatorSchema,
+    RawName, SchemaError, ValidationWarning, ValidatorSchema,
 };
 
-fn namespaced_entity_type_schema() -> SchemaFragment<RawName> {
+fn namespaced_entity_type_schema() -> json_schema::SchemaFragment<RawName> {
     serde_json::from_str(
         r#"
             { "N::S": {
@@ -188,7 +189,7 @@ fn namespaced_entity_wrong_namespace() {
 
 #[test]
 fn namespaced_entity_type_in_attribute() {
-    let schema: SchemaFragment<RawName> = serde_json::from_str(
+    let schema = json_schema::SchemaFragment::from_json_str(
         r#"{ "N::S":
             {
                 "entityTypes": {
@@ -236,7 +237,7 @@ fn namespaced_entity_type_in_attribute() {
 
 #[test]
 fn namespaced_entity_type_member_of() {
-    let schema: SchemaFragment<RawName> = serde_json::from_value(serde_json::json!(
+    let schema = json_schema::SchemaFragment::from_json_value(serde_json::json!(
     {"N::S": {
         "entityTypes": {
             "Foo": {
@@ -269,7 +270,7 @@ fn namespaced_entity_type_member_of() {
 
 #[test]
 fn namespaced_entity_type_applies_to() {
-    let schema: SchemaFragment<RawName> = serde_json::from_value(serde_json::json!(
+    let schema = json_schema::SchemaFragment::from_json_value(serde_json::json!(
     {"N::S": {
         "entityTypes": {
             "Foo": { },
@@ -295,7 +296,7 @@ fn namespaced_entity_type_applies_to() {
 
 #[test]
 fn multiple_namespaces_literals() {
-    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
+    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {"Foo": {}},
@@ -333,7 +334,7 @@ fn multiple_namespaces_literals() {
 
 #[test]
 fn multiple_namespaces_attributes() {
-    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
+    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -382,7 +383,7 @@ fn multiple_namespaces_attributes() {
 
 #[test]
 fn multiple_namespaces_member_of() {
-    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
+    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -421,7 +422,7 @@ fn multiple_namespaces_member_of() {
 
 #[test]
 fn multiple_namespaces_applies_to() {
-    let authorization_model: SchemaFragment<RawName> = serde_json::from_value(json!(
+    let authorization_model = json_schema::SchemaFragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -539,7 +540,7 @@ fn namespaced_entity_is_wrong_type_when() {
 
 #[test]
 fn multi_namespace_action_eq() {
-    let (schema, _) = SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
         r#"
             entity E;
             action "Action" appliesTo { context: {}, principal : [E], resource : [E] };
@@ -590,7 +591,7 @@ fn multi_namespace_action_eq() {
 
 #[test]
 fn multi_namespace_action_in() {
-    let (schema, _) = SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
         r#"
             entity E;
             namespace NS1 { action "Group"; }
@@ -656,7 +657,7 @@ fn multi_namespace_action_in() {
 
 #[test]
 fn test_cedar_policy_642() {
-    let (schema, _) = SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
         r#"
         namespace NS1 {
             entity SystemEntity2 in SystemEntity1;
@@ -693,7 +694,7 @@ fn test_cedar_policy_642() {
 
 #[test]
 fn multi_namespace_action_group_cycle() {
-    let (schema, _) = SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
         r#"
             namespace A { action "Act" in C::Action::"Act"; }
             namespace B { action "Act" in A::Action::"Act"; }

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -42,7 +42,7 @@ use crate::{
 };
 
 fn namespaced_entity_type_schema() -> json_schema::Fragment<RawName> {
-    serde_json::from_str(
+    json_schema::Fragment::from_json_str(
         r#"
             { "N::S": {
                 "entityTypes": {

--- a/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
+++ b/cedar-policy-validator/src/typecheck/test/optional_attributes.rs
@@ -24,16 +24,17 @@ use cedar_policy_core::{
 };
 
 use crate::{
-    diagnostics::ValidationError, types::EntityLUB, validation_errors::AttributeAccess,
-    NamespaceDefinition, NamespaceDefinitionWithActionAttributes, RawName, ValidationWarning,
+    diagnostics::ValidationError, json_schema, types::EntityLUB,
+    validation_errors::AttributeAccess, NamespaceDefinitionWithActionAttributes, RawName,
+    ValidationWarning,
 };
 
 use super::test_utils::{
     assert_policy_typecheck_fails, assert_policy_typecheck_warns, assert_policy_typechecks, get_loc,
 };
 
-fn schema_with_optionals() -> NamespaceDefinition<RawName> {
-    serde_json::from_str::<NamespaceDefinition<RawName>>(
+fn schema_with_optionals() -> json_schema::NamespaceDefinition<RawName> {
+    serde_json::from_str::<json_schema::NamespaceDefinition<RawName>>(
         r#"
 {
     "entityTypes": {
@@ -539,7 +540,7 @@ fn in_list_no_capability() {
 
 #[test]
 fn record_optional_attrs() {
-    let schema = serde_json::from_str::<NamespaceDefinition<RawName>>(
+    let schema = serde_json::from_str::<json_schema::NamespaceDefinition<RawName>>(
         r#"
 {
     "entityTypes": {

--- a/cedar-policy-validator/src/typecheck/test/partial.rs
+++ b/cedar-policy-validator/src/typecheck/test/partial.rs
@@ -25,13 +25,11 @@ use cedar_policy_core::parser::parse_policy;
 use super::test_utils::{
     assert_expected_type_errors, assert_expected_warnings, empty_schema_file, get_loc,
 };
+use crate::json_schema;
 use crate::typecheck::Typechecker;
 use crate::types::{EntityLUB, Type};
 use crate::validation_errors::{AttributeAccess, UnexpectedTypeHelp};
-use crate::{
-    NamespaceDefinition, RawName, ValidationError, ValidationMode, ValidationWarning,
-    ValidatorSchema,
-};
+use crate::{RawName, ValidationError, ValidationMode, ValidationWarning, ValidatorSchema};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_partial_typecheck(
@@ -485,7 +483,7 @@ mod fails_empty_schema {
     }
 }
 
-fn partial_schema_file() -> NamespaceDefinition<RawName> {
+fn partial_schema_file() -> json_schema::NamespaceDefinition<RawName> {
     serde_json::from_value(serde_json::json!(
         {
             "entityTypes": {

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -41,7 +41,7 @@ use super::test_utils::{assert_policy_typecheck_fails, expr_id_placeholder, get_
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
-    schema: json_schema::SchemaFragment<RawName>,
+    schema: json_schema::Fragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
@@ -67,7 +67,7 @@ fn assert_typechecks_strict(
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_strict_type_error(
-    schema: json_schema::SchemaFragment<RawName>,
+    schema: json_schema::Fragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
@@ -94,7 +94,7 @@ fn assert_strict_type_error(
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_types_must_match(
-    schema: json_schema::SchemaFragment<RawName>,
+    schema: json_schema::Fragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     snippet: impl AsRef<str>,
@@ -119,8 +119,8 @@ fn assert_types_must_match(
     )
 }
 
-fn simple_schema_file() -> json_schema::SchemaFragment<RawName> {
-    json_schema::SchemaFragment::from_json_value(json!(
+fn simple_schema_file() -> json_schema::Fragment<RawName> {
+    json_schema::Fragment::from_json_value(json!(
     { "": {
       "entityTypes": {
         "User": {},
@@ -147,7 +147,7 @@ fn simple_schema_file() -> json_schema::SchemaFragment<RawName> {
 
 fn with_simple_schema_and_request<F>(f: F)
 where
-    F: FnOnce(json_schema::SchemaFragment<RawName>, RequestEnv<'_>),
+    F: FnOnce(json_schema::Fragment<RawName>, RequestEnv<'_>),
 {
     f(
         simple_schema_file(),
@@ -709,7 +709,7 @@ fn true_false_set() {
 
 #[test]
 fn qualified_record_attr() {
-    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::Fragment::from_str_natural(
         r#"
         entity Foo;
         action A appliesTo { context: {num_of_things?: Long }, principal : [Foo], resource : [Foo] };"#,

--- a/cedar-policy-validator/src/typecheck/test/strict.rs
+++ b/cedar-policy-validator/src/typecheck/test/strict.rs
@@ -29,18 +29,19 @@ use cedar_policy_core::{
 };
 
 use crate::{
+    json_schema,
     typecheck::Typechecker,
     types::{AttributeType, CapabilitySet, OpenTag, RequestEnv, Type},
     validation_errors::LubContext,
     validation_errors::LubHelp,
-    RawName, SchemaFragment, ValidationError, ValidationMode,
+    RawName, ValidationError, ValidationMode,
 };
 
 use super::test_utils::{assert_policy_typecheck_fails, expr_id_placeholder, get_loc};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_typechecks_strict(
-    schema: SchemaFragment<RawName>,
+    schema: json_schema::SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
@@ -66,7 +67,7 @@ fn assert_typechecks_strict(
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_strict_type_error(
-    schema: SchemaFragment<RawName>,
+    schema: json_schema::SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     expected_type: Type,
@@ -93,7 +94,7 @@ fn assert_strict_type_error(
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_types_must_match(
-    schema: SchemaFragment<RawName>,
+    schema: json_schema::SchemaFragment<RawName>,
     env: &RequestEnv<'_>,
     e: Expr,
     snippet: impl AsRef<str>,
@@ -118,8 +119,8 @@ fn assert_types_must_match(
     )
 }
 
-fn simple_schema_file() -> SchemaFragment<RawName> {
-    serde_json::from_value(json!(
+fn simple_schema_file() -> json_schema::SchemaFragment<RawName> {
+    json_schema::SchemaFragment::from_json_value(json!(
     { "": {
       "entityTypes": {
         "User": {},
@@ -146,7 +147,7 @@ fn simple_schema_file() -> SchemaFragment<RawName> {
 
 fn with_simple_schema_and_request<F>(f: F)
 where
-    F: FnOnce(SchemaFragment<RawName>, RequestEnv<'_>),
+    F: FnOnce(json_schema::SchemaFragment<RawName>, RequestEnv<'_>),
 {
     f(
         simple_schema_file(),
@@ -708,7 +709,7 @@ fn true_false_set() {
 
 #[test]
 fn qualified_record_attr() {
-    let (schema, _) = SchemaFragment::from_str_natural(
+    let (schema, _) = json_schema::SchemaFragment::from_str_natural(
         r#"
         entity Foo;
         action A appliesTo { context: {num_of_things?: Long }, principal : [Foo], resource : [Foo] };"#,

--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -22,15 +22,15 @@ use cool_asserts::assert_matches;
 use std::{collections::HashSet, sync::Arc};
 
 use cedar_policy_core::ast::{EntityUID, Expr, PolicyID, Template, ACTION_ENTITY_TYPE};
+use cedar_policy_core::parser::Loc;
 
-use crate::typecheck::{TypecheckAnswer, Typechecker};
 use crate::{
+    json_schema,
+    typecheck::{TypecheckAnswer, Typechecker},
     types::{CapabilitySet, OpenTag, RequestEnv, Type},
     validation_errors::UnexpectedTypeHelp,
-    NamespaceDefinition, RawName, ValidationError, ValidationMode, ValidationWarning,
-    ValidatorSchema,
+    RawName, ValidationError, ValidationMode, ValidationWarning, ValidatorSchema,
 };
-use cedar_policy_core::parser::Loc;
 
 use similar_asserts::assert_eq;
 
@@ -323,8 +323,8 @@ pub(crate) fn assert_typecheck_fails_for_mode(
     });
 }
 
-pub(crate) fn empty_schema_file() -> NamespaceDefinition<RawName> {
-    NamespaceDefinition::new([], [])
+pub(crate) fn empty_schema_file() -> json_schema::NamespaceDefinition<RawName> {
+    json_schema::NamespaceDefinition::new([], [])
 }
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -21,7 +21,7 @@ use std::collections::HashSet;
 use cedar_policy_core::ast::{EntityUID, Expr, ExprBuilder, PolicyID};
 
 use super::test_utils::{empty_schema_file, expr_id_placeholder};
-use crate::{typecheck::Typechecker, types::Type, RawName, SchemaFragment, ValidationMode};
+use crate::{json_schema, typecheck::Typechecker, types::Type, ValidationMode};
 
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 fn assert_expr_has_annotated_ast(e: &Expr, annotated: &Expr<Option<Type>>) {
@@ -137,7 +137,7 @@ fn expr_typechecks_with_correct_annotation() {
         .unwrap(),
     );
 
-    let schema = serde_json::from_value::<SchemaFragment<RawName>>(
+    let schema = json_schema::SchemaFragment::from_json_value(
         json!({"": { "entityTypes": { "Foo": {} }, "actions": {} }}),
     )
     .unwrap()

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -137,7 +137,7 @@ fn expr_typechecks_with_correct_annotation() {
         .unwrap(),
     );
 
-    let schema = json_schema::SchemaFragment::from_json_value(
+    let schema = json_schema::Fragment::from_json_value(
         json!({"": { "entityTypes": { "Foo": {} }, "actions": {} }}),
     )
     .unwrap()

--- a/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
+++ b/cedar-policy-validator/src/typecheck/test/unspecified_entity.rs
@@ -16,7 +16,7 @@
 
 // GRCOV_STOP_COVERAGE
 
-use crate::{NamespaceDefinition, RawName};
+use crate::{json_schema, RawName};
 use cool_asserts::assert_matches;
 
 fn schema_with_unspecified() -> &'static str {
@@ -56,7 +56,7 @@ fn schema_with_unspecified() -> &'static str {
 #[test]
 fn unspecified_does_not_parse() {
     assert_matches!(
-        serde_json::from_str::<NamespaceDefinition<RawName>>(schema_with_unspecified()),
+        serde_json::from_str::<json_schema::NamespaceDefinition<RawName>>(schema_with_unspecified()),
         Err(_)
     );
 }

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1406,7 +1406,7 @@ pub enum Primitive {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::ActionBehavior;
+    use crate::{json_schema, ActionBehavior};
     use cool_asserts::assert_matches;
 
     impl Type {
@@ -1788,7 +1788,7 @@ mod test {
 
     fn simple_schema() -> ValidatorSchema {
         ValidatorSchema::from_schema_frag(
-            serde_json::from_value(serde_json::json!({ "":
+            json_schema::Fragment::from_json_value(serde_json::json!({ "":
             {
                 "entityTypes": {
                     "foo": {},
@@ -1879,7 +1879,7 @@ mod test {
 
     fn attr_schema() -> ValidatorSchema {
         ValidatorSchema::from_schema_frag(
-            serde_json::from_value(serde_json::json!(
+            json_schema::Fragment::from_json_value(serde_json::json!(
             {"": {
                 "entityTypes": {
                     "foo": {},
@@ -2011,7 +2011,7 @@ mod test {
     #[test]
     fn record_entity_lub_non_term() {
         let schema = ValidatorSchema::from_schema_frag(
-            serde_json::from_value(serde_json::json!(
+            json_schema::Fragment::from_json_value(serde_json::json!(
             {"": {
                 "entityTypes": {
                     "U": {
@@ -2052,7 +2052,7 @@ mod test {
 
     fn rec_schema() -> ValidatorSchema {
         ValidatorSchema::from_schema_frag(
-            serde_json::from_value(serde_json::json!(
+            json_schema::Fragment::from_json_value(serde_json::json!(
                 {"": {
                     "entityTypes": {
                         "biz": {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1194,7 +1194,7 @@ pub struct SchemaFragment {
         cedar_policy_validator::ConditionalName,
         cedar_policy_validator::ConditionalName,
     >,
-    lossless: cedar_policy_validator::SchemaFragment<cedar_policy_validator::RawName>,
+    lossless: cedar_policy_validator::json_schema::SchemaFragment<cedar_policy_validator::RawName>,
 }
 
 impl SchemaFragment {
@@ -1222,7 +1222,7 @@ impl SchemaFragment {
     /// Create an `SchemaFragment` from a JSON value (which should be an
     /// object of the shape required for Cedar schemas).
     pub fn from_json_value(json: serde_json::Value) -> Result<Self, SchemaError> {
-        let lossless = cedar_policy_validator::SchemaFragment::from_json_value(json)?;
+        let lossless = cedar_policy_validator::json_schema::SchemaFragment::from_json_value(json)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,
@@ -1233,10 +1233,11 @@ impl SchemaFragment {
     pub fn from_file_natural(
         r: impl std::io::Read,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (lossless, warnings) = cedar_policy_validator::SchemaFragment::from_file_natural(
-            r,
-            Extensions::all_available(),
-        )?;
+        let (lossless, warnings) =
+            cedar_policy_validator::json_schema::SchemaFragment::from_file_natural(
+                r,
+                Extensions::all_available(),
+            )?;
         Ok((
             Self {
                 value: lossless.clone().try_into()?,
@@ -1250,10 +1251,11 @@ impl SchemaFragment {
     pub fn from_str_natural(
         src: &str,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (lossless, warnings) = cedar_policy_validator::SchemaFragment::from_str_natural(
-            src,
-            Extensions::all_available(),
-        )?;
+        let (lossless, warnings) =
+            cedar_policy_validator::json_schema::SchemaFragment::from_str_natural(
+                src,
+                Extensions::all_available(),
+            )?;
         Ok((
             Self {
                 value: lossless.clone().try_into()?,
@@ -1265,7 +1267,7 @@ impl SchemaFragment {
 
     /// Create a [`SchemaFragment`] directly from a file.
     pub fn from_file(file: impl std::io::Read) -> Result<Self, SchemaError> {
-        let lossless = cedar_policy_validator::SchemaFragment::from_file(file)?;
+        let lossless = cedar_policy_validator::json_schema::SchemaFragment::from_file(file)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,
@@ -1314,7 +1316,7 @@ impl FromStr for SchemaFragment {
     /// to undefined entities) because this is not required until a `Schema` is
     /// constructed.
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let lossless = cedar_policy_validator::SchemaFragment::from_json_str(src)?;
+        let lossless = cedar_policy_validator::json_schema::SchemaFragment::from_json_str(src)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1194,7 +1194,7 @@ pub struct SchemaFragment {
         cedar_policy_validator::ConditionalName,
         cedar_policy_validator::ConditionalName,
     >,
-    lossless: cedar_policy_validator::json_schema::SchemaFragment<cedar_policy_validator::RawName>,
+    lossless: cedar_policy_validator::json_schema::Fragment<cedar_policy_validator::RawName>,
 }
 
 impl SchemaFragment {
@@ -1219,10 +1219,10 @@ impl SchemaFragment {
         })
     }
 
-    /// Create an `SchemaFragment` from a JSON value (which should be an
+    /// Create a [`SchemaFragment`] from a JSON value (which should be an
     /// object of the shape required for Cedar schemas).
     pub fn from_json_value(json: serde_json::Value) -> Result<Self, SchemaError> {
-        let lossless = cedar_policy_validator::json_schema::SchemaFragment::from_json_value(json)?;
+        let lossless = cedar_policy_validator::json_schema::Fragment::from_json_value(json)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,
@@ -1234,7 +1234,7 @@ impl SchemaFragment {
         r: impl std::io::Read,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
         let (lossless, warnings) =
-            cedar_policy_validator::json_schema::SchemaFragment::from_file_natural(
+            cedar_policy_validator::json_schema::Fragment::from_file_natural(
                 r,
                 Extensions::all_available(),
             )?;
@@ -1251,11 +1251,10 @@ impl SchemaFragment {
     pub fn from_str_natural(
         src: &str,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
-        let (lossless, warnings) =
-            cedar_policy_validator::json_schema::SchemaFragment::from_str_natural(
-                src,
-                Extensions::all_available(),
-            )?;
+        let (lossless, warnings) = cedar_policy_validator::json_schema::Fragment::from_str_natural(
+            src,
+            Extensions::all_available(),
+        )?;
         Ok((
             Self {
                 value: lossless.clone().try_into()?,
@@ -1267,7 +1266,7 @@ impl SchemaFragment {
 
     /// Create a [`SchemaFragment`] directly from a file.
     pub fn from_file(file: impl std::io::Read) -> Result<Self, SchemaError> {
-        let lossless = cedar_policy_validator::json_schema::SchemaFragment::from_file(file)?;
+        let lossless = cedar_policy_validator::json_schema::Fragment::from_file(file)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,
@@ -1316,7 +1315,7 @@ impl FromStr for SchemaFragment {
     /// to undefined entities) because this is not required until a `Schema` is
     /// constructed.
     fn from_str(src: &str) -> Result<Self, Self::Err> {
-        let lossless = cedar_policy_validator::json_schema::SchemaFragment::from_json_str(src)?;
+        let lossless = cedar_policy_validator::json_schema::Fragment::from_json_str(src)?;
         Ok(Self {
             value: lossless.clone().try_into()?,
             lossless,

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -34,7 +34,7 @@ main () {
     wasm-pack build --scope cedar-policy --target web  --out-dir pkg/web
     cp pkg/esm/README.md pkg/README.md
 
-    fix_package_json_files 
+    fix_package_json_files
 
     # Post-process TS types
     process_types_file "pkg/esm/cedar_wasm.d.ts"
@@ -87,7 +87,7 @@ process_types_file() {
     ' "$types_file" > "$types_file.tmp" && mv "$types_file.tmp" "$types_file"
 
     echo "type SmolStr = string;" >> "$types_file"
-    echo "export type TypeOfAttribute<N> = SchemaType<N> & { required?: boolean };" >> "$types_file"
+    echo "export type TypeOfAttribute<N> = Type<N> & { required?: boolean };" >> "$types_file"
 }
 
 check_types_file() {


### PR DESCRIPTION
## Description of changes

A number of pedestrian changes in this PR:

* Rename the `schema_file_format` module to `json_schema`, to make clearer it describes the JSON format specifically. This mirrors the existing module `human_schema`.
* Rename the `json_schema::SchemaFragment` type to `json_schema::Fragment`.
* Rename the `json_schema::SchemaType` type to `json_schema::Type`.
    * Previously we had `Type` in the root namespace, `SchemaType` in the root namespace, and `human_schema::Type`.  Now we have `Type` in the root namespace, `json_schema::Type`, and `human_schema::Type`.
    * Also rename `try_schema_type_into_validator_type()` to `try_jsonschema_type_into_validator_type()`.
* Rename the `json_schema::SchemaTypeVariant` type to `json_schema::TypeVariant`.
* Don't `use` items from `json_schema` in the root namespace of `cedar_policy_validator`.  Also avoid `use`ing these items in our own internal submodules outside of the `json_schema` module.  This has the effect of clarifying where JSON structures are being used.  For some important examples:
    * In `human_schema/to_json_schema.rs`, one function signature is now `Schema -> json_schema::Fragment` instead of `Schema -> SchemaFragment`.
    * In `schema.rs`, instead of constructing a `ValidatorSchemaFragment` from a `SchemaFragment`, we now construct a `ValidatorSchemaFragment` from a `json_schema::Fragment`.
    * In `namespace_def.rs`, instead of constructing a `ValidatorNamespaceDef` from a `NamespaceDefinition`, we now construct a `ValidatorNamespaceDef` from a `json_schema::NamespaceDefinition`.
    * Also in `namespace_def.rs`, instead of converting `SchemaType`s to `Type`s, we convert `json_schema::Type`s to `Type`s.
    * Outside of the `json_schema` module itself, this further distinguishes `json_schema`'s `EntityType` from `core::ast::EntityType` which is frequently `use`d in `cedar_policy_validator`.
* Export `Path` in `human_schema` directly, as opposed to just living in `human_schema::ast`.
* In tests, prefer to use `json_schema::SchemaFragment::from_json_value()` and similar, over direct calls to `serde_json`.
* No changes to the public (`cedar_policy`) API.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

