### PR TITLE
Backport #783

### DIFF
--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -311,6 +311,10 @@ pub enum JsonDeserializationErrorContext {
         /// ID of the policy we were deserializing
         id: PolicyID,
     },
+    /// The error occured while deserializing a template link
+    TemplateLink,
+    /// The context was unknown, this shouldn't surface to users
+    Unknown,
 }
 
 /// Type mismatch error (in terms of `SchemaType`)
@@ -346,6 +350,8 @@ impl std::fmt::Display for JsonDeserializationErrorContext {
             Self::EntityUid => write!(f, "in uid field of <unknown entity>"),
             Self::Context => write!(f, "while parsing context"),
             Self::Policy { id } => write!(f, "while parsing JSON policy `{id}`"),
+            Self::TemplateLink => write!(f, "while parsing a template link"),
+            Self::Unknown => write!(f, "parsing context was unknown, please file a bug report at https://github.com/cedar-policy/cedar so we can improve this error message"),
         }
     }
 }

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -738,7 +738,7 @@ pub trait DeserializationContext {
 }
 
 /// A [`DeserializationContext`] that always returns [`None`].
-/// This is the default behaviour,
+/// This is the default behaviour.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 pub struct NoStaticContext;
 

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -30,6 +30,7 @@ use crate::FromNormalizedStr;
 use either::Either;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use serde_with::{DeserializeAs, SerializeAs};
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashSet};
 use std::sync::Arc;
@@ -727,17 +728,40 @@ impl<'e> ValueParser<'e> {
     }
 }
 
+/// A (optional) static context for deserialization of entity uids
+/// This is useful when, for plumbing reasons, we can't get the appopriate values into the dynamic
+/// context. Primary use case is in the [`DeserializeAs`] trait.
+pub trait DeserializationContext {
+    /// Access the (optional) static context.
+    /// If returns [`None`], use the dynamic context.
+    fn static_context() -> Option<JsonDeserializationErrorContext>;
+}
+
+/// A [`DeserializationContext`] that always returns [`None`].
+/// This is the default behaviour,
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct NoStaticContext;
+
+impl DeserializationContext for NoStaticContext {
+    fn static_context() -> Option<JsonDeserializationErrorContext> {
+        None
+    }
+}
+
 /// Serde JSON format for Cedar values where we know we're expecting an entity
 /// reference
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(untagged)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum EntityUidJson {
+pub enum EntityUidJson<Context = NoStaticContext> {
     /// This was removed in 3.0 and is only here for generating nice error messages.
     ExplicitExprEscape {
         /// Contents are ignored.
         __expr: String,
+        /// Phantom value for the `Context` type parameter
+        #[serde(skip)]
+        context: std::marker::PhantomData<Context>,
     },
     /// Explicit `__entity` escape; see notes on `CedarValueJson::EntityEscape`
     ExplicitEntityEscape {
@@ -752,7 +776,31 @@ pub enum EntityUidJson {
     FoundValue(#[cfg_attr(feature = "wasm", tsify(type = "__skip"))] serde_json::Value),
 }
 
-impl EntityUidJson {
+impl<'de, C: DeserializationContext> DeserializeAs<'de, EntityUID> for EntityUidJson<C> {
+    fn deserialize_as<D>(deserializer: D) -> Result<EntityUID, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use serde::de::Error;
+        // We don't know the context that called us, so we'll rely on the statically set context
+        let context = || JsonDeserializationErrorContext::Unknown;
+        let s = EntityUidJson::<C>::deserialize(deserializer)?;
+        let euid = s.into_euid(context).map_err(Error::custom)?;
+        Ok(euid)
+    }
+}
+
+impl<C> SerializeAs<EntityUID> for EntityUidJson<C> {
+    fn serialize_as<S>(source: &EntityUID, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let json: EntityUidJson = source.clone().into();
+        json.serialize(serializer)
+    }
+}
+
+impl<C: DeserializationContext> EntityUidJson<C> {
     /// Construct an `EntityUidJson` from entity type name and eid.
     ///
     /// This will use the `ImplicitEntityEscape` form, if it matters.
@@ -766,8 +814,9 @@ impl EntityUidJson {
     /// Convert this `EntityUidJson` into an `EntityUID`
     pub fn into_euid(
         self,
-        ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
+        dynamic_ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
     ) -> Result<EntityUID, JsonDeserializationError> {
+        let ctx = || C::static_context().unwrap_or_else(&dynamic_ctx);
         match self {
             Self::ExplicitEntityEscape { __entity } | Self::ImplicitEntityEscape(__entity) => {
                 // reuse the same logic that parses CedarValueJson
@@ -785,7 +834,7 @@ impl EntityUidJson {
                 ctx: Box::new(ctx()),
                 got: Box::new(Either::Left(v)),
             }),
-            Self::ExplicitExprEscape { __expr } => {
+            Self::ExplicitExprEscape { __expr, .. } => {
                 Err(JsonDeserializationError::ExprTag(Box::new(ctx())))
             }
         }

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -728,8 +728,8 @@ impl<'e> ValueParser<'e> {
     }
 }
 
-/// A (optional) static context for deserialization of entity uids
-/// This is useful when, for plumbing reasons, we can't get the appopriate values into the dynamic
+/// An (optional) static context for deserialization of entity uids.
+/// This is useful when, for plumbing reasons, we can't get the appropriate values into the dynamic
 /// context. Primary use case is in the [`DeserializeAs`] trait.
 pub trait DeserializationContext {
     /// Access the (optional) static context.

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -22,6 +22,8 @@ mod expr;
 pub use expr::*;
 mod scope_constraints;
 pub use scope_constraints::*;
+mod policy_set;
+pub use policy_set::*;
 
 use crate::ast;
 use crate::entities::EntityUidJson;

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast;
+use crate::ast::{LinkingError, PolicySetError};
 use crate::entities::JsonDeserializationError;
 use crate::parser::err::ParseErrors;
 use crate::parser::unescape;
@@ -79,6 +80,14 @@ pub enum FromJsonError {
     #[error("invalid entity type: {0}")]
     #[diagnostic(transparent)]
     InvalidEntityType(ParseErrors),
+    /// Error reported when a policy set has duplicate ids
+    #[error("Error creating policy set: {0}")]
+    #[diagnostic(transparent)]
+    PolicySet(#[from] PolicySetError),
+    /// Error reported when attempting to create a template-link
+    #[error("Error linking policy set: {0}")]
+    #[diagnostic(transparent)]
+    Linking(#[from] LinkingError),
 }
 
 /// Errors while instantiating a policy

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -25,16 +25,20 @@ use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use std::collections::HashMap;
 
-/// An EST set of policies
+/// Serde JSON structure for a policy set in the EST format
+#[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct PolicySet {
     /// The set of templates in a policy set
-    pub templates: Vec<PolicyEntry>,
+    #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
+    pub templates: HashMap<PolicyID, Policy>,
     /// The set of static policies in a policy set
-    pub static_policies: Vec<PolicyEntry>,
+    #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
+    pub static_policies: HashMap<PolicyID, Policy>,
     /// The set of template links
-    pub links: Vec<Link>,
+    pub template_links: Vec<TemplateLink>,
 }
 
 impl PolicySet {
@@ -43,26 +47,16 @@ impl PolicySet {
     /// used in cases where the policy set is guaranteed to be well-formed
     /// (e.g., after successful conversion to an `ast::PolicySet`)
     pub fn get_policy(&self, id: &PolicyID) -> Option<Policy> {
-        let maybe_static_policy = self
-            .static_policies
-            .iter()
-            .filter_map(|entry| {
-                if &entry.id == id {
-                    Some(entry.policy.clone())
-                } else {
-                    None
-                }
-            })
-            .next();
+        let maybe_static_policy = self.static_policies.get(id).cloned();
 
         let maybe_link = self
-            .links
+            .template_links
             .iter()
             .filter_map(|link| {
-                if &link.id == id {
-                    self.get_template(&link.template).and_then(|template| {
+                if &link.new_id == id {
+                    self.get_template(&link.template_id).and_then(|template| {
                         let unwrapped_est_vals: HashMap<SlotId, EntityUidJson> =
-                            link.slots.iter().map(|(k, v)| (*k, v.into())).collect();
+                            link.values.iter().map(|(k, v)| (*k, v.into())).collect();
                         template.link(&unwrapped_est_vals).ok()
                     })
                 } else {
@@ -79,39 +73,23 @@ impl PolicySet {
     /// used in cases where the policy set is guaranteed to be well-formed
     /// (e.g., after successful conversion to an `ast::PolicySet`)
     pub fn get_template(&self, id: &PolicyID) -> Option<Policy> {
-        self.templates
-            .iter()
-            .filter_map(|entry| {
-                if &entry.id == id {
-                    Some(entry.policy.clone())
-                } else {
-                    None
-                }
-            })
-            .next()
+        self.templates.get(id).cloned()
     }
 }
 
-/// A policy id and EST policy pair
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct PolicyEntry {
-    /// The id of this policy
-    pub id: PolicyID,
-    /// The EST of this policy
-    pub policy: Policy,
-}
-
-/// A record of a template-linked policy
+/// Serde JSON structure describing a template-linked policy
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Link {
-    /// The id of the link
-    pub id: PolicyID,
-    /// The id of the template
-    pub template: PolicyID,
-    /// The mapping between slots and entity uids
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct TemplateLink {
+    /// Id of the template to link against
+    pub template_id: PolicyID,
+    /// Id of the generated policy
+    pub new_id: PolicyID,
+    /// Mapping between slots and entity uids
     #[serde_as(as = "serde_with::MapPreventDuplicates<_,EntityUidJson<TemplateLinkContext>>")]
-    pub slots: HashMap<SlotId, EntityUID>,
+    pub values: HashMap<SlotId, EntityUID>,
 }
 
 /// Statically set the deserialization error context to be deserialization of a template link
@@ -129,23 +107,23 @@ impl TryFrom<PolicySet> for ast::PolicySet {
     fn try_from(value: PolicySet) -> Result<Self, Self::Error> {
         let mut ast_pset = ast::PolicySet::default();
 
-        for PolicyEntry { id, policy } in value.templates {
+        for (id, policy) in value.templates {
             let ast = policy.try_into_ast_template(Some(id))?;
             ast_pset.add_template(ast)?;
         }
 
-        for PolicyEntry { id, policy } in value.static_policies {
+        for (id, policy) in value.static_policies {
             let ast = policy.try_into_ast_policy(Some(id))?;
             ast_pset.add(ast)?;
         }
 
-        for Link {
-            id,
-            template,
-            slots: env,
-        } in value.links
+        for TemplateLink {
+            template_id,
+            new_id,
+            values,
+        } in value.template_links
         {
-            ast_pset.link(template, id, env)?;
+            ast_pset.link(template_id, new_id, values)?;
         }
 
         Ok(ast_pset)
@@ -154,19 +132,173 @@ impl TryFrom<PolicySet> for ast::PolicySet {
 
 #[cfg(test)]
 mod test {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
-    fn link_prevents_duplicates() {
-        let value = r#"
-            "id" : "foo",
-            "template" : "bar",
-            "env" : {
+    fn valid_example() {
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": {
+                        "op": "==",
+                        "entity": { "type": "User", "id": "alice" }
+                    },
+                    "action": {
+                        "op": "==",
+                        "entity": { "type": "Action", "id": "view" }
+                    },
+                    "resource": {
+                        "op": "in",
+                        "entity": { "type": "Folder", "id": "foo" }
+                    },
+                    "conditions": []
+                }
+            },
+            "templates": {
+                "template": {
+                    "effect" : "permit",
+                    "principal" : {
+                        "op" : "==",
+                        "slot" : "?principal"
+                    },
+                    "action" : {
+                        "op" : "All"
+                    },
+                    "resource" : {
+                        "op" : "All",
+                    },
+                    "conditions": []
+                }
+            },
+            "templateLinks" : [
+                {
+                    "newId" : "link",
+                    "templateId" : "template",
+                    "values" : {
+                        "?principal" : { "type" : "User", "id" : "bob" }
+                    }
+                }
+            ]
+        });
+
+        let est_policy_set: PolicySet =
+            serde_json::from_value(json).expect("failed to parse from JSON");
+        let ast_policy_set: ast::PolicySet =
+            est_policy_set.try_into().expect("failed to convert to AST");
+        assert_eq!(ast_policy_set.policies().count(), 2);
+        assert_eq!(ast_policy_set.templates().count(), 1);
+        assert!(ast_policy_set
+            .get_template(&PolicyID::from_string("template"))
+            .is_some());
+        let link = ast_policy_set.get(&PolicyID::from_string("link")).unwrap();
+        assert_eq!(link.template().id(), &PolicyID::from_string("template"));
+        assert_eq!(
+            link.env(),
+            &HashMap::from_iter([(SlotId::principal(), r#"User::"bob""#.parse().unwrap())])
+        );
+        assert_eq!(
+            ast_policy_set
+                .get_linked_policies(&PolicyID::from_string("template"))
+                .unwrap()
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn unknown_field() {
+        let json = json!({
+            "staticPolicies": {
+                "policy1": {
+                    "effect": "permit",
+                    "principal": {
+                        "op": "==",
+                        "entity": { "type": "User", "id": "alice" }
+                    },
+                    "action": {
+                        "op" : "All"
+                    },
+                    "resource": {
+                        "op" : "All"
+                    },
+                    "conditions": []
+                }
+            },
+            "templates": {},
+            "links" : []
+        });
+
+        let err = serde_json::from_value::<PolicySet>(json)
+            .expect_err("should have failed to parse from JSON");
+        assert_eq!(
+            err.to_string(),
+            "unknown field `links`, expected one of `templates`, `staticPolicies`, `templateLinks`"
+        );
+    }
+
+    #[test]
+    fn duplicate_policy_ids() {
+        let str = r#"{
+            "staticPolicies" : {
+                "policy0": {
+                    "effect": "permit",
+                    "principal": {
+                        "op": "==",
+                        "entity": { "type": "User", "id": "alice" }
+                    },
+                    "action": {
+                        "op" : "All"
+                    },
+                    "resource": {
+                        "op" : "All"
+                    },
+                    "conditions": []
+                },
+                "policy0": {
+                    "effect": "permit",
+                    "principal": {
+                        "op": "==",
+                        "entity": { "type": "User", "id": "alice" }
+                    },
+                    "action": {
+                        "op" : "All"
+                    },
+                    "resource": {
+                        "op" : "All"
+                    },
+                    "conditions": []
+                }
+            },
+            "templates" : {},
+            "templateLinks" : []
+        }"#;
+        let err = serde_json::from_str::<PolicySet>(str)
+            .expect_err("should have failed to parse from JSON");
+        assert_eq!(
+            err.to_string(),
+            "invalid entry: found duplicate key at line 31 column 13"
+        );
+    }
+
+    #[test]
+    fn duplicate_slot_ids() {
+        let str = r#"{
+            "newId" : "foo",
+            "templateId" : "bar",
+            "values" : {
                 "?principal" : { "type" : "User", "id" : "John" },
                 "?principal" : { "type" : "User", "id" : "John" },
             }
         }"#;
-        let r: Result<Link, _> = serde_json::from_str(value);
-        assert!(r.is_err());
+
+        let err = serde_json::from_str::<TemplateLink>(str)
+            .expect_err("should have failed to parse from JSON");
+        assert_eq!(
+            err.to_string(),
+            "invalid entry: found duplicate key at line 6 column 65"
+        );
     }
 }

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -1,0 +1,116 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::FromJsonError;
+use super::Policy;
+use crate::ast;
+use crate::ast::EntityUID;
+use crate::ast::{PolicyID, SlotId};
+use crate::entities::EntityUidJson;
+use crate::entities::JsonDeserializationErrorContext;
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::collections::HashMap;
+
+/// An EST set of policies
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PolicySet {
+    /// The set of templates in a policy set
+    pub templates: Vec<PolicyEntry>,
+    /// The set of static policies in a policy set
+    pub static_policies: Vec<PolicyEntry>,
+    /// The set of template links
+    pub links: Vec<Link>,
+}
+
+/// A policy id and EST policy pair
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PolicyEntry {
+    /// The id of this policy
+    pub id: PolicyID,
+    /// The EST of this policy
+    pub policy: Policy,
+}
+
+/// A record of a template-linked policy
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Link {
+    /// The id of the link
+    pub id: PolicyID,
+    /// The id of the template
+    pub template: PolicyID,
+    /// The mapping between slots and entity uids
+    #[serde_as(as = "serde_with::MapPreventDuplicates<_,EntityUidJson<TemplateLinkContext>>")]
+    pub slots: HashMap<SlotId, EntityUID>,
+}
+
+/// Statically set the deserialization error context to be deserialization of a template link
+struct TemplateLinkContext;
+
+impl crate::entities::DeserializationContext for TemplateLinkContext {
+    fn static_context() -> Option<JsonDeserializationErrorContext> {
+        Some(JsonDeserializationErrorContext::TemplateLink)
+    }
+}
+
+impl TryFrom<PolicySet> for ast::PolicySet {
+    type Error = FromJsonError;
+
+    fn try_from(value: PolicySet) -> Result<Self, Self::Error> {
+        let mut ast_pset = ast::PolicySet::default();
+
+        for PolicyEntry { id, policy } in value.templates {
+            let ast = policy.try_into_ast_template(Some(id))?;
+            ast_pset.add_template(ast)?;
+        }
+
+        for PolicyEntry { id, policy } in value.static_policies {
+            let ast = policy.try_into_ast_policy(Some(id))?;
+            ast_pset.add(ast)?;
+        }
+
+        for Link {
+            id,
+            template,
+            slots: env,
+        } in value.links
+        {
+            ast_pset.link(template, id, env)?;
+        }
+
+        Ok(ast_pset)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn link_prevents_duplicates() {
+        let value = r#"
+            "id" : "foo",
+            "template" : "bar",
+            "env" : {
+                "?principal" : { "type" : "User", "id" : "John" },
+                "?principal" : { "type" : "User", "id" : "John" },
+            }
+        }"#;
+        let r: Result<Link, _> = serde_json::from_str(value);
+        assert!(r.is_err());
+    }
+}

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -27,6 +27,7 @@ use std::collections::HashMap;
 
 /// An EST set of policies
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct PolicySet {
     /// The set of templates in a policy set
     pub templates: Vec<PolicyEntry>,
@@ -34,6 +35,61 @@ pub struct PolicySet {
     pub static_policies: Vec<PolicyEntry>,
     /// The set of template links
     pub links: Vec<Link>,
+}
+
+impl PolicySet {
+    /// Get the static or template-linked policy with the given id.
+    /// Returns an `Option` rather than a `Result` because it is expected to be
+    /// used in cases where the policy set is guaranteed to be well-formed
+    /// (e.g., after successful conversion to an `ast::PolicySet`)
+    pub fn get_policy(&self, id: &PolicyID) -> Option<Policy> {
+        let maybe_static_policy = self
+            .static_policies
+            .iter()
+            .filter_map(|entry| {
+                if &entry.id == id {
+                    Some(entry.policy.clone())
+                } else {
+                    None
+                }
+            })
+            .next();
+
+        let maybe_link = self
+            .links
+            .iter()
+            .filter_map(|link| {
+                if &link.id == id {
+                    self.get_template(&link.template).and_then(|template| {
+                        let unwrapped_est_vals: HashMap<SlotId, EntityUidJson> =
+                            link.slots.iter().map(|(k, v)| (*k, v.into())).collect();
+                        template.link(&unwrapped_est_vals).ok()
+                    })
+                } else {
+                    None
+                }
+            })
+            .next();
+
+        maybe_static_policy.or(maybe_link)
+    }
+
+    /// Get the template with the given id.
+    /// Returns an `Option` rather than a `Result` because it is expected to be
+    /// used in cases where the policy set is guaranteed to be well-formed
+    /// (e.g., after successful conversion to an `ast::PolicySet`)
+    pub fn get_template(&self, id: &PolicyID) -> Option<Policy> {
+        self.templates
+            .iter()
+            .filter_map(|entry| {
+                if &entry.id == id {
+                    Some(entry.policy.clone())
+                } else {
+                    None
+                }
+            })
+            .next()
+    }
 }
 
 /// A policy id and EST policy pair

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -34,6 +34,7 @@ use cedar_policy_core::entities::{
     JsonDeserializationErrorContext,
 };
 use cedar_policy_core::est;
+use cedar_policy_core::est::{Link, PolicyEntry};
 use cedar_policy_core::evaluator::Evaluator;
 #[cfg(feature = "partial-eval")]
 use cedar_policy_core::evaluator::RestrictedEvaluator;
@@ -48,7 +49,7 @@ use cedar_policy_validator::RequestValidationError; // this type is unsuitable f
 pub use cedar_policy_validator::{
     TypeErrorKind, UnsupportedFeature, ValidationErrorKind, ValidationWarningKind,
 };
-use itertools::Itertools;
+use itertools::{Either, Itertools};
 use miette::Diagnostic;
 use nonempty::NonEmpty;
 use ref_cast::RefCast;
@@ -2344,6 +2345,17 @@ pub enum PolicySetError {
     /// Error when removing a link that is not a link
     #[error("unable to unlink `{0}` because it is not a link")]
     UnlinkLinkNotLinkError(PolicyId),
+    /// Error when converting from EST
+    #[error("Error deserializing a policy/template from JSON: {0}")]
+    #[diagnostic(transparent)]
+    FromJson(#[from] cedar_policy_core::est::FromJsonError),
+    /// Error when converting to EST
+    #[error("Error serializing a policy to JSON: {0}")]
+    #[diagnostic(transparent)]
+    ToJson(#[from] PolicyToJsonError),
+    /// Errors encountered in JSON ser/de
+    #[error("Error serializing or deserializng from JSON: {0})")]
+    Json(#[from] serde_json::Error),
 }
 
 impl From<ast::PolicySetError> for PolicySetError {
@@ -2416,6 +2428,84 @@ impl FromStr for PolicySet {
 }
 
 impl PolicySet {
+    /// Build the policy set AST from the EST
+    fn from_est(est: est::PolicySet) -> Result<Self, PolicySetError> {
+        let mut pset = Self::default();
+
+        for PolicyEntry { id, policy } in est.templates {
+            let template = Template::from_est(Some(PolicyId(id)), policy)?;
+            pset.add_template(template)?;
+        }
+
+        for PolicyEntry { id, policy } in est.static_policies {
+            let p = Policy::from_est(Some(PolicyId(id)), policy)?;
+            pset.add(p)?;
+        }
+
+        for Link {
+            id,
+            template,
+            slots,
+        } in est.links
+        {
+            let slots = slots
+                .into_iter()
+                .map(|(key, value)| (key.into(), EntityUid(value)))
+                .collect();
+            pset.link(PolicyId(template), PolicyId(id), slots)?;
+        }
+
+        Ok(pset)
+    }
+
+    /// Deserialize the [`PolicySet`] from a JSON string
+    pub fn from_json_str(src: impl AsRef<str>) -> Result<Self, PolicySetError> {
+        let est: est::PolicySet = serde_json::from_str(src.as_ref())?;
+        Self::from_est(est)
+    }
+
+    /// Deserialize the [`PolicySet`] from a JSON value
+    pub fn from_json_value(src: serde_json::Value) -> Result<Self, PolicySetError> {
+        let est: est::PolicySet = serde_json::from_value(src)?;
+        Self::from_est(est)
+    }
+
+    /// Deserialize the [`PolicySet`] from a JSON reader
+    pub fn from_json_file(r: impl std::io::Read) -> Result<Self, PolicySetError> {
+        let est: est::PolicySet = serde_json::from_reader(r)?;
+        Self::from_est(est)
+    }
+
+    /// Serialize the [`PolicySet`] as a JSON value
+    pub fn to_json(self) -> Result<serde_json::Value, PolicySetError> {
+        let est = self.est()?;
+        let value = serde_json::to_value(est)?;
+        Ok(value)
+    }
+
+    /// Get the EST representation of the [`PolicySet`]
+    fn est(self) -> Result<est::PolicySet, PolicyToJsonError> {
+        let (static_policies, links): (Vec<_>, Vec<_>) =
+            fold_partition(self.policies, is_static_or_link)?;
+        let templates = self
+            .templates
+            .into_iter()
+            .map(|(id, template)| {
+                template.lossless.est().map(|est| PolicyEntry {
+                    id: id.0,
+                    policy: est,
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let est = est::PolicySet {
+            templates,
+            static_policies,
+            links,
+        };
+
+        Ok(est)
+    }
+
     /// Create a fresh empty `PolicySet`
     pub fn new() -> Self {
         Self {
@@ -2680,6 +2770,53 @@ impl std::fmt::Display for PolicySet {
     }
 }
 
+/// Given a [`PolicyId`] and a [`Policy`], determine if the policy represents a static policy or a
+/// link
+fn is_static_or_link(
+    (id, policy): (PolicyId, Policy),
+) -> Result<Either<est::PolicyEntry, Link>, PolicyToJsonError> {
+    match policy.template_id() {
+        Some(template_id) => {
+            let slots = policy
+                .ast
+                .env()
+                .iter()
+                .map(|(id, euid)| (*id, euid.clone()))
+                .collect();
+            Ok(Either::Right(Link {
+                id: id.0,
+                template: template_id.clone().0,
+                slots,
+            }))
+        }
+        None => policy.lossless.est().map(|est| {
+            Either::Left(PolicyEntry {
+                id: id.0,
+                policy: est,
+            })
+        }),
+    }
+}
+
+/// Like [`itertools::Itertools::partition_map`], but accepts a function that can fail.
+/// The first invocation of `f` that fails causes the whole computation to fail
+fn fold_partition<T, A, B, E>(
+    i: impl IntoIterator<Item = T>,
+    f: impl Fn(T) -> Result<Either<A, B>, E>,
+) -> Result<(Vec<A>, Vec<B>), E> {
+    let mut lefts = vec![];
+    let mut rights = vec![];
+
+    for item in i {
+        match f(item)? {
+            Either::Left(left) => lefts.push(left),
+            Either::Right(right) => rights.push(right),
+        }
+    }
+
+    Ok((lefts, rights))
+}
+
 /// Policy template datatype
 #[derive(Debug, Clone)]
 pub struct Template {
@@ -2845,6 +2982,13 @@ impl Template {
     ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
         let est: est::Policy =
             serde_json::from_value(json).map_err(JsonDeserializationError::Serde)?;
+        Self::from_est(id, est)
+    }
+
+    fn from_est(
+        id: Option<PolicyId>,
+        est: est::Policy,
+    ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
         Ok(Self {
             ast: est.clone().try_into_ast_template(id.map(|id| id.0))?,
             lossless: LosslessPolicy::Est(est),
@@ -3272,6 +3416,13 @@ impl Policy {
     ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
         let est: est::Policy =
             serde_json::from_value(json).map_err(JsonDeserializationError::Serde)?;
+        Self::from_est(id, est)
+    }
+
+    fn from_est(
+        id: Option<PolicyId>,
+        est: est::Policy,
+    ) -> Result<Self, cedar_policy_core::est::FromJsonError> {
         Ok(Self {
             ast: est.clone().try_into_ast_policy(id.map(|id| id.0))?,
             lossless: LosslessPolicy::Est(est),
@@ -4546,5 +4697,638 @@ mod test {
             .collect();
         list_out.sort();
         assert_eq!(list_out, &["admin", "alice"]);
+    }
+
+    #[test]
+    fn test_partition_fold() {
+        let even_or_odd = |s: &str| {
+            i64::from_str_radix(s, 10).map(|i| {
+                if i % 2 == 0 {
+                    Either::Left(i)
+                } else {
+                    Either::Right(i)
+                }
+            })
+        };
+
+        let lst = ["23", "24", "75", "9320"];
+        let (evens, odds) = fold_partition(lst, even_or_odd).unwrap();
+        assert!(evens.into_iter().all(|i| i % 2 == 0));
+        assert!(odds.into_iter().all(|i| i % 2 != 0));
+    }
+
+    #[test]
+    fn test_partition_fold_err() {
+        let even_or_odd = |s: &str| {
+            i64::from_str_radix(s, 10).map(|i| {
+                if i % 2 == 0 {
+                    Either::Left(i)
+                } else {
+                    Either::Right(i)
+                }
+            })
+        };
+
+        let lst = ["23", "24", "not-a-number", "75", "9320"];
+        assert!(fold_partition(lst, even_or_odd).is_err());
+    }
+
+    #[test]
+    fn test_est_policyset_encoding() {
+        let mut pset = PolicySet::default();
+        let policy: Policy = r#"permit(principal, action, resource) when { principal.foo };"#
+            .parse()
+            .unwrap();
+        pset.add(policy.new_id(PolicyId::new("policy"))).unwrap();
+        let template: Template =
+            r#"permit(principal == ?principal, action, resource) when { principal.bar };"#
+                .parse()
+                .unwrap();
+        pset.add_template(template.new_id(PolicyId::new("template")))
+            .unwrap();
+
+        pset.link(
+            PolicyId::new("template"),
+            PolicyId::new("Link1"),
+            HashMap::from_iter([(SlotId::principal(), r#"User::"Joe""#.parse().unwrap())]),
+        )
+        .unwrap();
+        pset.link(
+            PolicyId::new("template"),
+            PolicyId::new("Link2"),
+            HashMap::from_iter([(SlotId::principal(), r#"User::"Sally""#.parse().unwrap())]),
+        )
+        .unwrap();
+
+        let json = pset.to_json().unwrap();
+
+        let pset2 = PolicySet::from_json_value(json).unwrap();
+
+        // There should be 2 policies, one static and two links
+        assert_eq!(pset2.policies().count(), 3);
+        let static_policy = pset2.policy(&PolicyId::new("policy")).unwrap();
+        assert!(static_policy.is_static());
+
+        let link = pset2.policy(&PolicyId::new("Link1")).unwrap();
+        assert!(!link.is_static());
+        assert_eq!(link.template_id(), Some(&PolicyId::new("template")));
+        assert_eq!(
+            link.template_links(),
+            Some(HashMap::from_iter([(
+                SlotId::principal(),
+                r#"User::"Joe""#.parse().unwrap()
+            )]))
+        );
+
+        let link = pset2.policy(&PolicyId::new("Link2")).unwrap();
+        assert!(!link.is_static());
+        assert_eq!(link.template_id(), Some(&PolicyId::new("template")));
+        assert_eq!(
+            link.template_links(),
+            Some(HashMap::from_iter([(
+                SlotId::principal(),
+                r#"User::"Sally""#.parse().unwrap()
+            )]))
+        );
+
+        let template = pset2.template(&PolicyId::new("template")).unwrap();
+        assert_eq!(template.slots().count(), 1);
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_empty() {
+        let empty = serde_json::json!({
+            "templates" : [],
+            "static_policies" : [],
+            "links" : []
+        });
+        let empty = PolicySet::from_json_value(empty).unwrap();
+        assert_eq!(empty, PolicySet::default());
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_single() {
+        let value = serde_json::json!({
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+        ],
+        "links" : [
+        ]});
+
+        let policyset = PolicySet::from_json_value(value).unwrap();
+        assert_eq!(policyset.templates().count(), 0);
+        assert_eq!(policyset.policies().count(), 1);
+        assert!(policyset.policy(&PolicyId::new("policy1")).is_some());
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_templates() {
+        let value = serde_json::json!({
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+            { "id" : "template",
+              "policy" : {
+                  "effect" : "permit",
+                  "principal" : {
+                      "op" : "==",
+                      "slot" : "?principal"
+                  },
+                  "action" : {
+                      "op" : "All"
+                  },
+                  "resource" : {
+                      "op" : "All",
+                  },
+                  "conditions": []
+              }
+            }
+        ],
+        "links" : [
+            {
+                "id" : "link",
+                "template" : "template",
+                "slots" : {
+                    "?principal" : { "type" : "User", "id" : "John" }
+                }
+            }
+        ]});
+
+        let policyset = PolicySet::from_json_value(value).unwrap();
+        assert_eq!(policyset.policies().count(), 2);
+        assert_eq!(policyset.templates().count(), 1);
+        assert!(policyset.template(&PolicyId::new("template")).is_some());
+        let link = policyset.policy(&PolicyId::new("link")).unwrap();
+        assert_eq!(link.template_id(), Some(&PolicyId::new("template")));
+        assert_eq!(
+            link.template_links(),
+            Some(HashMap::from_iter([(
+                SlotId::principal(),
+                r#"User::"John""#.parse().unwrap()
+            )]))
+        );
+        if let Err(_) = policyset
+            .get_linked_policies(PolicyId::new("template"))
+            .unwrap()
+            .exactly_one()
+        {
+            panic!("Should have exactly one");
+        };
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_templates_bad_link_name() {
+        let value = serde_json::json!({
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+            { "id" : "template1",
+              "policy" : {
+                  "effect" : "permit",
+                  "principal" : {
+                      "op" : "==",
+                      "slot" : "?principal"
+                  },
+                  "action" : {
+                      "op" : "All"
+                  },
+                  "resource" : {
+                      "op" : "All",
+                  },
+                  "conditions": []
+              }
+            }
+        ],
+        "links" : [
+            {
+                "id" : "link",
+                "template" : "non_existant",
+                "slots" : {
+                    "?principal" : { "type" : "User", "id" : "John" }
+                }
+            }
+        ]});
+
+        let err = PolicySet::from_json_value(value).err().unwrap();
+        let template1 = PolicyId::new("non_existant").0;
+        assert_matches!(
+            err,
+            PolicySetError::LinkingError(ast::LinkingError::NoSuchTemplate { id }) if id == template1
+        );
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_templates_empty_env() {
+        let value = serde_json::json!({
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+            { "id" : "template1",
+              "policy" : {
+                  "effect" : "permit",
+                  "principal" : {
+                      "op" : "==",
+                      "slot" : "?principal"
+                  },
+                  "action" : {
+                      "op" : "All"
+                  },
+                  "resource" : {
+                      "op" : "All",
+                  },
+                  "conditions": []
+              }
+            }
+        ],
+        "links" : [
+            {
+                "id" : "link",
+                "template" : "template1",
+                "slots" : {},
+            }
+        ]});
+
+        let err = PolicySet::from_json_value(value).err().unwrap();
+        let just_principal = vec![SlotId::principal().into()];
+        assert_matches!(
+            err,
+            PolicySetError::LinkingError(ast::LinkingError::ArityError {
+                unbound_values,
+                extra_values
+            }) if extra_values.is_empty() && unbound_values == just_principal
+        );
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_templates_bad_extra_vals() {
+        let value = serde_json::json!({
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+            { "id" : "template1",
+              "policy" : {
+                  "effect" : "permit",
+                  "principal" : {
+                      "op" : "==",
+                      "slot" : "?principal"
+                  },
+                  "action" : {
+                      "op" : "All"
+                  },
+                  "resource" : {
+                      "op" : "All",
+                  },
+                  "conditions": []
+              }
+            }
+        ],
+        "links" : [
+            {
+                "id" : "link",
+                "template" : "template1",
+                "slots" : {
+                    "?principal" : { "type" : "User", "id" : "John" },
+                    "?resource" : { "type" : "Box", "id" : "ABC" }
+                }
+            }
+        ]});
+
+        let err = PolicySet::from_json_value(value).err().unwrap();
+        let just_resource = vec![SlotId::resource().into()];
+        assert_matches!(
+            err,
+            PolicySetError::LinkingError(ast::LinkingError::ArityError {
+                unbound_values,
+                extra_values
+            }) if unbound_values.is_empty() && extra_values == just_resource
+        );
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_templates_bad_dup_vals() {
+        let value = r#" {
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+            { "id" : "template1",
+              "policy" : {
+                  "effect" : "permit",
+                  "principal" : {
+                      "op" : "==",
+                      "slot" : "?principal"
+                  },
+                  "action" : {
+                      "op" : "All"
+                  },
+                  "resource" : {
+                      "op" : "All"
+                  },
+                  "conditions": []
+              }
+            }
+        ],
+        "links" : [
+            {
+                "id" : "link",
+                "template" : "template1",
+                "slots" : {
+                    "?principal" : { "type" : "User", "id" : "John" },
+                    "?principal" : { "type" : "User", "id" : "Duplicate" }
+                }
+            }
+        ]}"#;
+
+        let err = PolicySet::from_json_str(value).err().unwrap().to_string();
+        assert!(err.contains("found duplicate key"));
+    }
+
+    #[test]
+    fn test_est_policyset_decoding_templates_bad_euid() {
+        let value = r#" {
+            "static_policies" : [
+                { "id" : "policy1",
+                   "policy" : {
+                        "effect": "permit",
+                        "principal": {
+                            "op": "==",
+                            "entity": { "type": "User", "id": "12UA45" }
+                        },
+                        "action": {
+                            "op": "==",
+                            "entity": { "type": "Action", "id": "view" }
+                        },
+                        "resource": {
+                            "op": "in",
+                            "entity": { "type": "Folder", "id": "abc" }
+                        },
+                        "conditions": [
+                            {
+                                "kind": "when",
+                                "body": {
+                                    "==": {
+                                        "left": {
+                                            ".": {
+                                                "left": {
+                                                    "Var": "context"
+                                                },
+                                            "attr": "tls_version"
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": "1.3"
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+            }
+        }],
+        "templates" : [
+            { "id" : "template1",
+              "policy" : {
+                  "effect" : "permit",
+                  "principal" : {
+                      "op" : "==",
+                      "slot" : "?principal"
+                  },
+                  "action" : {
+                      "op" : "All"
+                  },
+                  "resource" : {
+                      "op" : "All"
+                  },
+                  "conditions": []
+              }
+            }
+        ],
+        "links" : [
+            {
+                "id" : "link",
+                "template" : "template1",
+                "slots" : {
+                    "?principal" : { "type" : "User" }
+                }
+            }
+        ]}"#;
+
+        let err = PolicySet::from_json_str(value).err().unwrap().to_string();
+        assert!(err.contains("while parsing a template link, expected a literal entity reference"));
     }
 }


### PR DESCRIPTION
## Description of changes

First backport to the 3.3 release. I'm splitting this change out into its own PR because it needs manual review since nothing cherry picked cleanly 😢 In summary, this PR is a backport of #783, plus the followup changes made in #996 and #1017. The `PolicySet` JSON format in this PR matches what will be released in v4.0.

* Adds new variants to `JsonDeserializationErrorContext` and `FromJsonError` (neither of which is `pub use`d in 3.x)
* Adds new variants to `PolicySetError` (marked as non-exhaustive in the public API)
* Adds APIs `PolicySet::from_json_*` and `PolicySet::to_json`
