### PR TITLE
enhance `impl_diagnostic` macros

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -501,6 +501,7 @@ impl ContextCreationError {
 /// Error subtypes for [`ContextCreationError`]
 pub mod context_creation_errors {
     use super::Expr;
+    use crate::impl_diagnostic_from_expr_field;
     use miette::Diagnostic;
     use thiserror::Error;
 
@@ -518,18 +519,7 @@ pub mod context_creation_errors {
 
     // custom impl of `Diagnostic`: take source location from the `expr` field
     impl Diagnostic for NotARecord {
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            self.expr.source_loc().map(|loc| {
-                Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span)))
-                    as Box<dyn Iterator<Item = _>>
-            })
-        }
-
-        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            self.expr
-                .source_loc()
-                .map(|loc| &loc.src as &dyn miette::SourceCode)
-        }
+        impl_diagnostic_from_expr_field!(expr);
     }
 }
 

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -628,6 +628,7 @@ pub enum RestrictedExpressionError {
 /// Error subtypes for [`RestrictedExpressionError`]
 pub mod restricted_expr_errors {
     use super::Expr;
+    use crate::impl_diagnostic_from_expr_field;
     use miette::Diagnostic;
     use smol_str::SmolStr;
     use thiserror::Error;
@@ -650,18 +651,7 @@ pub mod restricted_expr_errors {
 
     // custom impl of `Diagnostic`: take source location from the `expr` field
     impl Diagnostic for InvalidRestrictedExpressionError {
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            self.expr.source_loc().map(|loc| {
-                Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span)))
-                    as Box<dyn Iterator<Item = _>>
-            })
-        }
-
-        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            self.expr
-                .source_loc()
-                .map(|loc| &loc.src as &dyn miette::SourceCode)
-        }
+        impl_diagnostic_from_expr_field!(expr);
     }
 }
 

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -330,7 +330,7 @@ pub mod evaluation_errors {
     // Or, we could have separate fields for source code and label instead of
     // combining them into `Loc`, which would work around the issue.
     impl Diagnostic for EntityDoesNotExistError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
@@ -365,7 +365,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for EntityAttrDoesNotExistError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             if self.available_attrs.is_empty() {
@@ -412,7 +412,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for RecordAttrDoesNotExistError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             if self.available_attrs.is_empty() {
@@ -457,7 +457,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for TypeError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             self.advice.as_ref().map(|advice| Box::new(advice) as _)
@@ -509,7 +509,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for WrongNumArgumentsError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
@@ -575,7 +575,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for BinaryOpOverflowError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
@@ -605,7 +605,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for UnaryOpOverflowError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
@@ -633,7 +633,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for UnlinkedSlotError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
@@ -663,7 +663,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for ExtensionFunctionExecutionError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None
@@ -700,7 +700,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for NonValueError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             Some(Box::new("consider using the partial evaluation APIs"))
@@ -726,7 +726,7 @@ pub mod evaluation_errors {
     }
 
     impl Diagnostic for RecursionLimitError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             None

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -331,16 +331,6 @@ pub mod evaluation_errors {
     // combining them into `Loc`, which would work around the issue.
     impl Diagnostic for EntityDoesNotExistError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Tried to get an attribute, but the specified entity didn't have that
@@ -383,13 +373,6 @@ pub mod evaluation_errors {
                 )))
             }
         }
-
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Tried to get an attribute of a (non-entity) record, but that record didn't
@@ -430,12 +413,6 @@ pub mod evaluation_errors {
                 )))
             }
         }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Tried to evaluate an operation on values with incorrect types for that
@@ -461,12 +438,6 @@ pub mod evaluation_errors {
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             self.advice.as_ref().map(|advice| Box::new(advice) as _)
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
         }
     }
 
@@ -510,16 +481,6 @@ pub mod evaluation_errors {
 
     impl Diagnostic for WrongNumArgumentsError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Overflow during an integer operation
@@ -576,16 +537,6 @@ pub mod evaluation_errors {
 
     impl Diagnostic for BinaryOpOverflowError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Overflow during a unary operation
@@ -606,16 +557,6 @@ pub mod evaluation_errors {
 
     impl Diagnostic for UnaryOpOverflowError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Not all template slots were linked
@@ -634,16 +575,6 @@ pub mod evaluation_errors {
 
     impl Diagnostic for UnlinkedSlotError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Evaluation error thrown by an extension function
@@ -664,16 +595,6 @@ pub mod evaluation_errors {
 
     impl Diagnostic for ExtensionFunctionExecutionError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     impl ExtensionFunctionExecutionError {
@@ -705,12 +626,6 @@ pub mod evaluation_errors {
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
             Some(Box::new("consider using the partial evaluation APIs"))
         }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 
     /// Maximum recursion limit reached for expression evaluation
@@ -727,16 +642,6 @@ pub mod evaluation_errors {
 
     impl Diagnostic for RecursionLimitError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
-
-        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn code<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
-        fn url<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            None
-        }
     }
 }
 

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -297,7 +297,7 @@ pub mod extension_function_lookup_errors {
     }
 
     impl Diagnostic for FuncDoesNotExistError {
-        impl_diagnostic_from_source_loc_field!();
+        impl_diagnostic_from_source_loc_opt_field!(source_loc);
     }
 }
 

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -77,12 +77,10 @@ pub struct ToASTError {
     loc: Loc,
 }
 
-// Construct `labels` and `source_code` based on the `loc` in this struct;
-// and everything else forwarded directly to `kind`.
+// Construct `labels` and `source_code` based on the `loc` in this
+// struct; and everything else forwarded directly to `kind`.
 impl Diagnostic for ToASTError {
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        Some(Box::new(iter::once(LabeledSpan::underline(self.loc.span))))
-    }
+    impl_diagnostic_from_source_loc_field!(loc);
 
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.kind.code()
@@ -98,10 +96,6 @@ impl Diagnostic for ToASTError {
 
     fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.kind.url()
-    }
-
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        Some(&self.loc.src as &dyn miette::SourceCode)
     }
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -110,8 +110,10 @@ impl<T: std::error::Error> std::error::Error for Node<T> {
     }
 }
 
-// impl Diagnostic by taking `labels()` from .loc and everything else from .node
+// impl Diagnostic by taking `labels()` and `source_code()` from .loc and everything else from .node
 impl<T: Diagnostic> Diagnostic for Node<T> {
+    impl_diagnostic_from_source_loc_field!(loc);
+
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.node.code()
     }
@@ -126,16 +128,6 @@ impl<T: Diagnostic> Diagnostic for Node<T> {
 
     fn url<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.node.url()
-    }
-
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        self.node.source_code()
-    }
-
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        Some(Box::new(std::iter::once(miette::LabeledSpan::underline(
-            self.loc.span,
-        ))))
     }
 
     fn related<'a>(&'a self) -> Option<Box<dyn Iterator<Item = &'a dyn Diagnostic> + 'a>> {

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -423,7 +423,7 @@ impl Diagnostic for ToJsonSchemaError {
 
 /// Error subtypes for [`SchemaWarning`]
 pub mod schema_warnings {
-    use cedar_policy_core::parser::Loc;
+    use cedar_policy_core::{impl_diagnostic_from_source_loc_field, parser::Loc};
     use miette::Diagnostic;
     use smol_str::SmolStr;
     use thiserror::Error;
@@ -441,11 +441,7 @@ pub mod schema_warnings {
     }
 
     impl Diagnostic for ShadowsBuiltinWarning {
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            Some(Box::new(std::iter::once(miette::LabeledSpan::underline(
-                self.loc.span,
-            ))))
-        }
+        impl_diagnostic_from_source_loc_field!(loc);
 
         fn severity(&self) -> Option<miette::Severity> {
             Some(miette::Severity::Warning)
@@ -472,6 +468,13 @@ pub mod schema_warnings {
                     .chain(std::iter::once(&self.common_loc))
                     .map(miette::LabeledSpan::underline),
             ))
+        }
+
+        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+            // just have to pick one; we assume `entity_loc` and `common_loc`
+            // have the same source code.
+            // if that isn't true we'll have a confusing underline.
+            Some(&self.entity_loc.src as _)
         }
 
         fn severity(&self) -> Option<miette::Severity> {

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -21,7 +21,7 @@ use thiserror::Error;
 
 use std::fmt::Display;
 
-use cedar_policy_core::impl_diagnostic_from_source_loc_field;
+use cedar_policy_core::impl_diagnostic_from_source_loc_opt_field;
 use cedar_policy_core::parser::Loc;
 
 use std::collections::BTreeSet;
@@ -50,7 +50,7 @@ pub struct UnrecognizedEntityType {
 }
 
 impl Diagnostic for UnrecognizedEntityType {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         match &self.suggested_entity_type {
@@ -76,7 +76,7 @@ pub struct UnrecognizedActionId {
 }
 
 impl Diagnostic for UnrecognizedActionId {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         match &self.suggested_action_id {
@@ -101,7 +101,7 @@ pub struct InvalidActionApplication {
 }
 
 impl Diagnostic for InvalidActionApplication {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         match (self.would_in_fix_principal, self.would_in_fix_resource) {
@@ -141,7 +141,7 @@ pub struct UnexpectedType {
 }
 
 impl Diagnostic for UnexpectedType {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.help.as_ref().map(|h| Box::new(h) as Box<dyn Display>)
@@ -198,7 +198,7 @@ pub struct IncompatibleTypes {
 }
 
 impl Diagnostic for IncompatibleTypes {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(format!(
@@ -274,7 +274,7 @@ pub struct UnsafeAttributeAccess {
 }
 
 impl Diagnostic for UnsafeAttributeAccess {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         match (&self.suggestion, self.may_exist) {
@@ -299,7 +299,7 @@ pub struct UnsafeOptionalAttributeAccess {
 }
 
 impl Diagnostic for UnsafeOptionalAttributeAccess {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(format!(
@@ -322,7 +322,7 @@ pub struct UndefinedFunction {
 }
 
 impl Diagnostic for UndefinedFunction {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 }
 
 /// Structure containing details about a wrong number of arguments error.
@@ -340,7 +340,7 @@ pub struct WrongNumberArguments {
 }
 
 impl Diagnostic for WrongNumberArguments {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 }
 
 /// Structure containing details about a function argument validation error.
@@ -356,7 +356,7 @@ pub struct FunctionArgumentValidation {
 }
 
 impl Diagnostic for FunctionArgumentValidation {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 }
 
 /// Structure containing details about a hierarchy not respected error
@@ -374,7 +374,7 @@ pub struct HierarchyNotRespected {
 }
 
 impl Diagnostic for HierarchyNotRespected {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         match (&self.in_lhs, &self.in_rhs) {
@@ -397,7 +397,7 @@ pub struct EmptySetForbidden {
 }
 
 impl Diagnostic for EmptySetForbidden {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 }
 
 /// The policy passes a non-literal to an extension constructor, which is
@@ -412,7 +412,7 @@ pub struct NonLitExtConstructor {
 }
 
 impl Diagnostic for NonLitExtConstructor {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(

--- a/cedar-policy-validator/src/diagnostics/validation_warnings.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_warnings.rs
@@ -27,7 +27,7 @@ macro_rules! impl_diagnostic_warning {
     };
 }
 
-use cedar_policy_core::{ast::PolicyID, impl_diagnostic_from_source_loc_field, parser::Loc};
+use cedar_policy_core::{ast::PolicyID, impl_diagnostic_from_source_loc_opt_field, parser::Loc};
 use miette::Diagnostic;
 use thiserror::Error;
 
@@ -44,7 +44,7 @@ pub struct MixedScriptString {
 }
 
 impl Diagnostic for MixedScriptString {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }
 
@@ -61,7 +61,7 @@ pub struct BidiCharsInString {
 }
 
 impl Diagnostic for BidiCharsInString {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }
 
@@ -78,7 +78,7 @@ pub struct BidiCharsInIdentifier {
 }
 
 impl Diagnostic for BidiCharsInIdentifier {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }
 
@@ -94,7 +94,7 @@ pub struct MixedScriptIdentifier {
     pub id: String,
 }
 impl Diagnostic for MixedScriptIdentifier {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }
 
@@ -111,7 +111,7 @@ pub struct ConfusableIdentifier {
 }
 
 impl Diagnostic for ConfusableIdentifier {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }
 
@@ -126,6 +126,6 @@ pub struct ImpossiblePolicy {
 }
 
 impl Diagnostic for ImpossiblePolicy {
-    impl_diagnostic_from_source_loc_field!();
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
     impl_diagnostic_warning!();
 }


### PR DESCRIPTION
## Description of changes

Enhances our `impl_diagnostic` macros, allowing them to be used in a few more places.

Partially addresses #977 -- specifically, addresses #977 for `schema_warnings::ShadowsBuiltinWarning` and `schema_warnings::ShadowsEntityWarning`, and also for generic `cedar_policy_core::parser::Node`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

