### PR TITLE
Backport more changes

### DIFF
--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -22,8 +22,9 @@ thiserror = "1.0"
 
 [features]
 default = []
-experimental = ["partial-validate"]
+experimental = ["partial-validate", "partial-eval"]
 partial-validate = ["cedar-policy/partial-validate"]
+partial-eval = ["cedar-policy/partial-eval"]
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-authorize/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-authorize/README.md
@@ -1,0 +1,16 @@
+# JSON formatted policies
+
+The Cedar policy CLI also supports using policies in the JSON policy format.
+See the [Cedar language reference](https://docs.cedarpolicy.com/policies/json-format.html) for a detailed description of this format.
+
+In general, you can select between the human-readable and JSON format using `--policy-format`.
+For example, we can use a JSON format policy in an authorization request
+
+```bash
+cedar authorize --policy-format json \
+    --policies policy.cedar.json \
+    --entities entity.json \
+    --principal 'User::"bob"' \
+    --action 'Action::"view"' \
+    --resource 'Photo::"VacationPhoto94.jpg"'`
+```

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-authorize/entity.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-authorize/entity.json
@@ -1,0 +1,19 @@
+[
+    {
+        "uid": { "type": "User", "id": "bob"} ,
+        "attrs": { },
+        "parents": []
+    },
+    {
+        "uid": { "type": "Action", "id": "view"},
+        "attrs": {},
+        "parents": []
+    },
+    {
+        "uid": { "type": "Photo", "id": "VacationPhoto94.jpg"},
+        "attrs": {
+            "owner": {"__entity": {"type": "User", "id": "bob"}}
+        },
+        "parents": []
+    }
+]

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-authorize/policy.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-authorize/policy.cedar.json
@@ -1,0 +1,37 @@
+{
+    "effect": "permit",
+    "principal": {
+        "op": "==",
+        "entity": { "type": "User", "id": "bob" }
+    },
+    "action": {
+        "op": "in",
+        "entities": [
+          { "type": "Action", "id": "view" },
+          { "type": "Action", "id": "edit" }
+        ]
+    },
+    "resource": {
+        "op": "All"
+    },
+    "conditions": [
+        {
+            "kind": "when",
+            "body": {
+                "==": {
+                    "left": {
+                        ".": {
+                            "left": {
+                                "Var": "resource"
+                            },
+                            "attr": "owner"
+                        }
+                    },
+                    "right": {
+                        "Var": "principal"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/README.md
@@ -1,0 +1,12 @@
+# JSON formatted policies
+
+The Cedar policy CLI also supports using policies in the JSON policy format.
+See the [Cedar language reference](https://docs.cedarpolicy.com/policies/json-format.html) for a detailed description of this format.
+
+In general, you can select between the human-readable and JSON format using `--policy-format`.
+For example, we can check if a JSON format policy parses:
+
+```bash
+cedar check-parse --policy-format json \
+    --policies policy.cedar.json
+```

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_mixed_properties.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_mixed_properties.cedar.json
@@ -1,0 +1,10 @@
+{
+    "effect": "",
+    "principal": {},
+    "action": {},
+    "resource": {},
+    "conditions": [],
+    "staticPolicies": {},
+    "templates": {},
+    "templateLinks": []
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_no_matching_properties.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_no_matching_properties.cedar.json
@@ -1,0 +1,10 @@
+{
+    "Xeffect": "",
+    "Xprincipal": {},
+    "Xaction": {},
+    "Xresource": {},
+    "Xconditions": [],
+    "XstaticPolicies": {},
+    "Xtemplates": {},
+    "XtemplateLinks": []
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_set.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_set.cedar.json
@@ -1,0 +1,52 @@
+{
+  "staticPolicies": {
+      "policy0": {
+          "effect": "permit",
+          "principal": {
+              "op": "==",
+              "entity": {
+                  "type": "User",
+                  "id": "bob"
+              }
+          },
+          "action": {
+              "op": "in",
+              "entities": [
+                  {
+                      "type": "Action",
+                      "id": "view"
+                  },
+                  {
+                      "type": "Action",
+                      "id": "edit"
+                  }
+              ]
+          },
+          "resource": {
+              "op": "All"
+          },
+          "conditions": [
+              {
+                  "kind": "when",
+                  "body": {
+                      "==": {
+                          "left": {
+                              ".": {
+                                  "left": {
+                                      "Var": "resource"
+                                  },
+                                  "attr": "owner"
+                              }
+                          },
+                          "right": {
+                              "Var": "principal"
+                          }
+                      }
+                  }
+              }
+          ]
+      }
+  },
+  "templates": {},
+  "templateLinks": []
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_template.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/policy_template.cedar.json
@@ -1,0 +1,44 @@
+{
+    "effect": "permit",
+    "principal": {
+        "op": "in",
+        "slot": "?principal"
+    },
+    "action": {
+        "op": "in",
+        "entities": [
+            {
+                "type": "Action",
+                "id": "view"
+            },
+            {
+                "type": "Action",
+                "id": "comment"
+            }
+        ]
+    },
+    "resource": {
+        "op": "in",
+        "slot": "?resource"
+    },
+    "conditions": [
+        {
+            "kind": "unless",
+            "body": {
+                "==": {
+                    "left": {
+                        ".": {
+                            "left": {
+                                "Var": "resource"
+                            },
+                            "attr": "tag"
+                        }
+                    },
+                    "right": {
+                        "Value": "private"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json
@@ -1,0 +1,37 @@
+{
+    "effect": "permit",
+    "principal": {
+        "op": "==",
+        "entity": { "type": "User", "id": "bob" }
+    },
+    "action": {
+        "op": "in",
+        "entities": [
+          { "type": "Action", "id": "view" },
+          { "type": "Action", "id": "edit" }
+        ]
+    },
+    "resource": {
+        "op": "All"
+    },
+    "conditions": [
+        {
+            "kind": "when",
+            "body": {
+                "==": {
+                    "left": {
+                        ".": {
+                            "left": {
+                                "Var": "resource"
+                            },
+                            "attr": "owner"
+                        }
+                    },
+                    "right": {
+                        "Var": "principal"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/README.md
@@ -1,0 +1,3 @@
+# translate-policy
+
+This sample is used to verify that the cedar-policy-cli's translate-policy command works as expected when converting from human to json format.

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/policy.cedar
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/policy.cedar
@@ -1,0 +1,5 @@
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/policy.cedar.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/policy.cedar.json
@@ -1,0 +1,1 @@
+{"templates":{},"staticPolicies":{"policy0":{"effect":"permit","principal":{"op":"==","entity":{"type":"User","id":"alice"}},"action":{"op":"==","entity":{"type":"Action","id":"update"}},"resource":{"op":"==","entity":{"type":"Photo","id":"VacationPhoto94.jpg"}},"conditions":[]}},"templateLinks":[]}

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -346,8 +346,8 @@ impl PoliciesArgs {
     /// Turn this `PoliciesArgs` into the appropriate `PolicySet` object
     fn get_policy_set(&self) -> Result<PolicySet> {
         let mut pset = match self.policy_format {
-            PolicyFormat::Human => read_policy_set(self.policies_file.as_ref()),
-            PolicyFormat::Json => read_json_policy(self.policies_file.as_ref()),
+            PolicyFormat::Human => read_human_policy_set(self.policies_file.as_ref()),
+            PolicyFormat::Json => read_json_policy_set(self.policies_file.as_ref()),
         }?;
         if let Some(links_filename) = self.template_linked_file.as_ref() {
             add_template_links_to_set(links_filename, &mut pset)?;
@@ -1151,7 +1151,9 @@ fn read_from_file(filename: impl AsRef<Path>, context: &str) -> Result<String> {
 
 /// Read a policy set, in Cedar human syntax, from the file given in `filename`,
 /// or from stdin if `filename` is `None`.
-fn read_policy_set(filename: Option<impl AsRef<Path> + std::marker::Copy>) -> Result<PolicySet> {
+fn read_human_policy_set(
+    filename: Option<impl AsRef<Path> + std::marker::Copy>,
+) -> Result<PolicySet> {
     let context = "policy set";
     let ps_str = read_from_file_or_stdin(filename, context)?;
     let ps = PolicySet::from_str(&ps_str)
@@ -1166,9 +1168,11 @@ fn read_policy_set(filename: Option<impl AsRef<Path> + std::marker::Copy>) -> Re
     rename_from_id_annotation(ps)
 }
 
-/// Read a policy or template, in Cedar JSON (EST) syntax, from the file given
+/// Read a static policy or a policy template, in Cedar JSON (EST) syntax, from the file given
 /// in `filename`, or from stdin if `filename` is `None`.
-fn read_json_policy(filename: Option<impl AsRef<Path> + std::marker::Copy>) -> Result<PolicySet> {
+fn read_json_policy_set(
+    filename: Option<impl AsRef<Path> + std::marker::Copy>,
+) -> Result<PolicySet> {
     let context = "JSON policy";
     let json_source = read_from_file_or_stdin(filename, context)?;
     let json: serde_json::Value = serde_json::from_str(&json_source).into_diagnostic()?;
@@ -1180,7 +1184,7 @@ fn read_json_policy(filename: Option<impl AsRef<Path> + std::marker::Copy>) -> R
         Report::new(err).with_source_code(NamedSource::new(name, json_source.clone()))
     };
 
-    match Policy::from_json(None, json.clone()).map_err(err_to_report) {
+    match Policy::from_json(None, json.clone()) {
         Ok(policy) => PolicySet::from_policies([policy])
             .wrap_err_with(|| format!("failed to create policy set from {context}")),
         Err(_) => match Template::from_json(None, json).map_err(err_to_report) {

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -99,6 +99,9 @@ pub enum Commands {
     TranslatePolicy(TranslatePolicyArgs),
     /// Translate JSON schema to natural schema syntax and vice versa (except comments)
     TranslateSchema(TranslateSchemaArgs),
+    /// Visualize a set of JSON entities to the graphviz format.
+    /// Warning: Entity visualization is best-effort and not well tested.
+    Visualize(VisualizeArgs),
     /// Create a Cedar project
     New(NewArgs),
 }
@@ -381,6 +384,12 @@ pub struct AuthorizeArgs {
     pub timing: bool,
 }
 
+#[derive(Args, Debug)]
+pub struct VisualizeArgs {
+    #[arg(long = "entities", value_name = "FILE")]
+    pub entities_file: String,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum PolicyFormat {
     /// The standard human-readable Cedar policy format, documented at <https://docs.cedarpolicy.com/policies/syntax-policy.html>
@@ -645,6 +654,19 @@ pub fn link(args: &LinkArgs) -> CedarExitCode {
         CedarExitCode::Failure
     } else {
         CedarExitCode::Success
+    }
+}
+
+pub fn visualize(args: &VisualizeArgs) -> CedarExitCode {
+    match load_entities(&args.entities_file, None) {
+        Ok(entities) => {
+            println!("{}", entities.to_dot_str());
+            CedarExitCode::Success
+        }
+        Err(report) => {
+            eprintln!("{report:?}");
+            CedarExitCode::Failure
+        }
     }
 }
 

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -104,6 +104,8 @@ pub enum Commands {
     Visualize(VisualizeArgs),
     /// Create a Cedar project
     New(NewArgs),
+    /// Partially evaluate an authorization request
+    PartiallyAuthorize(PartiallyAuthorizeArgs),
 }
 
 #[derive(Args, Debug)]
@@ -212,6 +214,31 @@ pub struct RequestArgs {
     /// not provided.
     #[arg(long = "request-validation", action = ArgAction::Set, default_value_t = true)]
     pub request_validation: bool,
+}
+
+#[cfg(feature = "partial-eval")]
+/// This struct contains the arguments that together specify a request.
+#[derive(Args, Debug)]
+pub struct PartialRequestArgs {
+    /// Principal for the request, e.g., User::"alice"
+    #[arg(short = 'l', long)]
+    pub principal: Option<String>,
+    /// Action for the request, e.g., Action::"view"
+    #[arg(short, long)]
+    pub action: Option<String>,
+    /// Resource for the request, e.g., File::"myfile.txt"
+    #[arg(short, long)]
+    pub resource: Option<String>,
+    /// File containing a JSON object representing the context for the request.
+    /// Should be a (possibly empty) map from keys to values.
+    #[arg(short, long = "context", value_name = "FILE")]
+    pub context_json_file: Option<String>,
+    /// File containing a JSON object representing the entire request. Must have
+    /// fields "principal", "action", "resource", and "context", where "context"
+    /// is a (possibly empty) map from keys to values. This option replaces
+    /// --principal, --action, etc.
+    #[arg(long = "request-json", value_name = "FILE", conflicts_with_all = &["principal", "action", "resource", "context_json_file"])]
+    pub request_json_file: Option<String>,
 }
 
 impl RequestArgs {
@@ -328,6 +355,90 @@ impl RequestArgs {
     }
 }
 
+#[cfg(feature = "partial-eval")]
+impl PartialRequestArgs {
+    fn get_request(&self) -> Result<Request> {
+        let mut builder = RequestBuilder::default();
+        let qjson: PartialRequestJSON = match self.request_json_file.as_ref() {
+            Some(jsonfile) => {
+                let jsonstring = std::fs::read_to_string(jsonfile)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("failed to open request-json file {jsonfile}"))?;
+                serde_json::from_str(&jsonstring)
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("failed to parse request-json file {jsonfile}"))?
+            }
+            None => PartialRequestJSON {
+                principal: self.principal.clone(),
+                action: self.action.clone(),
+                resource: self.resource.clone(),
+                context: self
+                    .context_json_file
+                    .as_ref()
+                    .map(|jsonfile| {
+                        let jsonstring = std::fs::read_to_string(jsonfile)
+                            .into_diagnostic()
+                            .wrap_err_with(|| {
+                                format!("failed to open context-json file {jsonfile}")
+                            })?;
+                        serde_json::from_str(&jsonstring)
+                            .into_diagnostic()
+                            .wrap_err_with(|| {
+                                format!("failed to parse context-json file {jsonfile}")
+                            })
+                    })
+                    .transpose()?,
+            },
+        };
+
+        if let Some(principal) = qjson
+            .principal
+            .map(|s| {
+                s.parse()
+                    .wrap_err_with(|| format!("failed to parse principal {s} as entity Uid"))
+            })
+            .transpose()?
+        {
+            builder = builder.principal(Some(principal));
+        }
+
+        if let Some(action) = qjson
+            .action
+            .map(|s| {
+                s.parse()
+                    .wrap_err_with(|| format!("failed to parse action {s} as entity Uid"))
+            })
+            .transpose()?
+        {
+            builder = builder.action(Some(action));
+        }
+
+        if let Some(resource) = qjson
+            .resource
+            .map(|s| {
+                s.parse()
+                    .wrap_err_with(|| format!("failed to parse resource {s} as entity Uid"))
+            })
+            .transpose()?
+        {
+            builder = builder.resource(Some(resource));
+        }
+
+        if let Some(context) = qjson
+            .context
+            .map(|json| {
+                Context::from_json_value(json.clone(), None)
+                    .wrap_err_with(|| format!("fail to convert context json {json} to Context"))
+            })
+            .transpose()?
+        {
+            builder = builder.context(context);
+        }
+
+        Ok(builder.build())
+    }
+}
+
 /// This struct contains the arguments that together specify an input policy or policy set.
 #[derive(Args, Debug)]
 pub struct PoliciesArgs {
@@ -383,6 +494,27 @@ pub struct AuthorizeArgs {
     #[arg(short, long)]
     pub timing: bool,
 }
+
+#[cfg(feature = "partial-eval")]
+#[derive(Args, Debug)]
+pub struct PartiallyAuthorizeArgs {
+    /// Request args (incorporated by reference)
+    #[command(flatten)]
+    pub request: PartialRequestArgs,
+    /// Policies args (incorporated by reference)
+    #[command(flatten)]
+    pub policies: PoliciesArgs,
+    /// File containing JSON representation of the Cedar entity hierarchy
+    #[arg(long = "entities", value_name = "FILE")]
+    pub entities_file: String,
+    /// Time authorization and report timing information
+    #[arg(short, long)]
+    pub timing: bool,
+}
+
+#[cfg(not(feature = "partial-eval"))]
+#[derive(Debug, Args)]
+pub struct PartiallyAuthorizeArgs;
 
 #[derive(Args, Debug)]
 pub struct VisualizeArgs {
@@ -489,6 +621,20 @@ struct RequestJSON {
     context: serde_json::Value,
 }
 
+#[cfg(feature = "partial-eval")]
+/// This struct is the serde structure expected for --request-json
+#[derive(Deserialize)]
+pub(self) struct PartialRequestJSON {
+    /// Principal for the request
+    pub(self) principal: Option<String>,
+    /// Action for the request
+    pub(self) action: Option<String>,
+    /// Resource for the request
+    pub(self) resource: Option<String>,
+    /// Context for the request
+    pub(self) context: Option<serde_json::Value>,
+}
+
 #[derive(Args, Debug)]
 pub struct EvaluateArgs {
     /// Request args (incorporated by reference)
@@ -524,6 +670,10 @@ pub enum CedarExitCode {
     // The command completed successfully, but it detected a validation failure
     // in the given schema and policies.
     ValidationFailure,
+    #[cfg(feature = "partial-eval")]
+    // The command completed successfully with an incomplete result, e.g.,
+    // partial authorization result is not determining.
+    Unknown,
 }
 
 impl Termination for CedarExitCode {
@@ -533,6 +683,8 @@ impl Termination for CedarExitCode {
             CedarExitCode::Failure => ExitCode::FAILURE,
             CedarExitCode::AuthorizeDeny => ExitCode::from(2),
             CedarExitCode::ValidationFailure => ExitCode::from(3),
+            #[cfg(feature = "partial-eval")]
+            CedarExitCode::Unknown => ExitCode::SUCCESS,
         }
     }
 }
@@ -1072,6 +1224,54 @@ pub fn authorize(args: &AuthorizeArgs) -> CedarExitCode {
     }
 }
 
+#[cfg(not(feature = "partial-eval"))]
+pub fn partial_authorize(_: &PartiallyAuthorizeArgs) -> CedarExitCode {
+    {
+        eprintln!("Error: option `partially-authorize` is experimental, but this executable was not built with `partial-eval` experimental feature enabled");
+        return CedarExitCode::Failure;
+    }
+}
+
+#[cfg(feature = "partial-eval")]
+pub fn partial_authorize(args: &PartiallyAuthorizeArgs) -> CedarExitCode {
+    println!();
+    let ans = execute_partial_request(
+        &args.request,
+        &args.policies,
+        &args.entities_file,
+        args.timing,
+    );
+    match ans {
+        Ok(ans) => {
+            let status = match ans.decision() {
+                Some(Decision::Allow) => {
+                    println!("ALLOW");
+                    CedarExitCode::Success
+                }
+                Some(Decision::Deny) => {
+                    println!("DENY");
+                    CedarExitCode::AuthorizeDeny
+                }
+                None => {
+                    println!("UNKNOWN");
+                    println!("All policy residuals:");
+                    for p in ans.nontrivial_residuals() {
+                        println!("{p}");
+                    }
+                    CedarExitCode::Unknown
+                }
+            };
+            status
+        }
+        Err(errs) => {
+            for err in errs {
+                println!("{err:?}");
+            }
+            CedarExitCode::Failure
+        }
+    }
+}
+
 /// Load an `Entities` object from the given JSON filename and optional schema.
 fn load_entities(entities_filename: impl AsRef<Path>, schema: Option<&Schema>) -> Result<Entities> {
     match std::fs::OpenOptions::new()
@@ -1288,6 +1488,50 @@ fn execute_request(
             let authorizer = Authorizer::new();
             let auth_start = Instant::now();
             let ans = authorizer.is_authorized(&request, &policies, &entities);
+            let auth_dur = auth_start.elapsed();
+            if compute_duration {
+                println!(
+                    "Authorization Time (micro seconds) : {}",
+                    auth_dur.as_micros()
+                );
+            }
+            Ok(ans)
+        }
+        Ok(_) => Err(errs),
+        Err(e) => {
+            errs.push(e.wrap_err("failed to parse request"));
+            Err(errs)
+        }
+    }
+}
+
+#[cfg(feature = "partial-eval")]
+fn execute_partial_request(
+    request: &PartialRequestArgs,
+    policies: &PoliciesArgs,
+    entities_filename: impl AsRef<Path>,
+    compute_duration: bool,
+) -> Result<PartialResponse, Vec<Report>> {
+    let mut errs = vec![];
+    let policies = match policies.get_policy_set() {
+        Ok(pset) => pset,
+        Err(e) => {
+            errs.push(e);
+            PolicySet::new()
+        }
+    };
+    let entities = match load_entities(entities_filename, None) {
+        Ok(entities) => entities,
+        Err(e) => {
+            errs.push(e);
+            Entities::empty()
+        }
+    };
+    match request.get_request() {
+        Ok(request) if errs.is_empty() => {
+            let authorizer = Authorizer::new();
+            let auth_start = Instant::now();
+            let ans = authorizer.is_authorized_partial(&request, &policies, &entities);
             let auth_dur = auth_start.elapsed();
             if compute_duration {
                 println!(

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1168,34 +1168,64 @@ fn read_human_policy_set(
     rename_from_id_annotation(ps)
 }
 
-/// Read a static policy or a policy template, in Cedar JSON (EST) syntax, from the file given
+/// Read a policy set, static policy or policy template, in Cedar JSON (EST) syntax, from the file given
 /// in `filename`, or from stdin if `filename` is `None`.
 fn read_json_policy_set(
     filename: Option<impl AsRef<Path> + std::marker::Copy>,
 ) -> Result<PolicySet> {
     let context = "JSON policy";
     let json_source = read_from_file_or_stdin(filename, context)?;
-    let json: serde_json::Value = serde_json::from_str(&json_source).into_diagnostic()?;
-    let err_to_report = |err| {
+    let json = serde_json::from_str::<serde_json::Value>(&json_source).into_diagnostic()?;
+    let policy_type = get_json_policy_type(&json)?;
+
+    let add_json_source = |report: Report| {
         let name = filename.map_or_else(
             || "<stdin>".to_owned(),
             |n| n.as_ref().display().to_string(),
         );
-        Report::new(err).with_source_code(NamedSource::new(name, json_source.clone()))
+        report.with_source_code(NamedSource::new(name, json_source.clone()))
     };
 
-    match Policy::from_json(None, json.clone()) {
-        Ok(policy) => PolicySet::from_policies([policy])
-            .wrap_err_with(|| format!("failed to create policy set from {context}")),
-        Err(_) => match Template::from_json(None, json).map_err(err_to_report) {
-            Ok(template) => {
-                let mut ps = PolicySet::new();
-                ps.add_template(template)?;
-                Ok(ps)
-            }
-            Err(err) => Err(err).wrap_err_with(|| format!("failed to parse {context}")),
+    match policy_type {
+        JsonPolicyType::SinglePolicy => match Policy::from_json(None, json.clone()) {
+            Ok(policy) => PolicySet::from_policies([policy])
+                .wrap_err_with(|| format!("failed to create policy set from {context}")),
+            Err(_) => match Template::from_json(None, json)
+                .map_err(|err| add_json_source(Report::new(err)))
+            {
+                Ok(template) => {
+                    let mut ps = PolicySet::new();
+                    ps.add_template(template)?;
+                    Ok(ps)
+                }
+                Err(err) => Err(err).wrap_err_with(|| format!("failed to parse {context}")),
+            },
         },
+        JsonPolicyType::PolicySet => PolicySet::from_json_value(json)
+            .map_err(|err| add_json_source(Report::new(err)))
+            .wrap_err_with(|| format!("failed to create policy set from {context}")),
     }
+}
+
+fn get_json_policy_type(json: &serde_json::Value) -> Result<JsonPolicyType> {
+    let policy_set_properties = ["staticPolicies", "templates", "templateLinks"];
+    let policy_properties = ["action", "effect", "principal", "resource", "conditions"];
+
+    let json_has_property = |p| json.get(p).is_some();
+    let has_any_policy_set_property = policy_set_properties.iter().any(json_has_property);
+    let has_any_policy_property = policy_properties.iter().any(json_has_property);
+
+    match (has_any_policy_set_property, has_any_policy_property) {
+        (false, false) => Err(miette!("cannot determine if json policy is a single policy or a policy set. Found no matching properties from either format")),
+        (true, true) => Err(miette!("cannot determine if json policy is a single policy or a policy set. Found matching properties from both formats")),
+        (true, _) => Ok(JsonPolicyType::PolicySet),
+        (_, true) => Ok(JsonPolicyType::SinglePolicy),
+    }
+}
+
+enum JsonPolicyType {
+    SinglePolicy,
+    PolicySet,
 }
 
 fn read_schema_file(

--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -20,8 +20,9 @@ use clap::Parser;
 use miette::ErrorHook;
 
 use cedar_policy_cli::{
-    authorize, check_parse, evaluate, format_policies, link, new, translate_policy,
-    translate_schema, validate, visualize, CedarExitCode, Cli, Commands, ErrorFormat,
+    authorize, check_parse, evaluate, format_policies, link, new, partial_authorize,
+    translate_policy, translate_schema, validate, visualize, CedarExitCode, Cli, Commands,
+    ErrorFormat,
 };
 
 fn main() -> CedarExitCode {
@@ -51,5 +52,6 @@ fn main() -> CedarExitCode {
         Commands::Visualize(args) => visualize(&args),
         Commands::TranslateSchema(args) => translate_schema(&args),
         Commands::New(args) => new(&args),
+        Commands::PartiallyAuthorize(args) => partial_authorize(&args),
     }
 }

--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -20,8 +20,8 @@ use clap::Parser;
 use miette::ErrorHook;
 
 use cedar_policy_cli::{
-    authorize, check_parse, evaluate, format_policies, link, new, translate_schema, validate,
-    CedarExitCode, Cli, Commands, ErrorFormat,
+    authorize, check_parse, evaluate, format_policies, link, new, translate_policy,
+    translate_schema, validate, CedarExitCode, Cli, Commands, ErrorFormat,
 };
 
 fn main() -> CedarExitCode {
@@ -47,6 +47,7 @@ fn main() -> CedarExitCode {
         Commands::Validate(args) => validate(&args),
         Commands::Format(args) => format_policies(&args),
         Commands::Link(args) => link(&args),
+        Commands::TranslatePolicy(args) => translate_policy(&args),
         Commands::TranslateSchema(args) => translate_schema(&args),
         Commands::New(args) => new(&args),
     }

--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -21,7 +21,7 @@ use miette::ErrorHook;
 
 use cedar_policy_cli::{
     authorize, check_parse, evaluate, format_policies, link, new, translate_policy,
-    translate_schema, validate, CedarExitCode, Cli, Commands, ErrorFormat,
+    translate_schema, validate, visualize, CedarExitCode, Cli, Commands, ErrorFormat,
 };
 
 fn main() -> CedarExitCode {
@@ -48,6 +48,7 @@ fn main() -> CedarExitCode {
         Commands::Format(args) => format_policies(&args),
         Commands::Link(args) => link(&args),
         Commands::TranslatePolicy(args) => translate_policy(&args),
+        Commands::Visualize(args) => visualize(&args),
         Commands::TranslateSchema(args) => translate_schema(&args),
         Commands::New(args) => new(&args),
     }

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -29,6 +29,8 @@ use cedar_policy_cli::{
     EvaluateArgs, LinkArgs, PoliciesArgs, PolicyFormat, RequestArgs, ValidateArgs,
 };
 
+use predicates::prelude::*;
+
 fn run_check_parse_test(policies_file: impl Into<String>, expected_exit_code: CedarExitCode) {
     let cmd = CheckParseArgs {
         policies: PoliciesArgs {
@@ -1024,8 +1026,7 @@ fn test_require_policies_for_write() {
 
 #[test]
 fn test_check_parse_json_static_policy() {
-    let json_static_policy: &str =
-        "sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json";
+    let json_policy: &str = "sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json";
 
     assert_cmd::Command::cargo_bin("cedar")
         .expect("bin exists")
@@ -1033,14 +1034,14 @@ fn test_check_parse_json_static_policy() {
         .arg("--policy-format")
         .arg("json")
         .arg("-p")
-        .arg(json_static_policy)
+        .arg(json_policy)
         .assert()
         .code(0);
 }
 
 #[test]
 fn test_check_parse_json_policy_template() {
-    let json_policy_template: &str =
+    let json_policy: &str =
         "sample-data/tiny_sandboxes/json-check-parse/policy_template.cedar.json";
 
     assert_cmd::Command::cargo_bin("cedar")
@@ -1049,9 +1050,60 @@ fn test_check_parse_json_policy_template() {
         .arg("--policy-format")
         .arg("json")
         .arg("-p")
-        .arg(json_policy_template)
+        .arg(json_policy)
         .assert()
         .code(0);
+}
+
+#[test]
+fn test_check_parse_json_policy_set() {
+    let json_policy: &str = "sample-data/tiny_sandboxes/json-check-parse/policy_set.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn test_check_parse_json_policy_mixed_properties() {
+    let json_policy: &str =
+        "sample-data/tiny_sandboxes/json-check-parse/policy_mixed_properties.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains(
+            "matching properties from both formats",
+        ));
+}
+
+#[test]
+fn test_check_parse_json_policy_no_matching_properties() {
+    let json_policy: &str =
+        "sample-data/tiny_sandboxes/json-check-parse/policy_no_matching_properties.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .assert()
+        .code(1)
+        .stdout(predicate::str::contains("no matching properties"));
 }
 
 #[test]

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1021,3 +1021,27 @@ fn test_require_policies_for_write() {
             "the following required arguments were not provided:\n  --policies <FILE>",
         ));
 }
+
+#[test]
+fn test_translate_policy() {
+    let human_filename = "sample-data/tiny_sandboxes/translate-policy/policy.cedar";
+    let json_filename = "sample-data/tiny_sandboxes/translate-policy/policy.cedar.json";
+    let human = std::fs::read_to_string(human_filename).unwrap();
+    let json = std::fs::read_to_string(json_filename).unwrap();
+    let translate_cmd = assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("translate-policy")
+        .arg("--direction")
+        .arg("human-to-json")
+        .arg("-p")
+        .arg(human_filename)
+        .assert();
+
+    let translated = std::str::from_utf8(&translate_cmd.get_output().stdout)
+        .expect("output should be decodable");
+
+    assert_eq!(
+        translated, json,
+        "\noriginal:\n{human}\n\ttranslated:\n{translated}",
+    );
+}

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1023,6 +1023,62 @@ fn test_require_policies_for_write() {
 }
 
 #[test]
+fn test_check_parse_json_static_policy() {
+    let json_static_policy: &str =
+        "sample-data/tiny_sandboxes/json-check-parse/static_policy.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_static_policy)
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn test_check_parse_json_policy_template() {
+    let json_policy_template: &str =
+        "sample-data/tiny_sandboxes/json-check-parse/policy_template.cedar.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("check-parse")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy_template)
+        .assert()
+        .code(0);
+}
+
+#[test]
+fn test_authorize_json_policy() {
+    let json_policy: &str = "sample-data/tiny_sandboxes/json-authorize/policy.cedar.json";
+    let entities: &str = "sample-data/tiny_sandboxes/json-authorize/entity.json";
+
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("authorize")
+        .arg("--policy-format")
+        .arg("json")
+        .arg("-p")
+        .arg(json_policy)
+        .arg("--entities")
+        .arg(entities)
+        .arg("--principal")
+        .arg(r#"User::"bob""#)
+        .arg("--action")
+        .arg(r#"Action::"view""#)
+        .arg("--resource")
+        .arg(r#"Photo::"VacationPhoto94.jpg""#)
+        .assert()
+        .code(0);
+}
+
+#[test]
 fn test_translate_policy() {
     let human_filename = "sample-data/tiny_sandboxes/translate-policy/policy.cedar";
     let json_filename = "sample-data/tiny_sandboxes/translate-policy/policy.cedar.json";

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -15,6 +15,7 @@
  */
 
 use crate::ast::*;
+use crate::entities::{EntitiesError, EntityJson, JsonSerializationError};
 use crate::evaluator::{EvaluationError, RestrictedEvaluator};
 use crate::extensions::Extensions;
 use crate::parser::err::ParseErrors;
@@ -437,6 +438,27 @@ impl Entity {
             attrs.into_iter().map(|(k, v)| (k, v.0)).collect(),
             ancestors,
         )
+    }
+
+    /// Write the entity to a json document
+    pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
+        let ejson = EntityJson::from_entity(self)?;
+        serde_json::to_writer_pretty(f, &ejson).map_err(JsonSerializationError::from)?;
+        Ok(())
+    }
+
+    /// write the entity to a json value
+    pub fn to_json_value(&self) -> Result<serde_json::Value, EntitiesError> {
+        let ejson = EntityJson::from_entity(self)?;
+        let v = serde_json::to_value(ejson).map_err(JsonSerializationError::from)?;
+        Ok(v)
+    }
+
+    /// write the entity to a json string
+    pub fn to_json_string(&self) -> Result<String, EntitiesError> {
+        let ejson = EntityJson::from_entity(self)?;
+        let string = serde_json::to_string(&ejson).map_err(JsonSerializationError::from)?;
+        Ok(string)
     }
 }
 

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -20,7 +20,6 @@ use crate::ast::*;
 use crate::extensions::Extensions;
 use crate::transitive_closure::{compute_tc, enforce_tc_and_dag};
 use std::collections::{hash_map, HashMap};
-use std::fmt::Write;
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -259,10 +258,10 @@ impl Entities {
     }
 
     /// Write entities into a DOT graph
-    pub fn to_dot_str(&self) -> std::result::Result<String, std::fmt::Error> {
+    pub fn to_dot_str(&self) -> String {
         let mut dot_str = String::new();
         // write prelude
-        dot_str.write_str("strict digraph {\n\tordering=\"out\"\n\tnode[shape=box]\n")?;
+        dot_str.push_str("strict digraph {\n\tordering=\"out\"\n\tnode[shape=box]\n");
 
         // From DOT language reference:
         // An ID is one of the following:
@@ -280,31 +279,31 @@ impl Entities {
         let entities_by_type = self.get_entities_by_entity_type();
 
         for (et, entities) in entities_by_type {
-            dot_str.write_str(&format!(
+            dot_str.push_str(&format!(
                 "\tsubgraph \"cluster_{et}\" {{\n\t\tlabel={}\n",
                 to_dot_id(&et)
-            ))?;
+            ));
             for entity in entities {
                 let euid = to_dot_id(&entity.uid());
                 let label = format!(r#"[label={}]"#, to_dot_id(&entity.uid().eid()));
-                dot_str.write_str(&format!("\t\t{euid} {label}\n"))?;
+                dot_str.push_str(&format!("\t\t{euid} {label}\n"));
             }
-            dot_str.write_str("\t}\n")?;
+            dot_str.push_str("\t}\n");
         }
 
         // adding edges
         for entity in self.iter() {
             for ancestor in entity.ancestors() {
-                dot_str.write_str(&format!(
+                dot_str.push_str(&format!(
                     "\t{} -> {}\n",
                     to_dot_id(&entity.uid()),
                     to_dot_id(&ancestor)
-                ))?;
+                ));
             }
         }
 
-        dot_str.write_str("}\n")?;
-        Ok(dot_str)
+        dot_str.push_str("}\n");
+        dot_str
     }
 }
 

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -22,6 +22,7 @@ use super::{
 use crate::ast::{
     BorrowedRestrictedExpr, Entity, EntityType, EntityUID, PartialValue, RestrictedExpr,
 };
+use crate::entities::conformance::EntitySchemaConformanceChecker;
 use crate::entities::{
     schematype_of_partialvalue, Entities, EntitiesError, EntitySchemaConformanceError,
     GetSchemaTypeError, TCComputation, UnexpectedEntityTypeError,
@@ -31,8 +32,8 @@ use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::SmolStr;
-use std::collections::HashMap;
 use std::sync::Arc;
+use std::{collections::HashMap, io::Read};
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
@@ -78,6 +79,7 @@ pub struct EntityJsonParser<'e, 's, S: Schema = NoEntitiesSchema> {
 }
 
 /// Schema information about a single entity can take one of these forms:
+#[derive(Debug)]
 enum EntitySchemaInfo<E: EntityTypeDescription> {
     /// There is no schema, i.e. we're not doing schema-based parsing
     NoSchema,
@@ -210,6 +212,39 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
             );
         }
         Ok(entities.into_iter())
+    }
+
+    /// Parse a single entity from an in-memory JSON value
+    pub fn single_from_json_value(
+        &self,
+        value: serde_json::Value,
+    ) -> Result<Entity, EntitiesError> {
+        let ejson = serde_json::from_value(value).map_err(JsonDeserializationError::from)?;
+        self.single_from_ejson(ejson)
+    }
+
+    /// Parse a single entity from a JSON string
+    pub fn single_from_json_str(&self, src: impl AsRef<str>) -> Result<Entity, EntitiesError> {
+        let ejson = serde_json::from_str(src.as_ref()).map_err(JsonDeserializationError::from)?;
+        self.single_from_ejson(ejson)
+    }
+
+    /// Parse a single entity from a JSON reader
+    pub fn single_from_json_file(&self, r: impl Read) -> Result<Entity, EntitiesError> {
+        let ejson = serde_json::from_reader(r).map_err(JsonDeserializationError::from)?;
+        self.single_from_ejson(ejson)
+    }
+
+    fn single_from_ejson(&self, ejson: EntityJson) -> Result<Entity, EntitiesError> {
+        let entity = self.parse_ejson(ejson)?;
+        match self.schema {
+            None => Ok(entity),
+            Some(schema) => {
+                let checker = EntitySchemaConformanceChecker::new(schema, self.extensions);
+                checker.validate_entity(&entity)?;
+                Ok(entity)
+            }
+        }
     }
 
     /// Internal function that creates an [`Entities`] from a stream of [`EntityJson`].

--- a/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__translate-policy__policy.cedar.snap
+++ b/cedar-policy-formatter/tests/cli-snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@tiny_sandboxes__translate-policy__policy.cedar.snap
@@ -1,0 +1,10 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-cli/sample-data/tiny_sandboxes/translate-policy/policy.cedar
+---
+permit (
+  principal == User::"alice",
+  action == Action::"update",
+  resource == Photo::"VacationPhoto94.jpg"
+);

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -82,6 +82,7 @@ impl<'a> entities::Schema for CoreSchema<'a> {
 }
 
 /// Struct which carries enough information that it can impl Core's `EntityTypeDescription`
+#[derive(Debug)]
 pub struct EntityTypeDescription {
     /// Core `EntityType` this is describing
     core_type: ast::EntityType,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -56,6 +56,7 @@ use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::convert::Infallible;
+use std::io::Read;
 use std::marker::PhantomData;
 use std::str::FromStr;
 use thiserror::Error;
@@ -268,6 +269,81 @@ impl Entity {
             attrs,
             ancestors.into_iter().map(EntityUid).collect(),
         )
+    }
+
+    /// Parse an entity from an in-memory JSON value
+    /// If a schema is provided, it is handled identically to [`Entities::from_json_str`]
+    pub fn from_json_value(
+        value: serde_json::Value,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
+        let eparser = cedar_policy_core::entities::EntityJsonParser::new(
+            schema.as_ref(),
+            Extensions::all_available(),
+            cedar_policy_core::entities::TCComputation::ComputeNow,
+        );
+        eparser.single_from_json_value(value).map(Self)
+    }
+
+    /// Parse an entity from a JSON string
+    /// If a schema is provided, it is handled identically to [`Entities::from_json_str`]
+    pub fn from_json_str(
+        src: impl AsRef<str>,
+        schema: Option<&Schema>,
+    ) -> Result<Self, EntitiesError> {
+        let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
+        let eparser = cedar_policy_core::entities::EntityJsonParser::new(
+            schema.as_ref(),
+            Extensions::all_available(),
+            cedar_policy_core::entities::TCComputation::ComputeNow,
+        );
+        eparser.single_from_json_str(src).map(Self)
+    }
+
+    /// Parse an entity from a JSON reader
+    /// If a schema is provided, it is handled identically to [`Entities::from_json_str`]
+    pub fn from_json_file(f: impl Read, schema: Option<&Schema>) -> Result<Self, EntitiesError> {
+        let schema = schema.map(|s| cedar_policy_validator::CoreSchema::new(&s.0));
+        let eparser = cedar_policy_core::entities::EntityJsonParser::new(
+            schema.as_ref(),
+            Extensions::all_available(),
+            cedar_policy_core::entities::TCComputation::ComputeNow,
+        );
+        eparser.single_from_json_file(f).map(Self)
+    }
+
+    /// Dump an `Entity` object into an entity JSON file.
+    ///
+    /// The resulting JSON will be suitable for parsing in via
+    /// `from_json_*`, and will be parse-able even with no [`Schema`].
+    ///
+    /// To read an `Entity` object from JSON , use
+    /// [`Self::from_json_file`], [`Self::from_json_value`], or [`Self::from_json_str`].
+    pub fn write_to_json(&self, f: impl std::io::Write) -> Result<(), EntitiesError> {
+        self.0.write_to_json(f)
+    }
+
+    /// Dump an `Entity` object into an in-memory JSON object.
+    ///
+    /// The resulting JSON will be suitable for parsing in via
+    /// `from_json_*`, and will be parse-able even with no `Schema`.
+    ///
+    /// To read an `Entity` object from JSON , use
+    /// [`Self::from_json_file`], [`Self::from_json_value`], or [`Self::from_json_str`].
+    pub fn to_json_value(&self) -> Result<serde_json::Value, EntitiesError> {
+        self.0.to_json_value()
+    }
+
+    /// Dump an `Entity` object into a JSON string.
+    ///
+    /// The resulting JSON will be suitable for parsing in via
+    /// `from_json_*`, and will be parse-able even with no `Schema`.
+    ///
+    /// To read an `Entity` object from JSON , use
+    /// [`Self::from_json_file`], [`Self::from_json_value`], or [`Self::from_json_str`].
+    pub fn to_json_string(&self) -> Result<String, EntitiesError> {
+        self.0.to_json_string()
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -725,6 +725,14 @@ impl Entities {
     ) -> std::result::Result<(), cedar_policy_core::entities::EntitiesError> {
         self.0.write_to_json(f)
     }
+
+    #[doc = include_str!("../experimental_warning.md")]
+    /// Visualize an `Entities` object in the graphviz `dot`
+    /// format. Entity visualization is best-effort and not well tested.
+    /// Feel free to submit an issue if you are using this feature and would like it improved.
+    pub fn to_dot_str(&self) -> String {
+        self.0.to_dot_str()
+    }
 }
 
 impl IntoIterator for Entities {


### PR DESCRIPTION
## Description of changes

This PR backports a variety of changes from `main` to `release/3.3.x`. All are "obviously" minor version compatible, and cherry picked relatively cleanly. All except #924 only impact the CLI.
* #924 
* #987 
* #960 
* #1038
* #1057 
* #1082