### PR TITLE
add deprecation warnings

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -893,17 +893,17 @@ pub fn translate_policy(args: &TranslatePolicyArgs) -> CedarExitCode {
 
 fn translate_schema_to_human(json_src: impl AsRef<str>) -> Result<String> {
     let fragment = SchemaFragment::from_str(json_src.as_ref())?;
-    let output = fragment.as_natural()?;
+    let output = fragment.to_cedarschema()?;
     Ok(output)
 }
 
 fn translate_schema_to_json(natural_src: impl AsRef<str>) -> Result<String> {
-    let (fragment, warnings) = SchemaFragment::from_str_natural(natural_src.as_ref())?;
+    let (fragment, warnings) = SchemaFragment::from_cedarschema_str(natural_src.as_ref())?;
     for warning in warnings {
         let report = miette::Report::new(warning);
         eprintln!("{:?}", report);
     }
-    let output = fragment.as_json_string()?;
+    let output = fragment.to_json_string()?;
     Ok(output)
 }
 
@@ -1441,7 +1441,7 @@ fn read_schema_file(
             )
         }),
         SchemaFormat::Human => {
-            let (schema, warnings) = Schema::from_str_natural(&schema_src)?;
+            let (schema, warnings) = Schema::from_cedarschema_str(&schema_src)?;
             for warning in warnings {
                 let report = miette::Report::new(warning);
                 eprintln!("{:?}", report);

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -236,6 +236,11 @@ impl Eid {
     pub fn new(eid: impl Into<SmolStr>) -> Self {
         Eid(eid.into())
     }
+
+    /// Get the contents of the `Eid` as an escaped string
+    pub fn escaped(&self) -> SmolStr {
+        self.0.escape_debug().collect()
+    }
 }
 
 impl AsRef<SmolStr> for Eid {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -66,6 +66,10 @@ pub enum ParseError {
 
 impl ParseError {
     /// Extract a primary source span locating the error, if one is available.
+    #[deprecated(
+        since = "3.3.0",
+        note = "Use the location information provided by miette::Diagnostic via `.labels()` and `.source_code()` instead"
+    )]
     pub fn primary_source_span(&self) -> Option<SourceSpan> {
         match self {
             ParseError::ToCST(to_cst_err) => Some(to_cst_err.primary_source_span()),
@@ -707,6 +711,10 @@ impl ParseErrors {
     }
 
     /// returns a Vec with stringified versions of the ParseErrors
+    #[deprecated(
+        since = "3.3.0",
+        note = "Use `.iter().map(ToString::to_string)` instead"
+    )]
     pub fn errors_as_strings(&self) -> Vec<String> {
         self.0.iter().map(ToString::to_string).collect()
     }

--- a/cedar-policy-validator/src/schema_file_format.rs
+++ b/cedar-policy-validator/src/schema_file_format.rs
@@ -103,6 +103,12 @@ impl SchemaFragment {
         serde_json::from_value(json).map_err(Into::into)
     }
 
+    /// Create a [`SchemaFragment`] from a string containing JSON (which should
+    /// be an object of the appropriate shape).
+    pub fn from_json_str(json: &str) -> Result<Self> {
+        serde_json::from_str(json).map_err(Into::into)
+    }
+
     /// Create a [`SchemaFragment`] directly from a file containing a JSON object.
     pub fn from_file(file: impl std::io::Read) -> Result<Self> {
         serde_json::from_reader(file).map_err(Into::into)

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1350,6 +1350,7 @@ impl SchemaFragment {
     }
 
     /// Parse a [`SchemaFragment`] from a reader containing the natural schema syntax
+    #[allow(deprecated)]
     pub fn from_cedarschema_file(
         r: impl std::io::Read,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
@@ -1372,6 +1373,7 @@ impl SchemaFragment {
     }
 
     /// Parse a [`SchemaFragment`] from a string containing the natural schema syntax
+    #[allow(deprecated)]
     pub fn from_cedarschema_str(
         src: &str,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
@@ -1389,6 +1391,7 @@ impl SchemaFragment {
     }
 
     /// Create a `SchemaFragment` directly from a file.
+    #[allow(deprecated)]
     pub fn from_json_file(file: impl std::io::Read) -> Result<Self, SchemaError> {
         Self::from_file(file)
     }
@@ -1407,6 +1410,7 @@ impl SchemaFragment {
     }
 
     /// Serialize this [`SchemaFragment`] as a json value
+    #[allow(deprecated)]
     pub fn to_json_string(&self) -> Result<String, SchemaError> {
         self.as_json_string()
     }
@@ -1419,6 +1423,7 @@ impl SchemaFragment {
     }
 
     /// Serialize this [`SchemaFragment`] into the natural syntax
+    #[allow(deprecated)]
     pub fn to_cedarschema(&self) -> Result<String, ToHumanSyntaxError> {
         self.as_natural()
     }
@@ -1509,6 +1514,7 @@ impl Schema {
     }
 
     /// Create a `Schema` directly from a file.
+    #[allow(deprecated)]
     pub fn from_json_file(file: impl std::io::Read) -> Result<Self, SchemaError> {
         Self::from_file(file)
     }
@@ -1526,6 +1532,7 @@ impl Schema {
     }
 
     /// Parse the schema from a reader
+    #[allow(deprecated)]
     pub fn from_cedarschema_file(
         file: impl std::io::Read,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {
@@ -1545,6 +1552,7 @@ impl Schema {
     }
 
     /// Parse the schema from a string
+    #[allow(deprecated)]
     pub fn from_cedarschema_str(
         src: &str,
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), HumanSchemaError> {

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -249,7 +249,7 @@ impl Schema {
         self,
     ) -> Result<(crate::Schema, Box<dyn Iterator<Item = SchemaWarning>>), miette::Report> {
         match self {
-            Self::Human(str) => crate::Schema::from_str_natural(&str)
+            Self::Human(str) => crate::Schema::from_cedarschema_str(&str)
                 .map(|(sch, warnings)| {
                     (
                         sch,

--- a/cedar-wasm/src/policies_and_templates.rs
+++ b/cedar-wasm/src/policies_and_templates.rs
@@ -76,7 +76,7 @@ pub fn policy_text_to_json(cedar_str: &str) -> PolicyToJsonResult {
     match parse_policy_or_template_to_est(cedar_str) {
         Ok(policy) => PolicyToJsonResult::Success { policy },
         Err(err) => PolicyToJsonResult::Error {
-            errors: err.errors_as_strings(),
+            errors: err.iter().map(ToString::to_string).collect(),
         },
     }
 }
@@ -97,7 +97,7 @@ pub enum CheckParsePolicySetResult {
 pub fn check_parse_policy_set(input_policies_str: &str) -> CheckParsePolicySetResult {
     match PolicySet::from_str(input_policies_str) {
         Err(parse_errors) => CheckParsePolicySetResult::Error {
-            errors: parse_errors.errors_as_strings(),
+            errors: parse_errors.iter().map(ToString::to_string).collect(),
         },
         Ok(policy_set) => {
             let policies_count: Result<i32, <i32 as TryFrom<usize>>::Error> =
@@ -132,7 +132,7 @@ pub enum CheckParseTemplateResult {
 pub fn check_parse_template(template_str: &str) -> CheckParseTemplateResult {
     match Template::from_str(template_str) {
         Err(parse_errs) => CheckParseTemplateResult::Error {
-            errors: parse_errs.errors_as_strings(),
+            errors: parse_errs.iter().map(ToString::to_string).collect(),
         },
         Ok(template) => match template.slots().count() {
             1 | 2 => CheckParseTemplateResult::Success {


### PR DESCRIPTION
## Description of changes

Add deprecation warnings to 3.3.x to support the API changes in the following PRs.
* #882 
* #908 
* #921 
* #1114 

This list of PRs is based on manual inspection of the 4.0 changelog to look for APIs that were removed or renamed. Let me know if you think I missed anything.