### PR TITLE
Improving error messages

### DIFF
--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -33,6 +33,29 @@ macro_rules! impl_diagnostic_from_source_loc_field {
 }
 
 /// Macro which implements the `.labels()` and `.source_code()` methods of
+/// `miette::Diagnostic` by using the parameters `$i` and `$j` which must be the name
+/// of fields of type `Loc`.
+/// Both spans are underlined, only the first span is reported as the source code location
+#[macro_export]
+macro_rules! impl_diagnostic_from_source_loc_fields {
+    ( $i:ident , $j:ident ) => {
+        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+            Some(&self.$i.src as &dyn miette::SourceCode)
+        }
+
+        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+            Some(Box::new(
+                [
+                    miette::LabeledSpan::underline(self.$i.span),
+                    miette::LabeledSpan::underline(self.$j.span),
+                ]
+                .into_iter(),
+            ) as _)
+        }
+    };
+}
+
+/// Macro which implements the `.labels()` and `.source_code()` methods of
 /// `miette::Diagnostic` by using the parameter `$i` which must be the name
 /// of a field of type `Option<Loc>`
 #[macro_export]
@@ -48,6 +71,42 @@ macro_rules! impl_diagnostic_from_source_loc_opt_field {
             self.$i
                 .as_ref()
                 .map(|loc| Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span))) as _)
+        }
+    };
+}
+
+/// Macro which implements the `.labels()` and `.source_code()` methods of
+/// `miette::Diagnostic` by using the parameters `$i` and `$j` which must be the name
+/// of fields of type `Option<Loc>`
+#[macro_export]
+macro_rules! impl_diagnostic_from_source_loc_opt_fields {
+    ( $i:ident , $j:ident ) => {
+        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+            self.$i
+                .as_ref()
+                .map(|loc| &loc.src as &dyn miette::SourceCode)
+                .or_else(|| {
+                    self.$j
+                        .as_ref()
+                        .map(|loc| &loc.src as &dyn miette::SourceCode)
+                })
+        }
+
+        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+            let x = self
+                .$i
+                .as_ref()
+                .map(|loc| miette::LabeledSpan::underline(loc.span));
+            let y = self
+                .$j
+                .as_ref()
+                .map(|loc| miette::LabeledSpan::underline(loc.span));
+
+            match (x, y) {
+                (None, None) => None,
+                (Some(span), None) | (None, Some(span)) => Some(Box::new(std::iter::once(span))),
+                (Some(span_a), Some(span_b)) => Some(Box::new([span_a, span_b].into_iter()) as _),
+            }
         }
     };
 }

--- a/cedar-policy-validator/src/cedar_schema/ast.rs
+++ b/cedar-policy-validator/src/cedar_schema/ast.rs
@@ -262,7 +262,7 @@ pub struct AttrDecl {
 }
 
 /// The target of a [`PRAppDecl`]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PR {
     /// Applies to the `principal` variable
     Principal,

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -491,6 +491,10 @@ impl Diagnostic for ReservedSchemaKeyword {
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
         Some(&self.loc.src as &dyn miette::SourceCode)
     }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new("Keywords such as `entity`, `extension`, `set` and `record` cannot be used as common type names"))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
@@ -507,6 +511,12 @@ impl Diagnostic for ReservedName {
 
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
         Some(&self.loc.src as &dyn miette::SourceCode)
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new(
+            "Names containing `__cedar` (for example: `__cedar::A`, `A::__cedar`, or `A::__cedar::B`) are reserved",
+        ))
     }
 }
 
@@ -536,7 +546,7 @@ impl Diagnostic for UnknownTypeName {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("duplicate `{kind}` declaration in action `{name}`. Action may have at most one {kind} declaration")]
+#[error("duplicate `{kind}` declaration in action `{name}`")]
 pub struct DuplicatePrincipalOrResource {
     name: SmolStr,
     kind: PR,
@@ -567,7 +577,7 @@ impl Diagnostic for DuplicatePrincipalOrResource {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("duplicate context declaration in action `{name}`. Action may have at most one context declaration")]
+#[error("duplicate context declaration in action `{name}`")]
 pub struct DuplicateContext {
     name: SmolStr,
     loc1: Loc,

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -364,10 +364,6 @@ impl Diagnostic for ToJsonSchemaErrors {
 /// For errors during schema format conversion
 #[derive(Clone, Debug, Error, PartialEq, Eq, Diagnostic)]
 pub enum ToJsonSchemaError {
-    /// Error raised when there are duplicate keys
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    DuplicateKeys(DuplicateKeys),
     /// Error raised when there are duplicate declarations
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -403,14 +399,6 @@ pub enum ToJsonSchemaError {
 }
 
 impl ToJsonSchemaError {
-    pub(crate) fn duplicate_keys(key: impl ToSmolStr, loc1: Loc, loc2: Loc) -> Self {
-        Self::DuplicateKeys(DuplicateKeys {
-            key: key.to_smolstr(),
-            loc1,
-            loc2,
-        })
-    }
-
     pub(crate) fn duplicate_context(name: impl ToSmolStr, loc1: Loc, loc2: Loc) -> Self {
         Self::DuplicateContext(DuplicateContext {
             name: name.to_smolstr(),
@@ -610,24 +598,6 @@ pub struct DuplicateDeclarations {
 }
 
 impl Diagnostic for DuplicateDeclarations {
-    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        underline_spans([self.loc1.span, self.loc2.span])
-    }
-
-    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-        Some(&self.loc1.src as &dyn miette::SourceCode)
-    }
-}
-
-#[derive(Debug, Clone, Eq, PartialEq, Error)]
-#[error("`{key}` declared twice")]
-pub struct DuplicateKeys {
-    key: SmolStr,
-    loc1: Loc,
-    loc2: Loc,
-}
-
-impl Diagnostic for DuplicateKeys {
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
         underline_spans([self.loc1.span, self.loc2.span])
     }

--- a/cedar-policy-validator/src/cedar_schema/test.rs
+++ b/cedar-policy-validator/src/cedar_schema/test.rs
@@ -29,7 +29,11 @@ mod demo_tests {
     use smol_str::ToSmolStr;
 
     use crate::{
-        cedar_schema::{self, ast::PR, err::ToJsonSchemaError},
+        cedar_schema::{
+            self,
+            ast::PR,
+            err::{ToJsonSchemaError, NO_PR_HELP_MSG},
+        },
         json_schema,
         schema::test::collect_warnings,
         CedarSchemaError, RawName,
@@ -66,8 +70,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -84,8 +89,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -101,8 +107,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -120,8 +127,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -140,8 +148,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `principal` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -159,8 +168,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -179,8 +189,9 @@ mod demo_tests {
             expect_err(
                 src,
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`. Actions must define both a `principals` and `resources` field")
+                &ExpectedErrorMessageBuilder::error("error parsing schema: missing `resource` declaration for `Foo`")
                     .exactly_one_underline("\"Foo\"")
+                    .help(NO_PR_HELP_MSG)
                     .build(),
             );
         });
@@ -279,16 +290,13 @@ mod demo_tests {
             };
         "#;
         assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(crate::CedarSchemaError::Parsing(err)) => {
-            assert_matches!(err.inner(), cedar_schema::parser::CedarSchemaParseErrors::JsonError(json_errs) => {
+            assert_matches!(err.errors(), cedar_schema::parser::CedarSchemaParseErrors::JsonError(json_errs) => {
                 assert!(json_errs
                     .iter()
                     .any(|err| {
                         matches!(
                             err,
-                            ToJsonSchemaError::DuplicatePrincipalOrResource {
-                                kind: PR::Principal,
-                                ..
-                            }
+                            ToJsonSchemaError::DuplicatePrincipalOrResource(err) if err.kind() == PR::Principal
                         )
                     })
                 );
@@ -309,16 +317,13 @@ mod demo_tests {
             };
         "#;
         assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(crate::CedarSchemaError::Parsing(err)) => {
-            assert_matches!(err.inner(), cedar_schema::parser::CedarSchemaParseErrors::JsonError(json_errs) => {
+            assert_matches!(err.errors(), cedar_schema::parser::CedarSchemaParseErrors::JsonError(json_errs) => {
                 assert!(json_errs
                     .iter()
                     .any(|err| {
                         matches!(
                             err,
-                            ToJsonSchemaError::DuplicatePrincipalOrResource {
-                                kind: PR::Resource,
-                                ..
-                            }
+                            ToJsonSchemaError::DuplicatePrincipalOrResource(err) if err.kind() == PR::Resource
                         )
                     }));
             });
@@ -489,7 +494,7 @@ namespace Baz {action "Foo" appliesTo {
             Extensions::all_available(),
         )), Err(err) => {
             assert_matches!(err, CedarSchemaError::Parsing(err) => {
-                assert_matches!(err.inner(), cedar_schema::parser::CedarSchemaParseErrors::SyntaxError(errs) => {
+                assert_matches!(err.errors(), cedar_schema::parser::CedarSchemaParseErrors::SyntaxError(errs) => {
                     assert!(errs.to_smolstr().contains("Invalid escape codes"));
                 });
             });

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -236,10 +236,13 @@ fn convert_qual_name(qn: Node<QualName>) -> json_schema::ActionEntityUID<RawName
     json_schema::ActionEntityUID::new(qn.node.path.map(Into::into), qn.node.eid)
 }
 
-// Convert the applies to decls
+/// Convert the applies to decls
+/// # Arguments
+/// * `name` - The (first) name of the action being declared
+/// * `name_loc` - The location of that first name
 fn convert_app_decls(
     name: &SmolStr,
-    loc: &Loc,
+    name_loc: &Loc,
     decls: Node<NonEmpty<Node<AppDecl>>>,
 ) -> Result<json_schema::ApplySpec<RawName>, ToJsonSchemaErrors> {
     // Split AppDecl's into context/principal/resource decls
@@ -325,12 +328,12 @@ fn convert_app_decls(
         }
     }
     Ok(json_schema::ApplySpec {
-        resource_types: resource_types
-            .map(|node| node.node)
-            .ok_or(ToJsonSchemaError::no_resource(name.clone(), loc.clone()))?,
-        principal_types: principal_types
-            .map(|node| node.node)
-            .ok_or(ToJsonSchemaError::no_principal(name.clone(), loc.clone()))?,
+        resource_types: resource_types.map(|node| node.node).ok_or(
+            ToJsonSchemaError::no_resource(name.clone(), name_loc.clone()),
+        )?,
+        principal_types: principal_types.map(|node| node.node).ok_or(
+            ToJsonSchemaError::no_principal(name.clone(), name_loc.clone()),
+        )?,
         context: context.map(|c| c.node).unwrap_or_default(),
     })
 }

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -42,7 +42,7 @@ pub enum CedarSchemaError {
 }
 
 /// Error parsing a Cedar-syntax schema
-// WARNING: this type is publicly exported from `cedar-core`
+// WARNING: this type is publicly exported from `cedar-policy`
 #[derive(Debug, Error)]
 #[error("error parsing schema: {errs}")]
 pub struct CedarSchemaParseError {
@@ -112,7 +112,7 @@ impl CedarSchemaParseError {
 
     /// Did the schema look like it was JSON data?
     /// If so, it was probably intended to be parsed as the JSON schema format.
-    /// In that case; the reported errors are probably not super helpful.
+    /// In that case, the reported errors are probably not super helpful.
     /// (This check is provided on a best-effort basis)
     pub fn suspect_json_format(&self) -> bool {
         self.suspect_json_format

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -42,6 +42,7 @@ pub enum CedarSchemaError {
 }
 
 /// Error parsing a Cedar-syntax schema
+// WARNING: this type is publicly exported from `cedar-core`
 #[derive(Debug, Error)]
 #[error("error parsing schema: {errs}")]
 pub struct CedarSchemaParseError {
@@ -109,8 +110,16 @@ impl CedarSchemaParseError {
         }
     }
 
-    #[cfg(test)]
-    pub(crate) fn inner(&self) -> &cedar_schema::parser::CedarSchemaParseErrors {
+    /// Did the schema look like it was JSON data?
+    /// If so, it was probably intended to be parsed as the JSON schema format.
+    /// In that case; the reported errors are probably not super helpful.
+    /// (This check is provided on a best-effort basis)
+    pub fn suspect_json_format(&self) -> bool {
+        self.suspect_json_format
+    }
+
+    /// Get the errors that were encountered while parsing
+    pub fn errors(&self) -> &cedar_schema::parser::CedarSchemaParseErrors {
         &self.errs
     }
 }

--- a/cedar-policy-validator/src/schema/test_579.rs
+++ b/cedar-policy-validator/src/schema/test_579.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-//! Tests described in https://github.com/cedar-policy/cedar/issues/579
+//! Tests described in <https://github.com/cedar-policy/cedar/issues/579>
 //!
 //! We test all possible (position, scenario) pairs where:
 //!

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -31,6 +31,8 @@ Cedar Language Version: 4.0
 
 ### Changed
 
+- `EntityUID::from_json` now returns a concrete type instead of an existential type
+- `CedarSchemaError::Parse` is more transparent
 - The API around `Request::new` has changed to remove the `Option`s
   around the entity type arguments. See [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md).
 - Significantly reworked all public-facing error types to address some issues

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -31,8 +31,6 @@ Cedar Language Version: 4.0
 
 ### Changed
 
-- `EntityUID::from_json` now returns a concrete type instead of an existential type
-- `CedarSchemaError::Parse` is more transparent
 - The API around `Request::new` has changed to remove the `Option`s
   around the entity type arguments. See [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md).
 - Significantly reworked all public-facing error types to address some issues

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -209,11 +209,7 @@ pub mod cedar_schema_errors {
     use miette::Diagnostic;
     use thiserror::Error;
 
-    /// Error parsing a schema in the Cedar syntax
-    #[derive(Debug, Error, Diagnostic)]
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    pub struct ParseError(#[from] pub(super) cedar_policy_validator::CedarSchemaParseError);
+    pub use cedar_policy_validator::CedarSchemaParseError as ParseError;
 
     /// IO error while parsing a Cedar schema
     #[derive(Debug, Error, Diagnostic)]
@@ -247,9 +243,7 @@ impl From<cedar_policy_validator::CedarSchemaError> for CedarSchemaError {
             cedar_policy_validator::CedarSchemaError::IO(e) => {
                 cedar_schema_errors::IoError(e).into()
             }
-            cedar_policy_validator::CedarSchemaError::Parsing(e) => {
-                cedar_schema_errors::ParseError(e).into()
-            }
+            cedar_policy_validator::CedarSchemaError::Parsing(e) => e.into(),
         }
     }
 }

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -229,13 +229,11 @@ impl EntityUid {
     /// # assert_eq!(euid.id(), &EntityId::from_str("123abc").unwrap());
     /// ```
     #[allow(clippy::result_large_err)]
-    pub fn from_json(json: serde_json::Value) -> Result<Self, impl miette::Diagnostic> {
+    pub fn from_json(json: serde_json::Value) -> Result<Self, JsonDeserializationError> {
         let parsed: cedar_policy_core::entities::EntityUidJson = serde_json::from_value(json)?;
-        Ok::<Self, JsonDeserializationError>(
-            parsed
-                .into_euid(|| JsonDeserializationErrorContext::EntityUid)?
-                .into(),
-        )
+        Ok(parsed
+            .into_euid(|| JsonDeserializationErrorContext::EntityUid)?
+            .into())
     }
 
     /// Testing utility for creating `EntityUids` a bit easier


### PR DESCRIPTION
Description of changes

Cleans up two remaining error tasks

* `EntityUid::from_json` returns a concrete type instead of an existential
* `CedarSchemaError::Parse` is more transparent

Issue #, if available

https://github.com/cedar-policy/cedar/issues/745

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):


- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

