### PR TITLE
Unify the signature of `PolicySet::annotation` and `PolicySet::template_annotation`

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -457,9 +457,14 @@ impl PolicySet {
         self.templates.is_empty() && self.links.is_empty()
     }
 
-    /// Lookup a template by policy id
+    /// Lookup a template by policy id, returns [`Option<Arc<Template>>`]
     pub fn get_template(&self, id: &PolicyID) -> Option<Arc<Template>> {
         self.templates.get(id).cloned()
+    }
+
+    /// Lookup a template by policy id, returns [`Option<&Template>`]
+    pub fn get_template_ref(&self, id: &PolicyID) -> Option<&Template> {
+        self.templates.get(id).map(AsRef::as_ref)
     }
 
     /// Lookup an policy by policy id

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -379,11 +379,11 @@ impl PolicySet {
         new_id: PolicyID,
         values: HashMap<SlotId, EntityUID>,
     ) -> Result<&Policy, LinkingError> {
-        let t = self
-            .get_template(&template_id)
-            .ok_or_else(|| LinkingError::NoSuchTemplate {
-                id: template_id.clone(),
-            })?;
+        let t =
+            self.get_template_arc(&template_id)
+                .ok_or_else(|| LinkingError::NoSuchTemplate {
+                    id: template_id.clone(),
+                })?;
         let r = Template::link(t, new_id.clone(), values)?;
 
         // Both maps must not contain the `new_id`
@@ -458,12 +458,12 @@ impl PolicySet {
     }
 
     /// Lookup a template by policy id, returns [`Option<Arc<Template>>`]
-    pub fn get_template(&self, id: &PolicyID) -> Option<Arc<Template>> {
+    pub fn get_template_arc(&self, id: &PolicyID) -> Option<Arc<Template>> {
         self.templates.get(id).cloned()
     }
 
     /// Lookup a template by policy id, returns [`Option<&Template>`]
-    pub fn get_template_ref(&self, id: &PolicyID) -> Option<&Template> {
+    pub fn get_template(&self, id: &PolicyID) -> Option<&Template> {
         self.templates.get(id).map(AsRef::as_ref)
     }
 
@@ -581,7 +581,7 @@ mod test {
             "Adding link should succeed, even though the template wasn't previously in the pset",
         );
         assert!(
-            pset.get_template(&PolicyID::from_string("t")).is_some(),
+            pset.get_template_arc(&PolicyID::from_string("t")).is_some(),
             "Adding link should implicitly add the template"
         );
 
@@ -897,13 +897,13 @@ mod test {
             &tid2
         );
         assert!(pset.get(&tid2).is_none());
-        assert!(pset.get_template(&id1).is_some()); // Static policies are also templates
-        assert!(pset.get_template(&id2).is_some()); // Static policies are also templates
-        assert!(pset.get_template(&tid2).is_some());
+        assert!(pset.get_template_arc(&id1).is_some()); // Static policies are also templates
+        assert!(pset.get_template_arc(&id2).is_some()); // Static policies are also templates
+        assert!(pset.get_template_arc(&tid2).is_some());
         assert_eq!(pset.policies().count(), 3);
 
         assert_eq!(
-            pset.get_template(&tid1)
+            pset.get_template_arc(&tid1)
                 .expect("should find the template")
                 .id(),
             &tid1

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -189,7 +189,7 @@ mod test {
         assert_eq!(ast_policy_set.policies().count(), 2);
         assert_eq!(ast_policy_set.templates().count(), 1);
         assert!(ast_policy_set
-            .get_template(&PolicyID::from_string("template"))
+            .get_template_arc(&PolicyID::from_string("template"))
             .is_some());
         let link = ast_policy_set.get(&PolicyID::from_string("link")).unwrap();
         assert_eq!(link.template().id(), &PolicyID::from_string("template"));

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -55,6 +55,8 @@ Cedar Language Version: 4.0
   Moreover, the `FromStr` implementations of `Schema` and `SchemaFragment`
   now parse strings in the Cedar schema format. Use `Schema::from_json_str` and `SchemaFragment::from_json_str`
   to parse strings in the JSON schema format.
+- `PolicySet::template_annotation` now returns `Option<&str>` as opposed to
+  `Option<String>` in the previous version (#1131, resolving #1116)
 
 ### Removed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1923,7 +1923,7 @@ impl PolicySet {
     /// Extract annotation data from a `Template` by its `PolicyId` and annotation key.
     pub fn template_annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<&str> {
         self.ast
-            .get_template_ref(id.as_ref())?
+            .get_template(id.as_ref())?
             .annotation(&key.as_ref().parse().ok()?)
             .map(AsRef::as_ref)
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1913,19 +1913,19 @@ impl PolicySet {
     }
 
     /// Extract annotation data from a `Policy` by its `PolicyId` and annotation key
-    pub fn annotation<'a>(&'a self, id: &PolicyId, key: impl AsRef<str>) -> Option<SmolStr> {
+    pub fn annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .get(id.as_ref())?
             .annotation(&key.as_ref().parse().ok()?)
-            .map(|ann| ann.val.clone())
+            .map(AsRef::as_ref)
     }
 
     /// Extract annotation data from a `Template` by its `PolicyId` and annotation key.
-    pub fn template_annotation(self, id: &PolicyId, key: impl AsRef<str>) -> Option<SmolStr> {
+    pub fn template_annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<&str> {
         self.ast
-            .get_template(id.as_ref())?
+            .get_template_ref(id.as_ref())?
             .annotation(&key.as_ref().parse().ok()?)
-            .map(|ann| ann.val.clone())
+            .map(AsRef::as_ref)
     }
 
     /// Returns true iff the `PolicySet` is empty

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1913,23 +1913,19 @@ impl PolicySet {
     }
 
     /// Extract annotation data from a `Policy` by its `PolicyId` and annotation key
-    pub fn annotation<'a>(&'a self, id: &PolicyId, key: impl AsRef<str>) -> Option<&'a str> {
+    pub fn annotation<'a>(&'a self, id: &PolicyId, key: impl AsRef<str>) -> Option<SmolStr> {
         self.ast
             .get(id.as_ref())?
             .annotation(&key.as_ref().parse().ok()?)
-            .map(AsRef::as_ref)
+            .map(|ann| ann.val.clone())
     }
 
     /// Extract annotation data from a `Template` by its `PolicyId` and annotation key.
-    //
-    // TODO: unfortunate that this method returns `Option<String>` and the corresponding method
-    // for policies (`.annotation()`) above returns `Option<&str>`, but this can't be changed
-    // without a semver break
-    pub fn template_annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<String> {
+    pub fn template_annotation(self, id: &PolicyId, key: impl AsRef<str>) -> Option<SmolStr> {
         self.ast
             .get_template(id.as_ref())?
             .annotation(&key.as_ref().parse().ok()?)
-            .map(|annot| annot.val.to_string())
+            .map(|ann| ann.val.clone())
     }
 
     /// Returns true iff the `PolicySet` is empty

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -408,10 +408,10 @@ fn policy_annotations() {
     s.add(p).unwrap();
     s.add_template(t).unwrap();
 
-    assert_eq!(s.annotation(&pid, "anno"), Some("good annotation".into()));
+    assert_eq!(s.annotation(&pid, "anno"), Some("good annotation"));
     assert_eq!(
         s.template_annotation(&tid, "tanno"),
-        Some("good annotation".into())
+        Some("good annotation")
     );
 }
 

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -408,10 +408,10 @@ fn policy_annotations() {
     s.add(p).unwrap();
     s.add_template(t).unwrap();
 
-    assert_eq!(s.annotation(&pid, "anno"), Some("good annotation"));
+    assert_eq!(s.annotation(&pid, "anno"), Some("good annotation".into()));
     assert_eq!(
         s.template_annotation(&tid, "tanno"),
-        Some("good annotation".to_string())
+        Some("good annotation".into())
     );
 }
 


### PR DESCRIPTION
## Description of changes

This PR change the return type to both methods to `Option<&str>`. Due to the author's limited knowledge of Rust, I have to add a new function in core to get a reference to the `Template`. Otherwise we could let the return type be `Option<SmolStr>`.

## Issue #, if available
#1116 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

