### PR TITLE
Check that action scopes do not contain non-actions entities in EST (#943)

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -572,6 +572,8 @@ pub struct EntityAttrEvaluationError {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
@@ -614,5 +616,17 @@ mod test {
 
         // e3 and e5 are displayed differently
         assert!(format!("{e3}") != format!("{e5}"));
+    }
+
+    #[test]
+    fn action_checker() {
+        let euid = EntityUID::from_str("Action::\"view\"").unwrap();
+        assert!(euid.is_action());
+        let euid = EntityUID::from_str("Foo::Action::\"view\"").unwrap();
+        assert!(euid.is_action());
+        let euid = EntityUID::from_str("Foo::\"view\"").unwrap();
+        assert!(!euid.is_action());
+        let euid = EntityUID::from_str("Action::Foo::\"view\"").unwrap();
+        assert!(!euid.is_action());
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3770,3 +3770,121 @@ mod issue_994 {
         );
     }
 }
+
+#[cfg(test)]
+mod issue_925 {
+    use crate::{
+        est,
+        test_utils::{expect_err, ExpectedErrorMessageBuilder},
+    };
+    use cool_asserts::assert_matches;
+    use serde_json::json;
+
+    #[test]
+    fn invalid_action_type() {
+        let src = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "All"
+                },
+                "action": {
+                    "op": "==",
+                    "entity": {
+                        "type": "NotAction",
+                        "id": "view",
+                    }
+                },
+                "resource": {
+                    "op": "All"
+                },
+                "conditions": []
+            }
+        );
+        let est: est::Policy = serde_json::from_value(src.clone()).unwrap();
+        assert_matches!(
+            est.try_into_ast_policy(None),
+            Err(e) => {
+                expect_err(
+                    &src,
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error(r#"expected that action entity uids would have the type `Action` but got `NotAction::"view"`"#)
+                        .help("action entities must have type `Action`, optionally in a namespace")
+                        .build()
+                );
+            }
+        );
+
+        let src = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "All"
+                },
+                "action": {
+                    "op": "in",
+                    "entity": {
+                        "type": "NotAction",
+                        "id": "view",
+                    }
+                },
+                "resource": {
+                    "op": "All"
+                },
+                "conditions": []
+            }
+        );
+        let est: est::Policy = serde_json::from_value(src.clone()).unwrap();
+        assert_matches!(
+            est.try_into_ast_policy(None),
+            Err(e) => {
+                expect_err(
+                    &src,
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error(r#"expected that action entity uids would have the type `Action` but got `NotAction::"view"`"#)
+                        .help("action entities must have type `Action`, optionally in a namespace")
+                        .build()
+                );
+            }
+        );
+
+        let src = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "All"
+                },
+                "action": {
+                    "op": "in",
+                    "entities": [
+                        {
+                            "type": "NotAction",
+                            "id": "view",
+                        },
+                        {
+                            "type": "Other",
+                            "id": "edit",
+                        }
+                    ]
+                },
+                "resource": {
+                    "op": "All"
+                },
+                "conditions": []
+            }
+        );
+        let est: est::Policy = serde_json::from_value(src.clone()).unwrap();
+        assert_matches!(
+            est.try_into_ast_policy(None),
+            Err(e) => {
+                expect_err(
+                    &src,
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error(r#"expected that action entity uids would have the type `Action` but got `NotAction::"view"` and `Other::"edit"`"#)
+                        .help("action entities must have type `Action`, optionally in a namespace")
+                        .build()
+                );
+            }
+        );
+    }
+}

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use crate::ast;
-use crate::ast::{LinkingError, PolicySetError};
+use crate::ast::PolicySetError;
 use crate::entities::JsonDeserializationError;
 use crate::parser::err::ParseErrors;
-use crate::parser::unescape;
+use crate::parser::{join_with_conjunction, unescape};
 use miette::Diagnostic;
+use nonempty::NonEmpty;
 use smol_str::SmolStr;
 use thiserror::Error;
 
@@ -87,7 +90,31 @@ pub enum FromJsonError {
     /// Error reported when attempting to create a template-link
     #[error("Error linking policy set: {0}")]
     #[diagnostic(transparent)]
-    Linking(#[from] LinkingError),
+    Linking(#[from] ast::LinkingError),
+    /// Error reported when the extension function name is unknown
+    #[error("Invalid extension function name: `{0}`")]
+    UnknownExtFunc(ast::Name),
+    /// Returned when an Entity UID used as an action does not have the type `Action`
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidActionType(#[from] InvalidActionType),
+}
+
+/// Details about an `InvalidActionType` error.
+#[derive(Debug, Diagnostic, Error)]
+#[diagnostic(help("action entities must have type `Action`, optionally in a namespace"))]
+pub struct InvalidActionType {
+    pub(crate) euids: NonEmpty<Arc<crate::ast::EntityUID>>,
+}
+
+impl std::fmt::Display for InvalidActionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "expected that action entity uids would have the type `Action` but got "
+        )?;
+        join_with_conjunction(f, "and", self.euids.iter(), |f, e| write!(f, "`{e}`"))
+    }
 }
 
 /// Errors while instantiating a policy

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -43,9 +43,8 @@ use super::loc::Loc;
 use super::node::Node;
 use super::unescape::{to_pattern, to_unescaped_string};
 use crate::ast::{
-    self, ActionConstraint, CallStyle, EntityReference, EntityType, EntityUID, Integer,
-    PatternElem, PolicySetError, PrincipalConstraint, PrincipalOrResourceConstraint,
-    ResourceConstraint,
+    self, ActionConstraint, CallStyle, EntityReference, EntityUID, Integer, PatternElem,
+    PolicySetError, PrincipalConstraint, PrincipalOrResourceConstraint, ResourceConstraint,
 };
 use crate::est::extract_single_argument;
 use itertools::{Either, Itertools};
@@ -703,62 +702,17 @@ impl Node<Option<cst::VariableDef>> {
             Some(ActionConstraint::Any)
         }?;
 
-        match action_constraint_contains_only_action_types(action_constraint, &self.loc) {
+        match action_constraint.contains_only_action_types() {
             Ok(a) => Some(a),
-            Err(mut id_errs) => {
-                errs.append(&mut id_errs);
+            Err(non_action_euids) => {
+                non_action_euids.map(|euid| {
+                    let new_err =
+                        self.to_ast_err(ToASTErrorKind::InvalidActionType(euid.as_ref().clone()));
+                    errs.push(new_err)
+                });
                 None
             }
         }
-    }
-}
-
-/// Check that all of the EUIDs in an action constraint have the type `Action`, under an arbitrary namespace
-fn action_constraint_contains_only_action_types(
-    a: ActionConstraint,
-    loc: &Loc,
-) -> Result<ActionConstraint, ParseErrors> {
-    match a {
-        ActionConstraint::Any => Ok(a),
-        ActionConstraint::In(ref euids) => {
-            let non_actions = euids
-                .iter()
-                .filter(|euid| !euid_has_action_type(euid))
-                .collect::<Vec<_>>();
-            if non_actions.is_empty() {
-                Ok(a)
-            } else {
-                Err(non_actions
-                    .into_iter()
-                    .map(|euid| {
-                        ToASTError::new(
-                            ToASTErrorKind::InvalidActionType(euid.as_ref().clone()),
-                            loc.clone(),
-                        )
-                    })
-                    .collect())
-            }
-        }
-        ActionConstraint::Eq(ref euid) => {
-            if euid_has_action_type(euid) {
-                Ok(a)
-            } else {
-                Err(ParseErrors(vec![ToASTError::new(
-                    ToASTErrorKind::InvalidActionType(euid.as_ref().clone()),
-                    loc.clone(),
-                )
-                .into()]))
-            }
-        }
-    }
-}
-
-/// Check if an EUID has the type `Action` under an arbitrary namespace
-fn euid_has_action_type(euid: &EntityUID) -> bool {
-    if let EntityType::Specified(name) = euid.entity_type() {
-        name.id.as_ref() == "Action"
-    } else {
-        false
     }
 }
 
@@ -4041,18 +3995,6 @@ mod tests {
                 );
             }
         });
-    }
-
-    #[test]
-    fn action_checker() {
-        let euid = EntityUID::from_str("Action::\"view\"").unwrap();
-        assert!(euid_has_action_type(&euid));
-        let euid = EntityUID::from_str("Foo::Action::\"view\"").unwrap();
-        assert!(euid_has_action_type(&euid));
-        let euid = EntityUID::from_str("Foo::\"view\"").unwrap();
-        assert!(!euid_has_action_type(&euid));
-        let euid = EntityUID::from_str("Action::Foo::\"view\"").unwrap();
-        assert!(!euid_has_action_type(&euid));
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Backport of #943. Adds new variants to `FromJsonError`, but this error type is not `pub use`d in 3.x.