### PR TITLE
implement schema-format parsers for RFC 68

### DIFF
--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -33,29 +33,6 @@ macro_rules! impl_diagnostic_from_source_loc_field {
 }
 
 /// Macro which implements the `.labels()` and `.source_code()` methods of
-/// `miette::Diagnostic` by using the parameters `$i` and `$j` which must be the name
-/// of fields of type `Loc`.
-/// Both spans are underlined, only the first span is reported as the source code location
-#[macro_export]
-macro_rules! impl_diagnostic_from_source_loc_fields {
-    ( $i:ident , $j:ident ) => {
-        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            Some(&self.$i.src as &dyn miette::SourceCode)
-        }
-
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            Some(Box::new(
-                [
-                    miette::LabeledSpan::underline(self.$i.span),
-                    miette::LabeledSpan::underline(self.$j.span),
-                ]
-                .into_iter(),
-            ) as _)
-        }
-    };
-}
-
-/// Macro which implements the `.labels()` and `.source_code()` methods of
 /// `miette::Diagnostic` by using the parameter `$i` which must be the name
 /// of a field of type `Option<Loc>`
 #[macro_export]

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -53,6 +53,31 @@ macro_rules! impl_diagnostic_from_source_loc_opt_field {
 }
 
 /// Macro which implements the `.labels()` and `.source_code()` methods of
+/// `miette::Diagnostic` by using the parameters `$i` and `$j` which must be
+/// names of fields of type `Loc`.
+/// Both locations will be underlined. It is assumed they have the same `src`.
+#[macro_export]
+macro_rules! impl_diagnostic_from_two_source_loc_fields {
+    ( $i:ident, $j:ident ) => {
+        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+            // use the `src` from the first location and assume it is the same
+            // as the `src` from the second location
+            Some(&self.$i.src as &dyn miette::SourceCode)
+        }
+
+        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+            Some(Box::new(
+                [
+                    miette::LabeledSpan::underline(self.$i.span),
+                    miette::LabeledSpan::underline(self.$j.span),
+                ]
+                .into_iter(),
+            ) as _)
+        }
+    };
+}
+
+/// Macro which implements the `.labels()` and `.source_code()` methods of
 /// `miette::Diagnostic` by using the parameter `$i` which must be an `Expr`
 /// (or `Box<Expr>`) type field.
 #[macro_export]

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -121,6 +121,17 @@ impl<'a> ExpectedErrorMessageBuilder<'a> {
         }
     }
 
+    /// Add expected underlined text. The error message will be expected to have
+    /// exactly two miette labels, and the underlined portions should be `snippet1`
+    /// and `snippet2`, in that order.
+    /// Both labels should have no associated label text.
+    pub fn exactly_two_underlines(self, snippet1: &'a str, snippet2: &'a str) -> Self {
+        Self {
+            underlines: vec![(snippet1, None), (snippet2, None)],
+            ..self
+        }
+    }
+
     /// Add expected contents of `source()`, or expected prefix of `source()` if
     /// this builder was originally constructed with `error_starts_with()`
     pub fn source(self, msg: &'a str) -> Self {

--- a/cedar-policy-validator/src/cedar_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema.rs
@@ -21,7 +21,7 @@ pub use ast::Path;
 mod err;
 pub mod fmt;
 pub mod parser;
-mod test;
+pub(crate) mod test;
 pub mod to_json_schema;
 pub use err::ParseError;
 pub use err::{schema_warnings, SchemaWarning};

--- a/cedar-policy-validator/src/cedar_schema/ast.rs
+++ b/cedar-policy-validator/src/cedar_schema/ast.rs
@@ -250,15 +250,29 @@ impl<N> From<PrimitiveType> for json_schema::TypeVariant<N> {
     }
 }
 
-/// Attribute declarations , used in records and entity types
+/// Attribute declarations, used in records and entity types.
+/// One [`AttrDecl`] is one key-value pair, or an embedded attribute map pair `?: value_ty`.
+///
+/// The data structures in this file, and the Cedar schema format parser in
+/// general, permissively allow `EAMap`s to appear anywhere an [`AttrDecl`] is
+/// expected (including inside other `EAMap`s), in order to provide better error
+/// messages when `EAMap`s are encountered in illegal but plausible positions
 #[derive(Debug, Clone)]
-pub struct AttrDecl {
-    /// Name of this attribute
-    pub name: Node<SmolStr>,
-    /// Whether or not it is a required attribute (implicitly `true`)
-    pub required: bool,
-    /// The type of this attribute
-    pub ty: Node<Type>,
+pub enum AttrDecl {
+    /// A normal attribute declaration `name: ty` or `name?: ty`
+    Concrete {
+        /// Name of this attribute
+        name: Node<SmolStr>,
+        /// Whether or not it is a required attribute (default `true`)
+        required: bool,
+        /// The type of this attribute
+        ty: Node<Type>,
+    },
+    /// An EAMap declaration `?: ty`
+    EAMap {
+        /// Value type of the EAMap
+        value_ty: Node<Type>,
+    },
 }
 
 /// The target of a [`PRAppDecl`]

--- a/cedar-policy-validator/src/cedar_schema/ast.rs
+++ b/cedar-policy-validator/src/cedar_schema/ast.rs
@@ -268,9 +268,9 @@ pub enum AttrDecl {
         /// The type of this attribute
         ty: Node<Type>,
     },
-    /// An EAMap declaration `?: ty`
+    /// An `EAMap` declaration `?: ty`
     EAMap {
-        /// Value type of the EAMap
+        /// Value type of the `EAMap`
         value_ty: Node<Type>,
     },
 }

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -527,10 +527,22 @@ impl Diagnostic for ReservedName {
 pub struct EAMapNotAllowedHereError {
     /// Source location of the `EAMap`
     pub(crate) source_loc: Loc,
+    /// Context-dependent help text
+    pub(crate) help: Option<EAMapNotAllowedHereHelp>,
 }
 
 impl Diagnostic for EAMapNotAllowedHereError {
     impl_diagnostic_from_source_loc_field!(source_loc);
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.help.as_ref().map(|help| Box::new(help) as _)
+    }
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub(crate) enum EAMapNotAllowedHereHelp {
+    #[error("Embedded attribute maps are not allowed as the top-level descriptor of all attributes of an entity. Try making an entity attribute to hold the embedded attribute map. E.g., `attributes: {{ ?: someType }}`.")]
+    TopLevelEAMap,
 }
 
 /// Encountered a type like `{ foo: Long, ?: String }` that mixes concrete attributes with an `EAMap`.

--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-//! `Display` implementations for formatting a schema in the Cedar schema syntax
+//! `Display` implementations for formatting a [`json_schema::Fragment`] in the
+//! Cedar schema syntax
 
 use std::{collections::HashSet, fmt::Display};
 
@@ -73,7 +74,7 @@ impl<N: Display> Display for json_schema::Type<N> {
     }
 }
 
-impl<N: Display> Display for json_schema::RecordType<N> {
+impl<N: Display> Display for json_schema::RecordType<json_schema::RecordAttributeType<N>> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
         for (i, (n, ty)) in self.attributes.iter().enumerate() {
@@ -90,6 +91,37 @@ impl<N: Display> Display for json_schema::RecordType<N> {
         }
         write!(f, "}}")?;
         Ok(())
+    }
+}
+
+impl<N: Display> Display for json_schema::RecordType<json_schema::EntityAttributeType<N>> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{")?;
+        for (i, (n, ty)) in self.attributes.iter().enumerate() {
+            write!(
+                f,
+                "\"{}\"{}: {}",
+                n.escape_debug(),
+                if ty.required { "" } else { "?" },
+                ty.ty
+            )?;
+            if i < (self.attributes.len() - 1) {
+                write!(f, ", ")?;
+            }
+        }
+        write!(f, "}}")?;
+        Ok(())
+    }
+}
+
+impl<N: Display> Display for json_schema::EntityAttributeTypeInternal<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            json_schema::EntityAttributeTypeInternal::Type(ty) => ty.fmt(f),
+            json_schema::EntityAttributeTypeInternal::EAMap { value_type } => {
+                write!(f, "{{ ?: {value_type} }}")
+            }
+        }
     }
 }
 

--- a/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
@@ -183,14 +183,17 @@ pub Type: Node<SType> = {
         => Node::with_source_loc(SType::Record(ds.unwrap_or_default()), Loc::new(l..r, Arc::clone(src))),
 }
 
-// AttrDecls := Name ['?'] ':' Type [',' | ',' AttrDecls]
+// AttrDecls := [Name ['?'] | '?'] ':' Type [',' | ',' AttrDecls]
 AttrDecls: Vec<Node<AttrDecl>> = {
     <l:@L> <name: Name> <required:"?"?> ":" <ty:Type> ","? <r:@R>
-        => vec![Node::with_source_loc(AttrDecl { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))],
+        => vec![Node::with_source_loc(AttrDecl::Concrete { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))],
     <l:@L> <name: Name> <required:"?"?> ":" <ty:Type> "," <r:@R> <mut ds: AttrDecls>
-        => {ds.insert(0, Node::with_source_loc(AttrDecl { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))); ds},
+        => {ds.insert(0, Node::with_source_loc(AttrDecl::Concrete { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))); ds},
+    <l:@L> "?" ":" <value_ty:Type> ","? <r:@R>
+        => vec![Node::with_source_loc(AttrDecl::EAMap { value_ty }, Loc::new(l..r, Arc::clone(src)))],
+    <l:@L> "?" ":" <value_ty:Type> "," <r:@R> <mut ds: AttrDecls>
+        => {ds.insert(0, Node::with_source_loc(AttrDecl::EAMap { value_ty }, Loc::new(l..r, Arc::clone(src)))); ds},
 }
-
 
 Comma<E>: Vec<E> = {
     <e:E?> => e.into_iter().collect(),

--- a/cedar-policy-validator/src/cedar_schema/test.rs
+++ b/cedar-policy-validator/src/cedar_schema/test.rs
@@ -2382,6 +2382,7 @@ mod ea_maps {
                 src,
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .help("Embedded attribute maps are not allowed as the top-level descriptor of all attributes of an entity. Try making an entity attribute to hold the embedded attribute map. E.g., `attributes: { ?: someType }`.")
                     .exactly_one_underline("?: Set<String>")
                     .build(),
             );

--- a/cedar-policy-validator/src/cedar_schema/test.rs
+++ b/cedar-policy-validator/src/cedar_schema/test.rs
@@ -14,10 +14,41 @@
  * limitations under the License.
  */
 
+#![cfg(test)]
+
+#[cfg(test)]
+pub use test_utils::*;
+
+#[cfg(test)]
+mod test_utils {
+    use crate::json_schema;
+
+    #[allow(dead_code)]
+    #[track_caller]
+    pub fn assert_record_attr_has_type<N: std::fmt::Debug + PartialEq>(
+        e: &json_schema::RecordAttributeType<N>,
+        expected: &json_schema::Type<N>,
+    ) {
+        assert!(e.required);
+        assert_eq!(&e.ty, expected);
+    }
+
+    #[track_caller]
+    pub fn assert_entity_attr_has_type<N: std::fmt::Debug + PartialEq>(
+        e: &json_schema::EntityAttributeType<N>,
+        expected: &json_schema::EntityAttributeTypeInternal<N>,
+    ) {
+        assert!(e.required);
+        assert_eq!(&e.ty, expected);
+    }
+}
+
 // PANIC SAFETY: unit tests
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod demo_tests {
+    use super::*;
+
     use std::{
         collections::HashMap,
         iter::{empty, once},
@@ -430,7 +461,7 @@ namespace Baz {action "Foo" appliesTo {
                 "a".parse().unwrap(),
                 json_schema::EntityType::<RawName> {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )]),
             actions: HashMap::from([(
@@ -440,7 +471,7 @@ namespace Baz {action "Foo" appliesTo {
                     applies_to: Some(json_schema::ApplySpec::<RawName> {
                         resource_types: vec![],
                         principal_types: vec!["a".parse().unwrap()],
-                        context: json_schema::AttributesOrContext::default(),
+                        context: json_schema::RecordOrContextAttributes::default(),
                     }),
                     member_of: None,
                 },
@@ -555,16 +586,17 @@ namespace Baz {action "Foo" appliesTo {
         assert!(repo.member_of_types.is_empty());
         let groups = ["readers", "writers", "triagers", "admins", "maintainers"];
         for group in groups {
-            assert_matches!(&repo.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+            assert_matches!(&repo.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
                 attributes,
                 additional_attributes: false,
-            }))) => {
-                let expected =
-                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
-                        type_name: "UserGroup".parse().unwrap(),
-                    });
+            }, .. }) => {
                 let attribute = attributes.get(group).expect("No attribute `{group}`");
-                assert_has_type(attribute, expected);
+                assert_entity_attr_has_type(
+                    attribute,
+                    &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                        type_name: "UserGroup".parse().unwrap(),
+                    })),
+                );
             });
         }
         let issue = github
@@ -572,23 +604,23 @@ namespace Baz {action "Foo" appliesTo {
             .get(&"Issue".parse().unwrap())
             .expect("No `Issue`");
         assert!(issue.member_of_types.is_empty());
-        assert_matches!(&issue.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        assert_matches!(&issue.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }))) => {
+        }, .. }) => {
             let attribute = attributes.get("repo").expect("No `repo`");
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attribute,
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "Repository".parse().unwrap(),
-                }),
+                })),
             );
             let attribute = attributes.get("reporter").expect("No `repo`");
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attribute,
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "User".parse().unwrap(),
-                }),
+                })),
             );
         });
         let org = github
@@ -598,26 +630,19 @@ namespace Baz {action "Foo" appliesTo {
         assert!(org.member_of_types.is_empty());
         let groups = ["members", "owners", "memberOfTypes"];
         for group in groups {
-            assert_matches!(&org.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+            assert_matches!(&org.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
                 attributes,
                 additional_attributes: false,
-            }))) => {
-                let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
-                    type_name: "UserGroup".parse().unwrap(),
-                });
+            }, .. }) => {
                 let attribute = attributes.get(group).expect("No attribute `{group}`");
-                assert_has_type(attribute, expected);
+                assert_entity_attr_has_type(
+                    attribute,
+                    &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                        type_name: "UserGroup".parse().unwrap(),
+                    })),
+                );
             });
         }
-    }
-
-    #[track_caller]
-    fn assert_has_type<N: std::fmt::Debug + PartialEq>(
-        e: &json_schema::TypeOfAttribute<N>,
-        expected: json_schema::Type<N>,
-    ) {
-        assert!(e.required);
-        assert_eq!(&e.ty, &expected);
     }
 
     #[track_caller]
@@ -661,23 +686,23 @@ namespace Baz {action "Foo" appliesTo {
             .get(&"User".parse().unwrap())
             .expect("No `User`");
         assert_eq!(&user.member_of_types, &vec!["Group".parse().unwrap()]);
-        assert_matches!(&user.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        assert_matches!(&user.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }))) => {
-            assert_has_type(
+        }, .. }) => {
+            assert_entity_attr_has_type(
                 attributes.get("personalGroup").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "Group".parse().unwrap(),
-                }),
+                })),
             );
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attributes.get("blocked").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::Set {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::Set {
                     element: Box::new(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     })),
-                }),
+                })),
             );
         });
         let group = doccloud
@@ -688,15 +713,15 @@ namespace Baz {action "Foo" appliesTo {
             &group.member_of_types,
             &vec!["DocumentShare".parse().unwrap()]
         );
-        assert_matches!(&group.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        assert_matches!(&group.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }))) => {
-            assert_has_type(
+        }, .. }) => {
+            assert_entity_attr_has_type(
                 attributes.get("owner").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "User".parse().unwrap(),
-                }),
+                })),
             );
         });
         let document = doccloud
@@ -704,45 +729,45 @@ namespace Baz {action "Foo" appliesTo {
             .get(&"Document".parse().unwrap())
             .expect("No `Group`");
         assert!(document.member_of_types.is_empty());
-        assert_matches!(&document.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        assert_matches!(&document.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }))) => {
-            assert_has_type(
+        }, .. }) => {
+            assert_entity_attr_has_type(
                 attributes.get("owner").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "User".parse().unwrap(),
-                }),
+                })),
             );
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attributes.get("isPrivate").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "Bool".parse().unwrap(),
-                }),
+                })),
             );
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attributes.get("publicAccess").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "String".parse().unwrap(),
-                }),
+                })),
             );
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attributes.get("viewACL").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "DocumentShare".parse().unwrap(),
-                }),
+                })),
             );
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attributes.get("modifyACL").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "DocumentShare".parse().unwrap(),
-                }),
+                })),
             );
-            assert_has_type(
+            assert_entity_attr_has_type(
                 attributes.get("manageACL").unwrap(),
-                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "DocumentShare".parse().unwrap(),
-                }),
+                })),
             );
         });
         let document_share = doccloud
@@ -876,15 +901,15 @@ namespace Baz {action "Foo" appliesTo {
             .entity_types
             .get(&"Resource".parse().unwrap())
             .unwrap();
-        assert_matches!(&resource.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        assert_matches!(&resource.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }))) => {
-            assert_matches!(attributes.get("tag"), Some(json_schema::TypeOfAttribute { ty, required: true }) => {
+        }, .. }) => {
+            assert_matches!(attributes.get("tag"), Some(json_schema::EntityAttributeType { ty: json_schema::EntityAttributeTypeInternal::Type(ty), required: true }) => {
                 assert_matches!(ty, json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name }) => {
                     assert_eq!(type_name, &"AWS::Tag".parse().unwrap());
                 });
-            });
+            })
         });
     }
 
@@ -911,7 +936,7 @@ namespace Baz {action "Foo" appliesTo {
         assert_labeled_span("type t =", "expected `{`, identifier, or `Set`");
         assert_labeled_span(
             "entity User {",
-            "expected `}`, identifier, or string literal",
+            "expected `?`, `}`, identifier, or string literal",
         );
         assert_labeled_span("entity User { name:", "expected `{`, identifier, or `Set`");
     }
@@ -1150,6 +1175,8 @@ mod parser_tests {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod translator_tests {
+    use super::*;
+
     use cedar_policy_core::ast as cedar_ast;
     use cedar_policy_core::extensions::Extensions;
     use cedar_policy_core::FromNormalizedStr;
@@ -1162,7 +1189,7 @@ mod translator_tests {
         },
         json_schema,
         schema::test::collect_warnings,
-        types::{EntityLUB, Type},
+        types::{EntityLUB, EntityRecordKind, Primitive, Type},
         ValidatorSchema,
     };
 
@@ -1327,16 +1354,13 @@ mod translator_tests {
                         match attr_name.as_ref() {
                             "ip" => assert_matches!(
                                 &attr.attr_type,
-                                crate::types::Type::EntityOrRecord(
-                                    crate::types::EntityRecordKind::Record {
-                                        attrs: _,
-                                        open_attributes: _
-                                    }
-                                )
+                                Type::EntityOrRecord(EntityRecordKind::Record { .. })
                             ),
                             "bandwidth" => assert_matches!(
                                 &attr.attr_type,
-                                crate::types::Type::ExtensionType { name } => assert_eq!(name, &cedar_policy_core::ast::Name::from_normalized_str("decimal").unwrap())
+                                Type::ExtensionType { name } => {
+                                    assert_eq!(name, &cedar_policy_core::ast::Name::from_normalized_str("decimal").unwrap());
+                                }
                             ),
                             _ => panic!("unexpected attr: {attr_name}"),
                         }
@@ -1347,7 +1371,9 @@ mod translator_tests {
                         match attr_name.as_ref() {
                             "groups" => assert_matches!(
                                 &attr.attr_type,
-                                crate::types::Type::Set { element_type: Some(t)} => assert_eq!(**t, crate::types::Type::Primitive { primitive_type: crate::types::Primitive::String }),
+                                Type::Set { element_type: Some(t) } => {
+                                    assert_eq!(**t, Type::Primitive { primitive_type: Primitive::String });
+                                }
                             ),
                             _ => panic!("unexpected attr: {attr_name}"),
                         }
@@ -1414,22 +1440,22 @@ mod translator_tests {
         .unwrap();
         let demo = schema.0.get(&Some("Demo".parse().unwrap())).unwrap();
         let user = demo.entity_types.get(&"User".parse().unwrap()).unwrap();
-        assert_matches!(&user.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        assert_matches!(&user.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }))) => {
-            assert_matches!(attributes.get("name"), Some(json_schema::TypeOfAttribute { ty, required: true }) => {
-                let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+        }, .. }) => {
+            assert_entity_attr_has_type(
+                attributes.get("name").unwrap(),
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "id".parse().unwrap(),
-                });
-                assert_eq!(ty, &expected);
-            });
-            assert_matches!(attributes.get("email"), Some(json_schema::TypeOfAttribute { ty, required: true }) => {
-                let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                })),
+            );
+            assert_entity_attr_has_type(
+                attributes.get("email").unwrap(),
+                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "email_address".parse().unwrap(),
-                });
-                assert_eq!(ty, &expected);
-            });
+                })),
+            );
         });
         assert_matches!(ValidatorSchema::try_from(schema), Ok(_));
     }
@@ -1465,9 +1491,9 @@ mod translator_tests {
         let attr = et.attr("foo").unwrap();
         assert_matches!(
             &attr.attr_type,
-            crate::types::Type::Primitive {
-                primitive_type: crate::types::Primitive::Bool
-            }
+            Type::Primitive {
+                primitive_type: Primitive::Bool
+            },
         );
 
         let (schema, _) = json_schema::Fragment::from_cedarschema_str(
@@ -1493,9 +1519,9 @@ mod translator_tests {
                 .attributes
                 .attrs["foo"]
                 .attr_type,
-            Type::EntityOrRecord(crate::types::EntityRecordKind::Entity(
-                EntityLUB::single_entity("X::Z".parse().unwrap())
-            ))
+            Type::EntityOrRecord(EntityRecordKind::Entity(EntityLUB::single_entity(
+                "X::Z".parse().unwrap()
+            )))
         );
     }
 
@@ -2148,7 +2174,12 @@ mod common_type_references {
                 .unwrap()
                 .attr("a")
                 .unwrap(),
-            AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::primitive_long()
+            AttributeType {
+                attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }),
+                is_required: true,
+            } => {
+                assert_eq!(attrs.attrs.get("a").unwrap().attr_type, Type::primitive_long());
+            }
         );
 
         let (schema, _) = json_schema::Fragment::from_cedarschema_str(
@@ -2170,7 +2201,12 @@ mod common_type_references {
                 .unwrap()
                 .attr("a")
                 .unwrap(),
-            AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::primitive_long()
+            AttributeType {
+                attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }),
+                is_required: true,
+            } => {
+                assert_eq!(attrs.attrs.get("a").unwrap().attr_type, Type::primitive_long());
+            }
         );
 
         let (schema, _) = json_schema::Fragment::from_cedarschema_str(
@@ -2196,7 +2232,12 @@ mod common_type_references {
                 .unwrap()
                 .attr("a")
                 .unwrap(),
-            AttributeType { attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }), is_required: true } if attrs.attrs.get("a").unwrap().attr_type == Type::set(Type::primitive_long())
+            AttributeType {
+                attr_type: Type::EntityOrRecord(EntityRecordKind::Record { attrs, open_attributes: _ }),
+                is_required: true,
+            } => {
+                assert_eq!(attrs.attrs.get("a").unwrap().attr_type, Type::set(Type::primitive_long()));
+            }
         );
     }
 
@@ -2268,5 +2309,164 @@ mod common_type_references {
             validator_schema,
             Err(SchemaError::CycleInCommonTypeReferences(_))
         );
+    }
+}
+
+/// Tests involving embedded attribute maps (RFC 68)
+#[cfg(test)]
+mod ea_maps {
+    use super::assert_entity_attr_has_type;
+    use crate::json_schema;
+    use crate::schema::test::collect_warnings;
+    use cedar_policy_core::extensions::Extensions;
+    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
+    use cool_asserts::assert_matches;
+
+    #[test]
+    fn entity_attribute() {
+        let src = "entity E { tags: { ?: Set<String> } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Ok((frag, warnings)) => {
+            assert!(warnings.is_empty());
+            let entity_type = frag.0.get(&None).unwrap().entity_types.get(&"E".parse().unwrap()).unwrap();
+            assert_matches!(&entity_type.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs, .. }) => {
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("tags").unwrap(),
+                    &json_schema::EntityAttributeTypeInternal::EAMap {
+                        value_type: json_schema::Type::Type(json_schema::TypeVariant::Set {
+                            element: Box::new(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name: "String".parse().unwrap() })),
+                        }),
+                    },
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn record_attribute_inside_entity_attribute() {
+        let src = "entity E { tags: { foo: { ?: Set<String> } } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .exactly_one_underline("?: Set<String>")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn context_attribute() {
+        let src = "entity E; action read appliesTo { principal: [E], resource: [E], context: { operationDetails: { ?: String } } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .exactly_one_underline("?: String")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn toplevel_entity() {
+        let src = "entity E { ?: Set<String> };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .exactly_one_underline("?: Set<String>")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn toplevel_context() {
+        let src = "entity E; action read appliesTo { principal: [E], resource: [E], context: { ?: String } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .exactly_one_underline("?: String")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn common_type() {
+        let src = "type blah = { ?: String }; entity User { blah: blah };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .exactly_one_underline("?: String")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn value_type_is_common_type() {
+        let src = "type blah = { foo: String }; entity User { blah: { ?: blah } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Ok((frag, warnings)) => {
+            assert!(warnings.is_empty());
+            let user = frag.0.get(&None).unwrap().entity_types.get(&"User".parse().unwrap()).unwrap();
+            assert_matches!(&user.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs, .. }) => {
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("blah").unwrap(),
+                    &json_schema::EntityAttributeTypeInternal::EAMap {
+                        value_type: json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name: "blah".parse().unwrap() }),
+                    }
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn nested_ea_map() {
+        let src = "entity E { tags: { ?: { ?: String } } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .exactly_one_underline("?: String")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn ea_map_and_attribute() {
+        let src = "entity E { tags: { foo: Long, ?: String } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: this type contains both concrete attributes and an embedded attribute map (`?:`), which is not allowed")
+                    .exactly_one_underline("?: String")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn two_ea_maps() {
+        let src = "entity E { tags: { ?: Long, ?: String } };";
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, &Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: this type contains two or more different embedded attribute map declarations (`?:`), which is not allowed")
+                    .exactly_two_underlines("?: Long,", "?: String")
+                    .build(),
+            );
+        });
     }
 }

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -28,15 +28,17 @@ use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::hash_map::Entry;
 
-use crate::{cedar_schema, json_schema, RawName};
-
 use super::{
     ast::{
         ActionDecl, AppDecl, AttrDecl, Decl, Declaration, EntityDecl, Namespace, PRAppDecl, Path,
         QualName, Schema, Type, TypeDecl, BUILTIN_TYPES, PR,
     },
-    err::{schema_warnings, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors},
+    err::{
+        schema_warnings, EAMapError, EAMapNotAllowedHereError, EAMapWithConcreteAttributesError,
+        MultipleEAMapDeclarationsError, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors,
+    },
 };
+use crate::{cedar_schema, json_schema, RawName};
 
 impl From<cedar_schema::Path> for RawName {
     fn from(p: cedar_schema::Path) -> Self {
@@ -95,23 +97,99 @@ fn is_valid_ext_type(ty: &Id, extensions: &Extensions<'_>) -> bool {
 }
 
 /// Convert a `Type` into the JSON representation of the type.
-pub fn cedar_type_to_json_type(ty: Node<Type>) -> json_schema::Type<RawName> {
+pub fn cedar_type_to_json_type(
+    ty: Node<Type>,
+) -> Result<json_schema::Type<RawName>, EAMapNotAllowedHereError> {
     match ty.node {
-        Type::Set(t) => json_schema::Type::Type(json_schema::TypeVariant::Set {
-            element: Box::new(cedar_type_to_json_type(*t)),
-        }),
-        Type::Ident(p) => json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
-            type_name: RawName::from(p),
-        }),
-        Type::Record(fields) => {
-            json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
+        Type::Set(t) => Ok(json_schema::Type::Type(json_schema::TypeVariant::Set {
+            element: Box::new(cedar_type_to_json_type(*t)?),
+        })),
+        Type::Ident(p) => Ok(json_schema::Type::Type(
+            json_schema::TypeVariant::EntityOrCommon {
+                type_name: RawName::from(p),
+            },
+        )),
+        Type::Record(fields) => Ok(json_schema::Type::Type(json_schema::TypeVariant::Record(
+            json_schema::RecordType {
                 attributes: fields
                     .into_iter()
-                    .map(|field| convert_attr_decl(field.node))
-                    .collect(),
+                    .map(|field| convert_attr_decl_for_record(field))
+                    .collect::<Result<_, _>>()?,
                 additional_attributes: false,
-            }))
+            },
+        ))),
+    }
+}
+
+/// Convert a [`Type`] representing an entity attribute type into the JSON
+/// representation of the type. Unlike [`cedar_type_to_json_type()`], this
+/// function allows (and handles) `EAMap` types as well.
+///
+/// This can still return [`EAMapNotAllowedHereError`] if an `EAMap` is found,
+/// e.g., in a set element type, or nested in another `EAMap`.
+pub fn cedar_type_to_entity_attr_type(
+    ty: Node<Type>,
+) -> Result<json_schema::EntityAttributeTypeInternal<RawName>, EAMapError> {
+    match &ty.node {
+        Type::Record(decls) => {
+            let ea_map_decls = decls
+                .iter()
+                .filter_map(|decl| match &decl.node {
+                    AttrDecl::EAMap { value_ty } => Some((&decl.loc, value_ty)),
+                    _ => None,
+                })
+                .collect::<Vec<(&Loc, &Node<Type>)>>();
+            match (decls.len(), ea_map_decls.len()) {
+                (_, 0) => {
+                    // no `EAMap` decls
+                    Ok(json_schema::EntityAttributeTypeInternal::Type(
+                        cedar_type_to_json_type(ty)?,
+                    ))
+                }
+                (1, 1) => {
+                    // exactly one decl, and it's an `EAMap` decl like `?: String`.
+                    // Convert to an `EAMap`.
+                    // PANIC SAFETY: already determined `ea_map_decls.len() == 1`
+                    #[allow(clippy::indexing_slicing)]
+                    let (_, value_type) = ea_map_decls[0];
+                    Ok(json_schema::EntityAttributeTypeInternal::EAMap {
+                        value_type: cedar_type_to_json_type(value_type.clone())?,
+                    })
+                }
+                (2.., 1) => {
+                    // one `EAMap` decl, but more than one decl total. This is an error.
+                    // PANIC SAFETY: already determined `ea_map_decls.len() == 1`
+                    #[allow(clippy::indexing_slicing)]
+                    let (source_loc, _) = ea_map_decls[0];
+                    Err(EAMapWithConcreteAttributesError {
+                        source_loc: source_loc.clone(),
+                    }
+                    .into())
+                }
+                (2.., 2..) => {
+                    // multiple `EAMap` decls, this is an error
+                    // PANIC SAFETY: already determined `ea_map_decls.len()` is at least 2
+                    #[allow(clippy::indexing_slicing)]
+                    let (source_loc_1, _) = ea_map_decls[0];
+                    // PANIC SAFETY: already determined `ea_map_decls.len()` is at least 2
+                    #[allow(clippy::indexing_slicing)]
+                    let (source_loc_2, _) = ea_map_decls[1];
+                    Err(MultipleEAMapDeclarationsError {
+                        source_loc_1: source_loc_1.clone(),
+                        source_loc_2: source_loc_2.clone(),
+                    }
+                    .into())
+                }
+                (0, 1..) | (1, 2..) => {
+                    // impossible: more `EAMap` decls than total decls
+                    // PANIC SAFETY: see above
+                    unreachable!("can't have more `EAMap` decls than total decls")
+                }
+            }
         }
+        Type::Set(_) | Type::Ident(_) => Ok(json_schema::EntityAttributeTypeInternal::Type(
+            cedar_type_to_json_type(ty)?,
+        )),
     }
 }
 
@@ -202,7 +280,10 @@ impl TryFrom<Namespace> for json_schema::NamespaceDefinition<RawName> {
                         loc: name_loc,
                     }))
                 } else {
-                    Ok((id, cedar_type_to_json_type(decl.def)))
+                    Ok((
+                        id,
+                        cedar_type_to_json_type(decl.def).map_err(EAMapError::from)?,
+                    ))
                 }
             })
             .collect::<Result<_, ToJsonSchemaError>>()?;
@@ -232,7 +313,7 @@ fn convert_action_decl(
         .unwrap_or_else(|| json_schema::ApplySpec {
             resource_types: vec![],
             principal_types: vec![],
-            context: json_schema::AttributesOrContext::default(),
+            context: json_schema::RecordOrContextAttributes::default(),
         });
     let member_of = parents.map(|parents| parents.into_iter().map(convert_qual_name).collect());
     let ty = json_schema::ActionType {
@@ -257,7 +338,7 @@ fn convert_app_decls(
     let (decls, _) = decls.into_inner();
     let mut principal_types: Option<Node<Vec<RawName>>> = None;
     let mut resource_types: Option<Node<Vec<RawName>>> = None;
-    let mut context: Option<Node<json_schema::AttributesOrContext<RawName>>> = None;
+    let mut context: Option<Node<json_schema::RecordOrContextAttributes<RawName>>> = None;
 
     for decl in decls {
         match decl {
@@ -274,7 +355,7 @@ fn convert_app_decls(
                 }
                 None => {
                     context = Some(Node::with_source_loc(
-                        convert_context_decl(context_decl),
+                        convert_context_decl(context_decl).map_err(EAMapError::from)?,
                         loc,
                     ));
                 }
@@ -372,7 +453,9 @@ fn convert_entity_decl(
     // First build up the defined entity type
     let etype = json_schema::EntityType {
         member_of_types: e.member_of_types.into_iter().map(RawName::from).collect(),
-        shape: convert_attr_decls(e.attrs),
+        shape: convert_attr_decls_for_entity(e.attrs)
+            .map(Into::into)
+            .map_err(ToJsonSchemaError::from)?,
     };
 
     // Then map over all of the bound names
@@ -385,25 +468,27 @@ fn convert_entity_decl(
     )
 }
 
-/// Create a [`json_schema::AttributesOrContext`] from a series of `AttrDecl`s
-fn convert_attr_decls(
+/// Create a [`json_schema::RecordType`] from a series of `AttrDecl`s
+/// representing the attributes of an entity
+fn convert_attr_decls_for_entity(
     attrs: impl IntoIterator<Item = Node<AttrDecl>>,
-) -> json_schema::AttributesOrContext<RawName> {
-    json_schema::RecordType {
+) -> Result<json_schema::RecordType<json_schema::EntityAttributeType<RawName>>, EAMapError> {
+    Ok(json_schema::RecordType {
         attributes: attrs
             .into_iter()
-            .map(|attr| convert_attr_decl(attr.node))
-            .collect(),
+            .map(|attr| convert_attr_decl_for_entity(attr))
+            .collect::<Result<_, _>>()?,
         additional_attributes: false,
-    }
-    .into()
+    })
 }
 
-/// Create a context decl
+/// Create a [`json_schema::RecordOrContextAttributes`] from a series of
+/// `AttrDecl`s representing the attributes of the context (or a `Path`
+/// representing the common-type defining those attributes)
 fn convert_context_decl(
     decl: Either<Path, Vec<Node<AttrDecl>>>,
-) -> json_schema::AttributesOrContext<RawName> {
-    json_schema::AttributesOrContext(match decl {
+) -> Result<json_schema::RecordOrContextAttributes<RawName>, EAMapNotAllowedHereError> {
+    Ok(json_schema::RecordOrContextAttributes(match decl {
         Either::Left(p) => json_schema::Type::CommonTypeRef {
             type_name: p.into(),
         },
@@ -411,23 +496,56 @@ fn convert_context_decl(
             json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
                 attributes: attrs
                     .into_iter()
-                    .map(|attr| convert_attr_decl(attr.node))
-                    .collect(),
+                    .map(|attr| convert_attr_decl_for_record(attr))
+                    .collect::<Result<_, _>>()?,
                 additional_attributes: false,
             }))
         }
-    })
+    }))
 }
 
 /// Convert an attribute type from an `AttrDecl`
-fn convert_attr_decl(attr: AttrDecl) -> (SmolStr, json_schema::TypeOfAttribute<RawName>) {
-    (
-        attr.name.node,
-        json_schema::TypeOfAttribute {
-            ty: cedar_type_to_json_type(attr.ty),
-            required: attr.required,
-        },
-    )
+fn convert_attr_decl_for_record(
+    attr: Node<AttrDecl>,
+) -> Result<(SmolStr, json_schema::RecordAttributeType<RawName>), EAMapNotAllowedHereError> {
+    match attr.node {
+        AttrDecl::Concrete { name, required, ty } => Ok((
+            name.node,
+            json_schema::RecordAttributeType {
+                ty: cedar_type_to_json_type(ty)?,
+                required,
+            },
+        )),
+        AttrDecl::EAMap { .. } => Err(EAMapNotAllowedHereError {
+            source_loc: attr.loc,
+        }),
+    }
+}
+
+/// Convert an `AttrDecl` representing an entity attribute type to a pair `(name, ty)`.
+/// `attr` is not allowed to be `AttrDecl::EAMap` itself, but in the returned pair
+/// `(name, ty)`, `ty` is allowed to be an `EAMap`.
+fn convert_attr_decl_for_entity(
+    attr: Node<AttrDecl>,
+) -> Result<(SmolStr, json_schema::EntityAttributeType<RawName>), EAMapError> {
+    match attr.node {
+        AttrDecl::Concrete { name, required, ty } => Ok((
+            name.node,
+            json_schema::EntityAttributeType {
+                ty: cedar_type_to_entity_attr_type(ty)?,
+                required,
+            },
+        )),
+        AttrDecl::EAMap { .. } => {
+            // EAMap is not allowed here, as the descriptor of all entity attributes.
+            // EAMap is only allowed as the top-level type of one of the entity attributes.
+            // That is, as `ty` in `AttrDecl::Concrete`.
+            Err(EAMapNotAllowedHereError {
+                source_loc: attr.loc,
+            }
+            .into())
+        }
+    }
 }
 
 /// Takes a collection of results returning multiple errors

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -96,8 +96,11 @@ fn is_valid_ext_type(ty: &Id, extensions: &Extensions<'_>) -> bool {
         .any(|ext_ty| ty == ext_ty.basename_as_ref())
 }
 
-/// Convert a `Type` into the JSON representation of the type.
-pub fn cedar_type_to_json_type(
+/// Convert a [`Type`] into the JSON representation of the type.
+/// In this function, `EAMap` types are not allowed and will result in errors.
+/// For a similar function that accepts `EAMap` types, see
+/// [`cedar_type_to_entity_attr_type()`].
+fn cedar_type_to_json_type(
     ty: Node<Type>,
 ) -> Result<json_schema::Type<RawName>, EAMapNotAllowedHereError> {
     match ty.node {
@@ -125,9 +128,9 @@ pub fn cedar_type_to_json_type(
 /// representation of the type. Unlike [`cedar_type_to_json_type()`], this
 /// function allows (and handles) `EAMap` types as well.
 ///
-/// This can still return [`EAMapNotAllowedHereError`] if an `EAMap` is found,
-/// e.g., in a set element type, or nested in another `EAMap`.
-pub fn cedar_type_to_entity_attr_type(
+/// This can still return [`EAMapError`] if an `EAMap` is found, e.g., in a set
+/// element type, or nested in another `EAMap`.
+fn cedar_type_to_entity_attr_type(
     ty: Node<Type>,
 ) -> Result<json_schema::EntityAttributeTypeInternal<RawName>, EAMapError> {
     match &ty.node {

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -34,8 +34,9 @@ use super::{
         QualName, Schema, Type, TypeDecl, BUILTIN_TYPES, PR,
     },
     err::{
-        schema_warnings, EAMapError, EAMapNotAllowedHereError, EAMapWithConcreteAttributesError,
-        MultipleEAMapDeclarationsError, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors,
+        schema_warnings, EAMapError, EAMapNotAllowedHereError, EAMapNotAllowedHereHelp,
+        EAMapWithConcreteAttributesError, MultipleEAMapDeclarationsError, SchemaWarning,
+        ToJsonSchemaError, ToJsonSchemaErrors,
     },
 };
 use crate::{cedar_schema, json_schema, RawName};
@@ -505,6 +506,7 @@ fn convert_attr_decl_for_record(
         )),
         AttrDecl::EAMap { .. } => Err(EAMapNotAllowedHereError {
             source_loc: attr.loc,
+            help: None,
         }),
     }
 }
@@ -529,6 +531,7 @@ fn convert_attr_decl_for_entity(
             // That is, as `ty` in `AttrDecl::Concrete`.
             Err(EAMapNotAllowedHereError {
                 source_loc: attr.loc,
+                help: Some(EAMapNotAllowedHereHelp::TopLevelEAMap),
             }
             .into())
         }

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -116,7 +116,7 @@ fn cedar_type_to_json_type(
             json_schema::RecordType {
                 attributes: fields
                     .into_iter()
-                    .map(|field| convert_attr_decl_for_record(field))
+                    .map(convert_attr_decl_for_record)
                     .collect::<Result<_, _>>()?,
                 additional_attributes: false,
             },
@@ -186,7 +186,10 @@ fn cedar_type_to_entity_attr_type(
                 (0, 1..) | (1, 2..) => {
                     // impossible: more `EAMap` decls than total decls
                     // PANIC SAFETY: see above
-                    unreachable!("can't have more `EAMap` decls than total decls")
+                    #[allow(clippy::unreachable)]
+                    {
+                        unreachable!("can't have more `EAMap` decls than total decls")
+                    }
                 }
             }
         }
@@ -460,7 +463,7 @@ fn convert_attr_decls_for_entity(
     Ok(json_schema::RecordType {
         attributes: attrs
             .into_iter()
-            .map(|attr| convert_attr_decl_for_entity(attr))
+            .map(convert_attr_decl_for_entity)
             .collect::<Result<_, _>>()?,
         additional_attributes: false,
     })
@@ -480,7 +483,7 @@ fn convert_context_decl(
             json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
                 attributes: attrs
                     .into_iter()
-                    .map(|attr| convert_attr_decl_for_record(attr))
+                    .map(convert_attr_decl_for_record)
                     .collect::<Result<_, _>>()?,
                 additional_attributes: false,
             }))

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -122,17 +122,21 @@ impl entities::EntityTypeDescription for EntityTypeDescription {
     }
 
     fn attr_type(&self, attr: &str) -> Option<entities::SchemaType> {
-        let attr_type: &crate::types::Type = &self.validator_type.attr(attr)?.attr_type;
+        let attr_type: &crate::types::AttributeType = self.validator_type.attr(attr)?;
         // This converts a type from a schema into the representation of schema
         // types used by core. `attr_type` is taken from a `ValidatorEntityType`
         // which was constructed from a schema.
         // PANIC SAFETY: see above
         #[allow(clippy::expect_used)]
         let core_schema_type: entities::SchemaType = attr_type
+            .attr_type
             .clone()
             .try_into()
             .expect("failed to convert validator type into Core SchemaType");
-        debug_assert!(attr_type.is_consistent_with(&core_schema_type));
+        debug_assert!(crate::types::Type::is_consistent_with(
+            &attr_type.attr_type,
+            &core_schema_type,
+        ));
         Some(core_schema_type)
     }
 

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -557,6 +557,10 @@ pub mod schema_errors {
         // Action attributes are allowed if `ActionBehavior` is `PermitAttributes`
         #[error("action declared with attributes: [{}]", .0.iter().join(", "))]
         ActionAttributes(Vec<String>),
+        #[error(
+            "Embedded attribute maps (RFC 68) are not fully implemented in this version of Cedar"
+        )]
+        EAMaps,
     }
 
     /// This error is thrown when `serde_json` fails to deserialize the JSON

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -1781,7 +1781,9 @@ pub enum TypeVariant<N> {
         element: Box<Type<N>>,
     },
     /// Record
-    #[tsify(type = r#"{ type: "Record"; attributes: Record<SmolStr, Type<N> & { required?: boolean }>, additionalAttributes?: boolean }"#)]
+    #[tsify(
+        type = r#"{ type: "Record"; attributes: Record<SmolStr, Type<N> & { required?: boolean }>, additionalAttributes?: boolean }"#
+    )]
     Record(RecordType<RecordAttributeType<N>>),
     /// Entity
     Entity {

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -2000,6 +2000,8 @@ impl<'a> arbitrary::Arbitrary<'a> for Type<RawName> {
 /// types for a record attribute. See
 /// [RFC 68](https://github.com/cedar-policy/rfcs/blob/main/text/0068-entity-tags.md).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub enum EntityAttributeTypeInternal<N> {
     /// A normal type. Attributes can be `String`, an entity type, a common type, a record type, etc
     Type(Type<N>),

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -1262,6 +1262,7 @@ impl TypeFields {
 /// for a particular type variant.
 /// We instead report that the field should not exist at all, so that the schema
 /// author can delete the field without wasting time fixing errors in the value.
+#[derive(Debug)]
 struct TypeFieldsWithData<N, E> {
     /// If this is `Some`, the `type` field is present, with the given value
     type_name: Option<std::result::Result<SmolStr, E>>,
@@ -1277,6 +1278,8 @@ struct TypeFieldsWithData<N, E> {
     default: Option<std::result::Result<Type<N>, E>>,
 }
 
+/// Manual impl of `Default` (rather than `derive(Default)`) because the derived
+/// impl of `Default` requires `N: Default`, but this manual impl works for all `N`
 impl<N, E> Default for TypeFieldsWithData<N, E> {
     fn default() -> Self {
         Self {
@@ -1352,7 +1355,7 @@ fn collect_type_fields_data<'de, N: Deserialize<'de> + From<RawName>, M: MapAcce
 /// reporting an error if there are any duplicate keys in the map. I could not
 /// find a way to do the `serde_with` conversion inline without introducing this
 /// struct.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 struct AttributesTypeMap(
     #[serde(with = "serde_with::rust::maps_duplicate_key_is_error")]
     BTreeMap<SmolStr, RecordAttributeType<RawName>>,

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -2192,8 +2192,7 @@ impl EntityAttributeType<ConditionalName> {
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+// no tsify derive because handled specially in build-wasm.sh due to the serde(flatten)
 pub struct RecordAttributeType<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -20,6 +20,7 @@ use cedar_policy_core::{
     ast::{Eid, EntityUID, InternalName, Name, UnreservedId},
     entities::CedarValueJson,
     extensions::Extensions,
+    jsonvalue::JsonValueWithNoDuplicateKeys,
     FromNormalizedStr,
 };
 use nonempty::nonempty;
@@ -317,8 +318,8 @@ pub struct EntityType<N> {
     pub member_of_types: Vec<N>,
     /// Description of the attributes for entities of this [`EntityType`].
     #[serde(default)]
-    #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
-    pub shape: AttributesOrContext<N>,
+    #[serde(skip_serializing_if = "EntityAttributes::is_empty_record")]
+    pub shape: EntityAttributes<N>,
 }
 
 impl EntityType<RawName> {
@@ -364,66 +365,66 @@ impl EntityType<ConditionalName> {
     }
 }
 
-/// Declaration of entity or record attributes, or of an action context.
+/// Declaration of record attributes, or of an action context.
 /// These share a JSON format.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
-/// this [`AttributesOrContext`], including recursively.
+/// this [`RecordOrContextAttributes`], including recursively.
 /// See notes on [`Fragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct AttributesOrContext<N>(
+pub struct RecordOrContextAttributes<N>(
     // We use the usual `Type` deserialization, but it will ultimately need to
     // be a `Record` or common-type reference which resolves to a `Record`.
     pub Type<N>,
 );
 
-impl<N> AttributesOrContext<N> {
-    /// Convert the [`AttributesOrContext`] into its [`Type`].
+impl<N> RecordOrContextAttributes<N> {
+    /// Convert the [`RecordOrContextAttributes`] into its [`Type`].
     pub fn into_inner(self) -> Type<N> {
         self.0
     }
 
-    /// Is this `AttributesOrContext` an empty record?
+    /// Is this [`RecordOrContextAttributes`] an empty record?
     pub fn is_empty_record(&self) -> bool {
         self.0.is_empty_record()
     }
 }
 
-impl<N> Default for AttributesOrContext<N> {
+impl<N> Default for RecordOrContextAttributes<N> {
     fn default() -> Self {
         Self::from(RecordType::default())
     }
 }
 
-impl<N: Display> Display for AttributesOrContext<N> {
+impl<N: Display> Display for RecordOrContextAttributes<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<N> From<RecordType<N>> for AttributesOrContext<N> {
-    fn from(rty: RecordType<N>) -> AttributesOrContext<N> {
+impl<N> From<RecordType<RecordAttributeType<N>>> for RecordOrContextAttributes<N> {
+    fn from(rty: RecordType<RecordAttributeType<N>>) -> RecordOrContextAttributes<N> {
         Self(Type::Type(TypeVariant::Record(rty)))
     }
 }
 
-impl AttributesOrContext<RawName> {
+impl RecordOrContextAttributes<RawName> {
     /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> AttributesOrContext<ConditionalName> {
-        AttributesOrContext(self.0.conditionally_qualify_type_references(ns))
+    ) -> RecordOrContextAttributes<ConditionalName> {
+        RecordOrContextAttributes(self.0.conditionally_qualify_type_references(ns))
     }
 }
 
-impl AttributesOrContext<ConditionalName> {
-    /// Convert this [`AttributesOrContext<ConditionalName>`] into an
-    /// [`AttributesOrContext<InternalName>`] by fully-qualifying all typenames
+impl RecordOrContextAttributes<ConditionalName> {
+    /// Convert this [`RecordOrContextAttributes<ConditionalName>`] into a
+    /// [`RecordOrContextAttributes<InternalName>`] by fully-qualifying all typenames
     /// that appear anywhere in any definitions.
     ///
     /// `all_common_defs` and `all_entity_defs` need to be the full set of all
@@ -433,11 +434,268 @@ impl AttributesOrContext<ConditionalName> {
         self,
         all_common_defs: &HashSet<InternalName>,
         all_entity_defs: &HashSet<InternalName>,
-    ) -> std::result::Result<AttributesOrContext<InternalName>, TypeResolutionError> {
-        Ok(AttributesOrContext(self.0.fully_qualify_type_references(
-            all_common_defs,
-            all_entity_defs,
-        )?))
+    ) -> std::result::Result<RecordOrContextAttributes<InternalName>, TypeResolutionError> {
+        Ok(RecordOrContextAttributes(
+            self.0
+                .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+        ))
+    }
+}
+
+/// Declaration of entity attributes
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`EntityAttributes`], including recursively.
+/// See notes on [`Fragment`].
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+#[serde(untagged)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub enum EntityAttributes<N> {
+    /// Anything valid as record attributes is valid as entity attributes.
+    /// Notably, this includes the possibility that we have a single common-type
+    /// reference, and not actually a record declaration.
+    RecordAttributes(RecordOrContextAttributes<N>),
+    /// [`EntityAttributesInternal`] is an analogue of
+    /// [`RecordOrContextAttributes`] that covers the JSON forms accepted for
+    /// entity attributes but not record attributes
+    EntityAttributes(EntityAttributesInternal<N>),
+}
+
+/// Helper struct containing the contents of
+/// `EntityAttributes::EntityAttributes`.
+/// This doesn't cover all possible legal JSON forms for entity attributes
+/// (use [`EntityAttributes`] for that) -- in particular this struct doesn't
+/// accept a single common-type reference; it requires a record declaration.
+/// But, this struct does cover all legal JSON forms for entity attributes that
+/// aren't accepted as legal JSON forms for record attributes.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+#[serde(deny_unknown_fields)]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct EntityAttributesInternal<N> {
+    /// a hack for the derived serializer/deserializer.
+    /// We need to require `"type": "Record"` here (it is required for the
+    /// corresponding struct [`RecordOrContextAttributes`] by virtue of using
+    /// the [`Type`] serialization/deserialization).
+    /// The `serialize_with` and `deserialize_with` accomplish this.
+    #[serde(rename = "type")]
+    #[serde(serialize_with = "record_string")]
+    #[serde(deserialize_with = "require_record_string")]
+    type_placeholder_hack: (),
+    /// Entity attribute types, as a [`RecordType`]. These may include `EAMap`s.
+    #[serde(flatten)]
+    pub attrs: RecordType<EntityAttributeType<N>>,
+}
+
+fn record_string<S: Serializer>(
+    _type_placeholder_hack: &(),
+    ser: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    ser.serialize_str("Record")
+}
+
+fn require_record_string<'de, D: Deserializer<'de>>(deser: D) -> std::result::Result<(), D::Error> {
+    /// Simple local visitor struct used only by this function
+    struct LocalVisitor;
+
+    impl<'de> Visitor<'de> for LocalVisitor {
+        type Value = ();
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(formatter, "the string `Record`")
+        }
+        fn visit_str<E: serde::de::Error>(self, s: &str) -> std::result::Result<(), E> {
+            if s == "Record" {
+                Ok(())
+            } else {
+                Err(serde::de::Error::invalid_value(
+                    serde::de::Unexpected::Str(s),
+                    &self,
+                ))
+            }
+        }
+    }
+
+    deser.deserialize_str(LocalVisitor)
+}
+
+impl<N> EntityAttributes<N> {
+    /// Is this [`EntityAttributes`] an empty record?
+    pub fn is_empty_record(&self) -> bool {
+        match self {
+            Self::RecordAttributes(attrs) => attrs.is_empty_record(),
+            Self::EntityAttributes(internal) => internal.is_empty_record(),
+        }
+    }
+}
+
+impl<N> EntityAttributesInternal<N> {
+    /// Is this [`EntityAttributesInternal`] an empty record?
+    pub fn is_empty_record(&self) -> bool {
+        self.attrs.is_empty_record()
+    }
+}
+
+impl<N> Default for EntityAttributes<N> {
+    fn default() -> Self {
+        Self::RecordAttributes(RecordOrContextAttributes::default())
+    }
+}
+
+impl<N: Display> Display for EntityAttributes<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RecordAttributes(attrs) => attrs.fmt(f),
+            Self::EntityAttributes(internal) => internal.fmt(f),
+        }
+    }
+}
+
+impl<N: Display> Display for EntityAttributesInternal<N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.attrs.fmt(f)
+    }
+}
+
+impl<N> From<RecordType<RecordAttributeType<N>>> for EntityAttributes<N> {
+    fn from(rty: RecordType<RecordAttributeType<N>>) -> EntityAttributes<N> {
+        Self::RecordAttributes(rty.into())
+    }
+}
+
+impl<N> From<RecordType<EntityAttributeType<N>>> for EntityAttributes<N> {
+    fn from(rty: RecordType<EntityAttributeType<N>>) -> EntityAttributes<N> {
+        Self::EntityAttributes(EntityAttributesInternal {
+            type_placeholder_hack: (),
+            attrs: rty,
+        })
+    }
+}
+
+impl EntityAttributes<RawName> {
+    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
+    pub fn conditionally_qualify_type_references(
+        self,
+        ns: Option<&InternalName>,
+    ) -> EntityAttributes<ConditionalName> {
+        match self {
+            Self::RecordAttributes(attrs) => {
+                EntityAttributes::RecordAttributes(attrs.conditionally_qualify_type_references(ns))
+            }
+            Self::EntityAttributes(internal) => EntityAttributes::EntityAttributes(
+                internal.conditionally_qualify_type_references(ns),
+            ),
+        }
+    }
+}
+
+impl EntityAttributesInternal<RawName> {
+    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
+    pub fn conditionally_qualify_type_references(
+        self,
+        ns: Option<&InternalName>,
+    ) -> EntityAttributesInternal<ConditionalName> {
+        EntityAttributesInternal {
+            type_placeholder_hack: self.type_placeholder_hack,
+            attrs: self.attrs.conditionally_qualify_type_references(ns),
+        }
+    }
+}
+
+impl EntityAttributes<ConditionalName> {
+    /// Convert this [`EntityAttributes<ConditionalName>`] into a
+    /// [`EntityAttributes<InternalName>`] by fully-qualifying all typenames
+    /// that appear anywhere in any definitions.
+    ///
+    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
+    /// fully-qualified typenames (of common and entity types respectively) that
+    /// are defined in the schema (in all schema fragments).
+    pub fn fully_qualify_type_references(
+        self,
+        all_common_defs: &HashSet<InternalName>,
+        all_entity_defs: &HashSet<InternalName>,
+    ) -> std::result::Result<EntityAttributes<InternalName>, TypeResolutionError> {
+        match self {
+            Self::RecordAttributes(attrs) => Ok(EntityAttributes::RecordAttributes(
+                attrs.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            )),
+            Self::EntityAttributes(internal) => Ok(EntityAttributes::EntityAttributes(
+                internal.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            )),
+        }
+    }
+}
+
+impl EntityAttributesInternal<ConditionalName> {
+    /// Convert this [`EntityAttributes<ConditionalName>`] into a
+    /// [`EntityAttributes<InternalName>`] by fully-qualifying all typenames
+    /// that appear anywhere in any definitions.
+    ///
+    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
+    /// fully-qualified typenames (of common and entity types respectively) that
+    /// are defined in the schema (in all schema fragments).
+    pub fn fully_qualify_type_references(
+        self,
+        all_common_defs: &HashSet<InternalName>,
+        all_entity_defs: &HashSet<InternalName>,
+    ) -> std::result::Result<EntityAttributesInternal<InternalName>, TypeResolutionError> {
+        Ok(EntityAttributesInternal {
+            type_placeholder_hack: self.type_placeholder_hack,
+            attrs: self
+                .attrs
+                .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+        })
+    }
+}
+
+impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for EntityAttributes<N> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::IntoDeserializer;
+        // This deserialization attempts to mimic what `serde(untagged)` would
+        // do, but if the process fails, it gives the error message for the
+        // `EntityAttributesInternal` case, assuming that that error message is
+        // usually the most helpful one.
+        // (The only case it doesn't cover is if you tried, but failed, to use a
+        // single common-type reference to represent the entity attributes.)
+
+        // Ideally we'd want to "try deserializing" as `RecordOrContextAttributes`
+        // and if that fails, restore the deserializer state to try
+        // `EntityAttributesInternal`.
+        // I'm not sure how `serde(untagged)` does that, and I can't easily
+        // figure it out from reading the serde source.
+        // Note that `D` isn't `Clone`.
+        // As a workaround, we deserialize into `serde_json::Value` first, then
+        // determine which variant we have, then deserialize the appropriate
+        // variant.
+        let value: serde_json::Value =
+            <JsonValueWithNoDuplicateKeys as Deserialize<'de>>::deserialize(deserializer)?.into();
+        match value.get("type") {
+            Some(s) if s != "Record" => {
+                // This is the only case where we need the `Self::RecordAttributes` variant;
+                // all other cases can deserialize as `Self::EntityAttributes`, or will have
+                // an error such that we want the error from the `Self::EntityAttributes`
+                // deserialization attempt.
+                let attrs = <RecordOrContextAttributes<N> as Deserialize<'de>>::deserialize(
+                    value.into_deserializer(),
+                )
+                .map_err(|e| serde::de::Error::custom(format!("{e}")))?;
+                Ok(Self::RecordAttributes(attrs))
+            }
+            _ => {
+                // In all other cases, we deserialize as `EntityAttributesInternal` or want the
+                // error message from trying to deserialize as `EntityAttributesInternal`.
+                let attrs = <EntityAttributesInternal<N> as Deserialize<'de>>::deserialize(
+                    value.into_deserializer(),
+                )
+                .map_err(|e| serde::de::Error::custom(format!("{e}")))?;
+                Ok(Self::EntityAttributes(attrs))
+            }
+        }
     }
 }
 
@@ -550,8 +808,8 @@ pub struct ApplySpec<N> {
     pub principal_types: Vec<N>,
     /// Context type that this action expects
     #[serde(default)]
-    #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
-    pub context: AttributesOrContext<N>,
+    #[serde(skip_serializing_if = "RecordOrContextAttributes::is_empty_record")]
+    pub context: RecordOrContextAttributes<N>,
 }
 
 impl ApplySpec<RawName> {
@@ -955,6 +1213,7 @@ enum TypeFields {
     Attributes,
     AdditionalAttributes,
     Name,
+    Default,
 }
 
 // This macro is used to avoid duplicating the fields names when calling
@@ -976,6 +1235,9 @@ macro_rules! type_field_name {
     (Name) => {
         "name"
     };
+    (Default) => {
+        "default"
+    };
 }
 
 impl TypeFields {
@@ -986,8 +1248,103 @@ impl TypeFields {
             TypeFields::Attributes => type_field_name!(Attributes),
             TypeFields::AdditionalAttributes => type_field_name!(AdditionalAttributes),
             TypeFields::Name => type_field_name!(Name),
+            TypeFields::Default => type_field_name!(Default),
         }
     }
+}
+
+/// The fields for a `SchemaType`, with their accompanying data.
+/// Used for implementing deserialization.
+///
+/// We keep field values wrapped in `Result` here so that we do not report
+/// errors due to the contents of a field when the field is not expected/allowed
+/// for a particular type variant.
+/// We instead report that the field should not exist at all, so that the schema
+/// author can delete the field without wasting time fixing errors in the value.
+struct TypeFieldsWithData<N, E> {
+    /// If this is `Some`, the `type` field is present, with the given value
+    type_name: Option<std::result::Result<SmolStr, E>>,
+    /// If this is `Some`, the `element` field is present, with the given value
+    element: Option<std::result::Result<Type<N>, E>>,
+    /// If this is `Some`, the `attributes` field is present, with the given value
+    attributes: Option<std::result::Result<AttributesTypeMap, E>>,
+    /// If this is `Some`, the `additional_attributes` field is present, with the given value
+    additional_attributes: Option<std::result::Result<bool, E>>,
+    /// If this is `Some`, the `name` field is present, with the given value
+    name: Option<std::result::Result<SmolStr, E>>,
+    /// If this is `Some`, the `default` field is present, with the given value
+    default: Option<std::result::Result<Type<N>, E>>,
+}
+
+impl<N, E> Default for TypeFieldsWithData<N, E> {
+    fn default() -> Self {
+        Self {
+            type_name: None,
+            element: None,
+            attributes: None,
+            additional_attributes: None,
+            name: None,
+            default: None,
+        }
+    }
+}
+
+/// Helper function to collect the [`TypeFieldsWithData`] from a map type during deserialization.
+/// Shared by [`SchemaTypeVisitor`] and [`EntityAttributeTypeInternalVisitor`].
+fn collect_type_fields_data<'de, N: Deserialize<'de> + From<RawName>, M: MapAccess<'de>>(
+    mut map: M,
+) -> std::result::Result<TypeFieldsWithData<N, M::Error>, M::Error> {
+    use TypeFields::*;
+
+    let mut fields: TypeFieldsWithData<N, M::Error> = TypeFieldsWithData::default();
+
+    // Gather all the fields in the object. Any fields that are not one of
+    // the possible fields for some schema type will have been reported by
+    // serde already.
+    while let Some(key) = map.next_key()? {
+        match key {
+            Type => {
+                if fields.type_name.is_some() {
+                    return Err(serde::de::Error::duplicate_field(Type.as_str()));
+                }
+                fields.type_name = Some(map.next_value());
+            }
+            Element => {
+                if fields.element.is_some() {
+                    return Err(serde::de::Error::duplicate_field(Element.as_str()));
+                }
+                fields.element = Some(map.next_value());
+            }
+            Attributes => {
+                if fields.attributes.is_some() {
+                    return Err(serde::de::Error::duplicate_field(Attributes.as_str()));
+                }
+                fields.attributes = Some(map.next_value());
+            }
+            AdditionalAttributes => {
+                if fields.additional_attributes.is_some() {
+                    return Err(serde::de::Error::duplicate_field(
+                        AdditionalAttributes.as_str(),
+                    ));
+                }
+                fields.additional_attributes = Some(map.next_value());
+            }
+            Name => {
+                if fields.name.is_some() {
+                    return Err(serde::de::Error::duplicate_field(Name.as_str()));
+                }
+                fields.name = Some(map.next_value());
+            }
+            Default => {
+                if fields.default.is_some() {
+                    return Err(serde::de::Error::duplicate_field(Default.as_str()));
+                }
+                fields.default = Some(map.next_value());
+            }
+        }
+    }
+
+    Ok(fields)
 }
 
 /// Used during deserialization to deserialize the attributes type map while
@@ -997,7 +1354,7 @@ impl TypeFields {
 #[derive(Deserialize)]
 struct AttributesTypeMap(
     #[serde(with = "serde_with::rust::maps_duplicate_key_is_error")]
-    BTreeMap<SmolStr, TypeOfAttribute<RawName>>,
+    BTreeMap<SmolStr, RecordAttributeType<RawName>>,
 );
 
 struct TypeVisitor<N> {
@@ -1011,64 +1368,18 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for TypeVisitor<N> {
         formatter.write_str("builtin type or reference to type defined in commonTypes")
     }
 
-    fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
+    fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
     where
         M: MapAccess<'de>,
     {
-        use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
-
-        // We keep field values wrapped in a `Result` initially so that we do
-        // not report errors due the contents of a field when the field is not
-        // expected for a particular type variant. We instead report that the
-        // field so not exist at all, so that the schema author can delete the
-        // field without wasting time fixing errors in the value.
-        let mut type_name: Option<std::result::Result<SmolStr, M::Error>> = None;
-        let mut element: Option<std::result::Result<Type<N>, M::Error>> = None;
-        let mut attributes: Option<std::result::Result<AttributesTypeMap, M::Error>> = None;
-        let mut additional_attributes: Option<std::result::Result<bool, M::Error>> = None;
-        let mut name: Option<std::result::Result<SmolStr, M::Error>> = None;
-
-        // Gather all the fields in the object. Any fields that are not one of
-        // the possible fields for some schema type will have been reported by
-        // serde already.
-        while let Some(key) = map.next_key()? {
-            match key {
-                TypeField => {
-                    if type_name.is_some() {
-                        return Err(serde::de::Error::duplicate_field(TypeField.as_str()));
-                    }
-                    type_name = Some(map.next_value());
-                }
-                Element => {
-                    if element.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Element.as_str()));
-                    }
-                    element = Some(map.next_value());
-                }
-                Attributes => {
-                    if attributes.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Attributes.as_str()));
-                    }
-                    attributes = Some(map.next_value());
-                }
-                AdditionalAttributes => {
-                    if additional_attributes.is_some() {
-                        return Err(serde::de::Error::duplicate_field(
-                            AdditionalAttributes.as_str(),
-                        ));
-                    }
-                    additional_attributes = Some(map.next_value());
-                }
-                Name => {
-                    if name.is_some() {
-                        return Err(serde::de::Error::duplicate_field(Name.as_str()));
-                    }
-                    name = Some(map.next_value());
-                }
-            }
+        let fields = collect_type_fields_data(map)?;
+        let eatype = Self::build_schema_type::<M>(fields)?;
+        // Here, in the deserializer for `Type`, we do not allow EAMap
+        // types (because `Type` does not allow EAMap types).
+        match eatype {
+            EntityAttributeTypeInternal::EAMap { .. } => Err(serde::de::Error::custom("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")),
+            EntityAttributeTypeInternal::Type(ty) => Ok(ty),
         }
-
-        Self::build_schema_type::<M>(type_name, element, attributes, additional_attributes, name)
     }
 }
 
@@ -1077,31 +1388,37 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
     /// Fields which were not present are `None`. It is an error for a field
     /// which is not used for a particular type to be `Some` when building that
     /// type.
+    ///
+    /// This method accepts EAMap types, and will construct one if it is encountered.
+    /// Thus it returns [`EntityAttributeTypeInternal`] rather than [`SchemaType`]
+    /// directly.
+    /// If EAMap types should not be accepted in this position, it is the caller's
+    /// responsibility to check that the [`EntityAttributeTypeInternal`] is an
+    /// acceptable variant.
     fn build_schema_type<M>(
-        type_name: Option<std::result::Result<SmolStr, M::Error>>,
-        element: Option<std::result::Result<Type<N>, M::Error>>,
-        attributes: Option<std::result::Result<AttributesTypeMap, M::Error>>,
-        additional_attributes: Option<std::result::Result<bool, M::Error>>,
-        name: Option<std::result::Result<SmolStr, M::Error>>,
-    ) -> std::result::Result<Type<N>, M::Error>
+        fields: TypeFieldsWithData<N, M::Error>,
+    ) -> std::result::Result<EntityAttributeTypeInternal<N>, M::Error>
     where
         M: MapAccess<'de>,
     {
-        use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
+        use TypeFields::{
+            AdditionalAttributes, Attributes, Default, Element, Name, Type as TypeField,
+        };
         // Fields that remain to be parsed
         let mut remaining_fields = [
-            (TypeField, type_name.is_some()),
-            (Element, element.is_some()),
-            (Attributes, attributes.is_some()),
-            (AdditionalAttributes, additional_attributes.is_some()),
-            (Name, name.is_some()),
+            (TypeField, fields.type_name.is_some()),
+            (Element, fields.element.is_some()),
+            (Attributes, fields.attributes.is_some()),
+            (AdditionalAttributes, fields.additional_attributes.is_some()),
+            (Name, fields.name.is_some()),
+            (Default, fields.default.is_some()),
         ]
         .into_iter()
         .filter(|(_, present)| *present)
         .map(|(field, _)| field)
         .collect::<HashSet<_>>();
 
-        match type_name.transpose()?.as_ref() {
+        match fields.type_name.transpose()?.as_ref() {
             Some(s) => {
                 // We've concluded that type exists
                 remaining_fields.remove(&TypeField);
@@ -1118,31 +1435,42 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                     Ok(())
                 };
                 let error_if_any_fields = || -> std::result::Result<(), M::Error> {
-                    error_if_fields(&[Element, Attributes, AdditionalAttributes, Name], &[])
+                    error_if_fields(
+                        &[Element, Attributes, AdditionalAttributes, Name, Default],
+                        &[],
+                    )
                 };
                 match s.as_str() {
                     "String" => {
                         error_if_any_fields()?;
-                        Ok(Type::Type(TypeVariant::String))
+                        Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                            TypeVariant::String,
+                        )))
                     }
                     "Long" => {
                         error_if_any_fields()?;
-                        Ok(Type::Type(TypeVariant::Long))
+                        Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                            TypeVariant::Long,
+                        )))
                     }
                     "Boolean" => {
                         error_if_any_fields()?;
-                        Ok(Type::Type(TypeVariant::Boolean))
+                        Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                            TypeVariant::Boolean,
+                        )))
                     }
                     "Set" => {
                         error_if_fields(
-                            &[Attributes, AdditionalAttributes, Name],
+                            &[Attributes, AdditionalAttributes, Default, Name],
                             &[type_field_name!(Element)],
                         )?;
 
-                        match element {
-                            Some(element) => Ok(Type::Type(TypeVariant::Set {
-                                element: Box::new(element?),
-                            })),
+                        match fields.element {
+                            Some(element) => Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                                TypeVariant::Set {
+                                    element: Box::new(element?),
+                                },
+                            ))),
                             None => Err(serde::de::Error::missing_field(Element.as_str())),
                         }
                     }
@@ -1152,99 +1480,121 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                             &[
                                 type_field_name!(Attributes),
                                 type_field_name!(AdditionalAttributes),
+                                type_field_name!(Default),
                             ],
                         )?;
 
-                        if let Some(attributes) = attributes {
-                            let additional_attributes =
-                                additional_attributes.unwrap_or(Ok(partial_schema_default()));
-                            Ok(Type::Type(TypeVariant::Record(RecordType {
-                                attributes: attributes?
-                                    .0
-                                    .into_iter()
-                                    .map(|(k, TypeOfAttribute { ty, required })| {
-                                        (
-                                            k,
-                                            TypeOfAttribute {
-                                                ty: ty.into_n(),
-                                                required,
-                                            },
-                                        )
-                                    })
-                                    .collect(),
-                                additional_attributes: additional_attributes?,
-                            })))
+                        if let Some(attributes) = fields.attributes {
+                            if fields.default.is_some() {
+                                return Err(serde::de::Error::custom("fields `default` and `attributes` cannot exist on the same record type"));
+                            }
+                            let additional_attributes = fields
+                                .additional_attributes
+                                .unwrap_or(Ok(partial_schema_default()));
+                            Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                                TypeVariant::Record(RecordType {
+                                    attributes: attributes?
+                                        .0
+                                        .into_iter()
+                                        .map(|(k, RecordAttributeType { ty, required })| {
+                                            (
+                                                k,
+                                                RecordAttributeType {
+                                                    ty: ty.into_n(),
+                                                    required,
+                                                },
+                                            )
+                                        })
+                                        .collect(),
+                                    additional_attributes: additional_attributes?,
+                                }),
+                            )))
+                        } else if let Some(default) = fields.default {
+                            if fields.attributes.is_some() {
+                                return Err(serde::de::Error::custom("fields `default` and `attributes` cannot exist on the same record type"));
+                            } else if fields.additional_attributes.is_some() {
+                                return Err(serde::de::Error::custom("fields `default` and `additionalAttributes` cannot exist on the same record type"));
+                            }
+                            Ok(EntityAttributeTypeInternal::EAMap {
+                                value_type: default?,
+                            })
                         } else {
                             Err(serde::de::Error::missing_field(Attributes.as_str()))
                         }
                     }
                     "Entity" => {
                         error_if_fields(
-                            &[Element, Attributes, AdditionalAttributes],
+                            &[Element, Attributes, AdditionalAttributes, Default],
                             &[type_field_name!(Name)],
                         )?;
-                        match name {
+                        match fields.name {
                             Some(name) => {
                                 let name = name?;
-                                Ok(Type::Type(TypeVariant::Entity {
-                                    name: RawName::from_normalized_str(&name)
-                                        .map_err(|err| {
-                                            serde::de::Error::custom(format!(
-                                                "invalid entity type `{name}`: {err}"
-                                            ))
-                                        })?
-                                        .into(),
-                                }))
+                                Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                                    TypeVariant::Entity {
+                                        name: RawName::from_normalized_str(&name)
+                                            .map_err(|err| {
+                                                serde::de::Error::custom(format!(
+                                                    "invalid entity type `{name}`: {err}"
+                                                ))
+                                            })?
+                                            .into(),
+                                    },
+                                )))
                             }
                             None => Err(serde::de::Error::missing_field(Name.as_str())),
                         }
                     }
                     "EntityOrCommon" => {
                         error_if_fields(
-                            &[Element, Attributes, AdditionalAttributes],
+                            &[Element, Attributes, AdditionalAttributes, Default],
                             &[type_field_name!(Name)],
                         )?;
-                        match name {
+                        match fields.name {
                             Some(name) => {
                                 let name = name?;
-                                Ok(Type::Type(TypeVariant::EntityOrCommon {
-                                    type_name: RawName::from_normalized_str(&name)
-                                        .map_err(|err| {
-                                            serde::de::Error::custom(format!(
-                                                "invalid entity or common type `{name}`: {err}"
-                                            ))
-                                        })?
-                                        .into(),
-                                }))
+                                Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                                    TypeVariant::EntityOrCommon {
+                                        type_name: RawName::from_normalized_str(&name)
+                                            .map_err(|err| {
+                                                serde::de::Error::custom(format!(
+                                                    "invalid entity or common type `{name}`: {err}"
+                                                ))
+                                            })?
+                                            .into(),
+                                    },
+                                )))
                             }
                             None => Err(serde::de::Error::missing_field(Name.as_str())),
                         }
                     }
                     "Extension" => {
                         error_if_fields(
-                            &[Element, Attributes, AdditionalAttributes],
+                            &[Element, Attributes, AdditionalAttributes, Default],
                             &[type_field_name!(Name)],
                         )?;
 
-                        match name {
+                        match fields.name {
                             Some(name) => {
                                 let name = name?;
-                                Ok(Type::Type(TypeVariant::Extension {
-                                    name: UnreservedId::from_normalized_str(&name).map_err(
-                                        |err| {
-                                            serde::de::Error::custom(format!(
-                                                "invalid extension type `{name}`: {err}"
-                                            ))
-                                        },
-                                    )?,
-                                }))
+                                Ok(EntityAttributeTypeInternal::Type(Type::Type(
+                                    TypeVariant::Extension {
+                                        name: UnreservedId::from_normalized_str(&name).map_err(
+                                            |err| {
+                                                serde::de::Error::custom(format!(
+                                                    "invalid extension type `{name}`: {err}"
+                                                ))
+                                            },
+                                        )?,
+                                    },
+                                )))
                             }
                             None => Err(serde::de::Error::missing_field(Name.as_str())),
                         }
                     }
                     type_name => {
                         error_if_any_fields()?;
-                        Ok(Type::CommonTypeRef {
+                        Ok(EntityAttributeTypeInternal::Type(Type::CommonTypeRef {
                             type_name: N::from(RawName::from_normalized_str(type_name).map_err(
                                 |err| {
                                     serde::de::Error::custom(format!(
@@ -1252,7 +1602,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                                     ))
                                 },
                             )?),
-                        })
+                        }))
                     }
                 }
             }
@@ -1269,24 +1619,29 @@ impl<N> From<TypeVariant<N>> for Type<N> {
 
 /// Represents the type-level information about a record type.
 ///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`RecordType`], including recursively.
-/// See notes on [`Fragment`].
+/// `V` is the type of attribute values in the record.
+/// For instance, when `V` is [`RecordAttributeType`], this [`RecordType`]
+/// represents the associated information for [`TypeVariant::Record`].
+/// Entity attribute values are also allowed to be `EAMap`s, so in that
+/// case `V` is [`EntityAttributeType`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+#[serde(bound(deserialize = "V: Deserialize<'de>"))]
+#[serde(bound(serialize = "V: Serialize"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct RecordType<N> {
+pub struct RecordType<V> {
     /// Attribute names and types for the record
-    pub attributes: BTreeMap<SmolStr, TypeOfAttribute<N>>,
+    #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
+    pub attributes: BTreeMap<SmolStr, V>,
     /// Whether "additional attributes" are possible on this record
     #[serde(default = "partial_schema_default")]
     #[serde(skip_serializing_if = "is_partial_schema_default")]
     pub additional_attributes: bool,
 }
 
-impl<N> Default for RecordType<N> {
+impl<V> Default for RecordType<V> {
     fn default() -> Self {
         Self {
             attributes: BTreeMap::new(),
@@ -1295,19 +1650,19 @@ impl<N> Default for RecordType<N> {
     }
 }
 
-impl<N> RecordType<N> {
+impl<V> RecordType<V> {
     /// Is this [`RecordType`] an empty record?
     pub fn is_empty_record(&self) -> bool {
         self.additional_attributes == partial_schema_default() && self.attributes.is_empty()
     }
 }
 
-impl RecordType<RawName> {
+impl RecordType<RecordAttributeType<RawName>> {
     /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> RecordType<ConditionalName> {
+    ) -> RecordType<RecordAttributeType<ConditionalName>> {
         RecordType {
             attributes: self
                 .attributes
@@ -1319,10 +1674,27 @@ impl RecordType<RawName> {
     }
 }
 
-impl RecordType<ConditionalName> {
-    /// Convert this [`RecordType<ConditionalName>`] into a
-    /// [`RecordType<InternalName>`] by fully-qualifying all typenames that
-    /// appear anywhere in any definitions.
+impl RecordType<EntityAttributeType<RawName>> {
+    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
+    pub fn conditionally_qualify_type_references(
+        self,
+        ns: Option<&InternalName>,
+    ) -> RecordType<EntityAttributeType<ConditionalName>> {
+        RecordType {
+            attributes: self
+                .attributes
+                .into_iter()
+                .map(|(k, v)| (k, v.conditionally_qualify_type_references(ns)))
+                .collect(),
+            additional_attributes: self.additional_attributes,
+        }
+    }
+}
+
+impl RecordType<RecordAttributeType<ConditionalName>> {
+    /// Convert this [`RecordType<RecordAttributeType<ConditionalName>>`] into a
+    /// [`RecordType<RecordAttributeType<InternalName>>`] by fully-qualifying
+    /// all typenames that appear anywhere in any definitions.
     ///
     /// `all_common_defs` and `all_entity_defs` need to be the full set of all
     /// fully-qualified typenames (of common and entity types respectively) that
@@ -1331,7 +1703,38 @@ impl RecordType<ConditionalName> {
         self,
         all_common_defs: &HashSet<InternalName>,
         all_entity_defs: &HashSet<InternalName>,
-    ) -> std::result::Result<RecordType<InternalName>, TypeResolutionError> {
+    ) -> std::result::Result<RecordType<RecordAttributeType<InternalName>>, TypeResolutionError>
+    {
+        Ok(RecordType {
+            attributes: self
+                .attributes
+                .into_iter()
+                .map(|(k, v)| {
+                    Ok((
+                        k,
+                        v.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+                    ))
+                })
+                .collect::<std::result::Result<_, _>>()?,
+            additional_attributes: self.additional_attributes,
+        })
+    }
+}
+
+impl RecordType<EntityAttributeType<ConditionalName>> {
+    /// Convert this [`RecordType<EntityAttributeType<ConditionalName>>`] into a
+    /// [`RecordType<EntityAttributeType<InternalName>>`] by fully-qualifying
+    /// all typenames that appear anywhere in any definitions.
+    ///
+    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
+    /// fully-qualified typenames (of common and entity types respectively) that
+    /// are defined in the schema (in all schema fragments).
+    pub fn fully_qualify_type_references(
+        self,
+        all_common_defs: &HashSet<InternalName>,
+        all_entity_defs: &HashSet<InternalName>,
+    ) -> std::result::Result<RecordType<EntityAttributeType<InternalName>>, TypeResolutionError>
+    {
         Ok(RecordType {
             attributes: self
                 .attributes
@@ -1373,7 +1776,7 @@ pub enum TypeVariant<N> {
         element: Box<Type<N>>,
     },
     /// Record
-    Record(RecordType<N>),
+    Record(RecordType<RecordAttributeType<N>>),
     /// Entity
     Entity {
         /// Name of the entity type.
@@ -1439,10 +1842,10 @@ impl TypeVariant<RawName> {
                 additional_attributes,
             }) => TypeVariant::Record(RecordType {
                 attributes: BTreeMap::from_iter(attributes.into_iter().map(
-                    |(attr, TypeOfAttribute { ty, required })| {
+                    |(attr, RecordAttributeType { ty, required })| {
                         (
                             attr,
-                            TypeOfAttribute {
+                            RecordAttributeType {
                                 ty: ty.conditionally_qualify_type_references(ns),
                                 required,
                             },
@@ -1516,10 +1919,10 @@ impl TypeVariant<ConditionalName> {
             }) => Ok(TypeVariant::Record(RecordType {
                 attributes: attributes
                     .into_iter()
-                    .map(|(attr, TypeOfAttribute { ty, required })| {
+                    .map(|(attr, RecordAttributeType { ty, required })| {
                         Ok((
                             attr,
-                            TypeOfAttribute {
+                            RecordAttributeType {
                                 ty: ty.fully_qualify_type_references(
                                     all_common_defs,
                                     all_entity_defs,
@@ -1588,13 +1991,190 @@ impl<'a> arbitrary::Arbitrary<'a> for Type<RawName> {
     }
 }
 
-/// Used to describe the type of a record or entity attribute. It contains a the
-/// type of the attribute and whether the attribute is required. The type is
-/// flattened for serialization, so, in JSON format, this appears as a regular
-/// type with one extra property `required`.
+/// Describes the underlying type of an entity attribute (not including the
+/// required/optional flag).
+///
+/// The allowed types for an entity attribute are different from the allowed
+/// types for a record attribute. See
+/// [RFC 68](https://github.com/cedar-policy/rfcs/blob/main/text/0068-entity-tags.md).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum EntityAttributeTypeInternal<N> {
+    /// A normal type. Attributes can be `String`, an entity type, a common type, a record type, etc
+    Type(Type<N>),
+    /// An embedded attribute map (RFC 68)
+    ///
+    /// That is, a map from String to the given value type.
+    EAMap {
+        /// The `EAMap` is a map from String to this value type.
+        ///
+        /// Note that this value type may not itself be (or contain) `EAMap`s.
+        value_type: Type<N>,
+    },
+}
+
+impl EntityAttributeTypeInternal<RawName> {
+    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
+    pub fn conditionally_qualify_type_references(
+        self,
+        ns: Option<&InternalName>,
+    ) -> EntityAttributeTypeInternal<ConditionalName> {
+        match self {
+            Self::Type(ty) => {
+                EntityAttributeTypeInternal::Type(ty.conditionally_qualify_type_references(ns))
+            }
+            Self::EAMap { value_type } => EntityAttributeTypeInternal::EAMap {
+                value_type: value_type.conditionally_qualify_type_references(ns),
+            },
+        }
+    }
+}
+
+impl EntityAttributeTypeInternal<ConditionalName> {
+    /// Convert this [`EntityAttributeTypeInternal<ConditionalName>`] into a
+    /// [`EntityAttributeTypeInternal<InternalName>`] by fully-qualifying all
+    /// typenames that appear anywhere in any definitions.
+    ///
+    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
+    /// fully-qualified typenames (of common and entity types respectively) that
+    /// are defined in the schema (in all schema fragments).
+    pub fn fully_qualify_type_references(
+        self,
+        all_common_defs: &HashSet<InternalName>,
+        all_entity_defs: &HashSet<InternalName>,
+    ) -> std::result::Result<EntityAttributeTypeInternal<InternalName>, TypeResolutionError> {
+        match self {
+            Self::Type(ty) => Ok(EntityAttributeTypeInternal::Type(
+                ty.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            )),
+            Self::EAMap { value_type } => Ok(EntityAttributeTypeInternal::EAMap {
+                value_type: value_type
+                    .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            }),
+        }
+    }
+}
+
+impl<N: Serialize> Serialize for EntityAttributeTypeInternal<N> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Type(ty) => ty.serialize(serializer),
+            Self::EAMap { value_type } => {
+                serde_json::json!({"type": "Record", "default": value_type}).serialize(serializer)
+            }
+        }
+    }
+}
+
+struct EntityAttributeTypeInternalVisitor<N> {
+    _phantom: PhantomData<N>,
+}
+
+impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for EntityAttributeTypeInternal<N> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(EntityAttributeTypeInternalVisitor {
+            _phantom: PhantomData,
+        })
+    }
+}
+
+impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de>
+    for EntityAttributeTypeInternalVisitor<N>
+{
+    type Value = EntityAttributeTypeInternal<N>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("any valid type, including an embedded attribute map type")
+    }
+
+    fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
+    where
+        M: MapAccess<'de>,
+    {
+        let fields = collect_type_fields_data(map)?;
+        TypeVisitor::build_schema_type::<M>(fields)
+    }
+}
+
+/// Describes the type of an entity attribute. It contains the type of the
+/// attribute and whether the attribute is required. The type is flattened for
+/// serialization, so, in JSON format, this appears as a regular type with one
+/// extra property `required`.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
-/// this [`TypeOfAttribute`], including recursively.
+/// this [`EntityAttributeType`], including recursively.
+/// See notes on [`SchemaFragment`].
+///
+/// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
+/// using `#[serde(tag = "type")]` in [`Type`] which is (eventually) flattened
+/// here.
+/// The way `serde(flatten)` is implemented means it may be possible to access
+/// fields incorrectly if a struct contains two structs that are flattened
+/// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
+/// us as we're using `flatten` only once
+/// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
+/// unknown fields for [`EntityAttributeType`] should be passed to [`Type`]
+/// where they will be denied
+/// (`<https://github.com/serde-rs/serde/issues/1600>`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+pub struct EntityAttributeType<N> {
+    /// Underlying type of the attribute
+    #[serde(flatten)]
+    pub ty: EntityAttributeTypeInternal<N>,
+    /// Whether the attribute is required
+    #[serde(default = "record_attribute_required_default")]
+    #[serde(skip_serializing_if = "is_record_attribute_required_default")]
+    pub required: bool,
+}
+
+impl EntityAttributeType<RawName> {
+    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
+    pub fn conditionally_qualify_type_references(
+        self,
+        ns: Option<&InternalName>,
+    ) -> EntityAttributeType<ConditionalName> {
+        EntityAttributeType {
+            ty: self.ty.conditionally_qualify_type_references(ns),
+            required: self.required,
+        }
+    }
+}
+
+impl EntityAttributeType<ConditionalName> {
+    /// Convert this [`EntityAttributeType<ConditionalName>`] into a
+    /// [`EntityAttributeType<InternalName>`] by fully-qualifying
+    /// all typenames that appear anywhere in any definitions.
+    ///
+    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
+    /// fully-qualified typenames (of common and entity types respectively) that
+    /// are defined in the schema (in all schema fragments).
+    pub fn fully_qualify_type_references(
+        self,
+        all_common_defs: &HashSet<InternalName>,
+        all_entity_defs: &HashSet<InternalName>,
+    ) -> std::result::Result<EntityAttributeType<InternalName>, TypeResolutionError> {
+        Ok(EntityAttributeType {
+            ty: self
+                .ty
+                .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            required: self.required,
+        })
+    }
+}
+
+/// Describes the type of a record attribute. It contains the type of the
+/// attribute and whether the attribute is required. The type is flattened for
+/// serialization, so, in JSON format, this appears as a regular type with one
+/// extra property `required`.
+///
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`RecordAttributeType`], including recursively.
 /// See notes on [`Fragment`].
 ///
 /// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
@@ -1608,7 +2188,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Type<RawName> {
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-pub struct TypeOfAttribute<N> {
+pub struct RecordAttributeType<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]
     pub ty: Type<N>,
@@ -1618,9 +2198,9 @@ pub struct TypeOfAttribute<N> {
     pub required: bool,
 }
 
-impl TypeOfAttribute<RawName> {
-    fn into_n<N: From<RawName>>(self) -> TypeOfAttribute<N> {
-        TypeOfAttribute {
+impl RecordAttributeType<RawName> {
+    fn into_n<N: From<RawName>>(self) -> RecordAttributeType<N> {
+        RecordAttributeType {
             ty: self.ty.into_n(),
             required: self.required,
         }
@@ -1630,18 +2210,18 @@ impl TypeOfAttribute<RawName> {
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> TypeOfAttribute<ConditionalName> {
-        TypeOfAttribute {
+    ) -> RecordAttributeType<ConditionalName> {
+        RecordAttributeType {
             ty: self.ty.conditionally_qualify_type_references(ns),
             required: self.required,
         }
     }
 }
 
-impl TypeOfAttribute<ConditionalName> {
-    /// Convert this [`TypeOfAttribute<ConditionalName>`] into a
-    /// [`TypeOfAttribute<InternalName>`] by fully-qualifying all typenames that
-    /// appear anywhere in any definitions.
+impl RecordAttributeType<ConditionalName> {
+    /// Convert this [`RecordAttributeType<ConditionalName>`] into a
+    /// [`RecordAttributeType<InternalName>`] by fully-qualifying
+    /// all typenames that appear anywhere in any definitions.
     ///
     /// `all_common_defs` and `all_entity_defs` need to be the full set of all
     /// fully-qualified typenames (of common and entity types respectively) that
@@ -1650,8 +2230,8 @@ impl TypeOfAttribute<ConditionalName> {
         self,
         all_common_defs: &HashSet<InternalName>,
         all_entity_defs: &HashSet<InternalName>,
-    ) -> std::result::Result<TypeOfAttribute<InternalName>, TypeResolutionError> {
-        Ok(TypeOfAttribute {
+    ) -> std::result::Result<RecordAttributeType<InternalName>, TypeResolutionError> {
+        Ok(RecordAttributeType {
             ty: self
                 .ty
                 .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
@@ -1661,7 +2241,7 @@ impl TypeOfAttribute<ConditionalName> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for TypeOfAttribute<RawName> {
+impl<'a> arbitrary::Arbitrary<'a> for RecordAttributeType<RawName> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             ty: u.arbitrary()?,
@@ -1716,10 +2296,12 @@ mod test {
         assert_eq!(et.member_of_types, vec!["UserGroup".parse().unwrap()]);
         assert_eq!(
             et.shape,
-            AttributesOrContext(Type::Type(TypeVariant::Record(RecordType {
-                attributes: BTreeMap::new(),
-                additional_attributes: false
-            }))),
+            EntityAttributes::RecordAttributes(RecordOrContextAttributes(Type::Type(
+                TypeVariant::Record(RecordType {
+                    attributes: BTreeMap::new(),
+                    additional_attributes: false
+                })
+            ))),
         );
     }
 
@@ -1732,10 +2314,12 @@ mod test {
         assert_eq!(et.member_of_types.len(), 0);
         assert_eq!(
             et.shape,
-            AttributesOrContext(Type::Type(TypeVariant::Record(RecordType {
-                attributes: BTreeMap::new(),
-                additional_attributes: false
-            }))),
+            EntityAttributes::RecordAttributes(RecordOrContextAttributes(Type::Type(
+                TypeVariant::Record(RecordType {
+                    attributes: BTreeMap::new(),
+                    additional_attributes: false
+                })
+            ))),
         );
     }
 
@@ -1754,7 +2338,7 @@ mod test {
         let spec = ApplySpec {
             resource_types: vec!["Album".parse().unwrap()],
             principal_types: vec!["User".parse().unwrap()],
-            context: AttributesOrContext::default(),
+            context: RecordOrContextAttributes::default(),
         };
         assert_eq!(at.applies_to, Some(spec));
         assert_eq!(
@@ -1845,7 +2429,7 @@ mod test {
                 "actions": {}
             }
         }"#;
-        let schema: Fragment<RawName> = serde_json::from_str(src).expect("Parse Error");
+        let schema = Fragment::from_json_str(src).expect("Parse Error");
         let (namespace, _descriptor) = schema.0.into_iter().next().unwrap();
         assert_eq!(namespace, Some("foo::foo::bar::baz".parse().unwrap()));
     }
@@ -2399,6 +2983,440 @@ mod strengthened_types {
     }
 }
 
+/// Tests involving `EAMap`s (RFC 68)
+#[cfg(test)]
+mod ea_maps {
+    use super::*;
+    use crate::cedar_schema::test::assert_entity_attr_has_type;
+    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
+    use cool_asserts::assert_matches;
+
+    #[test]
+    fn entity_attribute() {
+        // This schema taken directly from the RFC 68 text
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "jobLevel": {
+                                    "type": "Long",
+                                },
+                                "authTags": {
+                                    "type": "Record",
+                                    "default": {
+                                        "type": "Set",
+                                        "element": { "type": "String" },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "Document": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "owner": {
+                                    "type": "Entity",
+                                    "name": "User",
+                                },
+                                "policyTags": {
+                                    "type": "Record",
+                                    "default": {
+                                        "type": "Set",
+                                        "element": { "type": "String" },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src), Ok(frag) => {
+            let user = frag.0.get(&None).unwrap().entity_types.get(&"User".parse().unwrap()).unwrap();
+            assert_matches!(&user.shape, EntityAttributes::EntityAttributes(EntityAttributesInternal { attrs, .. }) => {
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("jobLevel").unwrap(),
+                    &EntityAttributeTypeInternal::Type(Type::Type(TypeVariant::Long)),
+                );
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("authTags").unwrap(),
+                    &EntityAttributeTypeInternal::EAMap { value_type: Type::Type(TypeVariant::Set { element: Box::new(Type::Type(TypeVariant::String)) }) },
+                );
+            });
+            let doc = frag.0.get(&None).unwrap().entity_types.get(&"Document".parse().unwrap()).unwrap();
+            assert_matches!(&doc.shape, EntityAttributes::EntityAttributes(EntityAttributesInternal { attrs, .. }) => {
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("owner").unwrap(),
+                    &EntityAttributeTypeInternal::Type(Type::Type(TypeVariant::Entity { name: "User".parse().unwrap() })),
+                );
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("policyTags").unwrap(),
+                    &EntityAttributeTypeInternal::EAMap { value_type: Type::Type(TypeVariant::Set { element: Box::new(Type::Type(TypeVariant::String)) }) },
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn record_attribute_inside_entity_attribute() {
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "userDetails": {
+                                    "type": "Record",
+                                    "attributes": {
+                                        "tags": {
+                                            "type": "Record",
+                                            "default": {
+                                                "type": "String"
+                                            }
+                                        },
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn context_attribute() {
+        let src = serde_json::json!({
+            "": {
+                "actions": {
+                    "read": {
+                        "appliesTo": {
+                            "principalTypes": ["E"],
+                            "resourceTypes": ["E"],
+                            "context": {
+                                "type": "Record",
+                                "attributes": {
+                                    "operationDetails": {
+                                        "type": "Record",
+                                        "default": {
+                                            "type": "String"
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn toplevel_entity() {
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "default": {
+                                "type": "String"
+                            }
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("missing field `attributes`").build(),
+            );
+        });
+    }
+
+    #[test]
+    fn toplevel_context() {
+        let src = serde_json::json!({
+            "": {
+                "actions": {
+                    "read": {
+                        "appliesTo": {
+                            "principalTypes": ["E"],
+                            "resourceTypes": ["E"],
+                            "context": {
+                                "type": "Record",
+                                "default": {
+                                    "type": "String"
+                                },
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn common_type() {
+        let src = serde_json::json!({
+            "": {
+                "commonTypes": {
+                    "blah": {
+                        "type": "Record",
+                        "default": {
+                            "type": "String"
+                        }
+                    },
+                },
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "blah": {
+                                    "type": "blah"
+                                },
+                            }
+                        }
+                    },
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn value_type_is_common_type() {
+        let src = serde_json::json!({
+            "": {
+                "commonTypes": {
+                    "blah": {
+                        "type": "Record",
+                        "attributes": {
+                            "foo": { "type": "String" },
+                        }
+                    },
+                },
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "blah": {
+                                    "type": "Record",
+                                    "default": {
+                                        "type": "blah"
+                                    }
+                                },
+                            }
+                        }
+                    },
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src), Ok(frag) => {
+            let user = frag.0.get(&None).unwrap().entity_types.get(&"User".parse().unwrap()).unwrap();
+            assert_matches!(&user.shape, EntityAttributes::EntityAttributes(EntityAttributesInternal { attrs, .. }) => {
+                assert_entity_attr_has_type(
+                    attrs.attributes.get("blah").unwrap(),
+                    &EntityAttributeTypeInternal::EAMap { value_type: Type::CommonTypeRef { type_name: "blah".parse().unwrap() } },
+                );
+            });
+        });
+    }
+
+    #[test]
+    fn nested_ea_map() {
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "userDetails": {
+                                    "type": "Record",
+                                    "default": {
+                                        "type": "Record",
+                                        "default": {
+                                            "type": "String"
+                                        }
+                                    }
+                                },
+                            }
+                        }
+                    }
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn bad_default() {
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "jobLevel": {
+                                    "type": "Long",
+                                },
+                                "authTags": {
+                                    "type": "Foo",
+                                    "default": {
+                                        "type": "Set",
+                                        "element": "String",
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("unknown field `default`, there are no fields")
+                    .build(),
+            );
+        });
+    }
+
+    #[test]
+    fn missing_type_record() {
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "jobLevel": {
+                                    "type": "Long",
+                                },
+                                "authTags": {
+                                    "default": {
+                                        "type": "Set",
+                                        "element": "String",
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("missing field `type`").build(),
+            );
+        });
+    }
+
+    #[test]
+    fn both_default_and_attributes() {
+        let src = serde_json::json!({
+            "": {
+                "entityTypes": {
+                    "User": {
+                        "shape": {
+                            "type": "Record",
+                            "attributes": {
+                                "jobLevel": {
+                                    "type": "Long",
+                                },
+                                "authTags": {
+                                    "type": "Record",
+                                    "attributes": {
+                                        "foo": {
+                                            "type": "String",
+                                        },
+                                    },
+                                    "default": {
+                                        "type": "Set",
+                                        "element": "String",
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                "actions": {}
+            }
+        });
+        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
+            expect_err(
+                &src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("fields `default` and `attributes` cannot exist on the same record type")
+                    .build(),
+            );
+        });
+    }
+}
+
 /// Check that (de)serialization works as expected.
 #[cfg(test)]
 mod test_json_roundtrip {
@@ -2447,10 +3465,12 @@ mod test_json_roundtrip {
                     "a".parse().unwrap(),
                     EntityType {
                         member_of_types: vec!["a".parse().unwrap()],
-                        shape: AttributesOrContext(Type::Type(TypeVariant::Record(RecordType {
-                            attributes: BTreeMap::new(),
-                            additional_attributes: false,
-                        }))),
+                        shape: EntityAttributes::RecordAttributes(RecordOrContextAttributes(
+                            Type::Type(TypeVariant::Record(RecordType {
+                                attributes: BTreeMap::new(),
+                                additional_attributes: false,
+                            })),
+                        )),
                     },
                 )]),
                 actions: HashMap::from([(
@@ -2460,12 +3480,7 @@ mod test_json_roundtrip {
                         applies_to: Some(ApplySpec {
                             resource_types: vec!["a".parse().unwrap()],
                             principal_types: vec!["a".parse().unwrap()],
-                            context: AttributesOrContext(Type::Type(TypeVariant::Record(
-                                RecordType {
-                                    attributes: BTreeMap::new(),
-                                    additional_attributes: false,
-                                },
-                            ))),
+                            context: RecordOrContextAttributes::default(),
                         }),
                         member_of: None,
                     },
@@ -2486,12 +3501,7 @@ mod test_json_roundtrip {
                         "a".parse().unwrap(),
                         EntityType {
                             member_of_types: vec!["a".parse().unwrap()],
-                            shape: AttributesOrContext(Type::Type(TypeVariant::Record(
-                                RecordType {
-                                    attributes: BTreeMap::new(),
-                                    additional_attributes: false,
-                                },
-                            ))),
+                            shape: EntityAttributes::default(),
                         },
                     )]),
                     actions: HashMap::new(),
@@ -2509,12 +3519,7 @@ mod test_json_roundtrip {
                             applies_to: Some(ApplySpec {
                                 resource_types: vec!["foo::a".parse().unwrap()],
                                 principal_types: vec!["foo::a".parse().unwrap()],
-                                context: AttributesOrContext(Type::Type(TypeVariant::Record(
-                                    RecordType {
-                                        attributes: BTreeMap::new(),
-                                        additional_attributes: false,
-                                    },
-                                ))),
+                                context: RecordOrContextAttributes::default(),
                             }),
                             member_of: None,
                         },
@@ -2528,7 +3533,7 @@ mod test_json_roundtrip {
 
 /// Tests in this module check the behavior of schema parsing given duplicate
 /// map keys. The `json!` macro silently drops duplicate keys before they reach
-/// our parser, so these tests must be written with `serde_json::from_str`
+/// our parser, so these tests must be written with `from_json_str`
 /// instead.
 #[cfg(test)]
 mod test_duplicates_error {
@@ -2547,7 +3552,7 @@ mod test_duplicates_error {
               "actions": {}
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
@@ -2562,7 +3567,7 @@ mod test_duplicates_error {
               "actions": {}
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
@@ -2577,7 +3582,7 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
@@ -2593,11 +3598,11 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
-    #[should_panic(expected = "invalid entry: found duplicate key")]
+    #[should_panic(expected = "the key `Baz` occurs two or more times in the same JSON object")]
     fn record_type() {
         let src = r#"{
             "Foo": {
@@ -2615,7 +3620,7 @@ mod test_duplicates_error {
               "actions": { }
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
@@ -2633,7 +3638,7 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
@@ -2651,7 +3656,7 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 
     #[test]
@@ -2668,6 +3673,6 @@ mod test_duplicates_error {
               }
             }
         }"#;
-        serde_json::from_str::<Fragment<RawName>>(src).unwrap();
+        Fragment::from_json_str(src).unwrap();
     }
 }

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -2197,7 +2197,8 @@ impl EntityAttributeType<ConditionalName> {
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-// no tsify derive because handled specially in build-wasm.sh due to the serde(flatten)
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct RecordAttributeType<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -2108,7 +2108,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de>
 ///
 /// The parameter `N` is the type of entity type names and common type names in
 /// this [`EntityAttributeType`], including recursively.
-/// See notes on [`SchemaFragment`].
+/// See notes on [`Fragment`].
 ///
 /// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
 /// using `#[serde(tag = "type")]` in [`Type`] which is (eventually) flattened
@@ -2184,7 +2184,7 @@ impl EntityAttributeType<ConditionalName> {
 /// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
 /// us as we're using `flatten` only once
 /// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
-/// unknown fields for [`TypeOfAttribute`] should be passed to [`Type`] where
+/// unknown fields for [`RecordAttributeType`] should be passed to [`Type`] where
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -475,6 +475,7 @@ pub enum EntityAttributes<N> {
 #[serde(deny_unknown_fields)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+#[allow(clippy::manual_non_exhaustive)] // a clippy false positive; that's not the reason we're using the `type_placeholder_hack`
 pub struct EntityAttributesInternal<N> {
     /// a hack for the derived serializer/deserializer.
     /// We need to require `"type": "Record"` here (it is required for the
@@ -987,7 +988,7 @@ impl ActionEntityUID<ConditionalName> {
                 }
             }
         }
-        return Err(ActionResolutionError(nonempty!(self)));
+        Err(ActionResolutionError(nonempty!(self)))
     }
 
     /// Get the possible fully-qualified [`ActionEntityUID<InternalName>`]s
@@ -1389,12 +1390,13 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
     /// which is not used for a particular type to be `Some` when building that
     /// type.
     ///
-    /// This method accepts EAMap types, and will construct one if it is encountered.
+    /// This method accepts `EAMap` types, and will construct one if it is
+    /// encountered.
     /// Thus it returns [`EntityAttributeTypeInternal`] rather than [`SchemaType`]
     /// directly.
-    /// If EAMap types should not be accepted in this position, it is the caller's
-    /// responsibility to check that the [`EntityAttributeTypeInternal`] is an
-    /// acceptable variant.
+    /// If `EAMap` types should not be accepted in this position, it is the
+    /// caller's responsibility to check that the [`EntityAttributeTypeInternal`]
+    /// is an acceptable variant.
     fn build_schema_type<M>(
         fields: TypeFieldsWithData<N, M::Error>,
     ) -> std::result::Result<EntityAttributeTypeInternal<N>, M::Error>

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -2125,6 +2125,8 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de>
 /// (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct EntityAttributeType<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]
@@ -2190,6 +2192,8 @@ impl EntityAttributeType<ConditionalName> {
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct RecordAttributeType<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -1781,6 +1781,7 @@ pub enum TypeVariant<N> {
         element: Box<Type<N>>,
     },
     /// Record
+    #[tsify(type = r#"{ type: "Record"; attributes: Record<SmolStr, Type<N> & { required?: boolean }>, additionalAttributes?: boolean }"#)]
     Record(RecordType<RecordAttributeType<N>>),
     /// Entity
     Entity {
@@ -2197,8 +2198,10 @@ impl EntityAttributeType<ConditionalName> {
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+// no tsify derive because, as of this writing, tsify produces a declaration
+// `export interface RecordAttributeType<N> extends Type<N> { required?: boolean; }`
+// which `tsc` fails with `error TS2312: An interface can only extend an object
+// type or intersection of object types with statically known members.`
 pub struct RecordAttributeType<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -232,14 +232,14 @@ mod test {
                     foo_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
                 (
                     bar_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
             ],
@@ -249,7 +249,7 @@ mod test {
                     applies_to: Some(json_schema::ApplySpec {
                         principal_types: vec!["foo_type".parse().unwrap()],
                         resource_types: vec!["bar_type".parse().unwrap()],
-                        context: json_schema::AttributesOrContext::default(),
+                        context: json_schema::RecordOrContextAttributes::default(),
                     }),
                     member_of: None,
                     attributes: None,

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -487,7 +487,7 @@ mod test {
                 foo_type.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )],
             [],
@@ -521,7 +521,7 @@ mod test {
                 "foo_type".parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )],
             [],
@@ -606,7 +606,7 @@ mod test {
                 p_name.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )],
             [],
@@ -630,7 +630,7 @@ mod test {
                 p_name.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )],
             [],
@@ -654,7 +654,7 @@ mod test {
                 p_name.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )],
             [],
@@ -944,7 +944,7 @@ mod test {
                 foo_type.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::AttributesOrContext::default(),
+                    shape: json_schema::EntityAttributes::default(),
                 },
             )],
             [],
@@ -977,14 +977,14 @@ mod test {
                     principal_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
                 (
                     resource_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
             ],
@@ -994,7 +994,7 @@ mod test {
                     applies_to: Some(json_schema::ApplySpec {
                         resource_types: vec![resource_type.parse().unwrap()],
                         principal_types: vec![principal_type.parse().unwrap()],
-                        context: json_schema::AttributesOrContext::default(),
+                        context: json_schema::RecordOrContextAttributes::default(),
                     }),
                     member_of: Some(vec![]),
                     attributes: None,
@@ -1366,28 +1366,28 @@ mod test {
                     principal_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
                 (
                     resource_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![resource_parent_type.parse().unwrap()],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
                 (
                     resource_parent_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![resource_grandparent_type.parse().unwrap()],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
                 (
                     resource_grandparent_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::AttributesOrContext::default(),
+                        shape: json_schema::EntityAttributes::default(),
                     },
                 ),
             ],
@@ -1398,7 +1398,7 @@ mod test {
                         applies_to: Some(json_schema::ApplySpec {
                             resource_types: vec![resource_type.parse().unwrap()],
                             principal_types: vec![principal_type.parse().unwrap()],
-                            context: json_schema::AttributesOrContext::default(),
+                            context: json_schema::RecordOrContextAttributes::default(),
                         }),
                         member_of: Some(vec![json_schema::ActionEntityUID::new(
                             None,

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -83,7 +83,7 @@ impl TryInto<ValidatorSchemaFragment<ConditionalName, ConditionalName>>
         ValidatorSchemaFragment::from_schema_fragment(
             self,
             ActionBehavior::default(),
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
     }
 }
@@ -194,7 +194,7 @@ impl TryFrom<json_schema::NamespaceDefinition<RawName>> for ValidatorSchema {
     fn try_from(nsd: json_schema::NamespaceDefinition<RawName>) -> Result<ValidatorSchema> {
         ValidatorSchema::from_schema_fragments(
             [ValidatorSchemaFragment::from_namespaces([nsd.try_into()?])],
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
     }
 }
@@ -203,7 +203,7 @@ impl TryFrom<json_schema::Fragment<RawName>> for ValidatorSchema {
     type Error = SchemaError;
 
     fn try_from(frag: json_schema::Fragment<RawName>) -> Result<ValidatorSchema> {
-        ValidatorSchema::from_schema_fragments([frag.try_into()?], &Extensions::all_available())
+        ValidatorSchema::from_schema_fragments([frag.try_into()?], Extensions::all_available())
     }
 }
 
@@ -407,7 +407,7 @@ impl ValidatorSchema {
         }
 
         let resolver = CommonTypeResolver::new(&common_types);
-        let common_types = resolver.resolve(&extensions)?;
+        let common_types = resolver.resolve(extensions)?;
 
         // Invert the `parents` relation defined by entities and action so far
         // to get a `children` relation.
@@ -800,10 +800,10 @@ impl TryInto<ValidatorSchema> for NamespaceDefinitionWithActionAttributes<RawNam
                     None,
                     self.0,
                     crate::ActionBehavior::PermitAttributes,
-                    &Extensions::all_available(),
+                    Extensions::all_available(),
                 )?,
             ])],
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
     }
 }
@@ -1634,7 +1634,7 @@ pub(crate) mod test {
         let schema = ValidatorSchemaFragment::from_schema_fragment(
             schema_json,
             ActionBehavior::ProhibitAttributes,
-            &Extensions::all_available(),
+            Extensions::all_available(),
         );
         match schema {
             Err(e) => {
@@ -1671,7 +1671,7 @@ pub(crate) mod test {
             .fully_qualify_type_references(&HashSet::new(), &all_entity_defs)
             .unwrap();
         let ty: Type =
-            try_jsonschema_type_into_validator_type(schema_ty, &Extensions::all_available())
+            try_jsonschema_type_into_validator_type(schema_ty, Extensions::all_available())
                 .expect("Error converting schema type to type.")
                 .resolve_common_type_refs(&HashMap::new())
                 .unwrap();
@@ -1699,7 +1699,7 @@ pub(crate) mod test {
             .fully_qualify_type_references(&HashSet::new(), &all_entity_defs)
             .unwrap();
         let ty: Type =
-            try_jsonschema_type_into_validator_type(schema_ty, &Extensions::all_available())
+            try_jsonschema_type_into_validator_type(schema_ty, Extensions::all_available())
                 .expect("Error converting schema type to type.")
                 .resolve_common_type_refs(&HashMap::new())
                 .unwrap();
@@ -1732,7 +1732,7 @@ pub(crate) mod test {
             .fully_qualify_type_references(&HashSet::new(), &all_entity_defs)
             .unwrap();
         let ty: Type =
-            try_jsonschema_type_into_validator_type(schema_ty, &Extensions::all_available())
+            try_jsonschema_type_into_validator_type(schema_ty, Extensions::all_available())
                 .expect("Error converting schema type to type.")
                 .resolve_common_type_refs(&HashMap::new())
                 .unwrap();
@@ -1776,7 +1776,7 @@ pub(crate) mod test {
     #[test]
     fn schema_no_fragments() {
         let schema =
-            ValidatorSchema::from_schema_fragments([], &Extensions::all_available()).unwrap();
+            ValidatorSchema::from_schema_fragments([], Extensions::all_available()).unwrap();
         assert!(schema.entity_types.is_empty());
         assert!(schema.action_ids.is_empty());
     }
@@ -2075,7 +2075,7 @@ pub(crate) mod test {
             .unwrap();
         let schema = ValidatorSchema::from_schema_fragments(
             [fragment1, fragment2],
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
         .unwrap();
 
@@ -2116,7 +2116,7 @@ pub(crate) mod test {
 
         let schema = ValidatorSchema::from_schema_fragments(
             [fragment1, fragment2],
-            &Extensions::all_available(),
+            Extensions::all_available(),
         );
 
         // should error because schema fragments have duplicate types
@@ -2467,7 +2467,7 @@ pub(crate) mod test {
               }
         );
         let schema =
-            ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available()).unwrap();
+            ValidatorSchema::from_json_value(src.clone(), Extensions::all_available()).unwrap();
         let mut attributes = schema
             .get_entity_type(&"Demo::User".parse().unwrap())
             .unwrap()
@@ -2507,7 +2507,7 @@ pub(crate) mod test {
                 }
               }
         );
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2534,7 +2534,7 @@ pub(crate) mod test {
                 }
               }
         );
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2566,7 +2566,7 @@ pub(crate) mod test {
                 }
               }
         );
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2596,7 +2596,7 @@ pub(crate) mod test {
                 }
               }
         );
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2628,7 +2628,7 @@ pub(crate) mod test {
                 "actions": {}
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2664,7 +2664,7 @@ pub(crate) mod test {
                 }
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2691,7 +2691,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2718,7 +2718,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -2759,7 +2759,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(_));
 
         let src: serde_json::Value = json!({
@@ -2789,7 +2789,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(_));
 
         let src: serde_json::Value = json!({
@@ -2819,7 +2819,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(_));
 
         let src: serde_json::Value = json!({
@@ -2849,7 +2849,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(_));
 
         let src: serde_json::Value = json!({
@@ -2879,7 +2879,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Ok(_));
 
         let src: serde_json::Value = json!({
@@ -2909,7 +2909,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Ok(_));
 
         let src: serde_json::Value = json!({
@@ -2939,7 +2939,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Ok(_));
     }
 
@@ -2952,7 +2952,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
 
         let src: serde_json::Value = json!({
@@ -2962,7 +2962,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
 
         let src: serde_json::Value = json!({
@@ -2976,7 +2976,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
 
         let src: serde_json::Value = json!({
@@ -2990,7 +2990,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
 
         let src: serde_json::Value = json!({
@@ -3004,7 +3004,7 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), &Extensions::all_available());
+        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
                 &src,
@@ -3060,7 +3060,7 @@ mod test_resolver {
         }
         let resolver = CommonTypeResolver::new(&defs);
         resolver
-            .resolve(&Extensions::all_available())
+            .resolve(Extensions::all_available())
             .map(|map| map.into_iter().map(|(k, v)| (k.clone(), v)).collect())
     }
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -49,6 +49,7 @@ pub(crate) use action::ValidatorApplySpec;
 mod entity_type;
 pub use entity_type::ValidatorEntityType;
 mod namespace_def;
+use namespace_def::try_entity_attributes_into_validator_type;
 pub(crate) use namespace_def::try_jsonschema_type_into_validator_type;
 pub use namespace_def::ValidatorNamespaceDef;
 mod raw_name;
@@ -434,8 +435,8 @@ impl ValidatorSchema {
                 // `check_for_undeclared`.
                 let descendants = entity_children.remove(&name).unwrap_or_default();
                 let (attributes, open_attributes) = {
-                    let unresolved = try_jsonschema_type_into_validator_type(
-                        entity_type.attributes.0,
+                    let unresolved = try_entity_attributes_into_validator_type(
+                        entity_type.attributes,
                         extensions,
                     )?;
                     Self::record_attributes_or_none(
@@ -605,9 +606,9 @@ impl ValidatorSchema {
         }
     }
 
-    // Check that all entity types appearing inside a type are in the set of
-    // declared entity types, adding any undeclared entity types to the
-    // `undeclared_types` set.
+    /// Check that all entity types appearing inside a type are in the set of
+    /// declared entity types, adding any undeclared entity types to the
+    /// `undeclared_types` set.
     fn check_undeclared_in_type(
         ty: &Type,
         entity_types: &HashMap<EntityType, ValidatorEntityType>,
@@ -1066,7 +1067,7 @@ impl<'a> CommonTypeResolver<'a> {
                             .map(|(attr, attr_ty)| {
                                 Ok((
                                     attr,
-                                    json_schema::TypeOfAttribute {
+                                    json_schema::RecordAttributeType {
                                         required: attr_ty.required,
                                         ty: Self::resolve_type(resolve_table, attr_ty.ty)?,
                                     },
@@ -1571,8 +1572,7 @@ pub(crate) mod test {
             .expect("Expected attribute name")
             .attr_type
             .clone();
-        let expected_name_type = Type::named_entity_reference(foo_name);
-        assert_eq!(name_type, expected_name_type);
+        assert_eq!(name_type, Type::named_entity_reference(foo_name));
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -38,8 +38,7 @@ pub struct ValidatorEntityType {
     /// descendants before it is used in any validation.
     pub descendants: HashSet<EntityType>,
 
-    /// The attributes associated with this entity. Keys are the attribute
-    /// identifiers while the values are the type of the attribute.
+    /// The attributes associated with this entity.
     pub(crate) attributes: Attributes,
 
     /// Indicates that this entity type may have additional attributes
@@ -61,7 +60,7 @@ impl ValidatorEntityType {
         self.attributes.iter()
     }
 
-    /// Return `true` if this entity type has an `EntityType` declared as a
+    /// Return `true` if this entity type has an [`EntityType`] declared as a
     /// possible descendant in the schema.
     pub fn has_descendant_entity_type(&self, ety: &EntityType) -> bool {
         self.descendants.contains(ety)

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -325,7 +325,7 @@ impl CommonTypeDefs<ConditionalName> {
                 }
                 Entry::Occupied(oentry) => {
                     return Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError(
-                        oentry.key().clone().into(),
+                        oentry.key().clone(),
                     )));
                 }
             }
@@ -944,7 +944,7 @@ impl TryInto<ValidatorNamespaceDef<ConditionalName, ConditionalName>>
             None,
             self,
             ActionBehavior::default(),
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )
     }
 }

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -472,7 +472,7 @@ pub struct EntityTypeFragment<N> {
     /// fragment).
     /// In the extreme case, this may itself be just a common type pointing to a
     /// `Record` type defined in another fragment.
-    pub(super) attributes: json_schema::AttributesOrContext<N>,
+    pub(super) attributes: json_schema::EntityAttributes<N>,
     /// Direct parent entity types for this entity type.
     /// These entity types may be declared in a different namespace or schema
     /// fragment.
@@ -973,7 +973,7 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
             Ok(try_jsonschema_type_into_validator_type(*element, extensions)?.map(Type::set))
         }
         json_schema::Type::Type(json_schema::TypeVariant::Record(rty)) => {
-            try_record_type_into_validator_type(rty, extensions)
+            try_record_record_type_into_validator_type(rty, extensions)
         }
         json_schema::Type::Type(json_schema::TypeVariant::Entity { name }) => {
             Ok(Type::named_entity_reference(internal_name_to_entity_type(name)?).into())
@@ -1037,10 +1037,10 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
     }
 }
 
-/// Convert a [`json_schema::RecordType`] (with fully qualified names) into the
-/// [`Type`] type used by the validator.
-pub(crate) fn try_record_type_into_validator_type(
-    rty: json_schema::RecordType<InternalName>,
+/// Convert a [`json_schema::RecordType<json_schema::RecordAttributeType>`]
+/// (with fully qualified names) into the [`Type`] type used by the validator.
+pub(crate) fn try_record_record_type_into_validator_type(
+    rty: json_schema::RecordType<json_schema::RecordAttributeType<InternalName>>,
     extensions: &Extensions<'_>,
 ) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
     if cfg!(not(feature = "partial-validate")) && rty.additional_attributes {
@@ -1061,12 +1061,52 @@ pub(crate) fn try_record_type_into_validator_type(
     }
 }
 
-/// Given the attributes for an entity or record type in the schema file format
-/// structures (but with fully-qualified names), convert the types of the
-/// attributes into the [`Type`] data structure used by the validator, and
-/// return the result as an [`Attributes`] structure.
+/// Convert a [`json_schema::RecordType<json_schema::EntityAttributeType>`]
+/// (with fully qualified names) into the [`Type`] type used by the validator.
+pub(crate) fn try_record_entity_type_into_validator_type(
+    rty: json_schema::RecordType<json_schema::EntityAttributeType<InternalName>>,
+    extensions: &Extensions<'_>,
+) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
+    if cfg!(not(feature = "partial-validate")) && rty.additional_attributes {
+        Err(UnsupportedFeatureError(UnsupportedFeature::OpenRecordsAndEntities).into())
+    } else {
+        Ok(
+            parse_entity_attributes(rty.attributes, extensions)?.map(move |attrs| {
+                Type::record_with_attributes(
+                    attrs,
+                    if rty.additional_attributes {
+                        OpenTag::OpenAttributes
+                    } else {
+                        OpenTag::ClosedAttributes
+                    },
+                )
+            }),
+        )
+    }
+}
+
+/// Convert a [`json_schema::EntityAttributes`] (with fully qualified names)
+/// into the [`Type`] type used by the validator.
+pub(crate) fn try_entity_attributes_into_validator_type(
+    attrs: json_schema::EntityAttributes<InternalName>,
+    extensions: &Extensions<'_>,
+) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
+    match attrs {
+        json_schema::EntityAttributes::RecordAttributes(attrs) => {
+            try_jsonschema_type_into_validator_type(attrs.0, extensions)
+        }
+        json_schema::EntityAttributes::EntityAttributes(
+            json_schema::EntityAttributesInternal { attrs, .. },
+        ) => try_record_entity_type_into_validator_type(attrs, extensions),
+    }
+}
+
+/// Given the attributes for a record type in the schema file format structures
+/// (but with fully-qualified names), convert the types of the attributes into
+/// the [`Type`] data structure used by the validator, and return the result as
+/// an [`Attributes`] structure.
 fn parse_record_attributes(
-    attrs: impl IntoIterator<Item = (SmolStr, json_schema::TypeOfAttribute<InternalName>)>,
+    attrs: impl IntoIterator<Item = (SmolStr, json_schema::RecordAttributeType<InternalName>)>,
     extensions: &Extensions<'_>,
 ) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Attributes>> {
     let attrs_with_common_type_refs = attrs
@@ -1081,8 +1121,45 @@ fn parse_record_attributes(
             ))
         })
         .collect::<crate::err::Result<Vec<_>>>()?;
-    Ok(WithUnresolvedCommonTypeRefs::new(|common_type_defs| {
-        attrs_with_common_type_refs
+    Ok(attributes_from_attributes(attrs_with_common_type_refs))
+}
+
+/// Given the attributes for an entity type in the schema file format structures
+/// (but with fully-qualified names), convert the types of the attributes into
+/// the [`Type`] data structure used by the validator, and return the result as
+/// an [`Attributes`] structure.
+fn parse_entity_attributes(
+    attrs: impl IntoIterator<Item = (SmolStr, json_schema::EntityAttributeType<InternalName>)>,
+    extensions: &Extensions<'_>,
+) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Attributes>> {
+    let attrs_with_common_type_refs = attrs
+        .into_iter()
+        .map(|(attr, ty)| -> crate::err::Result<_> {
+            match ty.ty {
+                json_schema::EntityAttributeTypeInternal::Type(inner_ty) => {
+                    let validator_type =
+                        try_jsonschema_type_into_validator_type(inner_ty, extensions)?;
+                    Ok((attr, (validator_type, ty.required)))
+                }
+                json_schema::EntityAttributeTypeInternal::EAMap { .. } => {
+                    // This will be implemented in the next RFC 68 PR, which will
+                    // introduce the necessary changes to [`Attributes`] and its
+                    // associated types
+                    Err(UnsupportedFeatureError(UnsupportedFeature::EAMaps).into())
+                }
+            }
+        })
+        .collect::<crate::err::Result<Vec<_>>>()?;
+    Ok(attributes_from_attributes(attrs_with_common_type_refs))
+}
+
+/// Given an iterator of attribute types `(attribute name, (attribute type, is_required))`,
+/// build an [`Attributes`] structure.
+fn attributes_from_attributes(
+    attrs: impl IntoIterator<Item = (SmolStr, (WithUnresolvedCommonTypeRefs<Type>, bool))> + 'static,
+) -> WithUnresolvedCommonTypeRefs<Attributes> {
+    WithUnresolvedCommonTypeRefs::new(|common_type_defs| {
+        attrs
             .into_iter()
             .map(|(s, (attr_ty, is_req))| {
                 attr_ty
@@ -1091,5 +1168,5 @@ fn parse_record_attributes(
             })
             .collect::<crate::err::Result<Vec<_>>>()
             .map(Attributes::with_attributes)
-    }))
+    })
 }

--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -180,9 +180,9 @@ impl std::str::FromStr for RawName {
 /// the same order), which in practice means they must be in the same
 /// current/active namespace. In particular:
 /// - two [`ConditionalName`]s which end up resolving to the same fully-qualified
-/// name may nonetheless not be `==` in their [`ConditionalName`] forms; and
+///   name may nonetheless not be `==` in their [`ConditionalName`] forms; and
 /// - two [`ConditionalName`]s which are written the same way in the original
-/// schema may nonetheless not be `==` in their [`ConditionalName`] forms
+///   schema may nonetheless not be `==` in their [`ConditionalName`] forms
 ///
 /// This type has only one (trivial) public constructor; it is normally
 /// constructed using [`RawName::conditionally_qualify_with()`].

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -890,8 +890,7 @@ impl<'a> Typechecker<'a> {
                     Some(typ_actual) => {
                         match Type::lookup_attribute_type(self.schema, typ_actual, attr) {
                             Some(AttributeType {
-                                attr_type: _,
-                                is_required: true,
+                                is_required: true, ..
                             }) => {
                                 // Since an entity doesn't always have to exist
                                 // in the entity store, and `has` evaluates to
@@ -925,8 +924,7 @@ impl<'a> Typechecker<'a> {
                             // that attribute, so we add an entry to the capability
                             // set.
                             Some(AttributeType {
-                                attr_type: _,
-                                is_required: false,
+                                is_required: false, ..
                             }) => TypecheckAnswer::success_with_capability(
                                 ExprBuilder::with_data(Some(
                                     // The optional attribute `HasAttr` can have

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -27,7 +27,7 @@ use smol_str::SmolStr;
 use crate::{
     diagnostics::ValidationError,
     json_schema,
-    types::Type,
+    types::{AttributeType, Type},
     validation_errors::{AttributeAccess, LubContext, LubHelp, UnexpectedTypeHelp},
     RawName, ValidationMode,
 };
@@ -60,7 +60,7 @@ fn slot_typechecks() {
 fn slot_in_typechecks() {
     let etype = json_schema::EntityType {
         member_of_types: vec![],
-        shape: json_schema::AttributesOrContext::default(),
+        shape: json_schema::EntityAttributes::default(),
     };
     let schema = json_schema::NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
@@ -89,7 +89,7 @@ fn slot_in_typechecks() {
 fn slot_equals_typechecks() {
     let etype = json_schema::EntityType {
         member_of_types: vec![],
-        shape: json_schema::AttributesOrContext::default(),
+        shape: json_schema::EntityAttributes::default(),
     };
     // These don't typecheck in strict mode because the test_util expression
     // typechecker doesn't have access to a schema, so it can't link
@@ -795,7 +795,6 @@ fn contains_typechecks() {
 
 #[test]
 fn contains_typecheck_fails() {
-    use crate::types::AttributeType;
     let src = r#""foo".contains("bar")"#;
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -87,7 +87,6 @@ process_types_file() {
     ' "$types_file" > "$types_file.tmp" && mv "$types_file.tmp" "$types_file"
 
     echo "type SmolStr = string;" >> "$types_file"
-    echo "export type RecordAttributeType<N> = Type<N> & { required?: boolean };" >> "$types_file"
 }
 
 check_types_file() {

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -87,7 +87,7 @@ process_types_file() {
     ' "$types_file" > "$types_file.tmp" && mv "$types_file.tmp" "$types_file"
 
     echo "type SmolStr = string;" >> "$types_file"
-    echo "export type TypeOfAttribute<N> = Type<N> & { required?: boolean };" >> "$types_file"
+    echo "export type RecordAttributeType<N> = Type<N> & { required?: boolean };" >> "$types_file"
 }
 
 check_types_file() {


### PR DESCRIPTION
## Description of changes

Implements the needed changes for RFC 68 in the parsers for both schema formats (Cedar schema format and JSON schema format).  Includes tests that things parse properly and that invalid uses of embedded attribute maps correctly fail to parse.  Does not include any changes to the validator/typechecker itself; those will come in a future PR.  These parser changes are reasonably separable though, and this PR is large enough as-is. 

With this PR, if anyone tries to use the new RFC 68 syntax, instead of an incomprehensible parser error, they will get a nice message saying that embedded attribute maps are not fully supported yet.

## Issue #, if available

Part of #1104 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

