### PR TITLE
add `non_exhaustive` to more error types

### DIFF
--- a/cedar-policy-core/src/entities/conformance/err.rs
+++ b/cedar-policy-core/src/entities/conformance/err.rs
@@ -23,6 +23,7 @@ use thiserror::Error;
 
 /// Errors raised when entities do not conform to the schema
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum EntitySchemaConformanceError {
     /// Encountered attribute that shouldn't exist on entities of this type
     #[error(transparent)]

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -51,6 +51,7 @@ impl Display for EscapeKind {
 
 /// Errors thrown during deserialization from JSON
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum JsonDeserializationError {
     /// Error thrown by the `serde_json` crate
     #[error(transparent)]
@@ -446,6 +447,7 @@ impl From<serde_json::Error> for JsonSerializationError {
 
 /// Errors thrown during serialization to JSON
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum JsonSerializationError {
     /// Error thrown by `serde_json`
     #[error(transparent)]

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -684,6 +684,7 @@ pub mod schema_warnings {
 // Don't make fields `pub`, don't make breaking changes, and use caution
 // when adding public methods.
 #[derive(Debug, Clone, Error, Diagnostic)]
+#[non_exhaustive]
 pub enum SchemaWarning {
     /// Warning when a declaration shadows a builtin type
     #[error(transparent)]

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -130,6 +130,7 @@ impl CedarSchemaParseError {
 // Don't make fields `pub`, don't make breaking changes, and use caution
 // when adding public methods.
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum SchemaError {
     /// Error thrown by the `serde_json` crate during serialization
     #[error(transparent)]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -55,6 +55,9 @@ Cedar Language Version: 4.0
   Moreover, the `FromStr` implementations of `Schema` and `SchemaFragment`
   now parse strings in the Cedar schema format. Use `Schema::from_json_str` and `SchemaFragment::from_json_str`
   to parse strings in the JSON schema format.
+- Marked errors/warnings related to parsing and entity/request validation as
+  `non_exhaustive`, allowing future variants to be added without a breaking
+  change. (#1137)
 
 ### Removed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1323,11 +1323,10 @@ impl TryInto<Schema> for SchemaFragment {
 impl FromStr for SchemaFragment {
     type Err = CedarSchemaError;
     /// Construct [`SchemaFragment`] from a string containing a schema formatted
-    /// in the Cedar schema format. This can fail if the string is not valid
-    /// JSON, or if the JSON structure does not form a valid schema. This
-    /// function does not check for consistency in the schema (e.g., references
-    /// to undefined entities) because this is not required until a `Schema` is
-    /// constructed.
+    /// in the Cedar schema format. This can fail if the string is not a valid
+    /// schema. This function does not check for consistency in the schema
+    /// (e.g., references to undefined entities) because this is not required
+    /// until a `Schema` is constructed.
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Self::from_cedarschema_str(src).map(|(frag, _)| frag)
     }
@@ -1343,7 +1342,7 @@ impl FromStr for Schema {
 
     /// Construct a [`Schema`] from a string containing a schema formatted in
     /// the Cedar schema format. This can fail if it is not possible to parse a
-    /// schema from the strings, or if errors in values in the schema are
+    /// schema from the string, or if errors in values in the schema are
     /// uncovered after parsing. For instance, when an entity attribute name is
     /// found to not be a valid attribute name according to the Cedar
     /// grammar.

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -163,6 +163,7 @@ impl From<cedar_policy_core::authorizer::ReauthorizationError> for Reauthorizati
 
 /// Errors serializing Schemas to the Cedar syntax
 #[derive(Debug, Error, Diagnostic)]
+#[non_exhaustive]
 pub enum ToCedarSchemaError {
     /// Duplicate names were found in the schema
     #[error(transparent)]
@@ -976,6 +977,7 @@ impl From<cedar_policy_core::ast::RestrictedExpressionParseError>
 
 /// The request does not conform to the schema
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum RequestValidationError {
     /// Request action is not declared in the schema
     #[error(transparent)]


### PR DESCRIPTION
## Description of changes

Adds `non_exhaustive` to some error types that would be reasonable to extend in the future (IMO). What prompted this was that I wanted to backport #890 to 3.3.x, but found that I couldn't due to a new variant in `SchemaError`. This would have been fine if the error type had been non-exhaustive.

Also includes a quick fix to a comment in `api.rs`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

