### PR TITLE
New APIs for Schemas

### DIFF
--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -207,6 +207,86 @@ impl TryFrom<json_schema::Fragment<RawName>> for ValidatorSchema {
 }
 
 impl ValidatorSchema {
+    /// Returns an iterator over every entity type that can be a principal for any action in this schema
+    pub fn principals(&self) -> impl Iterator<Item = &EntityType> {
+        self.action_ids
+            .values()
+            .flat_map(ValidatorActionId::principals)
+    }
+
+    /// Returns an iterator over every entity type that can be a resource for any action in this schema
+    pub fn resources(&self) -> impl Iterator<Item = &EntityType> {
+        self.action_ids
+            .values()
+            .flat_map(ValidatorActionId::resources)
+    }
+
+    /// Returns an iterator over every entity type that can be a principal for `action` in this schema
+    ///
+    /// # Errors
+    ///
+    /// Returns [`None`] if `action` is not found in the schema
+    pub fn principals_for_action(
+        &self,
+        action: &EntityUID,
+    ) -> Option<impl Iterator<Item = &EntityType>> {
+        self.action_ids
+            .get(action)
+            .map(ValidatorActionId::principals)
+    }
+
+    /// Returns an iterator over every entity type that can be a resource for `action` in this schema
+    ///
+    /// # Errors
+    ///
+    /// Returns [`None`] if `action` is not found in the schema
+    pub fn resources_for_action(
+        &self,
+        action: &EntityUID,
+    ) -> Option<impl Iterator<Item = &EntityType>> {
+        self.action_ids
+            .get(action)
+            .map(ValidatorActionId::resources)
+    }
+
+    /// Returns an iterator over all the entity types that can be a parent of `ty`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`None`] if the `ty` is not found in the schema
+    pub fn parents<'a>(
+        &'a self,
+        ty: &'a EntityType,
+    ) -> Option<impl Iterator<Item = &EntityType> + 'a> {
+        if self.entity_types.contains_key(ty) {
+            Some(self.entity_types.values().filter_map(|ety| {
+                if ety.descendants.contains(ty) {
+                    Some(&ety.name)
+                } else {
+                    None
+                }
+            }))
+        } else {
+            None
+        }
+    }
+
+    /// Returns an iterator over all the action groups defined in this schema
+    pub fn action_groups(&self) -> impl Iterator<Item = &EntityUID> {
+        self.action_ids.values().filter_map(|action| {
+            if action.descendants.is_empty() {
+                None
+            } else {
+                Some(&action.name)
+            }
+        })
+    }
+
+    /// Returns an iterator over all actions defined in this schema
+    pub fn action_euids(&self) -> impl Iterator<Item = &EntityUID> {
+        self.action_ids.keys()
+    }
+
     /// Create a [`ValidatorSchema`] without any definitions (of entity types,
     /// common types, or actions).
     pub fn empty() -> ValidatorSchema {
@@ -3376,5 +3456,443 @@ mod test_resolver {
         );
         let res = resolve(schema);
         assert_matches!(res, Err(SchemaError::CycleInCommonTypeReferences(_)));
+    }
+}
+
+#[cfg(test)]
+mod test_access {
+    use super::*;
+
+    fn schema() -> ValidatorSchema {
+        let src = r#"
+        type Task = {
+    "id": Long,
+    "name": String,
+    "state": String,
+};
+
+type Tasks = Set<Task>;
+entity List in [Application] = {
+  "editors": Team,
+  "name": String,
+  "owner": User,
+  "readers": Team,
+  "tasks": Tasks,
+};
+entity Application;
+entity User in [Team, Application] = {
+  "joblevel": Long,
+  "location": String,
+};
+
+entity CoolList;
+
+entity Team in [Team, Application];
+
+action Read, Write, Create;
+
+action DeleteList, EditShare, UpdateList, CreateTask, UpdateTask, DeleteTask in Write appliesTo {
+    principal: [User],
+    resource : [List]
+};
+
+action GetList in Read appliesTo {
+    principal : [User],
+    resource : [List, CoolList]
+};
+
+action GetLists in Read appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+
+action CreateList in Create appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+
+        "#;
+
+        src.parse().unwrap()
+    }
+
+    #[test]
+    fn principals() {
+        let schema = schema();
+        let principals = schema.principals().collect::<HashSet<_>>();
+        assert_eq!(principals.len(), 1);
+        let user: EntityType = "User".parse().unwrap();
+        assert!(principals.contains(&user));
+        let principals = schema.principals().collect::<Vec<_>>();
+        assert!(principals.len() > 1);
+        assert!(principals.iter().all(|ety| **ety == user));
+    }
+
+    #[test]
+    fn empty_schema_principals_and_resources() {
+        let empty: ValidatorSchema = "".parse().unwrap();
+        assert!(empty.principals().collect::<Vec<_>>().is_empty());
+        assert!(empty.resources().collect::<Vec<_>>().is_empty());
+    }
+
+    #[test]
+    fn resources() {
+        let schema = schema();
+        let resources = schema.resources().cloned().collect::<HashSet<_>>();
+        let expected: HashSet<EntityType> = HashSet::from([
+            "List".parse().unwrap(),
+            "Application".parse().unwrap(),
+            "CoolList".parse().unwrap(),
+        ]);
+        assert_eq!(resources, expected);
+    }
+
+    #[test]
+    fn principals_for_action() {
+        let schema = schema();
+        let delete_list: EntityUID = r#"Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUID = r#"Action::"DeleteUser""#.parse().unwrap();
+        let got = schema
+            .principals_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["User".parse().unwrap()]);
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn resources_for_action() {
+        let schema = schema();
+        let delete_list: EntityUID = r#"Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUID = r#"Action::"DeleteUser""#.parse().unwrap();
+        let create_list: EntityUID = r#"Action::"CreateList""#.parse().unwrap();
+        let get_list: EntityUID = r#"Action::"GetList""#.parse().unwrap();
+        let got = schema
+            .resources_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["List".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&create_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Application".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&get_list)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            got,
+            HashSet::from(["List".parse().unwrap(), "CoolList".parse().unwrap()])
+        );
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn principal_parents() {
+        let schema = schema();
+        let user: EntityType = "User".parse().unwrap();
+        let parents = schema
+            .parents(&user)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from(["Team".parse().unwrap(), "Application".parse().unwrap()]);
+        assert_eq!(parents, expected);
+        let parents = schema
+            .parents(&"List".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from(["Application".parse().unwrap()]);
+        assert_eq!(parents, expected);
+        assert!(schema.parents(&"Foo".parse().unwrap()).is_none());
+        let parents = schema
+            .parents(&"CoolList".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from([]);
+        assert_eq!(parents, expected);
+    }
+
+    #[test]
+    fn action_groups() {
+        let schema = schema();
+        let groups = schema.action_groups().cloned().collect::<HashSet<_>>();
+        let expected = ["Read", "Write", "Create"]
+            .into_iter()
+            .map(|ty| format!("Action::\"{ty}\"").parse().unwrap())
+            .collect::<HashSet<EntityUID>>();
+        assert_eq!(groups, expected);
+    }
+
+    #[test]
+    fn actions() {
+        let schema = schema();
+        let actions = schema.action_euids().cloned().collect::<HashSet<_>>();
+        let expected = [
+            "Read",
+            "Write",
+            "Create",
+            "DeleteList",
+            "EditShare",
+            "UpdateList",
+            "CreateTask",
+            "UpdateTask",
+            "DeleteTask",
+            "GetList",
+            "GetLists",
+            "CreateList",
+        ]
+        .into_iter()
+        .map(|ty| format!("Action::\"{ty}\"").parse().unwrap())
+        .collect::<HashSet<EntityUID>>();
+        assert_eq!(actions, expected);
+    }
+
+    #[test]
+    fn entities() {
+        let schema = schema();
+        let entities = schema
+            .entity_types()
+            .map(|(ty, _)| ty)
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = ["List", "Application", "User", "CoolList", "Team"]
+            .into_iter()
+            .map(|ty| ty.parse().unwrap())
+            .collect::<HashSet<EntityType>>();
+        assert_eq!(entities, expected);
+    }
+}
+
+#[cfg(test)]
+mod test_access_namespace {
+    use super::*;
+
+    fn schema() -> ValidatorSchema {
+        let src = r#"
+        namespace Foo {
+        type Task = {
+    "id": Long,
+    "name": String,
+    "state": String,
+};
+
+type Tasks = Set<Task>;
+entity List in [Application] = {
+  "editors": Team,
+  "name": String,
+  "owner": User,
+  "readers": Team,
+  "tasks": Tasks,
+};
+entity Application;
+entity User in [Team, Application] = {
+  "joblevel": Long,
+  "location": String,
+};
+
+entity CoolList;
+
+entity Team in [Team, Application];
+
+action Read, Write, Create;
+
+action DeleteList, EditShare, UpdateList, CreateTask, UpdateTask, DeleteTask in Write appliesTo {
+    principal: [User],
+    resource : [List]
+};
+
+action GetList in Read appliesTo {
+    principal : [User],
+    resource : [List, CoolList]
+};
+
+action GetLists in Read appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+
+action CreateList in Create appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+    }
+
+        "#;
+
+        src.parse().unwrap()
+    }
+
+    #[test]
+    fn principals() {
+        let schema = schema();
+        let principals = schema.principals().collect::<HashSet<_>>();
+        assert_eq!(principals.len(), 1);
+        let user: EntityType = "Foo::User".parse().unwrap();
+        assert!(principals.contains(&user));
+        let principals = schema.principals().collect::<Vec<_>>();
+        assert!(principals.len() > 1);
+        assert!(principals.iter().all(|ety| **ety == user));
+    }
+
+    #[test]
+    fn empty_schema_principals_and_resources() {
+        let empty: ValidatorSchema = "".parse().unwrap();
+        assert!(empty.principals().collect::<Vec<_>>().is_empty());
+        assert!(empty.resources().collect::<Vec<_>>().is_empty());
+    }
+
+    #[test]
+    fn resources() {
+        let schema = schema();
+        let resources = schema.resources().cloned().collect::<HashSet<_>>();
+        let expected: HashSet<EntityType> = HashSet::from([
+            "Foo::List".parse().unwrap(),
+            "Foo::Application".parse().unwrap(),
+            "Foo::CoolList".parse().unwrap(),
+        ]);
+        assert_eq!(resources, expected);
+    }
+
+    #[test]
+    fn principals_for_action() {
+        let schema = schema();
+        let delete_list: EntityUID = r#"Foo::Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUID = r#"Foo::Action::"DeleteUser""#.parse().unwrap();
+        let got = schema
+            .principals_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Foo::User".parse().unwrap()]);
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn resources_for_action() {
+        let schema = schema();
+        let delete_list: EntityUID = r#"Foo::Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUID = r#"Foo::Action::"DeleteUser""#.parse().unwrap();
+        let create_list: EntityUID = r#"Foo::Action::"CreateList""#.parse().unwrap();
+        let get_list: EntityUID = r#"Foo::Action::"GetList""#.parse().unwrap();
+        let got = schema
+            .resources_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Foo::List".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&create_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Foo::Application".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&get_list)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            got,
+            HashSet::from([
+                "Foo::List".parse().unwrap(),
+                "Foo::CoolList".parse().unwrap()
+            ])
+        );
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn principal_parents() {
+        let schema = schema();
+        let user: EntityType = "Foo::User".parse().unwrap();
+        let parents = schema
+            .parents(&user)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from([
+            "Foo::Team".parse().unwrap(),
+            "Foo::Application".parse().unwrap(),
+        ]);
+        assert_eq!(parents, expected);
+        let parents = schema
+            .parents(&"Foo::List".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from(["Foo::Application".parse().unwrap()]);
+        assert_eq!(parents, expected);
+        assert!(schema.parents(&"Foo::Foo".parse().unwrap()).is_none());
+        let parents = schema
+            .parents(&"Foo::CoolList".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from([]);
+        assert_eq!(parents, expected);
+    }
+
+    #[test]
+    fn action_groups() {
+        let schema = schema();
+        let groups = schema.action_groups().cloned().collect::<HashSet<_>>();
+        let expected = ["Read", "Write", "Create"]
+            .into_iter()
+            .map(|ty| format!("Foo::Action::\"{ty}\"").parse().unwrap())
+            .collect::<HashSet<EntityUID>>();
+        assert_eq!(groups, expected);
+    }
+
+    #[test]
+    fn actions() {
+        let schema = schema();
+        let actions = schema.action_euids().cloned().collect::<HashSet<_>>();
+        let expected = [
+            "Read",
+            "Write",
+            "Create",
+            "DeleteList",
+            "EditShare",
+            "UpdateList",
+            "CreateTask",
+            "UpdateTask",
+            "DeleteTask",
+            "GetList",
+            "GetLists",
+            "CreateList",
+        ]
+        .into_iter()
+        .map(|ty| format!("Foo::Action::\"{ty}\"").parse().unwrap())
+        .collect::<HashSet<EntityUID>>();
+        assert_eq!(actions, expected);
+    }
+
+    #[test]
+    fn entities() {
+        let schema = schema();
+        let entities = schema
+            .entity_types()
+            .map(|(ty, _)| ty)
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = [
+            "Foo::List",
+            "Foo::Application",
+            "Foo::User",
+            "Foo::CoolList",
+            "Foo::Team",
+        ]
+        .into_iter()
+        .map(|ty| ty.parse().unwrap())
+        .collect::<HashSet<EntityType>>();
+        assert_eq!(entities, expected);
     }
 }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -254,7 +254,7 @@ impl ValidatorSchema {
     /// # Errors
     ///
     /// Returns [`None`] if the `ty` is not found in the schema
-    pub fn parents<'a>(
+    pub fn ancestors<'a>(
         &'a self,
         ty: &'a EntityType,
     ) -> Option<impl Iterator<Item = &EntityType> + 'a> {
@@ -283,7 +283,7 @@ impl ValidatorSchema {
     }
 
     /// Returns an iterator over all actions defined in this schema
-    pub fn action_euids(&self) -> impl Iterator<Item = &EntityUID> {
+    pub fn actions(&self) -> impl Iterator<Item = &EntityUID> {
         self.action_ids.keys()
     }
 
@@ -3597,22 +3597,22 @@ action CreateList in Create appliesTo {
         let schema = schema();
         let user: EntityType = "User".parse().unwrap();
         let parents = schema
-            .parents(&user)
+            .ancestors(&user)
             .unwrap()
             .cloned()
             .collect::<HashSet<_>>();
         let expected = HashSet::from(["Team".parse().unwrap(), "Application".parse().unwrap()]);
         assert_eq!(parents, expected);
         let parents = schema
-            .parents(&"List".parse().unwrap())
+            .ancestors(&"List".parse().unwrap())
             .unwrap()
             .cloned()
             .collect::<HashSet<_>>();
         let expected = HashSet::from(["Application".parse().unwrap()]);
         assert_eq!(parents, expected);
-        assert!(schema.parents(&"Foo".parse().unwrap()).is_none());
+        assert!(schema.ancestors(&"Foo".parse().unwrap()).is_none());
         let parents = schema
-            .parents(&"CoolList".parse().unwrap())
+            .ancestors(&"CoolList".parse().unwrap())
             .unwrap()
             .cloned()
             .collect::<HashSet<_>>();
@@ -3634,7 +3634,7 @@ action CreateList in Create appliesTo {
     #[test]
     fn actions() {
         let schema = schema();
-        let actions = schema.action_euids().cloned().collect::<HashSet<_>>();
+        let actions = schema.actions().cloned().collect::<HashSet<_>>();
         let expected = [
             "Read",
             "Write",
@@ -3814,7 +3814,7 @@ action CreateList in Create appliesTo {
         let schema = schema();
         let user: EntityType = "Foo::User".parse().unwrap();
         let parents = schema
-            .parents(&user)
+            .ancestors(&user)
             .unwrap()
             .cloned()
             .collect::<HashSet<_>>();
@@ -3824,15 +3824,15 @@ action CreateList in Create appliesTo {
         ]);
         assert_eq!(parents, expected);
         let parents = schema
-            .parents(&"Foo::List".parse().unwrap())
+            .ancestors(&"Foo::List".parse().unwrap())
             .unwrap()
             .cloned()
             .collect::<HashSet<_>>();
         let expected = HashSet::from(["Foo::Application".parse().unwrap()]);
         assert_eq!(parents, expected);
-        assert!(schema.parents(&"Foo::Foo".parse().unwrap()).is_none());
+        assert!(schema.ancestors(&"Foo::Foo".parse().unwrap()).is_none());
         let parents = schema
-            .parents(&"Foo::CoolList".parse().unwrap())
+            .ancestors(&"Foo::CoolList".parse().unwrap())
             .unwrap()
             .cloned()
             .collect::<HashSet<_>>();
@@ -3854,7 +3854,7 @@ action CreateList in Create appliesTo {
     #[test]
     fn actions() {
         let schema = schema();
-        let actions = schema.action_euids().cloned().collect::<HashSet<_>>();
+        let actions = schema.actions().cloned().collect::<HashSet<_>>();
         let expected = [
             "Read",
             "Write",

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -905,7 +905,7 @@ impl EntityLUB {
 
 /// Represents the attributes of a record or entity type. Each attribute has an
 /// identifier, a flag indicating weather it is required, and a type.
-#[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize)]
+#[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Clone, Serialize, Default)]
 pub struct Attributes {
     /// Attributes map
     pub attrs: BTreeMap<SmolStr, AttributeType>,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,6 +13,8 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 Cedar Language Version: 4.0
 
 ### Added
+- A bunch of new APIs for schemas. Allows you to query
+  principals,actions, and resources. (#1141, resolving #1134)
 - JSON representation for Policy Sets, along with methods like
   `::from_json_value/file/str` and `::to_json` for `PolicySet`. (#783,
   resolving #549)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -14,7 +14,7 @@ Cedar Language Version: 4.0
 
 ### Added
 - A bunch of new APIs for schemas. Allows you to query
-  principals,actions, and resources. (#1141, resolving #1134)
+  principals, actions, and resources. (#1141, resolving #1134)
 - JSON representation for Policy Sets, along with methods like
   `::from_json_value/file/str` and `::to_json` for `PolicySet`. (#783,
   resolving #549)

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1363,7 +1363,7 @@ impl Schema {
         Ok(Self(
             cedar_policy_validator::ValidatorSchema::from_schema_fragments(
                 fragments.into_iter().map(|f| f.value),
-                &Extensions::all_available(),
+                Extensions::all_available(),
             )?,
         ))
     }
@@ -1374,7 +1374,7 @@ impl Schema {
         Ok(Self(
             cedar_policy_validator::ValidatorSchema::from_json_value(
                 json,
-                &Extensions::all_available(),
+                Extensions::all_available(),
             )?,
         ))
     }
@@ -1385,7 +1385,7 @@ impl Schema {
         Ok(Self(
             cedar_policy_validator::ValidatorSchema::from_json_str(
                 json,
-                &Extensions::all_available(),
+                Extensions::all_available(),
             )?,
         ))
     }
@@ -1396,7 +1396,7 @@ impl Schema {
         Ok(Self(
             cedar_policy_validator::ValidatorSchema::from_json_file(
                 file,
-                &Extensions::all_available(),
+                Extensions::all_available(),
             )?,
         ))
     }
@@ -1407,7 +1407,7 @@ impl Schema {
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning> + 'static), CedarSchemaError> {
         let (schema, warnings) = cedar_policy_validator::ValidatorSchema::from_cedarschema_file(
             file,
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )?;
         Ok((Self(schema), warnings))
     }
@@ -1418,7 +1418,7 @@ impl Schema {
     ) -> Result<(Self, impl Iterator<Item = SchemaWarning>), CedarSchemaError> {
         let (schema, warnings) = cedar_policy_validator::ValidatorSchema::from_cedarschema_str(
             src,
-            &Extensions::all_available(),
+            Extensions::all_available(),
         )?;
         Ok((Self(schema), warnings))
     }
@@ -1427,6 +1427,79 @@ impl Schema {
     /// declared in the schema.
     pub fn action_entities(&self) -> Result<Entities, EntitiesError> {
         Ok(Entities(self.0.action_entities()?))
+    }
+
+    /// Returns an iterator over every entity type that can be a principal for any action in this schema
+    ///
+    /// Note: this iterator may contain duplicates.
+    pub fn principals(&self) -> impl Iterator<Item = &EntityTypeName> {
+        self.0.principals().map(RefCast::ref_cast)
+    }
+
+    /// Returns an iterator over every entity type that can be a resource for any action in this schema
+    ///
+    /// Note: this iterator may contain duplicates.
+    pub fn resources(&self) -> impl Iterator<Item = &EntityTypeName> {
+        self.0.resources().map(RefCast::ref_cast)
+    }
+
+    /// Returns an iterator over every entity type that can be a principal for `action` in this schema
+    ///
+    /// # Errors
+    ///
+    /// Returns [`None`] if `action` is not found in the schema
+    pub fn principals_for_action(
+        &self,
+        action: &EntityUid,
+    ) -> Option<impl Iterator<Item = &EntityTypeName>> {
+        self.0
+            .principals_for_action(&action.0)
+            .map(|iter| iter.map(RefCast::ref_cast))
+    }
+
+    /// Returns an iterator over every entity type that can be a resource for `action` in this schema
+    ///
+    /// # Errors
+    ///
+    /// Returns [`None`] if `action` is not found in the schema
+    pub fn resources_for_action(
+        &self,
+        action: &EntityUid,
+    ) -> Option<impl Iterator<Item = &EntityTypeName>> {
+        self.0
+            .resources_for_action(&action.0)
+            .map(|iter| iter.map(RefCast::ref_cast))
+    }
+
+    /// Returns an iterator over all the entity types that can be a parent of `ty`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`None`] if the `ty` is not found in the schema
+    pub fn parents<'a>(
+        &'a self,
+        ty: &'a EntityTypeName,
+    ) -> Option<impl Iterator<Item = &EntityTypeName> + 'a> {
+        self.0
+            .parents(&ty.0)
+            .map(|iter| iter.map(RefCast::ref_cast))
+    }
+
+    /// Returns an iterator over all the action groups defined in this schema
+    pub fn action_groups(&self) -> impl Iterator<Item = &EntityUid> {
+        self.0.action_groups().map(RefCast::ref_cast)
+    }
+
+    /// Returns an iterator over all entity types defined in this schema
+    pub fn entity_types(&self) -> impl Iterator<Item = &EntityTypeName> {
+        self.0
+            .entity_types()
+            .map(|(name, _)| RefCast::ref_cast(name))
+    }
+
+    /// Returns an iterator over all actions defined in this schema
+    pub fn action_euids(&self) -> impl Iterator<Item = &EntityUid> {
+        self.0.action_euids().map(RefCast::ref_cast)
     }
 }
 
@@ -3730,4 +3803,435 @@ pub fn eval_expression(
         // Evaluate under the empty slot map, as an expression should not have slots
         eval.interpret(&expr.0, &ast::SlotEnv::new())?,
     ))
+}
+
+// These are the same tests in validator, just ensuring all the plumbing is done correctly
+#[cfg(test)]
+mod test_access {
+    use super::*;
+
+    fn schema() -> Schema {
+        let src = r#"
+        type Task = {
+    "id": Long,
+    "name": String,
+    "state": String,
+};
+
+type Tasks = Set<Task>;
+entity List in [Application] = {
+  "editors": Team,
+  "name": String,
+  "owner": User,
+  "readers": Team,
+  "tasks": Tasks,
+};
+entity Application;
+entity User in [Team, Application] = {
+  "joblevel": Long,
+  "location": String,
+};
+
+entity CoolList;
+
+entity Team in [Team, Application];
+
+action Read, Write, Create;
+
+action DeleteList, EditShare, UpdateList, CreateTask, UpdateTask, DeleteTask in Write appliesTo {
+    principal: [User],
+    resource : [List]
+};
+
+action GetList in Read appliesTo {
+    principal : [User],
+    resource : [List, CoolList]
+};
+
+action GetLists in Read appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+
+action CreateList in Create appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+
+        "#;
+
+        src.parse().unwrap()
+    }
+
+    #[test]
+    fn principals() {
+        let schema = schema();
+        let principals = schema.principals().collect::<HashSet<_>>();
+        assert_eq!(principals.len(), 1);
+        let user: EntityTypeName = "User".parse().unwrap();
+        assert!(principals.contains(&user));
+        let principals = schema.principals().collect::<Vec<_>>();
+        assert!(principals.len() > 1);
+        assert!(principals.iter().all(|ety| **ety == user));
+    }
+
+    #[test]
+    fn empty_schema_principals_and_resources() {
+        let empty: Schema = "".parse().unwrap();
+        assert!(empty.principals().collect::<Vec<_>>().is_empty());
+        assert!(empty.resources().collect::<Vec<_>>().is_empty());
+    }
+
+    #[test]
+    fn resources() {
+        let schema = schema();
+        let resources = schema.resources().cloned().collect::<HashSet<_>>();
+        let expected: HashSet<EntityTypeName> = HashSet::from([
+            "List".parse().unwrap(),
+            "Application".parse().unwrap(),
+            "CoolList".parse().unwrap(),
+        ]);
+        assert_eq!(resources, expected);
+    }
+
+    #[test]
+    fn principals_for_action() {
+        let schema = schema();
+        let delete_list: EntityUid = r#"Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUid = r#"Action::"DeleteUser""#.parse().unwrap();
+        let got = schema
+            .principals_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["User".parse().unwrap()]);
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn resources_for_action() {
+        let schema = schema();
+        let delete_list: EntityUid = r#"Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUid = r#"Action::"DeleteUser""#.parse().unwrap();
+        let create_list: EntityUid = r#"Action::"CreateList""#.parse().unwrap();
+        let get_list: EntityUid = r#"Action::"GetList""#.parse().unwrap();
+        let got = schema
+            .resources_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["List".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&create_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Application".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&get_list)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            got,
+            HashSet::from(["List".parse().unwrap(), "CoolList".parse().unwrap()])
+        );
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn principal_parents() {
+        let schema = schema();
+        let user: EntityTypeName = "User".parse().unwrap();
+        let parents = schema
+            .parents(&user)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from(["Team".parse().unwrap(), "Application".parse().unwrap()]);
+        assert_eq!(parents, expected);
+        let parents = schema
+            .parents(&"List".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from(["Application".parse().unwrap()]);
+        assert_eq!(parents, expected);
+        assert!(schema.parents(&"Foo".parse().unwrap()).is_none());
+        let parents = schema
+            .parents(&"CoolList".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from([]);
+        assert_eq!(parents, expected);
+    }
+
+    #[test]
+    fn action_groups() {
+        let schema = schema();
+        let groups = schema.action_groups().cloned().collect::<HashSet<_>>();
+        let expected = ["Read", "Write", "Create"]
+            .into_iter()
+            .map(|ty| format!("Action::\"{ty}\"").parse().unwrap())
+            .collect::<HashSet<EntityUid>>();
+        assert_eq!(groups, expected);
+    }
+
+    #[test]
+    fn actions() {
+        let schema = schema();
+        let actions = schema.action_euids().cloned().collect::<HashSet<_>>();
+        let expected = [
+            "Read",
+            "Write",
+            "Create",
+            "DeleteList",
+            "EditShare",
+            "UpdateList",
+            "CreateTask",
+            "UpdateTask",
+            "DeleteTask",
+            "GetList",
+            "GetLists",
+            "CreateList",
+        ]
+        .into_iter()
+        .map(|ty| format!("Action::\"{ty}\"").parse().unwrap())
+        .collect::<HashSet<EntityUid>>();
+        assert_eq!(actions, expected);
+    }
+
+    #[test]
+    fn entities() {
+        let schema = schema();
+        let entities = schema.entity_types().cloned().collect::<HashSet<_>>();
+        let expected = ["List", "Application", "User", "CoolList", "Team"]
+            .into_iter()
+            .map(|ty| ty.parse().unwrap())
+            .collect::<HashSet<EntityTypeName>>();
+        assert_eq!(entities, expected);
+    }
+}
+
+#[cfg(test)]
+mod test_access_namespace {
+    use super::*;
+
+    fn schema() -> Schema {
+        let src = r#"
+        namespace Foo {
+        type Task = {
+    "id": Long,
+    "name": String,
+    "state": String,
+};
+
+type Tasks = Set<Task>;
+entity List in [Application] = {
+  "editors": Team,
+  "name": String,
+  "owner": User,
+  "readers": Team,
+  "tasks": Tasks,
+};
+entity Application;
+entity User in [Team, Application] = {
+  "joblevel": Long,
+  "location": String,
+};
+
+entity CoolList;
+
+entity Team in [Team, Application];
+
+action Read, Write, Create;
+
+action DeleteList, EditShare, UpdateList, CreateTask, UpdateTask, DeleteTask in Write appliesTo {
+    principal: [User],
+    resource : [List]
+};
+
+action GetList in Read appliesTo {
+    principal : [User],
+    resource : [List, CoolList]
+};
+
+action GetLists in Read appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+
+action CreateList in Create appliesTo {
+    principal : [User],
+    resource : [Application]
+};
+    }
+
+        "#;
+
+        src.parse().unwrap()
+    }
+
+    #[test]
+    fn principals() {
+        let schema = schema();
+        let principals = schema.principals().collect::<HashSet<_>>();
+        assert_eq!(principals.len(), 1);
+        let user: EntityTypeName = "Foo::User".parse().unwrap();
+        assert!(principals.contains(&user));
+        let principals = schema.principals().collect::<Vec<_>>();
+        assert!(principals.len() > 1);
+        assert!(principals.iter().all(|ety| **ety == user));
+    }
+
+    #[test]
+    fn empty_schema_principals_and_resources() {
+        let empty: Schema = "".parse().unwrap();
+        assert!(empty.principals().collect::<Vec<_>>().is_empty());
+        assert!(empty.resources().collect::<Vec<_>>().is_empty());
+    }
+
+    #[test]
+    fn resources() {
+        let schema = schema();
+        let resources = schema.resources().cloned().collect::<HashSet<_>>();
+        let expected: HashSet<EntityTypeName> = HashSet::from([
+            "Foo::List".parse().unwrap(),
+            "Foo::Application".parse().unwrap(),
+            "Foo::CoolList".parse().unwrap(),
+        ]);
+        assert_eq!(resources, expected);
+    }
+
+    #[test]
+    fn principals_for_action() {
+        let schema = schema();
+        let delete_list: EntityUid = r#"Foo::Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUid = r#"Foo::Action::"DeleteUser""#.parse().unwrap();
+        let got = schema
+            .principals_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Foo::User".parse().unwrap()]);
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn resources_for_action() {
+        let schema = schema();
+        let delete_list: EntityUid = r#"Foo::Action::"DeleteList""#.parse().unwrap();
+        let delete_user: EntityUid = r#"Foo::Action::"DeleteUser""#.parse().unwrap();
+        let create_list: EntityUid = r#"Foo::Action::"CreateList""#.parse().unwrap();
+        let get_list: EntityUid = r#"Foo::Action::"GetList""#.parse().unwrap();
+        let got = schema
+            .resources_for_action(&delete_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Foo::List".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&create_list)
+            .unwrap()
+            .cloned()
+            .collect::<Vec<_>>();
+        assert_eq!(got, vec!["Foo::Application".parse().unwrap()]);
+        let got = schema
+            .resources_for_action(&get_list)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            got,
+            HashSet::from([
+                "Foo::List".parse().unwrap(),
+                "Foo::CoolList".parse().unwrap()
+            ])
+        );
+        assert!(schema.principals_for_action(&delete_user).is_none());
+    }
+
+    #[test]
+    fn principal_parents() {
+        let schema = schema();
+        let user: EntityTypeName = "Foo::User".parse().unwrap();
+        let parents = schema
+            .parents(&user)
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from([
+            "Foo::Team".parse().unwrap(),
+            "Foo::Application".parse().unwrap(),
+        ]);
+        assert_eq!(parents, expected);
+        let parents = schema
+            .parents(&"Foo::List".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from(["Foo::Application".parse().unwrap()]);
+        assert_eq!(parents, expected);
+        assert!(schema.parents(&"Foo::Foo".parse().unwrap()).is_none());
+        let parents = schema
+            .parents(&"Foo::CoolList".parse().unwrap())
+            .unwrap()
+            .cloned()
+            .collect::<HashSet<_>>();
+        let expected = HashSet::from([]);
+        assert_eq!(parents, expected);
+    }
+
+    #[test]
+    fn action_groups() {
+        let schema = schema();
+        let groups = schema.action_groups().cloned().collect::<HashSet<_>>();
+        let expected = ["Read", "Write", "Create"]
+            .into_iter()
+            .map(|ty| format!("Foo::Action::\"{ty}\"").parse().unwrap())
+            .collect::<HashSet<EntityUid>>();
+        assert_eq!(groups, expected);
+    }
+
+    #[test]
+    fn actions() {
+        let schema = schema();
+        let actions = schema.action_euids().cloned().collect::<HashSet<_>>();
+        let expected = [
+            "Read",
+            "Write",
+            "Create",
+            "DeleteList",
+            "EditShare",
+            "UpdateList",
+            "CreateTask",
+            "UpdateTask",
+            "DeleteTask",
+            "GetList",
+            "GetLists",
+            "CreateList",
+        ]
+        .into_iter()
+        .map(|ty| format!("Foo::Action::\"{ty}\"").parse().unwrap())
+        .collect::<HashSet<EntityUid>>();
+        assert_eq!(actions, expected);
+    }
+
+    #[test]
+    fn entities() {
+        let schema = schema();
+        let entities = schema.entity_types().cloned().collect::<HashSet<_>>();
+        let expected = [
+            "Foo::List",
+            "Foo::Application",
+            "Foo::User",
+            "Foo::CoolList",
+            "Foo::Team",
+        ]
+        .into_iter()
+        .map(|ty| ty.parse().unwrap())
+        .collect::<HashSet<EntityTypeName>>();
+        assert_eq!(entities, expected);
+    }
 }

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -95,7 +95,7 @@ impl AsRef<str> for EntityId {
 /// ```
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
-pub struct EntityTypeName(ast::EntityType);
+pub struct EntityTypeName(pub(crate) ast::EntityType);
 
 impl EntityTypeName {
     /// Get the basename of the `EntityTypeName` (ie, with namespaces stripped).
@@ -176,7 +176,7 @@ impl From<ast::EntityType> for EntityTypeName {
 // INVARIANT: this can never be an `ast::EntityType::Unspecified`
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
-pub struct EntityUid(ast::EntityUID);
+pub struct EntityUid(pub(crate) ast::EntityUID);
 
 impl EntityUid {
     /// Returns the portion of the Euid that represents namespace and entity type


### PR DESCRIPTION
## Description of changes
Adds a bunch of accessors for schemas:
* `principals()` gets all principal types
* `resources()` gets all resource types
* `principals_for_action()` get all principal types applicable to an action
* `resources_for_action()` get all resource types applicable to an action
* `parents()` get all the parent types of a type
* `action_groups()` get all action groups
* `enitty_types()` get all entity types
* `action_euids()` get all actions
## Issue #, if available
#1134 
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

