### PR TITLE
Limit the sizes of generated `Name`s

### DIFF
--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -264,9 +264,14 @@ impl FromNormalizedStr for InternalName {
 #[cfg(feature = "arbitrary")]
 impl<'a> arbitrary::Arbitrary<'a> for InternalName {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let path_size = u.int_in_range(0..=8)?;
         Ok(Self {
             id: u.arbitrary()?,
-            path: u.arbitrary()?,
+            path: Arc::new(
+                (0..path_size)
+                    .map(|_| u.arbitrary())
+                    .collect::<Result<Vec<Id>, _>>()?,
+            ),
             loc: None,
         })
     }


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

