### PR TITLE
implement RFC 70

### DIFF
--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -310,58 +310,6 @@ impl SchemaError {
 /// Convenience alias
 pub type Result<T> = std::result::Result<T, SchemaError>;
 
-/// Enum containing just the cases of [`SchemaError`] that can be returned when
-/// resolving entity/common type names
-#[derive(Debug, Diagnostic, Error)]
-pub enum TypeResolutionError {
-    /// This error occurs when we cannot resolve a typename (because it refers
-    /// to an entity type or common type that was not declared).
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    TypeNotDefined(#[from] schema_errors::TypeNotDefinedError),
-    /// Entity/common type shadowing error. Some shadowing relationships are not
-    /// allowed for clarity reasons; see
-    /// [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md).
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    TypeShadowing(#[from] schema_errors::TypeShadowingError),
-}
-
-impl From<TypeResolutionError> for SchemaError {
-    fn from(e: TypeResolutionError) -> SchemaError {
-        match e {
-            TypeResolutionError::TypeNotDefined(e) => e.into(),
-            TypeResolutionError::TypeShadowing(e) => e.into(),
-        }
-    }
-}
-
-/// Enum containing just the cases of [`SchemaError`] that can be returned when
-/// resolving action names
-#[derive(Debug, Diagnostic, Error)]
-pub enum ActionResolutionError {
-    /// This error occurs when we cannot resolve an action name (because it
-    /// refers to an action that was not declared).
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    ActionNotDefined(#[from] schema_errors::ActionNotDefinedError),
-    /// Action shadowing error. Some shadowing relationships are not allowed for
-    /// clarity reasons; see
-    /// [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md).
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    ActionShadowing(#[from] schema_errors::ActionShadowingError),
-}
-
-impl From<ActionResolutionError> for SchemaError {
-    fn from(e: ActionResolutionError) -> SchemaError {
-        match e {
-            ActionResolutionError::ActionNotDefined(e) => e.into(),
-            ActionResolutionError::ActionShadowing(e) => e.into(),
-        }
-    }
-}
-
 /// Error subtypes for [`SchemaError`]
 pub mod schema_errors {
     use std::{collections::BTreeSet, fmt::Display};

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -522,13 +522,13 @@ pub mod schema_errors {
         "definition of `{shadowing_def}` illegally shadows the existing definition of `{shadowed_def}`"
     )]
     #[diagnostic(help(
-        "try renaming one of the definitions, or moving `{shadowed_def}` to a different namespace"
+        "try renaming one of the actions, or moving `{shadowed_def}` to a different namespace"
     ))]
     pub struct ActionShadowingError {
         /// Definition that is being shadowed illegally
-        pub(crate) shadowed_def: crate::json_schema::ActionEntityUID<InternalName>,
+        pub(crate) shadowed_def: EntityUID,
         /// Definition that is responsible for shadowing it illegally
-        pub(crate) shadowing_def: crate::json_schema::ActionEntityUID<InternalName>,
+        pub(crate) shadowing_def: EntityUID,
     }
 
     /// Duplicate entity type error

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -162,13 +162,13 @@ pub enum SchemaError {
     #[diagnostic(transparent)]
     UndeclaredEntityTypes(#[from] schema_errors::UndeclaredEntityTypesError),
     /// This error occurs when we cannot resolve a typename (because it refers
-    /// to an entity type or common type that was not declared).
+    /// to an entity type or common type that was not defined).
     #[error(transparent)]
     #[diagnostic(transparent)]
     TypeNotDefined(#[from] schema_errors::TypeNotDefinedError),
     /// This error occurs when we cannot resolve an action name used in the
     /// `memberOf` field of an action (because it refers to an action that was
-    /// not declared).
+    /// not defined).
     #[error(transparent)]
     #[diagnostic(transparent)]
     ActionNotDefined(#[from] schema_errors::ActionNotDefinedError),

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -988,7 +988,6 @@ impl AllDefs {
     /// fragment that exists.
     /// Any names referring to definitions in other fragments will not resolve
     /// properly.
-    #[cfg(test)]
     pub fn single_fragment<N, A>(fragment: &ValidatorSchemaFragment<N, A>) -> Self {
         Self::new(|| std::iter::once(fragment))
     }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -384,7 +384,7 @@ impl ValidatorSchema {
         // in the empty namespace is convenient, because at this point the only
         // definitions in the empty namespace are the ones the user has put there, which
         // are thus subject to RFC 70 shadowing rules.
-        all_defs.rfc_70_checks()?;
+        all_defs.rfc_70_shadowing_checks()?;
 
         // Add aliases for primitive and extension typenames in the empty namespace,
         // so that they can be accessed without `__cedar`.
@@ -1016,9 +1016,14 @@ impl AllDefs {
     }
 
     /// Return an error if the definitions in this [`AllDefs`] violate the
-    /// restrictions specified in
-    /// [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md)
-    pub fn rfc_70_checks(&self) -> Result<()> {
+    /// restrictions specified in [RFC 70].
+    ///
+    /// RFC 70 disallows definitions of entity types, common types, and actions
+    /// that would shadow definitions of other entity types, common types, or
+    /// actions in the empty namespace.
+    ///
+    /// [RFC 70]: https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md
+    pub fn rfc_70_shadowing_checks(&self) -> Result<()> {
         for unqualified_name in self
             .entity_and_common_names()
             .filter(|name| name.is_unqualified())

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -1086,7 +1086,7 @@ impl AllDefs {
 /// common types that appear as keys in `defs`.
 /// This invariant is upheld by callers because the process of converting
 /// references to fully-qualified ensures that the targets exist (else, it
-/// throws `TypeResolutionError`).
+/// throws [`TypeNotDefinedError`]).
 #[derive(Debug)]
 struct CommonTypeResolver<'a> {
     /// Definition of each common type.
@@ -1118,7 +1118,7 @@ impl<'a> CommonTypeResolver<'a> {
     /// to common types that appear as keys in `defs`.
     /// This invariant is upheld by callers because the process of converting
     /// references to fully-qualified ensures that the targets exist (else, it
-    /// throws `TypeResolutionError`).
+    /// throws [`TypeNotDefinedError`]).
     fn new(defs: &'a HashMap<InternalName, json_schema::Type<InternalName>>) -> Self {
         let mut graph = HashMap::new();
         for (name, ty) in defs {

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -944,11 +944,11 @@ fn internal_name_to_entity_type(
 #[derive(Debug)]
 pub struct AllDefs {
     /// All entity type definitions, in all fragments, as fully-qualified names.
-    all_entity_defs: HashSet<TypeDefinitionInfo>,
+    entity_defs: HashSet<TypeDefinitionInfo>,
     /// All common type definitions, in all fragments, as fully-qualified names.
-    all_common_defs: HashSet<TypeDefinitionInfo>,
+    common_defs: HashSet<TypeDefinitionInfo>,
     /// All action definitions, in all fragments, with fully-qualified typenames.
-    all_action_defs: HashSet<EntityUID>,
+    action_defs: HashSet<EntityUID>,
 }
 
 impl AllDefs {
@@ -959,7 +959,7 @@ impl AllDefs {
         I: Iterator<Item = &'a ValidatorSchemaFragment<N, A>>,
     {
         Self {
-            all_entity_defs: fragments()
+            entity_defs: fragments()
                 .flat_map(|f| f.0.iter())
                 .flat_map(|ns_def| ns_def.all_declared_entity_type_names().cloned())
                 .map(|name| TypeDefinitionInfo {
@@ -967,7 +967,7 @@ impl AllDefs {
                     user_def: true,
                 })
                 .collect(),
-            all_common_defs: fragments()
+            common_defs: fragments()
                 .flat_map(|f| f.0.iter())
                 .flat_map(|ns_def| ns_def.all_declared_common_type_names().cloned())
                 .map(|name| TypeDefinitionInfo {
@@ -975,7 +975,7 @@ impl AllDefs {
                     user_def: true,
                 })
                 .collect(),
-            all_action_defs: fragments()
+            action_defs: fragments()
                 .flat_map(|f| f.0.iter())
                 .flat_map(|ns_def| ns_def.all_declared_action_names().cloned())
                 .collect(),
@@ -994,25 +994,25 @@ impl AllDefs {
     /// Get the [`TypeDefinitionInfo`] for the given entity type name, or `None`
     /// if it is not defined in any fragment
     pub fn get_entity_type(&self, name: &InternalName) -> Option<&TypeDefinitionInfo> {
-        self.all_entity_defs.iter().find(|tdi| &tdi.name == name)
+        self.entity_defs.iter().find(|tdi| &tdi.name == name)
     }
 
     /// Get the [`TypeDefinitionInfo`] for the given common type name, or `None`
     /// if it is not defined in any fragment
     pub fn get_common_type(&self, name: &InternalName) -> Option<&TypeDefinitionInfo> {
-        self.all_common_defs.iter().find(|tdi| &tdi.name == name)
+        self.common_defs.iter().find(|tdi| &tdi.name == name)
     }
 
     /// Is the given (fully-qualified) [`EntityUID`] defined as an action in any
     /// fragment?
     pub fn is_defined_as_action(&self, euid: &EntityUID) -> bool {
-        self.all_action_defs.contains(euid)
+        self.action_defs.contains(euid)
     }
 
     /// Mark the given [`InternalName`] as defined as an implicitly-defined
     /// common type. See notes on [`CommonTypeDefinitionInfo`].
     pub fn mark_as_implicitly_defined_common_type(&mut self, name: InternalName) {
-        self.all_common_defs.insert(TypeDefinitionInfo {
+        self.common_defs.insert(TypeDefinitionInfo {
             name,
             user_def: false,
         });
@@ -1024,15 +1024,15 @@ impl AllDefs {
     #[cfg(test)]
     pub(crate) fn from_entity_defs(names: impl IntoIterator<Item = InternalName>) -> Self {
         Self {
-            all_entity_defs: names
+            entity_defs: names
                 .into_iter()
                 .map(|name| TypeDefinitionInfo {
                     name,
                     user_def: true,
                 })
                 .collect(),
-            all_common_defs: HashSet::new(),
-            all_action_defs: HashSet::new(),
+            common_defs: HashSet::new(),
+            action_defs: HashSet::new(),
         }
     }
 }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -408,7 +408,7 @@ impl ValidatorSchema {
                     tyname.basename().clone(),
                     tyname.as_ref().qualify_with(Some(&InternalName::__cedar())),
                 ));
-                all_defs.mark_as_implicitly_defined_common_type(tyname.into());
+                all_defs.mark_as_defined_as_common_type(tyname.into());
             }
         }
 
@@ -1012,7 +1012,7 @@ impl AllDefs {
     }
 
     /// Mark the given [`InternalName`] as defined as a common type
-    pub fn mark_as_implicitly_defined_common_type(&mut self, name: InternalName) {
+    pub fn mark_as_defined_as_common_type(&mut self, name: InternalName) {
         self.common_defs.insert(name);
     }
 

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -503,7 +503,7 @@ impl EntityTypeFragment<ConditionalName> {
         let undeclared_parents: Option<NonEmpty<ConditionalName>> = NonEmpty::collect(
             parents
                 .iter()
-                .filter(|ety| all_defs.get_entity_type(ety).is_none())
+                .filter(|ety| !all_defs.is_defined_as_entity(ety))
                 .map(|ety| ConditionalName::unconditional(ety.clone(), ReferenceType::Entity)),
         );
         match (fully_qual_attributes, undeclared_parents) {

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -32,13 +32,13 @@ use itertools::Itertools;
 use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
 
-use super::{internal_name_to_entity_type, ValidatorApplySpec};
+use super::{internal_name_to_entity_type, AllDefs, ValidatorApplySpec};
 use crate::{
     err::{schema_errors::*, SchemaError},
     fuzzy_match::fuzzy_search,
     json_schema,
     types::{AttributeType, Attributes, OpenTag, Type},
-    ActionBehavior, ConditionalName, RawName, ReferenceType,
+    ActionBehavior, ConditionalName, RawName, ReferenceType, TypeResolutionError,
 };
 
 /// A single namespace definition from the schema JSON or Cedar syntax,
@@ -186,27 +186,16 @@ impl ValidatorNamespaceDef<ConditionalName, ConditionalName> {
     /// [`ValidatorNamespaceDef<InternalName>`] by fully-qualifying all
     /// typenames that appear anywhere in any definitions.
     ///
-    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
-    /// fully-qualified typenames (of common and entity types respectively) that
-    /// are defined in the schema (in all schema fragments).
-    /// `all_action_defs` needs to be the full set of all fully-qualified action
-    /// EUIDs that are defined in the schema (in all schema fragments).
+    /// `all_defs` needs to contain the full set of all fully-qualified typenames
+    /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
-        all_common_defs: &HashSet<InternalName>,
-        all_entity_defs: &HashSet<InternalName>,
-        all_action_defs: &HashSet<EntityUID>,
+        all_defs: &AllDefs,
     ) -> Result<ValidatorNamespaceDef<InternalName, EntityType>, SchemaError> {
         match (
-            self.common_types
-                .fully_qualify_type_references(all_common_defs, all_entity_defs),
-            self.entity_types
-                .fully_qualify_type_references(all_common_defs, all_entity_defs),
-            self.actions.fully_qualify_type_references(
-                all_common_defs,
-                all_entity_defs,
-                all_action_defs,
-            ),
+            self.common_types.fully_qualify_type_references(all_defs),
+            self.entity_types.fully_qualify_type_references(all_defs),
+            self.actions.fully_qualify_type_references(all_defs),
         ) {
             (Ok(common_types), Ok(entity_types), Ok(actions)) => Ok(ValidatorNamespaceDef {
                 namespace: self.namespace,
@@ -355,25 +344,18 @@ impl CommonTypeDefs<ConditionalName> {
     /// [`CommonTypeDefs<InternalName>`] by fully-qualifying all typenames that
     /// appear anywhere in any definitions.
     ///
-    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
-    /// fully-qualified typenames (of common and entity types respectively) that
-    /// are defined in the schema (in all schema fragments).
+    /// `all_defs` needs to contain the full set of all fully-qualified typenames
+    /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
-        all_common_defs: &HashSet<InternalName>,
-        all_entity_defs: &HashSet<InternalName>,
+        all_defs: &AllDefs,
     ) -> Result<CommonTypeDefs<InternalName>, TypeResolutionError> {
         Ok(CommonTypeDefs {
             defs: self
                 .defs
                 .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        k,
-                        v.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
-                    ))
-                })
-                .collect::<Result<_, _>>()?,
+                .map(|(k, v)| Ok((k, v.fully_qualify_type_references(all_defs)?)))
+                .collect::<Result<_, TypeResolutionError>>()?,
         })
     }
 }
@@ -435,25 +417,18 @@ impl EntityTypesDef<ConditionalName> {
     /// [`EntityTypesDef<InternalName>`] by fully-qualifying all typenames that
     /// appear anywhere in any definitions.
     ///
-    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
-    /// fully-qualified typenames (of common and entity types respectively) that
-    /// are defined in the schema (in all schema fragments).
+    /// `all_defs` needs to contain the full set of all fully-qualified typenames
+    /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
-        all_common_defs: &HashSet<InternalName>,
-        all_entity_defs: &HashSet<InternalName>,
+        all_defs: &AllDefs,
     ) -> Result<EntityTypesDef<InternalName>, TypeResolutionError> {
         Ok(EntityTypesDef {
             defs: self
                 .defs
                 .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        k,
-                        v.fully_qualify_type_references(all_common_defs, all_entity_defs)?,
-                    ))
-                })
-                .collect::<Result<_, _>>()?,
+                .map(|(k, v)| Ok((k, v.fully_qualify_type_references(all_defs)?)))
+                .collect::<Result<_, TypeResolutionError>>()?,
         })
     }
 }
@@ -508,31 +483,27 @@ impl EntityTypeFragment<ConditionalName> {
     /// [`EntityTypeFragment<InternalName>`] by fully-qualifying all typenames that
     /// appear anywhere in any definitions.
     ///
-    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
-    /// fully-qualified typenames (of common and entity types respectively) that
-    /// are defined in the schema (in all schema fragments).
+    /// `all_defs` needs to contain the full set of all fully-qualified typenames
+    /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
-        all_common_defs: &HashSet<InternalName>,
-        all_entity_defs: &HashSet<InternalName>,
+        all_defs: &AllDefs,
     ) -> Result<EntityTypeFragment<InternalName>, TypeResolutionError> {
         // Fully qualify typenames appearing in `attributes`
-        let fully_qual_attributes = self
-            .attributes
-            .fully_qualify_type_references(all_common_defs, all_entity_defs);
+        let fully_qual_attributes = self.attributes.fully_qualify_type_references(all_defs);
         // Fully qualify typenames appearing in `parents`
         let parents: HashSet<InternalName> = self
             .parents
             .into_iter()
-            .map(|parent| parent.resolve(all_common_defs, all_entity_defs).cloned())
-            .collect::<Result<_, _>>()?;
+            .map(|parent| parent.resolve(all_defs))
+            .collect::<Result<_, TypeResolutionError>>()?;
         // Now is the time to check whether any parents are dangling, i.e.,
         // refer to entity types that are not declared in any fragment (since we
         // now have the set of typenames that are declared in all fragments).
         let undeclared_parents: Option<NonEmpty<ConditionalName>> = NonEmpty::collect(
             parents
                 .iter()
-                .filter(|ety| !all_entity_defs.contains(ety))
+                .filter(|ety| all_defs.get_entity_type(ety).is_none())
                 .map(|ety| ConditionalName::unconditional(ety.clone(), ReferenceType::Entity)),
         );
         match (fully_qual_attributes, undeclared_parents) {
@@ -540,11 +511,16 @@ impl EntityTypeFragment<ConditionalName> {
                 attributes,
                 parents,
             }),
-            (Ok(_), Some(undeclared_parents)) => Err(TypeResolutionError(undeclared_parents)),
+            (Ok(_), Some(undeclared_parents)) => {
+                Err(TypeNotDefinedError(undeclared_parents).into())
+            }
             (Err(e), None) => Err(e),
             (Err(e), Some(mut undeclared)) => {
-                undeclared.extend(e.0);
-                Err(TypeResolutionError(undeclared))
+                match e {
+                    TypeResolutionError::TypeNotDefined(e) => undeclared.extend(e.0),
+                    TypeResolutionError::TypeShadowing(_) => (), // swallow this error in order to return a `TypeNotDefined` error for `undeclared` instead
+                }
+                Err(TypeNotDefinedError(undeclared).into())
             }
         }
     }
@@ -612,31 +588,17 @@ impl ActionsDef<ConditionalName, ConditionalName> {
     /// [`ActionsDef<InternalName>`] by fully-qualifying all typenames that
     /// appear anywhere in any definitions.
     ///
-    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
-    /// fully-qualified typenames (of common and entity types respectively) that
-    /// are defined in the schema (in all schema fragments).
-    /// `all_action_defs` needs to be the full set of all fully-qualified action
-    /// EUIDs that are defined in the schema (in all schema fragments).
+    /// `all_defs` needs to contain the full set of all fully-qualified typenames
+    /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
-        all_common_defs: &HashSet<InternalName>,
-        all_entity_defs: &HashSet<InternalName>,
-        all_action_defs: &HashSet<EntityUID>,
+        all_defs: &AllDefs,
     ) -> Result<ActionsDef<InternalName, EntityType>, SchemaError> {
         Ok(ActionsDef {
             actions: self
                 .actions
                 .into_iter()
-                .map(|(k, v)| {
-                    Ok((
-                        k,
-                        v.fully_qualify_type_references(
-                            all_common_defs,
-                            all_entity_defs,
-                            all_action_defs,
-                        )?,
-                    ))
-                })
+                .map(|(k, v)| Ok((k, v.fully_qualify_type_references(all_defs)?)))
                 .collect::<Result<_, SchemaError>>()?,
         })
     }
@@ -730,30 +692,21 @@ impl ActionFragment<ConditionalName, ConditionalName> {
     /// [`ActionFragment<InternalName>`] by fully-qualifying all typenames that
     /// appear anywhere in any definitions.
     ///
-    /// `all_common_defs` and `all_entity_defs` need to be the full set of all
-    /// fully-qualified typenames (of common and entity types respectively) that
-    /// are defined in the schema (in all schema fragments).
-    /// `all_action_defs` needs to be the full set of all fully-qualified action
-    /// EUIDs that are defined in the schema (in all schema fragments).
+    /// `all_defs` needs to contain the full set of all fully-qualified typenames
+    /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
-        all_common_defs: &HashSet<InternalName>,
-        all_entity_defs: &HashSet<InternalName>,
-        all_action_defs: &HashSet<EntityUID>,
+        all_defs: &AllDefs,
     ) -> Result<ActionFragment<InternalName, EntityType>, SchemaError> {
         Ok(ActionFragment {
-            context: self
-                .context
-                .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
-            applies_to: self
-                .applies_to
-                .fully_qualify_type_references(all_common_defs, all_entity_defs)?,
+            context: self.context.fully_qualify_type_references(all_defs)?,
+            applies_to: self.applies_to.fully_qualify_type_references(all_defs)?,
             parents: self
                 .parents
                 .into_iter()
                 .map(|parent| {
                     parent
-                        .fully_qualify_type_references(all_action_defs)
+                        .fully_qualify_type_references(all_defs)
                         .map_err(Into::into)
                 })
                 .collect::<Result<_, SchemaError>>()?,

--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -15,8 +15,8 @@
  */
 
 use crate::err::TypeResolutionError;
-use crate::schema::{AllDefs, TypeDefinitionInfo};
-use crate::schema_errors::{TypeNotDefinedError, TypeShadowingError};
+use crate::schema::AllDefs;
+use crate::schema_errors::TypeNotDefinedError;
 use cedar_policy_core::ast::{Id, InternalName, Name, UnreservedId};
 use itertools::Itertools;
 use nonempty::{nonempty, NonEmpty};
@@ -253,8 +253,7 @@ impl ConditionalName {
     /// names containing `__cedar` might be internally defined/valid, even
     /// though it is not valid for _end-users_ to define those names.
     pub fn resolve<'a>(self, all_defs: &AllDefs) -> Result<InternalName, TypeResolutionError> {
-        let mut resolved = None;
-        for possibility in self.possibilities.iter() {
+        for possibility in &self.possibilities {
             // Per RFC 24, we give priority to trying to resolve to a common
             // type, before trying to resolve to an entity type.
             // (However, we have an even stronger preference to resolve earlier
@@ -267,23 +266,20 @@ impl ConditionalName {
                 self.reference_type,
                 ReferenceType::Common | ReferenceType::CommonOrEntity
             ) {
-                if let Some(possibility) = all_defs.get_common_type(possibility) {
-                    update_resolved_name(&mut resolved, possibility)?;
+                if all_defs.is_defined_as_common(possibility) {
+                    return Ok(possibility.clone());
                 }
             }
             if matches!(
                 self.reference_type,
                 ReferenceType::Entity | ReferenceType::CommonOrEntity
             ) {
-                if let Some(possibility) = all_defs.get_entity_type(possibility) {
-                    update_resolved_name(&mut resolved, possibility)?;
+                if all_defs.is_defined_as_entity(possibility) {
+                    return Ok(possibility.clone());
                 }
             }
         }
-        match resolved {
-            Some(possibility) => Ok(possibility.clone()),
-            None => Err(TypeNotDefinedError(nonempty![self]).into()),
-        }
+        Err(TypeNotDefinedError(nonempty![self]).into())
     }
 
     /// Provide a help message for the case where this [`ConditionalName`] failed to resolve
@@ -336,56 +332,4 @@ pub enum ReferenceType {
     Entity,
     /// The reference can resolve to either an entity or common type name
     CommonOrEntity,
-}
-
-/// Given that we found a new `possibility` that is defined and we could resolve to,
-/// update the `resolved` for this, and return an error if we're in a situation
-/// disallowed by [RFC 70].
-///
-/// Assumes that we consider possibilities in decreasing order of priority.
-///
-/// [RFC 70]: https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md
-fn update_resolved_name<'a>(
-    resolved: &mut Option<&'a InternalName>,
-    possibility: &'a TypeDefinitionInfo,
-) -> Result<(), TypeShadowingError> {
-    match resolved {
-        Some(accepted_def) => {
-            // We just found a lower-priority definition than the one we already
-            // resolved to, meaning that the new definition is shadowed.
-            //
-            // Don't change `resolved` -- leave the higher-priority definition
-            // there.
-            //
-            // Do check whether this situation is disallowed by RFC 70.
-            // RFC 70 specifies that entity/common type definitions in a
-            // nonempty namespace cannot shadow entity/common type definitions
-            // in the empty namespace.
-            let shadowed_def = &possibility.name;
-            if shadowed_def.is_unqualified() && !accepted_def.is_unqualified() {
-                if possibility.user_def {
-                    // This is the situation disallowed by RFC 70
-                    Err(TypeShadowingError {
-                        shadowed_def: shadowed_def.clone(),
-                        shadowing_def: accepted_def.clone(),
-                    })
-                } else {
-                    // RFC 70 does not disallow defining types like `MyNamespace::String`,
-                    // if the user does not define their own `String` in the empty namespace.
-                    // Although this does shadow an empty-namespace definition (namely,
-                    // `type String = __cedar::String;`, which is added implicitly), we
-                    // don't throw an error, because shadowing _implicit_ definitions is
-                    // allowed.
-                    Ok(())
-                }
-            } else {
-                Ok(())
-            }
-        }
-        None => {
-            // We just found our highest-priority definition.
-            *resolved = Some(&possibility.name);
-            Ok(())
-        }
-    }
 }

--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use crate::err::TypeResolutionError;
 use crate::schema::AllDefs;
 use crate::schema_errors::TypeNotDefinedError;
 use cedar_policy_core::ast::{Id, InternalName, Name, UnreservedId};
@@ -252,7 +251,7 @@ impl ConditionalName {
     /// `all_defs` also internally includes [`InternalName`]s, because some
     /// names containing `__cedar` might be internally defined/valid, even
     /// though it is not valid for _end-users_ to define those names.
-    pub fn resolve<'a>(self, all_defs: &AllDefs) -> Result<InternalName, TypeResolutionError> {
+    pub fn resolve<'a>(self, all_defs: &AllDefs) -> Result<InternalName, TypeNotDefinedError> {
         for possibility in &self.possibilities {
             // Per RFC 24, we give priority to trying to resolve to a common
             // type, before trying to resolve to an entity type.
@@ -279,7 +278,7 @@ impl ConditionalName {
                 }
             }
         }
-        Err(TypeNotDefinedError(nonempty![self]).into())
+        Err(TypeNotDefinedError(nonempty![self]))
     }
 
     /// Provide a help message for the case where this [`ConditionalName`] failed to resolve

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -1182,7 +1182,7 @@ fn is_typecheck_fails() {
 fn is_typechecks() {
     let schema = json_schema::Fragment::from_json_value(json!({
             "": { "entityTypes": { "User": {}, "Photo": {} }, "actions": {} },
-            "N::S": { "entityTypes": { "User": {} }, "actions": {} }
+            "N::S": { "entityTypes": { "Foo": {} }, "actions": {} }
     }))
     .unwrap();
     assert_typechecks(
@@ -1197,12 +1197,12 @@ fn is_typechecks() {
     );
     assert_typechecks(
         schema.clone(),
-        r#"N::S::User::"alice" is N::S::User"#.parse().unwrap(),
+        r#"N::S::Foo::"alice" is N::S::Foo"#.parse().unwrap(),
         Type::singleton_boolean(true),
     );
     assert_typechecks(
         schema,
-        r#"N::S::User::"alice" is User"#.parse().unwrap(),
+        r#"N::S::Foo::"alice" is User"#.parse().unwrap(),
         Type::singleton_boolean(false),
     );
 }

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -383,7 +383,7 @@ fn multiple_namespaces_attributes() {
 
 #[test]
 fn multiple_namespaces_member_of() {
-    let authorization_model = json_schema::Fragment::from_json_value(json!(
+    let schema = json_schema::Fragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -408,7 +408,6 @@ fn multiple_namespaces_member_of() {
         }
     ))
     .unwrap();
-    let schema: ValidatorSchema = authorization_model.try_into().unwrap();
 
     assert_policy_typechecks(
         schema,
@@ -422,7 +421,7 @@ fn multiple_namespaces_member_of() {
 
 #[test]
 fn multiple_namespaces_applies_to() {
-    let authorization_model = json_schema::Fragment::from_json_value(json!(
+    let schema = json_schema::Fragment::from_json_value(json!(
         {
             "A": {
                 "entityTypes": {
@@ -466,7 +465,6 @@ fn multiple_namespaces_applies_to() {
         }
     ))
     .unwrap();
-    let schema: ValidatorSchema = authorization_model.try_into().unwrap();
 
     assert_policy_typechecks(
         schema.clone(),
@@ -543,14 +541,14 @@ fn multi_namespace_action_eq() {
     let (schema, _) = json_schema::Fragment::from_cedarschema_str(
         r#"
             entity E1;
-            action "Action" appliesTo { context: {}, principal : [E1], resource : [E1] };
+            action "A" appliesTo { context: {}, principal : [E1], resource : [E1] };
             namespace NS1 {
                 entity E;
-                action "Action" appliesTo { context: {}, principal : [E], resource : [E]};
+                action "B" appliesTo { context: {}, principal : [E], resource : [E]};
             }
             namespace NS2 {
                 entity E;
-                action "Action" appliesTo { context: {}, principal : [E], resource : [E]};
+                action "B" appliesTo { context: {}, principal : [E], resource : [E]};
             }
         "#,
         Extensions::all_available(),
@@ -561,7 +559,7 @@ fn multi_namespace_action_eq() {
         schema.clone(),
         parse_policy(
             None,
-            r#"permit(principal, action == Action::"Action", resource);"#,
+            r#"permit(principal, action == Action::"A", resource);"#,
         )
         .unwrap(),
     );
@@ -569,14 +567,14 @@ fn multi_namespace_action_eq() {
         schema.clone(),
         parse_policy(
             None,
-            r#"permit(principal, action == NS1::Action::"Action", resource);"#,
+            r#"permit(principal, action == NS1::Action::"B", resource);"#,
         )
         .unwrap(),
     );
 
     let policy = parse_policy(
         None,
-        r#"permit(principal, action, resource) when { NS1::Action::"Action" == NS2::Action::"Action" };"#,
+        r#"permit(principal, action, resource) when { NS1::Action::"B" == NS2::Action::"B" };"#,
     )
     .unwrap();
     assert_policy_typecheck_warns(

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -542,8 +542,8 @@ fn namespaced_entity_is_wrong_type_when() {
 fn multi_namespace_action_eq() {
     let (schema, _) = json_schema::Fragment::from_cedarschema_str(
         r#"
-            entity E;
-            action "Action" appliesTo { context: {}, principal : [E], resource : [E] };
+            entity E1;
+            action "Action" appliesTo { context: {}, principal : [E1], resource : [E1] };
             namespace NS1 {
                 entity E;
                 action "Action" appliesTo { context: {}, principal : [E], resource : [E]};
@@ -593,7 +593,7 @@ fn multi_namespace_action_eq() {
 fn multi_namespace_action_in() {
     let (schema, _) = json_schema::Fragment::from_cedarschema_str(
         r#"
-            entity E;
+            entity E1;
             namespace NS1 { action "Group"; }
             namespace NS2 { action "Group" in [NS1::Action::"Group"]; }
             namespace NS3 {

--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -157,7 +157,10 @@ pub(crate) fn assert_policy_typechecks_for_mode(
     mode: ValidationMode,
 ) {
     let policy = policy.into();
-    let schema = schema.try_into().map_err(miette::Report::new).unwrap_or_else(|e| panic!("failed to construct schema: {e:?}"));
+    let schema = schema
+        .try_into()
+        .map_err(miette::Report::new)
+        .unwrap_or_else(|e| panic!("failed to construct schema: {e:?}"));
     let mut typechecker = Typechecker::new(&schema, mode, expr_id_placeholder());
     let mut type_errors: HashSet<ValidationError> = HashSet::new();
     let mut warnings: HashSet<ValidationWarning> = HashSet::new();

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -25,6 +25,10 @@ Cedar Language Version: 4.0
 
 - The API around `Request::new` has changed to remove the `Option`s
   around the entity type arguments. See [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md).
+- Implemented [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md).
+  In both the Cedar and JSON schema syntaxes, it is now illegal to define the
+  same entity name, common type name, or action name in both the empty namespace
+  and a nonempty namespace.
 - Significantly reworked all public-facing error types to address some issues
   and improve consistency. See issue #745.
 - Finalized the `ffi` module and `cedar-wasm` crate which were preview-released

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -25,7 +25,7 @@ Cedar Language Version: 4.0
 
 - The API around `Request::new` has changed to remove the `Option`s
   around the entity type arguments. See [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md).
-- Implemented [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md).
+- (*) Implemented [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md).
   In both the Cedar and JSON schema syntaxes, it is now illegal to define the
   same entity name, common type name, or action name in both the empty namespace
   and a nonempty namespace.


### PR DESCRIPTION
## Description of changes

Implements [RFC 70](https://github.com/cedar-policy/rfcs/blob/main/text/0070-disallow-empty-namespace-shadowing.md)

~As of this writing, some tests are failing, but I believe I've written tests that cover all the behaviors we need to test according to RFC 70.  Unfortunately, the current approach (detecting RFC 70 violations at type-resolution time) may not be feasible, because it may not be able to catch cases like `entity T; namespace NS { entity T; }` where `T` is never referenced -- the current PR only catches this once there is an ambiguous reference to `T`.~

2024-08-26: tests should be passing now

## Issue #, if available

#1106 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

