### PR TITLE
Implement #1139

### DIFF
--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -52,6 +52,7 @@ wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 similar-asserts = "1.5.0"
 cool_asserts = "2.0"
 cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core", features = ["test-util"] }
+miette = { version = "7.1.0", features = ["fancy"] }
 
 [build-dependencies]
 lalrpop = "0.20.0"

--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -248,7 +248,7 @@ pub fn json_schema_to_cedar_schema_str<N: Display>(
             .common_types
             .keys()
             .map(|ty_name| {
-                RawName::new_from_unreserved(ty_name.clone())
+                RawName::new_from_unreserved(ty_name.clone().into())
                     .qualify_with_name(name.as_ref())
                     .to_smolstr()
             })

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -39,7 +39,11 @@ use super::{
         ToJsonSchemaError, ToJsonSchemaErrors,
     },
 };
-use crate::{cedar_schema, json_schema, RawName};
+use crate::{
+    cedar_schema,
+    json_schema::{self, is_reserved_schema_keyword, CommonTypeId},
+    RawName,
+};
 
 impl From<cedar_schema::Path> for RawName {
     fn from(p: cedar_schema::Path) -> Self {
@@ -234,12 +238,6 @@ fn convert_namespace(
     Ok((ns_name, def))
 }
 
-// Test if this id is a reserved JSON schema keyword.
-// Issue: https://github.com/cedar-policy/cedar/issues/1070
-fn is_reserved_schema_keyword(id: &UnreservedId) -> bool {
-    matches!(id.as_ref(), "Set" | "Record" | "Entity" | "Extension")
-}
-
 impl TryFrom<Namespace> for json_schema::NamespaceDefinition<RawName> {
     type Error = ToJsonSchemaErrors;
 
@@ -268,7 +266,7 @@ impl TryFrom<Namespace> for json_schema::NamespaceDefinition<RawName> {
                     Err(ToJsonSchemaError::reserved_keyword(id, name_loc))
                 } else {
                     Ok((
-                        id,
+                        CommonTypeId::unchecked(id),
                         cedar_type_to_json_type(decl.def).map_err(EAMapError::from)?,
                     ))
                 }

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -204,7 +204,7 @@ impl Display for CommonTypeId {
 pub(crate) fn is_reserved_schema_keyword(id: &UnreservedId) -> bool {
     matches!(
         id.as_ref(),
-        "Set" | "Record" | "Entity" | "Extension" | "Long" | "String" | "Boolean"
+        "Bool" | "Boolean" | "Entity" | "Extension" | "Long" | "Record" | "Set" | "String"
     )
 }
 

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -175,7 +175,9 @@ impl<N: Display> Fragment<N> {
 /// An [`UnreservedId`] that cannot be reserved JSON schema keywords
 /// like `Set`, `Long`, and etc.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
-pub struct CommonTypeId(UnreservedId);
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub struct CommonTypeId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] UnreservedId);
 
 impl From<CommonTypeId> for UnreservedId {
     fn from(value: CommonTypeId) -> Self {

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -217,7 +217,7 @@ impl<'de> Deserialize<'de> for CommonTypeId {
         UnreservedId::deserialize(deserializer).and_then(|id| {
             if is_reserved_schema_keyword(&id) {
                 Err(serde::de::Error::custom(format!(
-                    "Used reserved JSON schema keyword: {id} "
+                    "Used reserved schema keyword: {id} "
                 )))
             } else {
                 Ok(Self(id))

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -213,7 +213,7 @@ impl<'a> arbitrary::Arbitrary<'a> for CommonTypeId {
     }
 
     fn size_hint(depth: usize) -> (usize, Option<usize>) {
-        <Id as arbitrary::Arbitrary>::size_hint(depth)
+        <UnreservedId as arbitrary::Arbitrary>::size_hint(depth)
     }
 }
 

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -204,7 +204,8 @@ impl<'a> arbitrary::Arbitrary<'a> for CommonTypeId {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let id: UnreservedId = u.arbitrary()?;
         if is_reserved_schema_keyword(&id) {
-            // `_Bool`, `_Record`, and etc are valid common type names
+            // PANIC SAFETY: `_Bool`, `_Record`, and etc are valid common type names as well as valid unreserved names.
+            #[allow(clippy::unwrap_used)]
             let new_id = format!("_{id}").parse().unwrap();
             Ok(CommonTypeId::unchecked(new_id))
         } else {

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -3342,25 +3342,24 @@ pub(crate) mod test {
             "": {
                 "commonTypes": {
                     "Record": {
-                        "type": "Record",
-                        "attributes": {
-                            "a": {
-                                "type": "Long",
-                            }
+                        "type": "Set",
+                        "element": {
+                            "type": "Long"
                         }
                     }
                 },
                 "entityTypes": {
                     "b": {
-                        "shape" : {
-                            "type" : "Record",
+                        "shape" :
+                        {
+                            "type": "Record",
                             "attributes" : {
                                 "c" : {
-                                    "type" : "Long"
+                                    "type" : "String"
                                 }
+                            }
                         }
                     }
-                }
                 },
                 "actions": { },
             }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2918,7 +2918,7 @@ pub(crate) mod test {
     fn test_common_type_name_conflicts() {
         let assert_invalid_json_schema = |src: serde_json::Value| {
             let schema = ValidatorSchema::from_json_value(src, Extensions::all_available());
-            assert_matches!(schema, Err(SchemaError::JsonDeserialization(e)) if e.to_smolstr().contains("Used reserved JSON schema keyword"));
+            assert_matches!(schema, Err(SchemaError::JsonDeserialization(e)) if e.to_smolstr().contains("Used reserved schema keyword"));
         };
         // `Record` cannot be a common type name
         let src: serde_json::Value = json!({

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2916,6 +2916,11 @@ pub(crate) mod test {
     // Names like `Set`, `Record`, `Entity`, and Extension` are not allowed as common type names, as specified in #1070 and #1139.
     #[test]
     fn test_common_type_name_conflicts() {
+        let assert_invalid_json_schema = |src: serde_json::Value| {
+            let schema = ValidatorSchema::from_json_value(src, Extensions::all_available());
+            assert_matches!(schema, Err(SchemaError::JsonDeserialization(e)) if e.to_smolstr().contains("Used reserved JSON schema keyword"));
+        };
+        // `Record` cannot be a common type name
         let src: serde_json::Value = json!({
             "": {
                 "commonTypes": {
@@ -2943,9 +2948,38 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(_));
+        assert_invalid_json_schema(src);
 
+        let src: serde_json::Value = json!({
+            "NS": {
+                "commonTypes": {
+                    "Record": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Record"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
+
+        // `Extension` cannot be a common type name
         let src: serde_json::Value = json!({
             "": {
                 "commonTypes": {
@@ -2973,9 +3007,38 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(_));
+        assert_invalid_json_schema(src);
 
+        let src: serde_json::Value = json!({
+            "NS": {
+                "commonTypes": {
+                    "Extension": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Extension"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
+
+        // `Entity` cannot be a common type name
         let src: serde_json::Value = json!({
             "": {
                 "commonTypes": {
@@ -3003,9 +3066,38 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(_));
+        assert_invalid_json_schema(src);
 
+        let src: serde_json::Value = json!({
+            "NS": {
+                "commonTypes": {
+                    "Entity": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Entity"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
+
+        // `Set` cannot be a common type name
         let src: serde_json::Value = json!({
             "": {
                 "commonTypes": {
@@ -3033,9 +3125,38 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
+        assert_invalid_json_schema(src);
 
+        let src: serde_json::Value = json!({
+            "NS": {
+                "commonTypes": {
+                    "Set": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Set"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
+
+        // `Long` cannot be a common type name
         let src: serde_json::Value = json!({
             "": {
                 "commonTypes": {
@@ -3063,9 +3184,38 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
+        assert_invalid_json_schema(src);
 
+        let src: serde_json::Value = json!({
+            "NS": {
+                "commonTypes": {
+                    "Long": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "Long"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
+
+        // `Boolean` cannot be a common type name
         let src: serde_json::Value = json!({
             "": {
                 "commonTypes": {
@@ -3093,13 +3243,12 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
+        assert_invalid_json_schema(src);
 
         let src: serde_json::Value = json!({
             "NS": {
                 "commonTypes": {
-                    "Set": {
+                    "Boolean": {
                         "type": "Record",
                         "attributes": {
                             "a": {
@@ -3114,7 +3263,7 @@ pub(crate) mod test {
                             "type" : "Record",
                             "attributes" : {
                                 "c" : {
-                                    "type" : "Long"
+                                    "type" : "Boolean"
                                 }
                         }
                     }
@@ -3123,8 +3272,66 @@ pub(crate) mod test {
                 "actions": { },
             }
         });
-        let schema = ValidatorSchema::from_json_value(src.clone(), Extensions::all_available());
-        assert_matches!(schema, Err(SchemaError::JsonDeserialization(_)));
+        assert_invalid_json_schema(src);
+
+        // `String` cannot be a common type name
+        let src: serde_json::Value = json!({
+            "": {
+                "commonTypes": {
+                    "String": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "String"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
+
+        let src: serde_json::Value = json!({
+            "NS": {
+                "commonTypes": {
+                    "String": {
+                        "type": "Record",
+                        "attributes": {
+                            "a": {
+                                "type": "Long",
+                            }
+                        }
+                    }
+                },
+                "entityTypes": {
+                    "b": {
+                        "shape" : {
+                            "type" : "Record",
+                            "attributes" : {
+                                "c" : {
+                                    "type" : "String"
+                                }
+                        }
+                    }
+                }
+                },
+                "actions": { },
+            }
+        });
+        assert_invalid_json_schema(src);
     }
 
     #[test]

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -36,7 +36,7 @@ use super::{internal_name_to_entity_type, AllDefs, ValidatorApplySpec};
 use crate::{
     err::{schema_errors::*, SchemaError},
     fuzzy_match::fuzzy_search,
-    json_schema,
+    json_schema::{self, CommonTypeId},
     types::{AttributeType, Attributes, OpenTag, Type},
     ActionBehavior, ConditionalName, RawName, ReferenceType,
 };
@@ -276,12 +276,12 @@ impl CommonTypeDefs<ConditionalName> {
     /// structures used by the schema format to those used internally by the
     /// validator.
     pub(crate) fn from_raw_common_types(
-        schema_file_type_def: HashMap<UnreservedId, json_schema::Type<RawName>>,
+        schema_file_type_def: HashMap<CommonTypeId, json_schema::Type<RawName>>,
         schema_namespace: Option<&InternalName>,
     ) -> crate::err::Result<Self> {
         let mut defs = HashMap::with_capacity(schema_file_type_def.len());
         for (id, schema_ty) in schema_file_type_def {
-            let name = RawName::new_from_unreserved(id).qualify_with(schema_namespace); // the declaration name is always (unconditionally) prefixed by the current/active namespace
+            let name = RawName::new_from_unreserved(id.into()).qualify_with(schema_namespace); // the declaration name is always (unconditionally) prefixed by the current/active namespace
             match defs.entry(name) {
                 Entry::Vacant(ventry) => {
                     ventry

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -56,6 +56,7 @@ Cedar Language Version: 4.0
 - Marked errors/warnings related to parsing and entity/request validation as
   `non_exhaustive`, allowing future variants to be added without a breaking
   change. (#1137)
+- (*) `Bool`, `Boolean`, `Entity`, `Extension`, `Long`, `Record`, `Set`, and `String` cannot be common type names (#1150, resolving #1139)
 
 ### Removed
 


### PR DESCRIPTION
## Description of changes
This PR eagerly disallows common type declarations with names specified by #1139. That is, Cedar forbids schemas with such declarations even though they are never referenced.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.