### PR TITLE
fix comment

### DIFF
--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -121,14 +121,13 @@ pub(crate) fn assert_types_eq(schema: &ValidatorSchema, expected: &Type, actual:
 
 /// Assert that every [`ValidationError`] in the expected list of type errors appears
 /// in the expected list of type errors, and that the expected number of
-/// type errors were generated. Equality of types in [`ValidationError`]s is
-/// determined in the same way as in `assert_types_eq`.
+/// type errors were generated.
 #[track_caller] // report the caller's location as the location of the panic, not the location in this function
 pub(crate) fn assert_expected_type_errors(
     expected: impl IntoIterator<Item = ValidationError>,
     actual: &HashSet<ValidationError>,
 ) {
-    assert_eq!(&expected.into_iter().collect::<HashSet<_>>(), actual,)
+    assert_eq!(&expected.into_iter().collect::<HashSet<_>>(), actual)
 }
 
 /// Assert that every `ValidationWarning` in the expected list of warnings


### PR DESCRIPTION
## Description of changes

This comment did not accurately describe the behavior of the function it is commenting on.  I propose we remove the inaccurate comment.  Alternately, we could do more work to fix the function to match the comment.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


