### PR TITLE
fix cli translate-schema

### DIFF
--- a/cedar-policy-cli/sample-data/tiny_sandboxes/translate-schema/README.md
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/translate-schema/README.md
@@ -1,0 +1,4 @@
+# translate-schema
+
+This sample is used to verify that the cedar-policy-cli's translate-schema
+command works as expected when converting between the Cedar and JSON formats.

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/translate-schema/tinytodo.cedarschema
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/translate-schema/tinytodo.cedarschema
@@ -1,0 +1,35 @@
+type Task = {
+    "id": Long,
+    "name": String,
+    "state": String,
+};
+type Tasks = Set<Task>;
+entity List in [Application] = {
+  "editors": Team,
+  "name": String,
+  "owner": User,
+  "readers": Team,
+  "tasks": Tasks,
+};
+entity Application;
+entity User in [Team, Application] = {
+  "joblevel": Long,
+  "location": String,
+};
+entity Team in [Team, Application];
+action DeleteList, GetList, UpdateList appliesTo {
+  principal: [User],
+  resource: [List]
+};
+action CreateList, GetLists appliesTo {
+  principal: [User],
+  resource: [Application]
+};
+action CreateTask, UpdateTask, DeleteTask appliesTo {
+  principal: [User],
+  resource: [List]
+};
+action EditShare appliesTo {
+  principal: [User],
+  resource: [List]
+};

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/translate-schema/tinytodo.cedarschema.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/translate-schema/tinytodo.cedarschema.json
@@ -1,0 +1,169 @@
+{
+    "": {
+        "commonTypes": {
+            "Task": {
+                "type": "Record",
+                "attributes": {
+                    "id": {
+                        "type": "Long"
+                    },
+                    "name": {
+                        "type": "String"
+                    },
+                    "state": {
+                        "type": "String"
+                    }
+                }
+            },
+            "Tasks": {
+                "type": "Set",
+                "element": {
+                    "type": "Task"
+                }
+            }
+        },
+        "entityTypes": {
+            "Team": {
+                "memberOfTypes": [
+                    "Team",
+                    "Application"
+                ]
+            },
+            "Application": {},
+            "User": {
+                "memberOfTypes": [
+                    "Team",
+                    "Application"
+                ],
+                "shape": {
+                    "type": "Record",
+                    "attributes": {
+                        "joblevel": {
+                            "type": "Long"
+                        },
+                        "location": {
+                            "type": "String"
+                        }
+                    }
+                }
+            },
+            "List": {
+                "memberOfTypes": [
+                    "Application"
+                ],
+                "shape": {
+                    "type": "Record",
+                    "attributes": {
+                        "editors": {
+                            "type": "Team"
+                        },
+                        "name": {
+                            "type": "String"
+                        },
+                        "owner": {
+                            "type": "User"
+                        },
+                        "readers": {
+                            "type": "Team"
+                        },
+                        "tasks": {
+                            "type": "Tasks"
+                        }
+                    }
+                }
+            }
+        },
+        "actions": {
+            "UpdateTask": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "DeleteTask": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "CreateTask": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "CreateList": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Application"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "GetList": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "EditShare": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "GetLists": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "Application"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "DeleteList": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            },
+            "UpdateList": {
+                "appliesTo": {
+                    "resourceTypes": [
+                        "List"
+                    ],
+                    "principalTypes": [
+                        "User"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -900,7 +900,7 @@ pub fn translate_policy(args: &TranslatePolicyArgs) -> CedarExitCode {
 }
 
 fn translate_schema_to_cedar(json_src: impl AsRef<str>) -> Result<String> {
-    let fragment = SchemaFragment::from_str(json_src.as_ref())?;
+    let fragment = SchemaFragment::from_json_str(json_src.as_ref())?;
     let output = fragment.to_cedarschema()?;
     Ok(output)
 }

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1126,3 +1126,31 @@ fn test_translate_policy() {
         "\noriginal:\n{cedar}\n\ttranslated:\n{translated}",
     );
 }
+
+#[test]
+fn test_translate_schema() {
+    let cedar_filename = "sample-data/tiny_sandboxes/translate-schema/tinytodo.cedarschema";
+    let json_filename = "sample-data/tiny_sandboxes/translate-schema/tinytodo.cedarschema.json";
+
+    // json -> cedar
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("translate-schema")
+        .arg("--direction")
+        .arg("cedar-to-json")
+        .arg("-s")
+        .arg(cedar_filename)
+        .assert()
+        .code(0);
+
+    // cedar -> json
+    assert_cmd::Command::cargo_bin("cedar")
+        .expect("bin exists")
+        .arg("translate-schema")
+        .arg("--direction")
+        .arg("json-to-cedar")
+        .arg("-s")
+        .arg(json_filename)
+        .assert()
+        .code(0);
+}

--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -32,7 +32,7 @@ impl<N: Display> Display for json_schema::Fragment<N> {
         for (ns, def) in &self.0 {
             match ns {
                 None => write!(f, "{def}")?,
-                Some(ns) => write!(f, "namespace {ns} {{\n{def}}}")?,
+                Some(ns) => write!(f, "namespace {ns} {{\n{def}}}\n")?,
             }
         }
         Ok(())


### PR DESCRIPTION
## Description of changes

Fixes a behavior change introduced by #1114, which switched `SchemaFragment::from_str` to expect the Cedar format (it previously expected JSON). This PR is only on `main`, so it doesn't affect released code. Added a test case to avoid breaking this again in the future.

## Issue #, if available

Resolves #1159 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
