### PR TITLE
add non_exhaustive to a couple more types

### DIFF
--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -657,9 +657,7 @@ pub mod restricted_expr_errors {
 
 /// Errors possible from `RestrictedExpr::from_str()`
 //
-// CAUTION: this type is publicly exported in `cedar-policy`.
-// Don't make fields `pub`, don't make breaking changes, and use caution when
-// adding public methods.
+// This is NOT a publicly exported error type.
 #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
 pub enum RestrictedExpressionParseError {
     /// Failed to parse the expression

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -580,6 +580,8 @@ impl Diagnostic for MultipleEAMapDeclarationsError {
 }
 
 /// Errors relating to embedded attribute maps (`EAMap`s)
+//
+// This is NOT a publicly exported error type.
 #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum EAMapError {

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -581,6 +581,7 @@ impl Diagnostic for MultipleEAMapDeclarationsError {
 
 /// Errors relating to embedded attribute maps (`EAMap`s)
 #[derive(Debug, Clone, Diagnostic, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum EAMapError {
     /// An embedded attribute map (RFC 68) was encountered where one is not allowed
     #[error(transparent)]

--- a/cedar-policy-validator/src/cedar_schema/parser.rs
+++ b/cedar-policy-validator/src/cedar_schema/parser.rs
@@ -84,6 +84,8 @@ lazy_static::lazy_static! {
 }
 
 /// Parse errors for parsing a schema in the Cedar syntax
+//
+// This is NOT a publicly exported error type.
 #[derive(Debug, Diagnostic, Error)]
 #[non_exhaustive]
 pub enum CedarSchemaParseErrors {

--- a/cedar-policy-validator/src/cedar_schema/parser.rs
+++ b/cedar-policy-validator/src/cedar_schema/parser.rs
@@ -85,6 +85,7 @@ lazy_static::lazy_static! {
 
 /// Parse errors for parsing a schema in the Cedar syntax
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum CedarSchemaParseErrors {
     /// Parse error for the Cedar syntax
     #[error(transparent)]

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -257,8 +257,8 @@ impl<'a> ast::RequestSchema for CoreSchema<'a> {
 }
 
 /// Error when the request does not conform to the schema.
-///
-/// This is NOT a publicly exported error type.
+//
+// This is NOT a publicly exported error type.
 #[derive(Debug, Diagnostic, Error)]
 pub enum RequestValidationError {
     /// Request action is not declared in the schema

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -257,6 +257,8 @@ impl<'a> ast::RequestSchema for CoreSchema<'a> {
 }
 
 /// Error when the request does not conform to the schema.
+///
+/// This is NOT a publicly exported error type.
 #[derive(Debug, Diagnostic, Error)]
 pub enum RequestValidationError {
     /// Request action is not declared in the schema

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -87,8 +87,8 @@ impl ValidationResult {
 /// policy. The error contains a enumeration that specifies the kind of problem,
 /// and provides details specific to that kind of problem. The error also records
 /// where the problem was encountered.
-///
-/// This is NOT a publicly exported error type.
+//
+// This is NOT a publicly exported error type.
 #[derive(Clone, Debug, Diagnostic, Error, Hash, Eq, PartialEq)]
 pub enum ValidationError {
     /// A policy contains an entity type that is not declared in the schema.

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -87,6 +87,8 @@ impl ValidationResult {
 /// policy. The error contains a enumeration that specifies the kind of problem,
 /// and provides details specific to that kind of problem. The error also records
 /// where the problem was encountered.
+///
+/// This is NOT a publicly exported error type.
 #[derive(Clone, Debug, Diagnostic, Error, Hash, Eq, PartialEq)]
 pub enum ValidationError {
     /// A policy contains an entity type that is not declared in the schema.

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,7 @@ Cedar Language Version: 4.0
 ### Added
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)
   that provides the Entity Manifest: a data
-  structure that describes what data is required to satisfy a 
+  structure that describes what data is required to satisfy a
   Cedar request. To use this API you must enable the `entity-manifest` feature flag.
 - Additional functionality to the JSON FFI including parsing utilities (#1079)
   and conversion between the Cedar and JSON formats (#1087)
@@ -53,9 +53,8 @@ Cedar Language Version: 4.0
   to parse strings in the JSON schema format.
 - `PolicySet::template_annotation` now returns `Option<&str>` as opposed to
   `Option<String>` in the previous version (#1131, resolving #1116)
-- Marked errors/warnings related to parsing and entity/request validation as
-  `non_exhaustive`, allowing future variants to be added without a breaking
-  change. (#1137)
+- Marked errors/warnings related to parsing and validation as `non_exhaustive`,
+  allowing future variants to be added without a breaking change. (#1137, #1169)
 - (*) Improved consistency between JSON and Cedar schema formats. Both now
   forbid using `Bool`, `Boolean`, `Entity`, `Extension`, `Long`, `Record`, `Set`,
   and `String` as common type names. (#1150, resolving #1139)

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -956,6 +956,7 @@ pub mod context_json_errors {
 
 /// Error type for parsing a `RestrictedExpression`
 #[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
 pub enum RestrictedExpressionParseError {
     /// Failed to parse the expression
     #[error(transparent)]


### PR DESCRIPTION
## Description of changes

Adds `non_exhaustive` to a couple more error types related to parsing or validation.  Most of our public error types related to parsing or validation already had `non_exhaustive`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] updates the CHANGELOG appropriately

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

