### PR TITLE
Add methods to get number of policies and templates in a PolicySet

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -11,7 +11,6 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ## [Unreleased]
 Cedar Language Version: TBD
-* Add convenience methods to see how many policies and templates a policy set has (#1179).
 
 ### Added
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)
@@ -30,6 +29,7 @@ Cedar Language Version: 4.0
   typename that can resolve to either an entity or common type, matching the
   behavior of typenames written in the human-readable (Cedar) syntax. (#1060, as
   part of resolving #579)
+- Add convenience methods to see how many policies and templates a policy set has (#1179)
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -11,6 +11,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 ## [Unreleased]
 Cedar Language Version: TBD
+* Add convenience methods to see how many policies and templates a policy set has (#1179).
 
 ### Added
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2057,6 +2057,18 @@ impl PolicySet {
         self.ast.is_empty()
     }
 
+    /// Returns the number of `Template`s in the `PolicySet`.
+    /// 
+    /// This will include both static and template-linked policies.
+    pub fn num_of_policies(&self) -> usize {
+        self.policies.len()
+    }
+
+    /// Returns the number of `Template`s in the `PolicySet`.
+    pub fn num_of_templates(&self) -> usize {
+        self.templates.len()
+    }
+
     /// Attempt to link a template and add the new template-linked policy to the policy set.
     /// If link fails, the `PolicySet` is not modified.
     /// Failure can happen for three reasons

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2058,7 +2058,7 @@ impl PolicySet {
     }
 
     /// Returns the number of `Template`s in the `PolicySet`.
-    /// 
+    ///
     /// This will include both static and template-linked policies.
     pub fn num_of_policies(&self) -> usize {
         self.policies.len()

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2057,7 +2057,7 @@ impl PolicySet {
         self.ast.is_empty()
     }
 
-    /// Returns the number of `Template`s in the `PolicySet`.
+    /// Returns the number of `Policy`s in the `PolicySet`.
     ///
     /// This will include both static and template-linked policies.
     pub fn num_of_policies(&self) -> usize {

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -720,8 +720,8 @@ mod policy_set_tests {
         )
         .expect("Link failure");
 
-        assert_eq!(pset.templates().count(), 1);
-        assert_eq!(pset.policies().count(), 2);
+        assert_eq!(pset.num_of_templates(), 1);
+        assert_eq!(pset.num_of_policies(), 2);
         assert_eq!(pset.policies().filter(|p| p.is_static()).count(), 1);
 
         assert_eq!(
@@ -4211,7 +4211,7 @@ mod policy_set_est_tests {
         let pset2 = PolicySet::from_json_value(json).unwrap();
 
         // There should be 2 policies, one static and two links
-        assert_eq!(pset2.policies().count(), 3);
+        assert_eq!(pset2.num_of_policies(), 3);
         let static_policy = pset2.policy(&PolicyId::new("policy")).unwrap();
         assert!(static_policy.is_static());
 
@@ -4297,8 +4297,8 @@ mod policy_set_est_tests {
         });
 
         let policyset = PolicySet::from_json_value(value).unwrap();
-        assert_eq!(policyset.templates().count(), 0);
-        assert_eq!(policyset.policies().count(), 1);
+        assert_eq!(policyset.num_of_templates(), 0);
+        assert_eq!(policyset.num_of_policies(), 1);
         assert!(policyset.policy(&PolicyId::new("policy1")).is_some());
     }
 
@@ -4370,8 +4370,8 @@ mod policy_set_est_tests {
         });
 
         let policyset = PolicySet::from_json_value(value).unwrap();
-        assert_eq!(policyset.policies().count(), 2);
-        assert_eq!(policyset.templates().count(), 1);
+        assert_eq!(policyset.num_of_policies(), 2);
+        assert_eq!(policyset.num_of_templates(), 1);
         assert!(policyset.template(&PolicyId::new("template")).is_some());
         let link = policyset.policy(&PolicyId::new("link")).unwrap();
         assert_eq!(link.template_id(), Some(&PolicyId::new("template")));


### PR DESCRIPTION
## Description of changes

Add methods to get number of policies and templates in a PolicySet.

Regarding unit testing, I decided to just reuse this API in previous places where the size of existing iterators are used, it feels like more effort would feel silly here.

## Issue #, if available
#1179

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

