### PR TITLE
Avoid calling `schematype_of_restricted_expr` for parsing extension type entity attribute

### DIFF
--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -52,11 +52,10 @@ pub mod entities_errors {
 pub mod entities_json_errors {
     pub use cedar_policy_core::entities::json::err::{
         ActionParentIsNotAction, DuplicateKey, ExpectedExtnValue, ExpectedLiteralEntityRef,
-        ExtensionFunctionLookup, ExtnCall0Arguments, ExtnCall2OrMoreArguments, HeterogeneousSet,
-        JsonDeserializationError, JsonError, JsonSerializationError, MissingImpliedConstructor,
-        MissingRequiredRecordAttr, ParseEscape, ReservedKey, Residual, TypeMismatch,
-        TypeMismatchError, UnexpectedRecordAttr, UnexpectedRestrictedExprKind,
-        UnknownInImplicitConstructorArg,
+        ExtnCall0Arguments, ExtnCall2OrMoreArguments, JsonDeserializationError, JsonError,
+        JsonSerializationError, MissingImpliedConstructor, MissingRequiredRecordAttr, ParseEscape,
+        ReservedKey, Residual, TypeMismatch, TypeMismatchError, UnexpectedRecordAttr,
+        UnexpectedRestrictedExprKind,
     };
 }
 


### PR DESCRIPTION
This change assumes that there exists one constructor for each entity type, so it's enough to know the type we want to construct without also needing to infer the actual type of the arguments.

Multiple single argument constructors previously could exist for one extension type as long as the argument types were distinct. This would now be an error when building the `Extensions` struct. Our current extensions abide by this limitation.

First PR towards removing all uses of `schematype_of_restricted_expr`
