### PR TITLE
Revert "implement schema-format parsers for RFC 68 (#1136)"

### DIFF
--- a/cedar-policy-validator/src/cedar_schema/ast.rs
+++ b/cedar-policy-validator/src/cedar_schema/ast.rs
@@ -251,28 +251,15 @@ impl<N> From<PrimitiveType> for json_schema::TypeVariant<N> {
 }
 
 /// Attribute declarations, used in records and entity types.
-/// One [`AttrDecl`] is one key-value pair, or an embedded attribute map pair `?: value_ty`.
-///
-/// The data structures in this file, and the Cedar schema format parser in
-/// general, permissively allow `EAMap`s to appear anywhere an [`AttrDecl`] is
-/// expected (including inside other `EAMap`s), in order to provide better error
-/// messages when `EAMap`s are encountered in illegal but plausible positions
+/// One [`AttrDecl`] is one key-value pair.
 #[derive(Debug, Clone)]
-pub enum AttrDecl {
-    /// A normal attribute declaration `name: ty` or `name?: ty`
-    Concrete {
-        /// Name of this attribute
-        name: Node<SmolStr>,
-        /// Whether or not it is a required attribute (default `true`)
-        required: bool,
-        /// The type of this attribute
-        ty: Node<Type>,
-    },
-    /// An `EAMap` declaration `?: ty`
-    EAMap {
-        /// Value type of the `EAMap`
-        value_ty: Node<Type>,
-    },
+pub struct AttrDecl {
+    /// Name of this attribute
+    pub name: Node<SmolStr>,
+    /// Whether or not it is a required attribute (default `true`)
+    pub required: bool,
+    /// The type of this attribute
+    pub ty: Node<Type>,
 }
 
 /// The target of a [`PRAppDecl`]

--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -74,7 +74,7 @@ impl<N: Display> Display for json_schema::Type<N> {
     }
 }
 
-impl<N: Display> Display for json_schema::RecordType<json_schema::RecordAttributeType<N>> {
+impl<N: Display> Display for json_schema::RecordType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{{")?;
         for (i, (n, ty)) in self.attributes.iter().enumerate() {
@@ -91,37 +91,6 @@ impl<N: Display> Display for json_schema::RecordType<json_schema::RecordAttribut
         }
         write!(f, "}}")?;
         Ok(())
-    }
-}
-
-impl<N: Display> Display for json_schema::RecordType<json_schema::EntityAttributeType<N>> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{")?;
-        for (i, (n, ty)) in self.attributes.iter().enumerate() {
-            write!(
-                f,
-                "\"{}\"{}: {}",
-                n.escape_debug(),
-                if ty.required { "" } else { "?" },
-                ty.ty
-            )?;
-            if i < (self.attributes.len() - 1) {
-                write!(f, ", ")?;
-            }
-        }
-        write!(f, "}}")?;
-        Ok(())
-    }
-}
-
-impl<N: Display> Display for json_schema::EntityAttributeTypeInternal<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            json_schema::EntityAttributeTypeInternal::Type(ty) => ty.fmt(f),
-            json_schema::EntityAttributeTypeInternal::EAMap { value_type } => {
-                write!(f, "{{ ?: {value_type} }}")
-            }
-        }
     }
 }
 

--- a/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
@@ -183,17 +183,14 @@ pub Type: Node<SType> = {
         => Node::with_source_loc(SType::Record(ds.unwrap_or_default()), Loc::new(l..r, Arc::clone(src))),
 }
 
-// AttrDecls := [Name ['?'] | '?'] ':' Type [',' | ',' AttrDecls]
+// AttrDecls := Name ['?'] ':' Type [',' | ',' AttrDecls]
 AttrDecls: Vec<Node<AttrDecl>> = {
     <l:@L> <name: Name> <required:"?"?> ":" <ty:Type> ","? <r:@R>
-        => vec![Node::with_source_loc(AttrDecl::Concrete { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))],
+        => vec![Node::with_source_loc(AttrDecl { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))],
     <l:@L> <name: Name> <required:"?"?> ":" <ty:Type> "," <r:@R> <mut ds: AttrDecls>
-        => {ds.insert(0, Node::with_source_loc(AttrDecl::Concrete { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))); ds},
-    <l:@L> "?" ":" <value_ty:Type> ","? <r:@R>
-        => vec![Node::with_source_loc(AttrDecl::EAMap { value_ty }, Loc::new(l..r, Arc::clone(src)))],
-    <l:@L> "?" ":" <value_ty:Type> "," <r:@R> <mut ds: AttrDecls>
-        => {ds.insert(0, Node::with_source_loc(AttrDecl::EAMap { value_ty }, Loc::new(l..r, Arc::clone(src)))); ds},
+        => {ds.insert(0, Node::with_source_loc(AttrDecl { name, required: required.is_none(), ty}, Loc::new(l..r, Arc::clone(src)))); ds},
 }
+
 
 Comma<E>: Vec<E> = {
     <e:E?> => e.into_iter().collect(),

--- a/cedar-policy-validator/src/cedar_schema/test.rs
+++ b/cedar-policy-validator/src/cedar_schema/test.rs
@@ -14,41 +14,10 @@
  * limitations under the License.
  */
 
-#![cfg(test)]
-
-#[cfg(test)]
-pub use test_utils::*;
-
-#[cfg(test)]
-mod test_utils {
-    use crate::json_schema;
-
-    #[allow(dead_code)]
-    #[track_caller]
-    pub fn assert_record_attr_has_type<N: std::fmt::Debug + PartialEq>(
-        e: &json_schema::RecordAttributeType<N>,
-        expected: &json_schema::Type<N>,
-    ) {
-        assert!(e.required);
-        assert_eq!(&e.ty, expected);
-    }
-
-    #[track_caller]
-    pub fn assert_entity_attr_has_type<N: std::fmt::Debug + PartialEq>(
-        e: &json_schema::EntityAttributeType<N>,
-        expected: &json_schema::EntityAttributeTypeInternal<N>,
-    ) {
-        assert!(e.required);
-        assert_eq!(&e.ty, expected);
-    }
-}
-
 // PANIC SAFETY: unit tests
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod demo_tests {
-    use super::*;
-
     use std::{
         collections::HashMap,
         iter::{empty, once},
@@ -466,7 +435,7 @@ namespace Baz {action "Foo" appliesTo {
                 "a".parse().unwrap(),
                 json_schema::EntityType::<RawName> {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )]),
             actions: HashMap::from([(
@@ -476,7 +445,7 @@ namespace Baz {action "Foo" appliesTo {
                     applies_to: Some(json_schema::ApplySpec::<RawName> {
                         resource_types: vec![],
                         principal_types: vec!["a".parse().unwrap()],
-                        context: json_schema::RecordOrContextAttributes::default(),
+                        context: json_schema::AttributesOrContext::default(),
                     }),
                     member_of: None,
                 },
@@ -591,17 +560,16 @@ namespace Baz {action "Foo" appliesTo {
         assert!(repo.member_of_types.is_empty());
         let groups = ["readers", "writers", "triagers", "admins", "maintainers"];
         for group in groups {
-            assert_matches!(&repo.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+            assert_matches!(&repo.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
                 attributes,
                 additional_attributes: false,
-            }, .. }) => {
-                let attribute = attributes.get(group).expect("No attribute `{group}`");
-                assert_entity_attr_has_type(
-                    attribute,
-                    &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+            }))) => {
+                let expected =
+                    json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "UserGroup".parse().unwrap(),
-                    })),
-                );
+                    });
+                let attribute = attributes.get(group).expect("No attribute `{group}`");
+                assert_has_type(attribute, expected);
             });
         }
         let issue = github
@@ -609,23 +577,23 @@ namespace Baz {action "Foo" appliesTo {
             .get(&"Issue".parse().unwrap())
             .expect("No `Issue`");
         assert!(issue.member_of_types.is_empty());
-        assert_matches!(&issue.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+        assert_matches!(&issue.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }, .. }) => {
+        }))) => {
             let attribute = attributes.get("repo").expect("No `repo`");
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attribute,
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "Repository".parse().unwrap(),
-                })),
+                }),
             );
             let attribute = attributes.get("reporter").expect("No `repo`");
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attribute,
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "User".parse().unwrap(),
-                })),
+                }),
             );
         });
         let org = github
@@ -635,19 +603,26 @@ namespace Baz {action "Foo" appliesTo {
         assert!(org.member_of_types.is_empty());
         let groups = ["members", "owners", "memberOfTypes"];
         for group in groups {
-            assert_matches!(&org.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+            assert_matches!(&org.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
                 attributes,
                 additional_attributes: false,
-            }, .. }) => {
+            }))) => {
+                let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                    type_name: "UserGroup".parse().unwrap(),
+                });
                 let attribute = attributes.get(group).expect("No attribute `{group}`");
-                assert_entity_attr_has_type(
-                    attribute,
-                    &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
-                        type_name: "UserGroup".parse().unwrap(),
-                    })),
-                );
+                assert_has_type(attribute, expected);
             });
         }
+    }
+
+    #[track_caller]
+    fn assert_has_type<N: std::fmt::Debug + PartialEq>(
+        e: &json_schema::TypeOfAttribute<N>,
+        expected: json_schema::Type<N>,
+    ) {
+        assert!(e.required);
+        assert_eq!(&e.ty, &expected);
     }
 
     #[track_caller]
@@ -691,23 +666,23 @@ namespace Baz {action "Foo" appliesTo {
             .get(&"User".parse().unwrap())
             .expect("No `User`");
         assert_eq!(&user.member_of_types, &vec!["Group".parse().unwrap()]);
-        assert_matches!(&user.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+        assert_matches!(&user.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }, .. }) => {
-            assert_entity_attr_has_type(
+        }))) => {
+            assert_has_type(
                 attributes.get("personalGroup").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "Group".parse().unwrap(),
-                })),
+                }),
             );
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attributes.get("blocked").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::Set {
+                json_schema::Type::Type(json_schema::TypeVariant::Set {
                     element: Box::new(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                         type_name: "User".parse().unwrap(),
                     })),
-                })),
+                }),
             );
         });
         let group = doccloud
@@ -718,15 +693,15 @@ namespace Baz {action "Foo" appliesTo {
             &group.member_of_types,
             &vec!["DocumentShare".parse().unwrap()]
         );
-        assert_matches!(&group.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+        assert_matches!(&group.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }, .. }) => {
-            assert_entity_attr_has_type(
+        }))) => {
+            assert_has_type(
                 attributes.get("owner").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "User".parse().unwrap(),
-                })),
+                }),
             );
         });
         let document = doccloud
@@ -734,45 +709,45 @@ namespace Baz {action "Foo" appliesTo {
             .get(&"Document".parse().unwrap())
             .expect("No `Group`");
         assert!(document.member_of_types.is_empty());
-        assert_matches!(&document.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+        assert_matches!(&document.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }, .. }) => {
-            assert_entity_attr_has_type(
+        }))) => {
+            assert_has_type(
                 attributes.get("owner").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "User".parse().unwrap(),
-                })),
+                }),
             );
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attributes.get("isPrivate").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "Bool".parse().unwrap(),
-                })),
+                }),
             );
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attributes.get("publicAccess").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "String".parse().unwrap(),
-                })),
+                }),
             );
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attributes.get("viewACL").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "DocumentShare".parse().unwrap(),
-                })),
+                }),
             );
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attributes.get("modifyACL").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "DocumentShare".parse().unwrap(),
-                })),
+                }),
             );
-            assert_entity_attr_has_type(
+            assert_has_type(
                 attributes.get("manageACL").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "DocumentShare".parse().unwrap(),
-                })),
+                }),
             );
         });
         let document_share = doccloud
@@ -906,15 +881,15 @@ namespace Baz {action "Foo" appliesTo {
             .entity_types
             .get(&"Resource".parse().unwrap())
             .unwrap();
-        assert_matches!(&resource.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+        assert_matches!(&resource.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }, .. }) => {
-            assert_matches!(attributes.get("tag"), Some(json_schema::EntityAttributeType { ty: json_schema::EntityAttributeTypeInternal::Type(ty), required: true }) => {
+        }))) => {
+            assert_matches!(attributes.get("tag"), Some(json_schema::TypeOfAttribute { ty, required: true }) => {
                 assert_matches!(ty, json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name }) => {
                     assert_eq!(type_name, &"AWS::Tag".parse().unwrap());
                 });
-            })
+            });
         });
     }
 
@@ -941,7 +916,7 @@ namespace Baz {action "Foo" appliesTo {
         assert_labeled_span("type t =", "expected `{`, identifier, or `Set`");
         assert_labeled_span(
             "entity User {",
-            "expected `?`, `}`, identifier, or string literal",
+            "expected `}`, identifier, or string literal",
         );
         assert_labeled_span("entity User { name:", "expected `{`, identifier, or `Set`");
     }
@@ -1180,8 +1155,6 @@ mod parser_tests {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod translator_tests {
-    use super::*;
-
     use cedar_policy_core::ast as cedar_ast;
     use cedar_policy_core::extensions::Extensions;
     use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
@@ -1444,22 +1417,22 @@ mod translator_tests {
             json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available()).unwrap();
         let demo = frag.0.get(&Some("Demo".parse().unwrap())).unwrap();
         let user = demo.entity_types.get(&"User".parse().unwrap()).unwrap();
-        assert_matches!(&user.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs: json_schema::RecordType {
+        assert_matches!(&user.shape, json_schema::AttributesOrContext(json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
             attributes,
             additional_attributes: false,
-        }, .. }) => {
-            assert_entity_attr_has_type(
-                attributes.get("name").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+        }))) => {
+            assert_matches!(attributes.get("name"), Some(json_schema::TypeOfAttribute { ty, required: true }) => {
+                let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "id".parse().unwrap(),
-                })),
-            );
-            assert_entity_attr_has_type(
-                attributes.get("email").unwrap(),
-                &json_schema::EntityAttributeTypeInternal::Type(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+                });
+                assert_eq!(ty, &expected);
+            });
+            assert_matches!(attributes.get("email"), Some(json_schema::TypeOfAttribute { ty, required: true }) => {
+                let expected = json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
                     type_name: "email_address".parse().unwrap(),
-                })),
-            );
+                });
+                assert_eq!(ty, &expected);
+            });
         });
         assert_matches!(ValidatorSchema::try_from(frag), Err(e) => {
             expect_err(
@@ -2321,166 +2294,5 @@ mod common_type_references {
             validator_schema,
             Err(SchemaError::CycleInCommonTypeReferences(_))
         );
-    }
-}
-
-/// Tests involving embedded attribute maps (RFC 68)
-#[cfg(test)]
-mod ea_maps {
-    use super::assert_entity_attr_has_type;
-    use crate::json_schema;
-    use crate::schema::test::collect_warnings;
-    use cedar_policy_core::extensions::Extensions;
-    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
-    use cool_asserts::assert_matches;
-
-    #[test]
-    fn entity_attribute() {
-        let src = "entity E { tags: { ?: Set<String> } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Ok((frag, warnings)) => {
-            assert!(warnings.is_empty());
-            let entity_type = frag.0.get(&None).unwrap().entity_types.get(&"E".parse().unwrap()).unwrap();
-            assert_matches!(&entity_type.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs, .. }) => {
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("tags").unwrap(),
-                    &json_schema::EntityAttributeTypeInternal::EAMap {
-                        value_type: json_schema::Type::Type(json_schema::TypeVariant::Set {
-                            element: Box::new(json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name: "String".parse().unwrap() })),
-                        }),
-                    },
-                );
-            });
-        });
-    }
-
-    #[test]
-    fn record_attribute_inside_entity_attribute() {
-        let src = "entity E { tags: { foo: { ?: Set<String> } } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .exactly_one_underline("?: Set<String>")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn context_attribute() {
-        let src = "entity E; action read appliesTo { principal: [E], resource: [E], context: { operationDetails: { ?: String } } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .exactly_one_underline("?: String")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn toplevel_entity() {
-        let src = "entity E { ?: Set<String> };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .help("Embedded attribute maps are not allowed as the top-level descriptor of all attributes of an entity. Try making an entity attribute to hold the embedded attribute map. E.g., `attributes: { ?: someType }`.")
-                    .exactly_one_underline("?: Set<String>")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn toplevel_context() {
-        let src = "entity E; action read appliesTo { principal: [E], resource: [E], context: { ?: String } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .exactly_one_underline("?: String")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn common_type() {
-        let src = "type blah = { ?: String }; entity User { blah: blah };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .exactly_one_underline("?: String")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn value_type_is_common_type() {
-        let src = "type blah = { foo: String }; entity User { blah: { ?: blah } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Ok((frag, warnings)) => {
-            assert!(warnings.is_empty());
-            let user = frag.0.get(&None).unwrap().entity_types.get(&"User".parse().unwrap()).unwrap();
-            assert_matches!(&user.shape, json_schema::EntityAttributes::EntityAttributes(json_schema::EntityAttributesInternal { attrs, .. }) => {
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("blah").unwrap(),
-                    &json_schema::EntityAttributeTypeInternal::EAMap {
-                        value_type: json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon { type_name: "blah".parse().unwrap() }),
-                    }
-                );
-            });
-        });
-    }
-
-    #[test]
-    fn nested_ea_map() {
-        let src = "entity E { tags: { ?: { ?: String } } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .exactly_one_underline("?: String")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn ea_map_and_attribute() {
-        let src = "entity E { tags: { foo: Long, ?: String } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: this type contains both concrete attributes and an embedded attribute map (`?:`), which is not allowed")
-                    .exactly_one_underline("?: String")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn two_ea_maps() {
-        let src = "entity E { tags: { ?: Long, ?: String } };";
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: this type contains two or more different embedded attribute map declarations (`?:`), which is not allowed")
-                    .help("try separating this into two different attributes")
-                    .exactly_two_underlines("?: Long,", "?: String")
-                    .build(),
-            );
-        });
     }
 }

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -23,7 +23,7 @@ use cedar_policy_core::{
     extensions::Extensions,
     parser::{Loc, Node},
 };
-use itertools::{Either, Itertools};
+use itertools::Either;
 use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
 use std::collections::hash_map::Entry;

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -33,17 +33,9 @@ use super::{
         ActionDecl, AppDecl, AttrDecl, Decl, Declaration, EntityDecl, Namespace, PRAppDecl, Path,
         QualName, Schema, Type, TypeDecl, BUILTIN_TYPES, PR,
     },
-    err::{
-        schema_warnings, EAMapError, EAMapNotAllowedHereError, EAMapNotAllowedHereHelp,
-        EAMapWithConcreteAttributesError, MultipleEAMapDeclarationsError, SchemaWarning,
-        ToJsonSchemaError, ToJsonSchemaErrors,
-    },
+    err::{schema_warnings, SchemaWarning, ToJsonSchemaError, ToJsonSchemaErrors},
 };
-use crate::{
-    cedar_schema,
-    json_schema::{self, CommonTypeId},
-    RawName,
-};
+use crate::{cedar_schema, json_schema, RawName};
 
 impl From<cedar_schema::Path> for RawName {
     fn from(p: cedar_schema::Path) -> Self {
@@ -101,97 +93,24 @@ fn is_valid_ext_type(ty: &Id, extensions: &Extensions<'_>) -> bool {
         .any(|ext_ty| ty == ext_ty.basename_as_ref())
 }
 
-/// Convert a [`Type`] into the JSON representation of the type.
-/// In this function, `EAMap` types are not allowed and will result in errors.
-/// For a similar function that accepts `EAMap` types, see
-/// [`cedar_type_to_entity_attr_type()`].
-fn cedar_type_to_json_type(
-    ty: Node<Type>,
-) -> Result<json_schema::Type<RawName>, EAMapNotAllowedHereError> {
+/// Convert a `Type` into the JSON representation of the type.
+pub fn cedar_type_to_json_type(ty: Node<Type>) -> json_schema::Type<RawName> {
     match ty.node {
-        Type::Set(t) => Ok(json_schema::Type::Type(json_schema::TypeVariant::Set {
-            element: Box::new(cedar_type_to_json_type(*t)?),
-        })),
-        Type::Ident(p) => Ok(json_schema::Type::Type(
-            json_schema::TypeVariant::EntityOrCommon {
-                type_name: RawName::from(p),
-            },
-        )),
-        Type::Record(fields) => Ok(json_schema::Type::Type(json_schema::TypeVariant::Record(
-            json_schema::RecordType {
+        Type::Set(t) => json_schema::Type::Type(json_schema::TypeVariant::Set {
+            element: Box::new(cedar_type_to_json_type(*t)),
+        }),
+        Type::Ident(p) => json_schema::Type::Type(json_schema::TypeVariant::EntityOrCommon {
+            type_name: RawName::from(p),
+        }),
+        Type::Record(fields) => {
+            json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
                 attributes: fields
                     .into_iter()
-                    .map(convert_attr_decl_for_record)
-                    .collect::<Result<_, _>>()?,
+                    .map(|field| convert_attr_decl(field.node))
+                    .collect(),
                 additional_attributes: false,
-            },
-        ))),
-    }
-}
-
-/// Convert a [`Type`] representing an entity attribute type into the JSON
-/// representation of the type. Unlike [`cedar_type_to_json_type()`], this
-/// function allows (and handles) `EAMap` types as well.
-///
-/// This can still return [`EAMapError`] if an `EAMap` is found, e.g., in a set
-/// element type, or nested in another `EAMap`.
-fn cedar_type_to_entity_attr_type(
-    ty: Node<Type>,
-) -> Result<json_schema::EntityAttributeTypeInternal<RawName>, EAMapError> {
-    match &ty.node {
-        Type::Record(decls) => {
-            let (ea_map_decls, non_ea_map_decls): (Vec<(&Loc, &Node<Type>)>, Vec<&Node<AttrDecl>>) =
-                decls.iter().partition_map(|decl| match &decl.node {
-                    AttrDecl::EAMap { value_ty } => Either::Left((&decl.loc, value_ty)),
-                    _ => Either::Right(decl),
-                });
-            match (ea_map_decls.len(), non_ea_map_decls.len()) {
-                (0, _) => {
-                    // no `EAMap` decls
-                    Ok(json_schema::EntityAttributeTypeInternal::Type(
-                        cedar_type_to_json_type(ty)?,
-                    ))
-                }
-                (1, 0) => {
-                    // exactly one decl, and it's an `EAMap` decl like `?: String`.
-                    // Convert to an `EAMap`.
-                    // PANIC SAFETY: already determined `ea_map_decls.len() == 1`
-                    #[allow(clippy::indexing_slicing)]
-                    let (_, value_type) = ea_map_decls[0];
-                    Ok(json_schema::EntityAttributeTypeInternal::EAMap {
-                        value_type: cedar_type_to_json_type(value_type.clone())?,
-                    })
-                }
-                (1, 1..) => {
-                    // one `EAMap` decl, but also at least one non-`EAMap` decl.
-                    // This is an error.
-                    // PANIC SAFETY: already determined `ea_map_decls.len() == 1`
-                    #[allow(clippy::indexing_slicing)]
-                    let (source_loc, _) = ea_map_decls[0];
-                    Err(EAMapWithConcreteAttributesError {
-                        source_loc: source_loc.clone(),
-                    }
-                    .into())
-                }
-                (2.., _) => {
-                    // multiple `EAMap` decls. This is an error.
-                    // PANIC SAFETY: already determined `ea_map_decls.len()` is at least 2
-                    #[allow(clippy::indexing_slicing)]
-                    let (source_loc_1, _) = ea_map_decls[0];
-                    // PANIC SAFETY: already determined `ea_map_decls.len()` is at least 2
-                    #[allow(clippy::indexing_slicing)]
-                    let (source_loc_2, _) = ea_map_decls[1];
-                    Err(MultipleEAMapDeclarationsError {
-                        source_loc_1: source_loc_1.clone(),
-                        source_loc_2: source_loc_2.clone(),
-                    }
-                    .into())
-                }
-            }
+            }))
         }
-        Type::Set(_) | Type::Ident(_) => Ok(json_schema::EntityAttributeTypeInternal::Type(
-            cedar_type_to_json_type(ty)?,
-        )),
     }
 }
 
@@ -262,15 +181,12 @@ impl TryFrom<Namespace> for json_schema::NamespaceDefinition<RawName> {
                 let name_loc = decl.name.loc.clone();
                 let id = UnreservedId::try_from(decl.name.node)
                     .map_err(|e| ToJsonSchemaError::reserved_name(e.name(), name_loc.clone()))?;
-                let ctid = CommonTypeId::new(id).map_err(|e| match e {
+                let ctid = json_schema::CommonTypeId::new(id).map_err(|e| match e {
                     json_schema::ReservedCommonTypeBasenameError { id } => {
                         ToJsonSchemaError::reserved_keyword(id, name_loc)
                     }
                 })?;
-                Ok((
-                    ctid,
-                    cedar_type_to_json_type(decl.def).map_err(EAMapError::from)?,
-                ))
+                Ok((ctid, cedar_type_to_json_type(decl.def)))
             })
             .collect::<Result<_, ToJsonSchemaError>>()?;
 
@@ -298,7 +214,7 @@ fn convert_action_decl(
         .unwrap_or_else(|| json_schema::ApplySpec {
             resource_types: vec![],
             principal_types: vec![],
-            context: json_schema::RecordOrContextAttributes::default(),
+            context: json_schema::AttributesOrContext::default(),
         });
     let member_of = parents.map(|parents| parents.into_iter().map(convert_qual_name).collect());
     let ty = json_schema::ActionType {
@@ -327,7 +243,7 @@ fn convert_app_decls(
     let (decls, _) = decls.into_inner();
     let mut principal_types: Option<Node<Vec<RawName>>> = None;
     let mut resource_types: Option<Node<Vec<RawName>>> = None;
-    let mut context: Option<Node<json_schema::RecordOrContextAttributes<RawName>>> = None;
+    let mut context: Option<Node<json_schema::AttributesOrContext<RawName>>> = None;
 
     for decl in decls {
         match decl {
@@ -345,7 +261,7 @@ fn convert_app_decls(
                 }
                 None => {
                     context = Some(Node::with_source_loc(
-                        convert_context_decl(context_decl).map_err(EAMapError::from)?,
+                        convert_context_decl(context_decl),
                         loc,
                     ));
                 }
@@ -431,9 +347,7 @@ fn convert_entity_decl(
     // First build up the defined entity type
     let etype = json_schema::EntityType {
         member_of_types: e.member_of_types.into_iter().map(RawName::from).collect(),
-        shape: convert_attr_decls_for_entity(e.attrs)
-            .map(Into::into)
-            .map_err(ToJsonSchemaError::from)?,
+        shape: convert_attr_decls(e.attrs),
     };
 
     // Then map over all of the bound names
@@ -446,27 +360,25 @@ fn convert_entity_decl(
     )
 }
 
-/// Create a [`json_schema::RecordType`] from a series of `AttrDecl`s
-/// representing the attributes of an entity
-fn convert_attr_decls_for_entity(
+/// Create a [`json_schema::AttributesOrContext`] from a series of `AttrDecl`s
+fn convert_attr_decls(
     attrs: impl IntoIterator<Item = Node<AttrDecl>>,
-) -> Result<json_schema::RecordType<json_schema::EntityAttributeType<RawName>>, EAMapError> {
-    Ok(json_schema::RecordType {
+) -> json_schema::AttributesOrContext<RawName> {
+    json_schema::RecordType {
         attributes: attrs
             .into_iter()
-            .map(convert_attr_decl_for_entity)
-            .collect::<Result<_, _>>()?,
+            .map(|attr| convert_attr_decl(attr.node))
+            .collect(),
         additional_attributes: false,
-    })
+    }
+    .into()
 }
 
-/// Create a [`json_schema::RecordOrContextAttributes`] from a series of
-/// `AttrDecl`s representing the attributes of the context (or a `Path`
-/// representing the common-type defining those attributes)
+/// Create a context decl
 fn convert_context_decl(
     decl: Either<Path, Vec<Node<AttrDecl>>>,
-) -> Result<json_schema::RecordOrContextAttributes<RawName>, EAMapNotAllowedHereError> {
-    Ok(json_schema::RecordOrContextAttributes(match decl {
+) -> json_schema::AttributesOrContext<RawName> {
+    json_schema::AttributesOrContext(match decl {
         Either::Left(p) => json_schema::Type::CommonTypeRef {
             type_name: p.into(),
         },
@@ -474,58 +386,23 @@ fn convert_context_decl(
             json_schema::Type::Type(json_schema::TypeVariant::Record(json_schema::RecordType {
                 attributes: attrs
                     .into_iter()
-                    .map(convert_attr_decl_for_record)
-                    .collect::<Result<_, _>>()?,
+                    .map(|attr| convert_attr_decl(attr.node))
+                    .collect(),
                 additional_attributes: false,
             }))
         }
-    }))
+    })
 }
 
 /// Convert an attribute type from an `AttrDecl`
-fn convert_attr_decl_for_record(
-    attr: Node<AttrDecl>,
-) -> Result<(SmolStr, json_schema::RecordAttributeType<RawName>), EAMapNotAllowedHereError> {
-    match attr.node {
-        AttrDecl::Concrete { name, required, ty } => Ok((
-            name.node,
-            json_schema::RecordAttributeType {
-                ty: cedar_type_to_json_type(ty)?,
-                required,
-            },
-        )),
-        AttrDecl::EAMap { .. } => Err(EAMapNotAllowedHereError {
-            source_loc: attr.loc,
-            help: None,
-        }),
-    }
-}
-
-/// Convert an `AttrDecl` representing an entity attribute type to a pair `(name, ty)`.
-/// `attr` is not allowed to be `AttrDecl::EAMap` itself, but in the returned pair
-/// `(name, ty)`, `ty` is allowed to be an `EAMap`.
-fn convert_attr_decl_for_entity(
-    attr: Node<AttrDecl>,
-) -> Result<(SmolStr, json_schema::EntityAttributeType<RawName>), EAMapError> {
-    match attr.node {
-        AttrDecl::Concrete { name, required, ty } => Ok((
-            name.node,
-            json_schema::EntityAttributeType {
-                ty: cedar_type_to_entity_attr_type(ty)?,
-                required,
-            },
-        )),
-        AttrDecl::EAMap { .. } => {
-            // EAMap is not allowed here, as the descriptor of all entity attributes.
-            // EAMap is only allowed as the top-level type of one of the entity attributes.
-            // That is, as `ty` in `AttrDecl::Concrete`.
-            Err(EAMapNotAllowedHereError {
-                source_loc: attr.loc,
-                help: Some(EAMapNotAllowedHereHelp::TopLevelEAMap),
-            }
-            .into())
-        }
-    }
+fn convert_attr_decl(attr: AttrDecl) -> (SmolStr, json_schema::TypeOfAttribute<RawName>) {
+    (
+        attr.name.node,
+        json_schema::TypeOfAttribute {
+            ty: cedar_type_to_json_type(attr.ty),
+            required: attr.required,
+        },
+    )
 }
 
 /// Takes a collection of results returning multiple errors

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -122,21 +122,17 @@ impl entities::EntityTypeDescription for EntityTypeDescription {
     }
 
     fn attr_type(&self, attr: &str) -> Option<entities::SchemaType> {
-        let attr_type: &crate::types::AttributeType = self.validator_type.attr(attr)?;
+        let attr_type: &crate::types::Type = &self.validator_type.attr(attr)?.attr_type;
         // This converts a type from a schema into the representation of schema
         // types used by core. `attr_type` is taken from a `ValidatorEntityType`
         // which was constructed from a schema.
         // PANIC SAFETY: see above
         #[allow(clippy::expect_used)]
         let core_schema_type: entities::SchemaType = attr_type
-            .attr_type
             .clone()
             .try_into()
             .expect("failed to convert validator type into Core SchemaType");
-        debug_assert!(crate::types::Type::is_consistent_with(
-            &attr_type.attr_type,
-            &core_schema_type,
-        ));
+        debug_assert!(attr_type.is_consistent_with(&core_schema_type));
         Some(core_schema_type)
     }
 

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -621,10 +621,6 @@ pub mod schema_errors {
         // Action attributes are allowed if `ActionBehavior` is `PermitAttributes`
         #[error("action declared with attributes: [{}]", .0.iter().join(", "))]
         ActionAttributes(Vec<String>),
-        #[error(
-            "Embedded attribute maps (RFC 68) are not fully implemented in this version of Cedar"
-        )]
-        EAMaps,
     }
 
     /// This error is thrown when `serde_json` fails to deserialize the JSON

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -20,7 +20,6 @@ use cedar_policy_core::{
     ast::{Eid, EntityUID, InternalName, Name, UnreservedId},
     entities::CedarValueJson,
     extensions::Extensions,
-    jsonvalue::JsonValueWithNoDuplicateKeys,
     FromNormalizedStr,
 };
 use nonempty::nonempty;
@@ -393,8 +392,8 @@ pub struct EntityType<N> {
     pub member_of_types: Vec<N>,
     /// Description of the attributes for entities of this [`EntityType`].
     #[serde(default)]
-    #[serde(skip_serializing_if = "EntityAttributes::is_empty_record")]
-    pub shape: EntityAttributes<N>,
+    #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
+    pub shape: AttributesOrContext<N>,
 }
 
 impl EntityType<RawName> {
@@ -436,66 +435,66 @@ impl EntityType<ConditionalName> {
     }
 }
 
-/// Declaration of record attributes, or of an action context.
+/// Declaration of entity or record attributes, or of an action context.
 /// These share a JSON format.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
-/// this [`RecordOrContextAttributes`], including recursively.
+/// this [`AttributesOrContext`], including recursively.
 /// See notes on [`Fragment`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct RecordOrContextAttributes<N>(
+pub struct AttributesOrContext<N>(
     // We use the usual `Type` deserialization, but it will ultimately need to
     // be a `Record` or common-type reference which resolves to a `Record`.
     pub Type<N>,
 );
 
-impl<N> RecordOrContextAttributes<N> {
-    /// Convert the [`RecordOrContextAttributes`] into its [`Type`].
+impl<N> AttributesOrContext<N> {
+    /// Convert the [`AttributesOrContext`] into its [`Type`].
     pub fn into_inner(self) -> Type<N> {
         self.0
     }
 
-    /// Is this [`RecordOrContextAttributes`] an empty record?
+    /// Is this `AttributesOrContext` an empty record?
     pub fn is_empty_record(&self) -> bool {
         self.0.is_empty_record()
     }
 }
 
-impl<N> Default for RecordOrContextAttributes<N> {
+impl<N> Default for AttributesOrContext<N> {
     fn default() -> Self {
         Self::from(RecordType::default())
     }
 }
 
-impl<N: Display> Display for RecordOrContextAttributes<N> {
+impl<N: Display> Display for AttributesOrContext<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<N> From<RecordType<RecordAttributeType<N>>> for RecordOrContextAttributes<N> {
-    fn from(rty: RecordType<RecordAttributeType<N>>) -> RecordOrContextAttributes<N> {
+impl<N> From<RecordType<N>> for AttributesOrContext<N> {
+    fn from(rty: RecordType<N>) -> AttributesOrContext<N> {
         Self(Type::Type(TypeVariant::Record(rty)))
     }
 }
 
-impl RecordOrContextAttributes<RawName> {
+impl AttributesOrContext<RawName> {
     /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> RecordOrContextAttributes<ConditionalName> {
-        RecordOrContextAttributes(self.0.conditionally_qualify_type_references(ns))
+    ) -> AttributesOrContext<ConditionalName> {
+        AttributesOrContext(self.0.conditionally_qualify_type_references(ns))
     }
 }
 
-impl RecordOrContextAttributes<ConditionalName> {
-    /// Convert this [`RecordOrContextAttributes<ConditionalName>`] into a
-    /// [`RecordOrContextAttributes<InternalName>`] by fully-qualifying all typenames
+impl AttributesOrContext<ConditionalName> {
+    /// Convert this [`AttributesOrContext<ConditionalName>`] into an
+    /// [`AttributesOrContext<InternalName>`] by fully-qualifying all typenames
     /// that appear anywhere in any definitions.
     ///
     /// `all_defs` needs to contain the full set of all fully-qualified typenames
@@ -503,263 +502,10 @@ impl RecordOrContextAttributes<ConditionalName> {
     pub fn fully_qualify_type_references(
         self,
         all_defs: &AllDefs,
-    ) -> std::result::Result<RecordOrContextAttributes<InternalName>, TypeNotDefinedError> {
-        Ok(RecordOrContextAttributes(
+    ) -> std::result::Result<AttributesOrContext<InternalName>, TypeNotDefinedError> {
+        Ok(AttributesOrContext(
             self.0.fully_qualify_type_references(all_defs)?,
         ))
-    }
-}
-
-/// Declaration of entity attributes
-///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`EntityAttributes`], including recursively.
-/// See notes on [`Fragment`].
-#[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[serde(untagged)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum EntityAttributes<N> {
-    /// Anything valid as record attributes is valid as entity attributes.
-    /// Notably, this includes the possibility that we have a single common-type
-    /// reference, and not actually a record declaration.
-    RecordAttributes(RecordOrContextAttributes<N>),
-    /// [`EntityAttributesInternal`] is an analogue of
-    /// [`RecordOrContextAttributes`] that covers the JSON forms accepted for
-    /// entity attributes but not record attributes
-    EntityAttributes(EntityAttributesInternal<N>),
-}
-
-/// Helper struct containing the contents of
-/// `EntityAttributes::EntityAttributes`.
-/// This doesn't cover all possible legal JSON forms for entity attributes
-/// (use [`EntityAttributes`] for that) -- in particular this struct doesn't
-/// accept a single common-type reference; it requires a record declaration.
-/// But, this struct does cover all legal JSON forms for entity attributes that
-/// aren't accepted as legal JSON forms for record attributes.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[serde(deny_unknown_fields)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-#[allow(clippy::manual_non_exhaustive)] // a clippy false positive; that's not the reason we're using the `type_placeholder_hack`
-pub struct EntityAttributesInternal<N> {
-    /// a hack for the derived serializer/deserializer.
-    /// We need to require `"type": "Record"` here (it is required for the
-    /// corresponding struct [`RecordOrContextAttributes`] by virtue of using
-    /// the [`Type`] serialization/deserialization).
-    /// The `serialize_with` and `deserialize_with` accomplish this.
-    #[serde(rename = "type")]
-    #[serde(serialize_with = "record_string")]
-    #[serde(deserialize_with = "require_record_string")]
-    #[cfg_attr(feature = "wasm", tsify(type = "\"Record\""))]
-    type_placeholder_hack: (),
-    /// Entity attribute types, as a [`RecordType`]. These may include `EAMap`s.
-    #[serde(flatten)]
-    pub attrs: RecordType<EntityAttributeType<N>>,
-}
-
-fn record_string<S: Serializer>(
-    _type_placeholder_hack: &(),
-    ser: S,
-) -> std::result::Result<S::Ok, S::Error> {
-    ser.serialize_str("Record")
-}
-
-fn require_record_string<'de, D: Deserializer<'de>>(deser: D) -> std::result::Result<(), D::Error> {
-    /// Simple local visitor struct used only by this function
-    struct LocalVisitor;
-
-    impl<'de> Visitor<'de> for LocalVisitor {
-        type Value = ();
-        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(formatter, "the string `Record`")
-        }
-        fn visit_str<E: serde::de::Error>(self, s: &str) -> std::result::Result<(), E> {
-            if s == "Record" {
-                Ok(())
-            } else {
-                Err(serde::de::Error::invalid_value(
-                    serde::de::Unexpected::Str(s),
-                    &self,
-                ))
-            }
-        }
-    }
-
-    deser.deserialize_str(LocalVisitor)
-}
-
-impl<N> EntityAttributes<N> {
-    /// Is this [`EntityAttributes`] an empty record?
-    pub fn is_empty_record(&self) -> bool {
-        match self {
-            Self::RecordAttributes(attrs) => attrs.is_empty_record(),
-            Self::EntityAttributes(internal) => internal.is_empty_record(),
-        }
-    }
-}
-
-impl<N> EntityAttributesInternal<N> {
-    /// Is this [`EntityAttributesInternal`] an empty record?
-    pub fn is_empty_record(&self) -> bool {
-        self.attrs.is_empty_record()
-    }
-}
-
-impl<N> Default for EntityAttributes<N> {
-    fn default() -> Self {
-        Self::RecordAttributes(RecordOrContextAttributes::default())
-    }
-}
-
-impl<N: Display> Display for EntityAttributes<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::RecordAttributes(attrs) => attrs.fmt(f),
-            Self::EntityAttributes(internal) => internal.fmt(f),
-        }
-    }
-}
-
-impl<N: Display> Display for EntityAttributesInternal<N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.attrs.fmt(f)
-    }
-}
-
-impl<N> From<RecordType<RecordAttributeType<N>>> for EntityAttributes<N> {
-    fn from(rty: RecordType<RecordAttributeType<N>>) -> EntityAttributes<N> {
-        Self::RecordAttributes(rty.into())
-    }
-}
-
-impl<N> From<RecordType<EntityAttributeType<N>>> for EntityAttributes<N> {
-    fn from(rty: RecordType<EntityAttributeType<N>>) -> EntityAttributes<N> {
-        Self::EntityAttributes(EntityAttributesInternal {
-            type_placeholder_hack: (),
-            attrs: rty,
-        })
-    }
-}
-
-impl EntityAttributes<RawName> {
-    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
-    pub fn conditionally_qualify_type_references(
-        self,
-        ns: Option<&InternalName>,
-    ) -> EntityAttributes<ConditionalName> {
-        match self {
-            Self::RecordAttributes(attrs) => {
-                EntityAttributes::RecordAttributes(attrs.conditionally_qualify_type_references(ns))
-            }
-            Self::EntityAttributes(internal) => EntityAttributes::EntityAttributes(
-                internal.conditionally_qualify_type_references(ns),
-            ),
-        }
-    }
-}
-
-impl EntityAttributesInternal<RawName> {
-    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
-    pub fn conditionally_qualify_type_references(
-        self,
-        ns: Option<&InternalName>,
-    ) -> EntityAttributesInternal<ConditionalName> {
-        EntityAttributesInternal {
-            type_placeholder_hack: self.type_placeholder_hack,
-            attrs: self.attrs.conditionally_qualify_type_references(ns),
-        }
-    }
-}
-
-impl EntityAttributes<ConditionalName> {
-    /// Convert this [`EntityAttributes<ConditionalName>`] into a
-    /// [`EntityAttributes<InternalName>`] by fully-qualifying all typenames
-    /// that appear anywhere in any definitions.
-    ///
-    /// `all_defs` needs to contain the full set of all fully-qualified typenames
-    /// and actions that are defined in the schema (in all schema fragments).
-    pub fn fully_qualify_type_references(
-        self,
-        all_defs: &AllDefs,
-    ) -> std::result::Result<EntityAttributes<InternalName>, TypeNotDefinedError> {
-        match self {
-            Self::RecordAttributes(attrs) => Ok(EntityAttributes::RecordAttributes(
-                attrs.fully_qualify_type_references(all_defs)?,
-            )),
-            Self::EntityAttributes(internal) => Ok(EntityAttributes::EntityAttributes(
-                internal.fully_qualify_type_references(all_defs)?,
-            )),
-        }
-    }
-}
-
-impl EntityAttributesInternal<ConditionalName> {
-    /// Convert this [`EntityAttributes<ConditionalName>`] into a
-    /// [`EntityAttributes<InternalName>`] by fully-qualifying all typenames
-    /// that appear anywhere in any definitions.
-    ///
-    /// `all_defs` needs to contain the full set of all fully-qualified typenames
-    /// and actions that are defined in the schema (in all schema fragments).
-    pub fn fully_qualify_type_references(
-        self,
-        all_defs: &AllDefs,
-    ) -> std::result::Result<EntityAttributesInternal<InternalName>, TypeNotDefinedError> {
-        Ok(EntityAttributesInternal {
-            type_placeholder_hack: self.type_placeholder_hack,
-            attrs: self.attrs.fully_qualify_type_references(all_defs)?,
-        })
-    }
-}
-
-impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for EntityAttributes<N> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        use serde::de::IntoDeserializer;
-        // This deserialization attempts to mimic what `serde(untagged)` would
-        // do, but if the process fails, it gives the error message for the
-        // `EntityAttributesInternal` case, assuming that that error message is
-        // usually the most helpful one.
-        // (The only case it doesn't cover is if you tried, but failed, to use a
-        // single common-type reference to represent the entity attributes.)
-
-        // Ideally we'd want to "try deserializing" as `RecordOrContextAttributes`
-        // and if that fails, restore the deserializer state to try
-        // `EntityAttributesInternal`.
-        // I'm not sure how `serde(untagged)` does that, and I can't easily
-        // figure it out from reading the serde source.
-        // Note that `D` isn't `Clone`.
-        // As a workaround, we deserialize into `serde_json::Value` first, then
-        // determine which variant we have, then deserialize the appropriate
-        // variant.
-        let value: serde_json::Value =
-            <JsonValueWithNoDuplicateKeys as Deserialize<'de>>::deserialize(deserializer)?.into();
-        match value.get("type") {
-            Some(s) if s != "Record" => {
-                // This is the only case where we need the `Self::RecordAttributes` variant;
-                // all other cases can deserialize as `Self::EntityAttributes`, or will have
-                // an error such that we want the error from the `Self::EntityAttributes`
-                // deserialization attempt.
-                let attrs = <RecordOrContextAttributes<N> as Deserialize<'de>>::deserialize(
-                    value.into_deserializer(),
-                )
-                .map_err(|e| serde::de::Error::custom(format!("{e}")))?;
-                Ok(Self::RecordAttributes(attrs))
-            }
-            _ => {
-                // In all other cases, we deserialize as `EntityAttributesInternal` or want the
-                // error message from trying to deserialize as `EntityAttributesInternal`.
-                let attrs = <EntityAttributesInternal<N> as Deserialize<'de>>::deserialize(
-                    value.into_deserializer(),
-                )
-                .map_err(|e| serde::de::Error::custom(format!("{e}")))?;
-                Ok(Self::EntityAttributes(attrs))
-            }
-        }
     }
 }
 
@@ -864,8 +610,8 @@ pub struct ApplySpec<N> {
     pub principal_types: Vec<N>,
     /// Context type that this action expects
     #[serde(default)]
-    #[serde(skip_serializing_if = "RecordOrContextAttributes::is_empty_record")]
-    pub context: RecordOrContextAttributes<N>,
+    #[serde(skip_serializing_if = "AttributesOrContext::is_empty_record")]
+    pub context: AttributesOrContext<N>,
 }
 
 impl ApplySpec<RawName> {
@@ -1261,7 +1007,6 @@ enum TypeFields {
     Attributes,
     AdditionalAttributes,
     Name,
-    Default,
 }
 
 // This macro is used to avoid duplicating the fields names when calling
@@ -1283,9 +1028,6 @@ macro_rules! type_field_name {
     (Name) => {
         "name"
     };
-    (Default) => {
-        "default"
-    };
 }
 
 impl TypeFields {
@@ -1296,106 +1038,8 @@ impl TypeFields {
             TypeFields::Attributes => type_field_name!(Attributes),
             TypeFields::AdditionalAttributes => type_field_name!(AdditionalAttributes),
             TypeFields::Name => type_field_name!(Name),
-            TypeFields::Default => type_field_name!(Default),
         }
     }
-}
-
-/// The fields for a `SchemaType`, with their accompanying data.
-/// Used for implementing deserialization.
-///
-/// We keep field values wrapped in `Result` here so that we do not report
-/// errors due to the contents of a field when the field is not expected/allowed
-/// for a particular type variant.
-/// We instead report that the field should not exist at all, so that the schema
-/// author can delete the field without wasting time fixing errors in the value.
-#[derive(Debug)]
-struct TypeFieldsWithData<N, E> {
-    /// If this is `Some`, the `type` field is present, with the given value
-    type_name: Option<std::result::Result<SmolStr, E>>,
-    /// If this is `Some`, the `element` field is present, with the given value
-    element: Option<std::result::Result<Type<N>, E>>,
-    /// If this is `Some`, the `attributes` field is present, with the given value
-    attributes: Option<std::result::Result<AttributesTypeMap, E>>,
-    /// If this is `Some`, the `additional_attributes` field is present, with the given value
-    additional_attributes: Option<std::result::Result<bool, E>>,
-    /// If this is `Some`, the `name` field is present, with the given value
-    name: Option<std::result::Result<SmolStr, E>>,
-    /// If this is `Some`, the `default` field is present, with the given value
-    default: Option<std::result::Result<Type<N>, E>>,
-}
-
-/// Manual impl of `Default` (rather than `derive(Default)`) because the derived
-/// impl of `Default` requires `N: Default`, but this manual impl works for all `N`
-impl<N, E> Default for TypeFieldsWithData<N, E> {
-    fn default() -> Self {
-        Self {
-            type_name: None,
-            element: None,
-            attributes: None,
-            additional_attributes: None,
-            name: None,
-            default: None,
-        }
-    }
-}
-
-/// Helper function to collect the [`TypeFieldsWithData`] from a map type during deserialization.
-/// Shared by [`SchemaTypeVisitor`] and [`EntityAttributeTypeInternalVisitor`].
-fn collect_type_fields_data<'de, N: Deserialize<'de> + From<RawName>, M: MapAccess<'de>>(
-    mut map: M,
-) -> std::result::Result<TypeFieldsWithData<N, M::Error>, M::Error> {
-    use TypeFields::*;
-
-    let mut fields: TypeFieldsWithData<N, M::Error> = TypeFieldsWithData::default();
-
-    // Gather all the fields in the object. Any fields that are not one of
-    // the possible fields for some schema type will have been reported by
-    // serde already.
-    while let Some(key) = map.next_key()? {
-        match key {
-            Type => {
-                if fields.type_name.is_some() {
-                    return Err(serde::de::Error::duplicate_field(Type.as_str()));
-                }
-                fields.type_name = Some(map.next_value());
-            }
-            Element => {
-                if fields.element.is_some() {
-                    return Err(serde::de::Error::duplicate_field(Element.as_str()));
-                }
-                fields.element = Some(map.next_value());
-            }
-            Attributes => {
-                if fields.attributes.is_some() {
-                    return Err(serde::de::Error::duplicate_field(Attributes.as_str()));
-                }
-                fields.attributes = Some(map.next_value());
-            }
-            AdditionalAttributes => {
-                if fields.additional_attributes.is_some() {
-                    return Err(serde::de::Error::duplicate_field(
-                        AdditionalAttributes.as_str(),
-                    ));
-                }
-                fields.additional_attributes = Some(map.next_value());
-            }
-            Name => {
-                if fields.name.is_some() {
-                    return Err(serde::de::Error::duplicate_field(Name.as_str()));
-                }
-                fields.name = Some(map.next_value());
-            }
-            Default => {
-                if fields.default.is_some() {
-                    return Err(serde::de::Error::duplicate_field(Default.as_str()));
-                }
-                fields.default = Some(map.next_value());
-            }
-        }
-    }
-
-    Ok(fields)
 }
 
 /// Used during deserialization to deserialize the attributes type map while
@@ -1405,7 +1049,7 @@ fn collect_type_fields_data<'de, N: Deserialize<'de> + From<RawName>, M: MapAcce
 #[derive(Debug, Deserialize)]
 struct AttributesTypeMap(
     #[serde(with = "serde_with::rust::maps_duplicate_key_is_error")]
-    BTreeMap<SmolStr, RecordAttributeType<RawName>>,
+    BTreeMap<SmolStr, TypeOfAttribute<RawName>>,
 );
 
 struct TypeVisitor<N> {
@@ -1419,18 +1063,64 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for TypeVisitor<N> {
         formatter.write_str("builtin type or reference to type defined in commonTypes")
     }
 
-    fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
+    fn visit_map<M>(self, mut map: M) -> std::result::Result<Self::Value, M::Error>
     where
         M: MapAccess<'de>,
     {
-        let fields = collect_type_fields_data(map)?;
-        let eatype = Self::build_schema_type::<M>(fields)?;
-        // Here, in the deserializer for `Type`, we do not allow EAMap
-        // types (because `Type` does not allow EAMap types).
-        match eatype {
-            EntityAttributeTypeInternal::EAMap { .. } => Err(serde::de::Error::custom("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")),
-            EntityAttributeTypeInternal::Type(ty) => Ok(ty),
+        use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
+
+        // We keep field values wrapped in a `Result` initially so that we do
+        // not report errors due the contents of a field when the field is not
+        // expected for a particular type variant. We instead report that the
+        // field so not exist at all, so that the schema author can delete the
+        // field without wasting time fixing errors in the value.
+        let mut type_name: Option<std::result::Result<SmolStr, M::Error>> = None;
+        let mut element: Option<std::result::Result<Type<N>, M::Error>> = None;
+        let mut attributes: Option<std::result::Result<AttributesTypeMap, M::Error>> = None;
+        let mut additional_attributes: Option<std::result::Result<bool, M::Error>> = None;
+        let mut name: Option<std::result::Result<SmolStr, M::Error>> = None;
+
+        // Gather all the fields in the object. Any fields that are not one of
+        // the possible fields for some schema type will have been reported by
+        // serde already.
+        while let Some(key) = map.next_key()? {
+            match key {
+                TypeField => {
+                    if type_name.is_some() {
+                        return Err(serde::de::Error::duplicate_field(TypeField.as_str()));
+                    }
+                    type_name = Some(map.next_value());
+                }
+                Element => {
+                    if element.is_some() {
+                        return Err(serde::de::Error::duplicate_field(Element.as_str()));
+                    }
+                    element = Some(map.next_value());
+                }
+                Attributes => {
+                    if attributes.is_some() {
+                        return Err(serde::de::Error::duplicate_field(Attributes.as_str()));
+                    }
+                    attributes = Some(map.next_value());
+                }
+                AdditionalAttributes => {
+                    if additional_attributes.is_some() {
+                        return Err(serde::de::Error::duplicate_field(
+                            AdditionalAttributes.as_str(),
+                        ));
+                    }
+                    additional_attributes = Some(map.next_value());
+                }
+                Name => {
+                    if name.is_some() {
+                        return Err(serde::de::Error::duplicate_field(Name.as_str()));
+                    }
+                    name = Some(map.next_value());
+                }
+            }
         }
+
+        Self::build_schema_type::<M>(type_name, element, attributes, additional_attributes, name)
     }
 }
 
@@ -1439,38 +1129,31 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
     /// Fields which were not present are `None`. It is an error for a field
     /// which is not used for a particular type to be `Some` when building that
     /// type.
-    ///
-    /// This method accepts `EAMap` types, and will construct one if it is
-    /// encountered.
-    /// Thus it returns [`EntityAttributeTypeInternal`] rather than [`SchemaType`]
-    /// directly.
-    /// If `EAMap` types should not be accepted in this position, it is the
-    /// caller's responsibility to check that the [`EntityAttributeTypeInternal`]
-    /// is an acceptable variant.
     fn build_schema_type<M>(
-        fields: TypeFieldsWithData<N, M::Error>,
-    ) -> std::result::Result<EntityAttributeTypeInternal<N>, M::Error>
+        type_name: Option<std::result::Result<SmolStr, M::Error>>,
+        element: Option<std::result::Result<Type<N>, M::Error>>,
+        attributes: Option<std::result::Result<AttributesTypeMap, M::Error>>,
+        additional_attributes: Option<std::result::Result<bool, M::Error>>,
+        name: Option<std::result::Result<SmolStr, M::Error>>,
+    ) -> std::result::Result<Type<N>, M::Error>
     where
         M: MapAccess<'de>,
     {
-        use TypeFields::{
-            AdditionalAttributes, Attributes, Default, Element, Name, Type as TypeField,
-        };
+        use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
         // Fields that remain to be parsed
         let mut remaining_fields = [
-            (TypeField, fields.type_name.is_some()),
-            (Element, fields.element.is_some()),
-            (Attributes, fields.attributes.is_some()),
-            (AdditionalAttributes, fields.additional_attributes.is_some()),
-            (Name, fields.name.is_some()),
-            (Default, fields.default.is_some()),
+            (TypeField, type_name.is_some()),
+            (Element, element.is_some()),
+            (Attributes, attributes.is_some()),
+            (AdditionalAttributes, additional_attributes.is_some()),
+            (Name, name.is_some()),
         ]
         .into_iter()
         .filter(|(_, present)| *present)
         .map(|(field, _)| field)
         .collect::<HashSet<_>>();
 
-        match fields.type_name.transpose()?.as_ref() {
+        match type_name.transpose()?.as_ref() {
             Some(s) => {
                 // We've concluded that type exists
                 remaining_fields.remove(&TypeField);
@@ -1487,42 +1170,31 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                     Ok(())
                 };
                 let error_if_any_fields = || -> std::result::Result<(), M::Error> {
-                    error_if_fields(
-                        &[Element, Attributes, AdditionalAttributes, Name, Default],
-                        &[],
-                    )
+                    error_if_fields(&[Element, Attributes, AdditionalAttributes, Name], &[])
                 };
                 match s.as_str() {
                     "String" => {
                         error_if_any_fields()?;
-                        Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                            TypeVariant::String,
-                        )))
+                        Ok(Type::Type(TypeVariant::String))
                     }
                     "Long" => {
                         error_if_any_fields()?;
-                        Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                            TypeVariant::Long,
-                        )))
+                        Ok(Type::Type(TypeVariant::Long))
                     }
                     "Boolean" => {
                         error_if_any_fields()?;
-                        Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                            TypeVariant::Boolean,
-                        )))
+                        Ok(Type::Type(TypeVariant::Boolean))
                     }
                     "Set" => {
                         error_if_fields(
-                            &[Attributes, AdditionalAttributes, Default, Name],
+                            &[Attributes, AdditionalAttributes, Name],
                             &[type_field_name!(Element)],
                         )?;
 
-                        match fields.element {
-                            Some(element) => Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                                TypeVariant::Set {
-                                    element: Box::new(element?),
-                                },
-                            ))),
+                        match element {
+                            Some(element) => Ok(Type::Type(TypeVariant::Set {
+                                element: Box::new(element?),
+                            })),
                             None => Err(serde::de::Error::missing_field(Element.as_str())),
                         }
                     }
@@ -1532,121 +1204,99 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                             &[
                                 type_field_name!(Attributes),
                                 type_field_name!(AdditionalAttributes),
-                                type_field_name!(Default),
                             ],
                         )?;
 
-                        if let Some(attributes) = fields.attributes {
-                            if fields.default.is_some() {
-                                return Err(serde::de::Error::custom("fields `default` and `attributes` cannot exist on the same record type"));
-                            }
-                            let additional_attributes = fields
-                                .additional_attributes
-                                .unwrap_or(Ok(partial_schema_default()));
-                            Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                                TypeVariant::Record(RecordType {
-                                    attributes: attributes?
-                                        .0
-                                        .into_iter()
-                                        .map(|(k, RecordAttributeType { ty, required })| {
-                                            (
-                                                k,
-                                                RecordAttributeType {
-                                                    ty: ty.into_n(),
-                                                    required,
-                                                },
-                                            )
-                                        })
-                                        .collect(),
-                                    additional_attributes: additional_attributes?,
-                                }),
-                            )))
-                        } else if let Some(default) = fields.default {
-                            if fields.attributes.is_some() {
-                                return Err(serde::de::Error::custom("fields `default` and `attributes` cannot exist on the same record type"));
-                            } else if fields.additional_attributes.is_some() {
-                                return Err(serde::de::Error::custom("fields `default` and `additionalAttributes` cannot exist on the same record type"));
-                            }
-                            Ok(EntityAttributeTypeInternal::EAMap {
-                                value_type: default?,
-                            })
+                        if let Some(attributes) = attributes {
+                            let additional_attributes =
+                                additional_attributes.unwrap_or(Ok(partial_schema_default()));
+                            Ok(Type::Type(TypeVariant::Record(RecordType {
+                                attributes: attributes?
+                                    .0
+                                    .into_iter()
+                                    .map(|(k, TypeOfAttribute { ty, required })| {
+                                        (
+                                            k,
+                                            TypeOfAttribute {
+                                                ty: ty.into_n(),
+                                                required,
+                                            },
+                                        )
+                                    })
+                                    .collect(),
+                                additional_attributes: additional_attributes?,
+                            })))
                         } else {
                             Err(serde::de::Error::missing_field(Attributes.as_str()))
                         }
                     }
                     "Entity" => {
                         error_if_fields(
-                            &[Element, Attributes, AdditionalAttributes, Default],
+                            &[Element, Attributes, AdditionalAttributes],
                             &[type_field_name!(Name)],
                         )?;
-                        match fields.name {
+                        match name {
                             Some(name) => {
                                 let name = name?;
-                                Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                                    TypeVariant::Entity {
-                                        name: RawName::from_normalized_str(&name)
-                                            .map_err(|err| {
-                                                serde::de::Error::custom(format!(
-                                                    "invalid entity type `{name}`: {err}"
-                                                ))
-                                            })?
-                                            .into(),
-                                    },
-                                )))
+                                Ok(Type::Type(TypeVariant::Entity {
+                                    name: RawName::from_normalized_str(&name)
+                                        .map_err(|err| {
+                                            serde::de::Error::custom(format!(
+                                                "invalid entity type `{name}`: {err}"
+                                            ))
+                                        })?
+                                        .into(),
+                                }))
                             }
                             None => Err(serde::de::Error::missing_field(Name.as_str())),
                         }
                     }
                     "EntityOrCommon" => {
                         error_if_fields(
-                            &[Element, Attributes, AdditionalAttributes, Default],
+                            &[Element, Attributes, AdditionalAttributes],
                             &[type_field_name!(Name)],
                         )?;
-                        match fields.name {
+                        match name {
                             Some(name) => {
                                 let name = name?;
-                                Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                                    TypeVariant::EntityOrCommon {
-                                        type_name: RawName::from_normalized_str(&name)
-                                            .map_err(|err| {
-                                                serde::de::Error::custom(format!(
-                                                    "invalid entity or common type `{name}`: {err}"
-                                                ))
-                                            })?
-                                            .into(),
-                                    },
-                                )))
+                                Ok(Type::Type(TypeVariant::EntityOrCommon {
+                                    type_name: RawName::from_normalized_str(&name)
+                                        .map_err(|err| {
+                                            serde::de::Error::custom(format!(
+                                                "invalid entity or common type `{name}`: {err}"
+                                            ))
+                                        })?
+                                        .into(),
+                                }))
                             }
                             None => Err(serde::de::Error::missing_field(Name.as_str())),
                         }
                     }
                     "Extension" => {
                         error_if_fields(
-                            &[Element, Attributes, AdditionalAttributes, Default],
+                            &[Element, Attributes, AdditionalAttributes],
                             &[type_field_name!(Name)],
                         )?;
 
-                        match fields.name {
+                        match name {
                             Some(name) => {
                                 let name = name?;
-                                Ok(EntityAttributeTypeInternal::Type(Type::Type(
-                                    TypeVariant::Extension {
-                                        name: UnreservedId::from_normalized_str(&name).map_err(
-                                            |err| {
-                                                serde::de::Error::custom(format!(
-                                                    "invalid extension type `{name}`: {err}"
-                                                ))
-                                            },
-                                        )?,
-                                    },
-                                )))
+                                Ok(Type::Type(TypeVariant::Extension {
+                                    name: UnreservedId::from_normalized_str(&name).map_err(
+                                        |err| {
+                                            serde::de::Error::custom(format!(
+                                                "invalid extension type `{name}`: {err}"
+                                            ))
+                                        },
+                                    )?,
+                                }))
                             }
                             None => Err(serde::de::Error::missing_field(Name.as_str())),
                         }
                     }
                     type_name => {
                         error_if_any_fields()?;
-                        Ok(EntityAttributeTypeInternal::Type(Type::CommonTypeRef {
+                        Ok(Type::CommonTypeRef {
                             type_name: N::from(RawName::from_normalized_str(type_name).map_err(
                                 |err| {
                                     serde::de::Error::custom(format!(
@@ -1654,7 +1304,7 @@ impl<'de, N: Deserialize<'de> + From<RawName>> TypeVisitor<N> {
                                     ))
                                 },
                             )?),
-                        }))
+                        })
                     }
                 }
             }
@@ -1671,29 +1321,24 @@ impl<N> From<TypeVariant<N>> for Type<N> {
 
 /// Represents the type-level information about a record type.
 ///
-/// `V` is the type of attribute values in the record.
-/// For instance, when `V` is [`RecordAttributeType`], this [`RecordType`]
-/// represents the associated information for [`TypeVariant::Record`].
-/// Entity attribute values are also allowed to be `EAMap`s, so in that
-/// case `V` is [`EntityAttributeType`].
+/// The parameter `N` is the type of entity type names and common type names in
+/// this [`RecordType`], including recursively.
+/// See notes on [`Fragment`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(rename_all = "camelCase")]
-#[serde(deny_unknown_fields)]
-#[serde(bound(deserialize = "V: Deserialize<'de>"))]
-#[serde(bound(serialize = "V: Serialize"))]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct RecordType<V> {
+pub struct RecordType<N> {
     /// Attribute names and types for the record
-    #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    pub attributes: BTreeMap<SmolStr, V>,
+    pub attributes: BTreeMap<SmolStr, TypeOfAttribute<N>>,
     /// Whether "additional attributes" are possible on this record
     #[serde(default = "partial_schema_default")]
     #[serde(skip_serializing_if = "is_partial_schema_default")]
     pub additional_attributes: bool,
 }
 
-impl<V> Default for RecordType<V> {
+impl<N> Default for RecordType<N> {
     fn default() -> Self {
         Self {
             attributes: BTreeMap::new(),
@@ -1702,19 +1347,19 @@ impl<V> Default for RecordType<V> {
     }
 }
 
-impl<V> RecordType<V> {
+impl<N> RecordType<N> {
     /// Is this [`RecordType`] an empty record?
     pub fn is_empty_record(&self) -> bool {
         self.additional_attributes == partial_schema_default() && self.attributes.is_empty()
     }
 }
 
-impl RecordType<RecordAttributeType<RawName>> {
+impl RecordType<RawName> {
     /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> RecordType<RecordAttributeType<ConditionalName>> {
+    ) -> RecordType<ConditionalName> {
         RecordType {
             attributes: self
                 .attributes
@@ -1726,58 +1371,17 @@ impl RecordType<RecordAttributeType<RawName>> {
     }
 }
 
-impl RecordType<EntityAttributeType<RawName>> {
-    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
-    pub fn conditionally_qualify_type_references(
-        self,
-        ns: Option<&InternalName>,
-    ) -> RecordType<EntityAttributeType<ConditionalName>> {
-        RecordType {
-            attributes: self
-                .attributes
-                .into_iter()
-                .map(|(k, v)| (k, v.conditionally_qualify_type_references(ns)))
-                .collect(),
-            additional_attributes: self.additional_attributes,
-        }
-    }
-}
-
-impl RecordType<RecordAttributeType<ConditionalName>> {
-    /// Convert this [`RecordType<RecordAttributeType<ConditionalName>>`] into a
-    /// [`RecordType<RecordAttributeType<InternalName>>`] by fully-qualifying
-    /// all typenames that appear anywhere in any definitions.
+impl RecordType<ConditionalName> {
+    /// Convert this [`RecordType<ConditionalName>`] into a
+    /// [`RecordType<InternalName>`] by fully-qualifying all typenames that
+    /// appear anywhere in any definitions.
     ///
     /// `all_defs` needs to contain the full set of all fully-qualified typenames
     /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
         all_defs: &AllDefs,
-    ) -> std::result::Result<RecordType<RecordAttributeType<InternalName>>, TypeNotDefinedError>
-    {
-        Ok(RecordType {
-            attributes: self
-                .attributes
-                .into_iter()
-                .map(|(k, v)| Ok((k, v.fully_qualify_type_references(all_defs)?)))
-                .collect::<std::result::Result<_, TypeNotDefinedError>>()?,
-            additional_attributes: self.additional_attributes,
-        })
-    }
-}
-
-impl RecordType<EntityAttributeType<ConditionalName>> {
-    /// Convert this [`RecordType<EntityAttributeType<ConditionalName>>`] into a
-    /// [`RecordType<EntityAttributeType<InternalName>>`] by fully-qualifying
-    /// all typenames that appear anywhere in any definitions.
-    ///
-    /// `all_defs` needs to contain the full set of all fully-qualified typenames
-    /// and actions that are defined in the schema (in all schema fragments).
-    pub fn fully_qualify_type_references(
-        self,
-        all_defs: &AllDefs,
-    ) -> std::result::Result<RecordType<EntityAttributeType<InternalName>>, TypeNotDefinedError>
-    {
+    ) -> std::result::Result<RecordType<InternalName>, TypeNotDefinedError> {
         Ok(RecordType {
             attributes: self
                 .attributes
@@ -1814,7 +1418,7 @@ pub enum TypeVariant<N> {
         element: Box<Type<N>>,
     },
     /// Record
-    Record(RecordType<RecordAttributeType<N>>),
+    Record(RecordType<N>),
     /// Entity
     Entity {
         /// Name of the entity type.
@@ -1880,10 +1484,10 @@ impl TypeVariant<RawName> {
                 additional_attributes,
             }) => TypeVariant::Record(RecordType {
                 attributes: BTreeMap::from_iter(attributes.into_iter().map(
-                    |(attr, RecordAttributeType { ty, required })| {
+                    |(attr, TypeOfAttribute { ty, required })| {
                         (
                             attr,
-                            RecordAttributeType {
+                            TypeOfAttribute {
                                 ty: ty.conditionally_qualify_type_references(ns),
                                 required,
                             },
@@ -1953,10 +1557,10 @@ impl TypeVariant<ConditionalName> {
             }) => Ok(TypeVariant::Record(RecordType {
                 attributes: attributes
                     .into_iter()
-                    .map(|(attr, RecordAttributeType { ty, required })| {
+                    .map(|(attr, TypeOfAttribute { ty, required })| {
                         Ok((
                             attr,
-                            RecordAttributeType {
+                            TypeOfAttribute {
                                 ty: ty.fully_qualify_type_references(all_defs)?,
                                 required,
                             },
@@ -2022,192 +1626,13 @@ impl<'a> arbitrary::Arbitrary<'a> for Type<RawName> {
     }
 }
 
-/// Describes the underlying type of an entity attribute (not including the
-/// required/optional flag).
-///
-/// The allowed types for an entity attribute are different from the allowed
-/// types for a record attribute. See
-/// [RFC 68](https://github.com/cedar-policy/rfcs/blob/main/text/0068-entity-tags.md).
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub enum EntityAttributeTypeInternal<N> {
-    /// A normal type. Attributes can be `String`, an entity type, a common type, a record type, etc
-    Type(Type<N>),
-    /// An embedded attribute map (RFC 68)
-    ///
-    /// That is, a map from String to the given value type.
-    EAMap {
-        /// The `EAMap` is a map from String to this value type.
-        ///
-        /// Note that this value type may not itself be (or contain) `EAMap`s.
-        value_type: Type<N>,
-    },
-}
-
-impl EntityAttributeTypeInternal<RawName> {
-    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
-    pub fn conditionally_qualify_type_references(
-        self,
-        ns: Option<&InternalName>,
-    ) -> EntityAttributeTypeInternal<ConditionalName> {
-        match self {
-            Self::Type(ty) => {
-                EntityAttributeTypeInternal::Type(ty.conditionally_qualify_type_references(ns))
-            }
-            Self::EAMap { value_type } => EntityAttributeTypeInternal::EAMap {
-                value_type: value_type.conditionally_qualify_type_references(ns),
-            },
-        }
-    }
-}
-
-impl EntityAttributeTypeInternal<ConditionalName> {
-    /// Convert this [`EntityAttributeTypeInternal<ConditionalName>`] into a
-    /// [`EntityAttributeTypeInternal<InternalName>`] by fully-qualifying all
-    /// typenames that appear anywhere in any definitions.
-    ///
-    /// `all_defs` needs to contain the full set of all fully-qualified typenames
-    /// and actions that are defined in the schema (in all schema fragments).
-    pub fn fully_qualify_type_references(
-        self,
-        all_defs: &AllDefs,
-    ) -> std::result::Result<EntityAttributeTypeInternal<InternalName>, TypeNotDefinedError> {
-        match self {
-            Self::Type(ty) => Ok(EntityAttributeTypeInternal::Type(
-                ty.fully_qualify_type_references(all_defs)?,
-            )),
-            Self::EAMap { value_type } => Ok(EntityAttributeTypeInternal::EAMap {
-                value_type: value_type.fully_qualify_type_references(all_defs)?,
-            }),
-        }
-    }
-}
-
-impl<N: Serialize> Serialize for EntityAttributeTypeInternal<N> {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            Self::Type(ty) => ty.serialize(serializer),
-            Self::EAMap { value_type } => {
-                serde_json::json!({"type": "Record", "default": value_type}).serialize(serializer)
-            }
-        }
-    }
-}
-
-struct EntityAttributeTypeInternalVisitor<N> {
-    _phantom: PhantomData<N>,
-}
-
-impl<'de, N: Deserialize<'de> + From<RawName>> Deserialize<'de> for EntityAttributeTypeInternal<N> {
-    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        deserializer.deserialize_any(EntityAttributeTypeInternalVisitor {
-            _phantom: PhantomData,
-        })
-    }
-}
-
-impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de>
-    for EntityAttributeTypeInternalVisitor<N>
-{
-    type Value = EntityAttributeTypeInternal<N>;
-
-    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        formatter.write_str("any valid type, including an embedded attribute map type")
-    }
-
-    fn visit_map<M>(self, map: M) -> std::result::Result<Self::Value, M::Error>
-    where
-        M: MapAccess<'de>,
-    {
-        let fields = collect_type_fields_data(map)?;
-        TypeVisitor::build_schema_type::<M>(fields)
-    }
-}
-
-/// Describes the type of an entity attribute. It contains the type of the
-/// attribute and whether the attribute is required. The type is flattened for
-/// serialization, so, in JSON format, this appears as a regular type with one
-/// extra property `required`.
+/// Used to describe the type of a record or entity attribute. It contains a the
+/// type of the attribute and whether the attribute is required. The type is
+/// flattened for serialization, so, in JSON format, this appears as a regular
+/// type with one extra property `required`.
 ///
 /// The parameter `N` is the type of entity type names and common type names in
-/// this [`EntityAttributeType`], including recursively.
-/// See notes on [`Fragment`].
-///
-/// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
-/// using `#[serde(tag = "type")]` in [`Type`] which is (eventually) flattened
-/// here.
-/// The way `serde(flatten)` is implemented means it may be possible to access
-/// fields incorrectly if a struct contains two structs that are flattened
-/// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
-/// us as we're using `flatten` only once
-/// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
-/// unknown fields for [`EntityAttributeType`] should be passed to [`Type`]
-/// where they will be denied
-/// (`<https://github.com/serde-rs/serde/issues/1600>`).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
-#[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct EntityAttributeType<N> {
-    /// Underlying type of the attribute
-    #[serde(flatten)]
-    // without this explicit `tsify` type, as of this writing, tsify produces a declaration
-    // `export interface EntityAttributeType<N> extends EntityAttributeTypeInternal<N> { required?: boolean; }`
-    // which `tsc` fails with `error TS2312: An interface can only extend an object
-    // type or intersection of object types with statically known members.`
-    #[cfg_attr(feature = "wasm", tsify(type = "EntityAttributeTypeInternal<N>"))]
-    pub ty: EntityAttributeTypeInternal<N>,
-    /// Whether the attribute is required
-    #[serde(default = "record_attribute_required_default")]
-    #[serde(skip_serializing_if = "is_record_attribute_required_default")]
-    pub required: bool,
-}
-
-impl EntityAttributeType<RawName> {
-    /// (Conditionally) prefix unqualified entity and common type references with the namespace they are in
-    pub fn conditionally_qualify_type_references(
-        self,
-        ns: Option<&InternalName>,
-    ) -> EntityAttributeType<ConditionalName> {
-        EntityAttributeType {
-            ty: self.ty.conditionally_qualify_type_references(ns),
-            required: self.required,
-        }
-    }
-}
-
-impl EntityAttributeType<ConditionalName> {
-    /// Convert this [`EntityAttributeType<ConditionalName>`] into a
-    /// [`EntityAttributeType<InternalName>`] by fully-qualifying
-    /// all typenames that appear anywhere in any definitions.
-    ///
-    /// `all_defs` needs to contain the full set of all fully-qualified typenames
-    /// and actions that are defined in the schema (in all schema fragments).
-    pub fn fully_qualify_type_references(
-        self,
-        all_defs: &AllDefs,
-    ) -> std::result::Result<EntityAttributeType<InternalName>, TypeNotDefinedError> {
-        Ok(EntityAttributeType {
-            ty: self.ty.fully_qualify_type_references(all_defs)?,
-            required: self.required,
-        })
-    }
-}
-
-/// Describes the type of a record attribute. It contains the type of the
-/// attribute and whether the attribute is required. The type is flattened for
-/// serialization, so, in JSON format, this appears as a regular type with one
-/// extra property `required`.
-///
-/// The parameter `N` is the type of entity type names and common type names in
-/// this [`RecordAttributeType`], including recursively.
+/// this [`TypeOfAttribute`], including recursively.
 /// See notes on [`Fragment`].
 ///
 /// Note that we can't add `#[serde(deny_unknown_fields)]` here because we are
@@ -2217,20 +1642,13 @@ impl EntityAttributeType<ConditionalName> {
 /// (`<https://github.com/serde-rs/serde/issues/1547>`). This shouldn't apply to
 /// us as we're using `flatten` only once
 /// (`<https://github.com/serde-rs/serde/issues/1600>`). This should be ok because
-/// unknown fields for [`RecordAttributeType`] should be passed to [`Type`] where
+/// unknown fields for [`TypeOfAttribute`] should be passed to [`Type`] where
 /// they will be denied (`<https://github.com/serde-rs/serde/issues/1600>`).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Eq, PartialOrd, Ord)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
-#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
-#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct RecordAttributeType<N> {
+pub struct TypeOfAttribute<N> {
     /// Underlying type of the attribute
     #[serde(flatten)]
-    // without this explicit `tsify` type, as of this writing, tsify produces a declaration
-    // `export interface RecordAttributeType<N> extends Type<N> { required?: boolean; }`
-    // which `tsc` fails with `error TS2312: An interface can only extend an object
-    // type or intersection of object types with statically known members.`
-    #[cfg_attr(feature = "wasm", tsify(type = "Type<N>"))]
     pub ty: Type<N>,
     /// Whether the attribute is required
     #[serde(default = "record_attribute_required_default")]
@@ -2238,9 +1656,9 @@ pub struct RecordAttributeType<N> {
     pub required: bool,
 }
 
-impl RecordAttributeType<RawName> {
-    fn into_n<N: From<RawName>>(self) -> RecordAttributeType<N> {
-        RecordAttributeType {
+impl TypeOfAttribute<RawName> {
+    fn into_n<N: From<RawName>>(self) -> TypeOfAttribute<N> {
+        TypeOfAttribute {
             ty: self.ty.into_n(),
             required: self.required,
         }
@@ -2250,26 +1668,26 @@ impl RecordAttributeType<RawName> {
     pub fn conditionally_qualify_type_references(
         self,
         ns: Option<&InternalName>,
-    ) -> RecordAttributeType<ConditionalName> {
-        RecordAttributeType {
+    ) -> TypeOfAttribute<ConditionalName> {
+        TypeOfAttribute {
             ty: self.ty.conditionally_qualify_type_references(ns),
             required: self.required,
         }
     }
 }
 
-impl RecordAttributeType<ConditionalName> {
-    /// Convert this [`RecordAttributeType<ConditionalName>`] into a
-    /// [`RecordAttributeType<InternalName>`] by fully-qualifying
-    /// all typenames that appear anywhere in any definitions.
+impl TypeOfAttribute<ConditionalName> {
+    /// Convert this [`TypeOfAttribute<ConditionalName>`] into a
+    /// [`TypeOfAttribute<InternalName>`] by fully-qualifying all typenames that
+    /// appear anywhere in any definitions.
     ///
     /// `all_defs` needs to contain the full set of all fully-qualified typenames
     /// and actions that are defined in the schema (in all schema fragments).
     pub fn fully_qualify_type_references(
         self,
         all_defs: &AllDefs,
-    ) -> std::result::Result<RecordAttributeType<InternalName>, TypeNotDefinedError> {
-        Ok(RecordAttributeType {
+    ) -> std::result::Result<TypeOfAttribute<InternalName>, TypeNotDefinedError> {
+        Ok(TypeOfAttribute {
             ty: self.ty.fully_qualify_type_references(all_defs)?,
             required: self.required,
         })
@@ -2277,7 +1695,7 @@ impl RecordAttributeType<ConditionalName> {
 }
 
 #[cfg(feature = "arbitrary")]
-impl<'a> arbitrary::Arbitrary<'a> for RecordAttributeType<RawName> {
+impl<'a> arbitrary::Arbitrary<'a> for TypeOfAttribute<RawName> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(Self {
             ty: u.arbitrary()?,
@@ -2332,12 +1750,10 @@ mod test {
         assert_eq!(et.member_of_types, vec!["UserGroup".parse().unwrap()]);
         assert_eq!(
             et.shape,
-            EntityAttributes::RecordAttributes(RecordOrContextAttributes(Type::Type(
-                TypeVariant::Record(RecordType {
-                    attributes: BTreeMap::new(),
-                    additional_attributes: false
-                })
-            ))),
+            AttributesOrContext(Type::Type(TypeVariant::Record(RecordType {
+                attributes: BTreeMap::new(),
+                additional_attributes: false
+            }))),
         );
     }
 
@@ -2350,12 +1766,10 @@ mod test {
         assert_eq!(et.member_of_types.len(), 0);
         assert_eq!(
             et.shape,
-            EntityAttributes::RecordAttributes(RecordOrContextAttributes(Type::Type(
-                TypeVariant::Record(RecordType {
-                    attributes: BTreeMap::new(),
-                    additional_attributes: false
-                })
-            ))),
+            AttributesOrContext(Type::Type(TypeVariant::Record(RecordType {
+                attributes: BTreeMap::new(),
+                additional_attributes: false
+            }))),
         );
     }
 
@@ -2374,7 +1788,7 @@ mod test {
         let spec = ApplySpec {
             resource_types: vec!["Album".parse().unwrap()],
             principal_types: vec!["User".parse().unwrap()],
-            context: RecordOrContextAttributes::default(),
+            context: AttributesOrContext::default(),
         };
         assert_eq!(at.applies_to, Some(spec));
         assert_eq!(
@@ -2465,7 +1879,7 @@ mod test {
                 "actions": {}
             }
         }"#;
-        let schema = Fragment::from_json_str(src).expect("Parse Error");
+        let schema: Fragment<RawName> = serde_json::from_str(src).expect("Parse Error");
         let (namespace, _descriptor) = schema.0.into_iter().next().unwrap();
         assert_eq!(namespace, Some("foo::foo::bar::baz".parse().unwrap()));
     }
@@ -3019,440 +2433,6 @@ mod strengthened_types {
     }
 }
 
-/// Tests involving `EAMap`s (RFC 68)
-#[cfg(test)]
-mod ea_maps {
-    use super::*;
-    use crate::cedar_schema::test::assert_entity_attr_has_type;
-    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
-    use cool_asserts::assert_matches;
-
-    #[test]
-    fn entity_attribute() {
-        // This schema taken directly from the RFC 68 text
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "jobLevel": {
-                                    "type": "Long",
-                                },
-                                "authTags": {
-                                    "type": "Record",
-                                    "default": {
-                                        "type": "Set",
-                                        "element": { "type": "String" },
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "Document": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "owner": {
-                                    "type": "Entity",
-                                    "name": "User",
-                                },
-                                "policyTags": {
-                                    "type": "Record",
-                                    "default": {
-                                        "type": "Set",
-                                        "element": { "type": "String" },
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src), Ok(frag) => {
-            let user = frag.0.get(&None).unwrap().entity_types.get(&"User".parse().unwrap()).unwrap();
-            assert_matches!(&user.shape, EntityAttributes::EntityAttributes(EntityAttributesInternal { attrs, .. }) => {
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("jobLevel").unwrap(),
-                    &EntityAttributeTypeInternal::Type(Type::Type(TypeVariant::Long)),
-                );
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("authTags").unwrap(),
-                    &EntityAttributeTypeInternal::EAMap { value_type: Type::Type(TypeVariant::Set { element: Box::new(Type::Type(TypeVariant::String)) }) },
-                );
-            });
-            let doc = frag.0.get(&None).unwrap().entity_types.get(&"Document".parse().unwrap()).unwrap();
-            assert_matches!(&doc.shape, EntityAttributes::EntityAttributes(EntityAttributesInternal { attrs, .. }) => {
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("owner").unwrap(),
-                    &EntityAttributeTypeInternal::Type(Type::Type(TypeVariant::Entity { name: "User".parse().unwrap() })),
-                );
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("policyTags").unwrap(),
-                    &EntityAttributeTypeInternal::EAMap { value_type: Type::Type(TypeVariant::Set { element: Box::new(Type::Type(TypeVariant::String)) }) },
-                );
-            });
-        });
-    }
-
-    #[test]
-    fn record_attribute_inside_entity_attribute() {
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "userDetails": {
-                                    "type": "Record",
-                                    "attributes": {
-                                        "tags": {
-                                            "type": "Record",
-                                            "default": {
-                                                "type": "String"
-                                            }
-                                        },
-                                    },
-                                }
-                            }
-                        }
-                    }
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn context_attribute() {
-        let src = serde_json::json!({
-            "": {
-                "actions": {
-                    "read": {
-                        "appliesTo": {
-                            "principalTypes": ["E"],
-                            "resourceTypes": ["E"],
-                            "context": {
-                                "type": "Record",
-                                "attributes": {
-                                    "operationDetails": {
-                                        "type": "Record",
-                                        "default": {
-                                            "type": "String"
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "entityTypes": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn toplevel_entity() {
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "default": {
-                                "type": "String"
-                            }
-                        }
-                    }
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("missing field `attributes`").build(),
-            );
-        });
-    }
-
-    #[test]
-    fn toplevel_context() {
-        let src = serde_json::json!({
-            "": {
-                "actions": {
-                    "read": {
-                        "appliesTo": {
-                            "principalTypes": ["E"],
-                            "resourceTypes": ["E"],
-                            "context": {
-                                "type": "Record",
-                                "default": {
-                                    "type": "String"
-                                },
-                            }
-                        }
-                    }
-                },
-                "entityTypes": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn common_type() {
-        let src = serde_json::json!({
-            "": {
-                "commonTypes": {
-                    "blah": {
-                        "type": "Record",
-                        "default": {
-                            "type": "String"
-                        }
-                    },
-                },
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "blah": {
-                                    "type": "blah"
-                                },
-                            }
-                        }
-                    },
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn value_type_is_common_type() {
-        let src = serde_json::json!({
-            "": {
-                "commonTypes": {
-                    "blah": {
-                        "type": "Record",
-                        "attributes": {
-                            "foo": { "type": "String" },
-                        }
-                    },
-                },
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "blah": {
-                                    "type": "Record",
-                                    "default": {
-                                        "type": "blah"
-                                    }
-                                },
-                            }
-                        }
-                    },
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src), Ok(frag) => {
-            let user = frag.0.get(&None).unwrap().entity_types.get(&"User".parse().unwrap()).unwrap();
-            assert_matches!(&user.shape, EntityAttributes::EntityAttributes(EntityAttributesInternal { attrs, .. }) => {
-                assert_entity_attr_has_type(
-                    attrs.attributes.get("blah").unwrap(),
-                    &EntityAttributeTypeInternal::EAMap { value_type: Type::CommonTypeRef { type_name: "blah".parse().unwrap() } },
-                );
-            });
-        });
-    }
-
-    #[test]
-    fn nested_ea_map() {
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "userDetails": {
-                                    "type": "Record",
-                                    "default": {
-                                        "type": "Record",
-                                        "default": {
-                                            "type": "String"
-                                        }
-                                    }
-                                },
-                            }
-                        }
-                    }
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("found an embedded attribute map type, but embedded attribute maps are not allowed in this position")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn bad_default() {
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "jobLevel": {
-                                    "type": "Long",
-                                },
-                                "authTags": {
-                                    "type": "Foo",
-                                    "default": {
-                                        "type": "Set",
-                                        "element": "String",
-                                    }
-                                }
-                            }
-                        }
-                    },
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("unknown field `default`, there are no fields")
-                    .build(),
-            );
-        });
-    }
-
-    #[test]
-    fn missing_type_record() {
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "jobLevel": {
-                                    "type": "Long",
-                                },
-                                "authTags": {
-                                    "default": {
-                                        "type": "Set",
-                                        "element": "String",
-                                    }
-                                }
-                            }
-                        }
-                    },
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("missing field `type`").build(),
-            );
-        });
-    }
-
-    #[test]
-    fn both_default_and_attributes() {
-        let src = serde_json::json!({
-            "": {
-                "entityTypes": {
-                    "User": {
-                        "shape": {
-                            "type": "Record",
-                            "attributes": {
-                                "jobLevel": {
-                                    "type": "Long",
-                                },
-                                "authTags": {
-                                    "type": "Record",
-                                    "attributes": {
-                                        "foo": {
-                                            "type": "String",
-                                        },
-                                    },
-                                    "default": {
-                                        "type": "Set",
-                                        "element": "String",
-                                    }
-                                }
-                            }
-                        }
-                    },
-                },
-                "actions": {}
-            }
-        });
-        assert_matches!(Fragment::from_json_value(src.clone()), Err(e) => {
-            expect_err(
-                &src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("fields `default` and `attributes` cannot exist on the same record type")
-                    .build(),
-            );
-        });
-    }
-}
-
 /// Check that (de)serialization works as expected.
 #[cfg(test)]
 mod test_json_roundtrip {
@@ -3501,12 +2481,10 @@ mod test_json_roundtrip {
                     "a".parse().unwrap(),
                     EntityType {
                         member_of_types: vec!["a".parse().unwrap()],
-                        shape: EntityAttributes::RecordAttributes(RecordOrContextAttributes(
-                            Type::Type(TypeVariant::Record(RecordType {
-                                attributes: BTreeMap::new(),
-                                additional_attributes: false,
-                            })),
-                        )),
+                        shape: AttributesOrContext(Type::Type(TypeVariant::Record(RecordType {
+                            attributes: BTreeMap::new(),
+                            additional_attributes: false,
+                        }))),
                     },
                 )]),
                 actions: HashMap::from([(
@@ -3516,7 +2494,12 @@ mod test_json_roundtrip {
                         applies_to: Some(ApplySpec {
                             resource_types: vec!["a".parse().unwrap()],
                             principal_types: vec!["a".parse().unwrap()],
-                            context: RecordOrContextAttributes::default(),
+                            context: AttributesOrContext(Type::Type(TypeVariant::Record(
+                                RecordType {
+                                    attributes: BTreeMap::new(),
+                                    additional_attributes: false,
+                                },
+                            ))),
                         }),
                         member_of: None,
                     },
@@ -3537,7 +2520,12 @@ mod test_json_roundtrip {
                         "a".parse().unwrap(),
                         EntityType {
                             member_of_types: vec!["a".parse().unwrap()],
-                            shape: EntityAttributes::default(),
+                            shape: AttributesOrContext(Type::Type(TypeVariant::Record(
+                                RecordType {
+                                    attributes: BTreeMap::new(),
+                                    additional_attributes: false,
+                                },
+                            ))),
                         },
                     )]),
                     actions: HashMap::new(),
@@ -3555,7 +2543,12 @@ mod test_json_roundtrip {
                             applies_to: Some(ApplySpec {
                                 resource_types: vec!["foo::a".parse().unwrap()],
                                 principal_types: vec!["foo::a".parse().unwrap()],
-                                context: RecordOrContextAttributes::default(),
+                                context: AttributesOrContext(Type::Type(TypeVariant::Record(
+                                    RecordType {
+                                        attributes: BTreeMap::new(),
+                                        additional_attributes: false,
+                                    },
+                                ))),
                             }),
                             member_of: None,
                         },
@@ -3638,7 +2631,7 @@ mod test_duplicates_error {
     }
 
     #[test]
-    #[should_panic(expected = "the key `Baz` occurs two or more times in the same JSON object")]
+    #[should_panic(expected = "invalid entry: found duplicate key")]
     fn record_type() {
         let src = r#"{
             "Foo": {

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -234,14 +234,14 @@ mod test {
                     foo_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     bar_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
             ],
@@ -251,7 +251,7 @@ mod test {
                     applies_to: Some(json_schema::ApplySpec {
                         principal_types: vec!["foo_type".parse().unwrap()],
                         resource_types: vec!["bar_type".parse().unwrap()],
-                        context: json_schema::RecordOrContextAttributes::default(),
+                        context: json_schema::AttributesOrContext::default(),
                     }),
                     member_of: None,
                     attributes: None,

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -487,7 +487,7 @@ mod test {
                 foo_type.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -521,7 +521,7 @@ mod test {
                 "foo_type".parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -606,7 +606,7 @@ mod test {
                 p_name.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -630,7 +630,7 @@ mod test {
                 p_name.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -654,7 +654,7 @@ mod test {
                 p_name.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -944,7 +944,7 @@ mod test {
                 foo_type.parse().unwrap(),
                 json_schema::EntityType {
                     member_of_types: vec![],
-                    shape: json_schema::EntityAttributes::default(),
+                    shape: json_schema::AttributesOrContext::default(),
                 },
             )],
             [],
@@ -977,14 +977,14 @@ mod test {
                     principal_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
             ],
@@ -994,7 +994,7 @@ mod test {
                     applies_to: Some(json_schema::ApplySpec {
                         resource_types: vec![resource_type.parse().unwrap()],
                         principal_types: vec![principal_type.parse().unwrap()],
-                        context: json_schema::RecordOrContextAttributes::default(),
+                        context: json_schema::AttributesOrContext::default(),
                     }),
                     member_of: Some(vec![]),
                     attributes: None,
@@ -1366,28 +1366,28 @@ mod test {
                     principal_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![resource_parent_type.parse().unwrap()],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_parent_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![resource_grandparent_type.parse().unwrap()],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
                 (
                     resource_grandparent_type.parse().unwrap(),
                     json_schema::EntityType {
                         member_of_types: vec![],
-                        shape: json_schema::EntityAttributes::default(),
+                        shape: json_schema::AttributesOrContext::default(),
                     },
                 ),
             ],
@@ -1398,7 +1398,7 @@ mod test {
                         applies_to: Some(json_schema::ApplySpec {
                             resource_types: vec![resource_type.parse().unwrap()],
                             principal_types: vec![principal_type.parse().unwrap()],
-                            context: json_schema::RecordOrContextAttributes::default(),
+                            context: json_schema::AttributesOrContext::default(),
                         }),
                         member_of: Some(vec![json_schema::ActionEntityUID::new(
                             None,

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -49,7 +49,6 @@ pub(crate) use action::ValidatorApplySpec;
 mod entity_type;
 pub use entity_type::ValidatorEntityType;
 mod namespace_def;
-use namespace_def::try_entity_attributes_into_validator_type;
 pub(crate) use namespace_def::try_jsonschema_type_into_validator_type;
 pub use namespace_def::ValidatorNamespaceDef;
 mod raw_name;
@@ -493,8 +492,8 @@ impl ValidatorSchema {
                 // `check_for_undeclared`.
                 let descendants = entity_children.remove(&name).unwrap_or_default();
                 let (attributes, open_attributes) = {
-                    let unresolved = try_entity_attributes_into_validator_type(
-                        entity_type.attributes,
+                    let unresolved = try_jsonschema_type_into_validator_type(
+                        entity_type.attributes.0,
                         extensions,
                     )?;
                     Self::record_attributes_or_none(
@@ -1257,7 +1256,7 @@ impl<'a> CommonTypeResolver<'a> {
                             .map(|(attr, attr_ty)| {
                                 Ok((
                                     attr,
-                                    json_schema::RecordAttributeType {
+                                    json_schema::TypeOfAttribute {
                                         required: attr_ty.required,
                                         ty: Self::resolve_type(resolve_table, attr_ty.ty)?,
                                     },

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -447,7 +447,7 @@ pub struct EntityTypeFragment<N> {
     /// fragment).
     /// In the extreme case, this may itself be just a common type pointing to a
     /// `Record` type defined in another fragment.
-    pub(super) attributes: json_schema::EntityAttributes<N>,
+    pub(super) attributes: json_schema::AttributesOrContext<N>,
     /// Direct parent entity types for this entity type.
     /// These entity types may be declared in a different namespace or schema
     /// fragment.
@@ -921,7 +921,7 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
             Ok(try_jsonschema_type_into_validator_type(*element, extensions)?.map(Type::set))
         }
         json_schema::Type::Type(json_schema::TypeVariant::Record(rty)) => {
-            try_record_record_type_into_validator_type(rty, extensions)
+            try_record_type_into_validator_type(rty, extensions)
         }
         json_schema::Type::Type(json_schema::TypeVariant::Entity { name }) => {
             Ok(Type::named_entity_reference(internal_name_to_entity_type(name)?).into())
@@ -985,10 +985,10 @@ pub(crate) fn try_jsonschema_type_into_validator_type(
     }
 }
 
-/// Convert a [`json_schema::RecordType<json_schema::RecordAttributeType>`]
-/// (with fully qualified names) into the [`Type`] type used by the validator.
-pub(crate) fn try_record_record_type_into_validator_type(
-    rty: json_schema::RecordType<json_schema::RecordAttributeType<InternalName>>,
+/// Convert a [`json_schema::RecordType`] (with fully qualified names) into the
+/// [`Type`] type used by the validator.
+pub(crate) fn try_record_type_into_validator_type(
+    rty: json_schema::RecordType<InternalName>,
     extensions: &Extensions<'_>,
 ) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
     if cfg!(not(feature = "partial-validate")) && rty.additional_attributes {
@@ -1009,52 +1009,12 @@ pub(crate) fn try_record_record_type_into_validator_type(
     }
 }
 
-/// Convert a [`json_schema::RecordType<json_schema::EntityAttributeType>`]
-/// (with fully qualified names) into the [`Type`] type used by the validator.
-pub(crate) fn try_record_entity_type_into_validator_type(
-    rty: json_schema::RecordType<json_schema::EntityAttributeType<InternalName>>,
-    extensions: &Extensions<'_>,
-) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
-    if cfg!(not(feature = "partial-validate")) && rty.additional_attributes {
-        Err(UnsupportedFeatureError(UnsupportedFeature::OpenRecordsAndEntities).into())
-    } else {
-        Ok(
-            parse_entity_attributes(rty.attributes, extensions)?.map(move |attrs| {
-                Type::record_with_attributes(
-                    attrs,
-                    if rty.additional_attributes {
-                        OpenTag::OpenAttributes
-                    } else {
-                        OpenTag::ClosedAttributes
-                    },
-                )
-            }),
-        )
-    }
-}
-
-/// Convert a [`json_schema::EntityAttributes`] (with fully qualified names)
-/// into the [`Type`] type used by the validator.
-pub(crate) fn try_entity_attributes_into_validator_type(
-    attrs: json_schema::EntityAttributes<InternalName>,
-    extensions: &Extensions<'_>,
-) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Type>> {
-    match attrs {
-        json_schema::EntityAttributes::RecordAttributes(attrs) => {
-            try_jsonschema_type_into_validator_type(attrs.0, extensions)
-        }
-        json_schema::EntityAttributes::EntityAttributes(
-            json_schema::EntityAttributesInternal { attrs, .. },
-        ) => try_record_entity_type_into_validator_type(attrs, extensions),
-    }
-}
-
-/// Given the attributes for a record type in the schema file format structures
-/// (but with fully-qualified names), convert the types of the attributes into
-/// the [`Type`] data structure used by the validator, and return the result as
-/// an [`Attributes`] structure.
+/// Given the attributes for an entity or record type in the schema file format
+/// structures (but with fully-qualified names), convert the types of the
+/// attributes into the [`Type`] data structure used by the validator, and
+/// return the result as an [`Attributes`] structure.
 fn parse_record_attributes(
-    attrs: impl IntoIterator<Item = (SmolStr, json_schema::RecordAttributeType<InternalName>)>,
+    attrs: impl IntoIterator<Item = (SmolStr, json_schema::TypeOfAttribute<InternalName>)>,
     extensions: &Extensions<'_>,
 ) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Attributes>> {
     let attrs_with_common_type_refs = attrs
@@ -1069,45 +1029,8 @@ fn parse_record_attributes(
             ))
         })
         .collect::<crate::err::Result<Vec<_>>>()?;
-    Ok(attributes_from_attributes(attrs_with_common_type_refs))
-}
-
-/// Given the attributes for an entity type in the schema file format structures
-/// (but with fully-qualified names), convert the types of the attributes into
-/// the [`Type`] data structure used by the validator, and return the result as
-/// an [`Attributes`] structure.
-fn parse_entity_attributes(
-    attrs: impl IntoIterator<Item = (SmolStr, json_schema::EntityAttributeType<InternalName>)>,
-    extensions: &Extensions<'_>,
-) -> crate::err::Result<WithUnresolvedCommonTypeRefs<Attributes>> {
-    let attrs_with_common_type_refs = attrs
-        .into_iter()
-        .map(|(attr, ty)| -> crate::err::Result<_> {
-            match ty.ty {
-                json_schema::EntityAttributeTypeInternal::Type(inner_ty) => {
-                    let validator_type =
-                        try_jsonschema_type_into_validator_type(inner_ty, extensions)?;
-                    Ok((attr, (validator_type, ty.required)))
-                }
-                json_schema::EntityAttributeTypeInternal::EAMap { .. } => {
-                    // This will be implemented in the next RFC 68 PR, which will
-                    // introduce the necessary changes to [`Attributes`] and its
-                    // associated types
-                    Err(UnsupportedFeatureError(UnsupportedFeature::EAMaps).into())
-                }
-            }
-        })
-        .collect::<crate::err::Result<Vec<_>>>()?;
-    Ok(attributes_from_attributes(attrs_with_common_type_refs))
-}
-
-/// Given an iterator of attribute types `(attribute name, (attribute type, is_required))`,
-/// build an [`Attributes`] structure.
-fn attributes_from_attributes(
-    attrs: impl IntoIterator<Item = (SmolStr, (WithUnresolvedCommonTypeRefs<Type>, bool))> + 'static,
-) -> WithUnresolvedCommonTypeRefs<Attributes> {
-    WithUnresolvedCommonTypeRefs::new(|common_type_defs| {
-        attrs
+    Ok(WithUnresolvedCommonTypeRefs::new(|common_type_defs| {
+        attrs_with_common_type_refs
             .into_iter()
             .map(|(s, (attr_ty, is_req))| {
                 attr_ty
@@ -1116,5 +1039,5 @@ fn attributes_from_attributes(
             })
             .collect::<crate::err::Result<Vec<_>>>()
             .map(Attributes::with_attributes)
-    })
+    }))
 }

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -27,7 +27,7 @@ use smol_str::SmolStr;
 use crate::{
     diagnostics::ValidationError,
     json_schema,
-    types::{AttributeType, Type},
+    types::Type,
     validation_errors::{AttributeAccess, LubContext, LubHelp, UnexpectedTypeHelp},
     RawName, ValidationMode,
 };
@@ -60,7 +60,7 @@ fn slot_typechecks() {
 fn slot_in_typechecks() {
     let etype = json_schema::EntityType {
         member_of_types: vec![],
-        shape: json_schema::EntityAttributes::default(),
+        shape: json_schema::AttributesOrContext::default(),
     };
     let schema = json_schema::NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
@@ -89,7 +89,7 @@ fn slot_in_typechecks() {
 fn slot_equals_typechecks() {
     let etype = json_schema::EntityType {
         member_of_types: vec![],
-        shape: json_schema::EntityAttributes::default(),
+        shape: json_schema::AttributesOrContext::default(),
     };
     // These don't typecheck in strict mode because the test_util expression
     // typechecker doesn't have access to a schema, so it can't link
@@ -795,6 +795,7 @@ fn contains_typechecks() {
 
 #[test]
 fn contains_typecheck_fails() {
+    use crate::types::AttributeType;
     let src = r#""foo".contains("bar")"#;
     assert_typecheck_fails_empty_schema(
         src.parse().unwrap(),

--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -87,6 +87,7 @@ process_types_file() {
     ' "$types_file" > "$types_file.tmp" && mv "$types_file.tmp" "$types_file"
 
     echo "type SmolStr = string;" >> "$types_file"
+    echo "export type TypeOfAttribute<N> = Type<N> & { required?: boolean };" >> "$types_file"
 }
 
 check_types_file() {


### PR DESCRIPTION
This reverts commit e63f6638276dd312178e57be97baf5fe4cf803e1 (#1136).

Not a totally clean revert, I had to resolve some conflicts.  I also chose not to revert some of the changes, eg changes to `error_macros.rs`.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)


