### PR TITLE
implement schema parsers for RFC 82

### DIFF
--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -32,7 +32,6 @@ extern {
     type Error = RawUserError;
 }
 
-// New tokens should be reflected in the `FRIENDLY_TOKEN_NAMES` map in err.rs.
 match {
     // Whitespace and comments
     r"\s*" => { }, // The default whitespace skipping is disabled an `ignore pattern` is specified

--- a/cedar-policy-validator/src/cedar_schema/ast.rs
+++ b/cedar-policy-validator/src/cedar_schema/ast.rs
@@ -216,6 +216,8 @@ pub struct EntityDecl {
     pub member_of_types: Vec<Path>,
     /// Attributes this entity has
     pub attrs: Vec<Node<AttrDecl>>,
+    /// Tag type for this entity (`None` means no tags on this entity)
+    pub tags: Option<Node<Type>>,
 }
 
 /// Type definitions

--- a/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
@@ -51,7 +51,6 @@ extern {
     type Error = RawUserError;
 }
 
-// New tokens should be reflected in the `FRIENDLY_TOKEN_NAMES` map in err.rs.
 match {
     // Whitespace and comments
     r"\s*" => { }, // The default whitespace skipping is disabled an `ignore pattern` is specified
@@ -62,6 +61,7 @@ match {
     "entity" => ENTITY,
     "in" => IN,
     "type" => TYPE,
+    "tags" => TAGS,
     "Set" => SET,
     "appliesTo" => APPLIESTO,
     "principal" => PRINCIPAL,
@@ -108,8 +108,8 @@ Decl: Node<Declaration> = {
 
 // Entity := 'entity' Idents ['in' EntOrTypes] [['='] RecType] ';'
 Entity: Node<Declaration> = {
-    <l:@L> ENTITY <ets: Idents> <ps:(IN <EntTypes>)?> <ds:("="? "{" <AttrDecls?> "}")?> ";" <r:@R>
-        => Node::with_source_loc(Declaration::Entity(EntityDecl { names: ets, member_of_types: ps.unwrap_or_default(), attrs: ds.map(|ds| ds.unwrap_or_default()).unwrap_or_default()}), Loc::new(l..r, Arc::clone(src))),
+    <l:@L> ENTITY <ets: Idents> <ps:(IN <EntTypes>)?> <ds:("="? "{" <AttrDecls?> "}")?> <ts:(TAGS <Type>)?> ";" <r:@R>
+        => Node::with_source_loc(Declaration::Entity(EntityDecl { names: ets, member_of_types: ps.unwrap_or_default(), attrs: ds.map(|ds| ds.unwrap_or_default()).unwrap_or_default(), tags: ts }), Loc::new(l..r, Arc::clone(src))),
 }
 
 // Action := 'action' Names ['in' QualNameOrNames]

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -348,6 +348,7 @@ fn convert_entity_decl(
     let etype = json_schema::EntityType {
         member_of_types: e.member_of_types.into_iter().map(RawName::from).collect(),
         shape: convert_attr_decls(e.attrs),
+        tags: e.tags.map(|tag_ty| cedar_type_to_json_type(tag_ty)),
     };
 
     // Then map over all of the bound names

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -621,8 +621,6 @@ pub mod schema_errors {
         // Action attributes are allowed if `ActionBehavior` is `PermitAttributes`
         #[error("action declared with attributes: [{}]", .0.iter().join(", "))]
         ActionAttributes(Vec<String>),
-        #[error("Entity tags (RFC 82) are not fully implemented in this version of Cedar")]
-        EntityTags,
     }
 
     /// This error is thrown when `serde_json` fails to deserialize the JSON

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -621,6 +621,8 @@ pub mod schema_errors {
         // Action attributes are allowed if `ActionBehavior` is `PermitAttributes`
         #[error("action declared with attributes: [{}]", .0.iter().join(", "))]
         ActionAttributes(Vec<String>),
+        #[error("Entity tags (RFC 82) are not fully implemented in this version of Cedar")]
+        EntityTags,
     }
 
     /// This error is thrown when `serde_json` fails to deserialize the JSON

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -235,6 +235,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
                 (
@@ -242,6 +243,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
             ],

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -488,6 +488,7 @@ mod test {
                 json_schema::EntityType {
                     member_of_types: vec![],
                     shape: json_schema::AttributesOrContext::default(),
+                    tags: None,
                 },
             )],
             [],
@@ -522,6 +523,7 @@ mod test {
                 json_schema::EntityType {
                     member_of_types: vec![],
                     shape: json_schema::AttributesOrContext::default(),
+                    tags: None,
                 },
             )],
             [],
@@ -607,6 +609,7 @@ mod test {
                 json_schema::EntityType {
                     member_of_types: vec![],
                     shape: json_schema::AttributesOrContext::default(),
+                    tags: None,
                 },
             )],
             [],
@@ -631,6 +634,7 @@ mod test {
                 json_schema::EntityType {
                     member_of_types: vec![],
                     shape: json_schema::AttributesOrContext::default(),
+                    tags: None,
                 },
             )],
             [],
@@ -655,6 +659,7 @@ mod test {
                 json_schema::EntityType {
                     member_of_types: vec![],
                     shape: json_schema::AttributesOrContext::default(),
+                    tags: None,
                 },
             )],
             [],
@@ -945,6 +950,7 @@ mod test {
                 json_schema::EntityType {
                     member_of_types: vec![],
                     shape: json_schema::AttributesOrContext::default(),
+                    tags: None,
                 },
             )],
             [],
@@ -978,6 +984,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
                 (
@@ -985,6 +992,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
             ],
@@ -1367,6 +1375,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
                 (
@@ -1374,6 +1383,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![resource_parent_type.parse().unwrap()],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
                 (
@@ -1381,6 +1391,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![resource_grandparent_type.parse().unwrap()],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
                 (
@@ -1388,6 +1399,7 @@ mod test {
                     json_schema::EntityType {
                         member_of_types: vec![],
                         shape: json_schema::AttributesOrContext::default(),
+                        tags: None,
                     },
                 ),
             ],

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -22,7 +22,7 @@ use std::collections::HashSet;
 
 use cedar_policy_core::{ast::EntityType, transitive_closure::TCNode};
 
-use crate::types::{AttributeType, Attributes, OpenTag};
+use crate::types::{AttributeType, Attributes, OpenTag, Type};
 
 /// Contains entity type information for use by the validator. The contents of
 /// the struct are the same as the schema entity type structure, but the
@@ -47,6 +47,10 @@ pub struct ValidatorEntityType {
     /// their type when they are present. Attempting to access an undeclared
     /// attribute under standard validation is an error regardless of this flag.
     pub(crate) open_attributes: OpenTag,
+
+    /// Tag type for this entity type. `None` indicates that entities of this
+    /// type are not allowed to have tags.
+    pub(crate) tags: Option<Type>,
 }
 
 impl ValidatorEntityType {
@@ -64,6 +68,12 @@ impl ValidatorEntityType {
     /// possible descendant in the schema.
     pub fn has_descendant_entity_type(&self, ety: &EntityType) -> bool {
         self.descendants.contains(ety)
+    }
+
+    /// Get the type of tags on this entity. `None` indicates that entities of
+    /// this type are not allowed to have tags.
+    pub fn tag_type(&self) -> Option<&Type> {
+        self.tags.as_ref()
     }
 }
 

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -61,6 +61,7 @@ fn slot_in_typechecks() {
     let etype = json_schema::EntityType {
         member_of_types: vec![],
         shape: json_schema::AttributesOrContext::default(),
+        tags: None,
     };
     let schema = json_schema::NamespaceDefinition::new([("typename".parse().unwrap(), etype)], []);
     assert_typechecks_for_mode(
@@ -90,6 +91,7 @@ fn slot_equals_typechecks() {
     let etype = json_schema::EntityType {
         member_of_types: vec![],
         shape: json_schema::AttributesOrContext::default(),
+        tags: None,
     };
     // These don't typecheck in strict mode because the test_util expression
     // typechecker doesn't have access to a schema, so it can't link


### PR DESCRIPTION
## Description of changes

This PR contains the schema parsing changes (both JSON and Cedar formats) for RFC 82 entity tags.  It does not contain the validator changes that would allow you to actually validate `getTag` and `hasTag` operations, but it does allow you to declare tag types on entities.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)


