### PR TITLE
add `getTag` and `hasTag` operations to AST, EST, policy parser, and evaluator

### DIFF
--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -51,6 +51,7 @@ test-util = []
 
 # Experimental features.
 partial-eval = []
+entity-tags = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [build-dependencies]

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -322,6 +322,7 @@ pub struct Entity {
     /// deterministic order.
     /// And like in `attrs`, the values in `tags` appear as `RestrictedExpr` in
     /// the serialized form of `Entity`.
+    #[cfg(feature = "entity-tags")]
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
     tags: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
 }
@@ -361,6 +362,7 @@ impl Entity {
             uid,
             attrs: evaluated_attrs,
             ancestors,
+            #[cfg(feature = "entity-tags")]
             tags: BTreeMap::new(),
         })
     }
@@ -385,6 +387,7 @@ impl Entity {
             uid,
             attrs: attrs.into_iter().map(|(k, v)| (k, v.into())).collect(), // TODO(#540): can we do this without disassembling and reassembling the HashMap
             ancestors,
+            #[cfg(feature = "entity-tags")]
             tags: BTreeMap::new(),
         }
     }
@@ -402,6 +405,7 @@ impl Entity {
             uid,
             attrs,
             ancestors,
+            #[cfg(feature = "entity-tags")]
             tags: BTreeMap::new(),
         }
     }
@@ -417,6 +421,7 @@ impl Entity {
     }
 
     /// Get the value for the given tag, or `None` if not present
+    #[cfg(feature = "entity-tags")]
     pub fn get_tag(&self, tag: &str) -> Option<&PartialValue> {
         self.tags.get(tag).map(|v| v.as_ref())
     }
@@ -437,6 +442,7 @@ impl Entity {
     }
 
     /// Get the number of tags on this entity
+    #[cfg(feature = "entity-tags")]
     pub fn tags_len(&self) -> usize {
         self.tags.len()
     }
@@ -447,6 +453,7 @@ impl Entity {
     }
 
     /// Iterate over this entity's tag names
+    #[cfg(feature = "entity-tags")]
     pub fn tag_keys(&self) -> impl Iterator<Item = &SmolStr> {
         self.tags.keys()
     }
@@ -457,6 +464,7 @@ impl Entity {
     }
 
     /// Iterate over this entity's tags
+    #[cfg(feature = "entity-tags")]
     pub fn tags(&self) -> impl Iterator<Item = (&SmolStr, &PartialValue)> {
         self.tags.iter().map(|(k, v)| (k, v.as_ref()))
     }
@@ -467,6 +475,7 @@ impl Entity {
             uid,
             attrs: BTreeMap::new(),
             ancestors: HashSet::new(),
+            #[cfg(feature = "entity-tags")]
             tags: BTreeMap::new(),
         }
     }
@@ -502,6 +511,7 @@ impl Entity {
     /// Set the given tag to the given value.
     // Only used for convenience in some tests and when fuzzing
     #[cfg(any(test, fuzzing))]
+    #[cfg(feature = "entity-tags")]
     pub fn set_tag(
         &mut self,
         tag: SmolStr,
@@ -538,13 +548,17 @@ impl Entity {
             uid,
             attrs,
             ancestors,
+            #[cfg(feature = "entity-tags")]
             tags,
         } = self;
         (
             uid,
             attrs.into_iter().map(|(k, v)| (k, v.0)).collect(),
             ancestors,
+            #[cfg(feature = "entity-tags")]
             tags.into_iter().map(|(k, v)| (k, v.0)).collect(),
+            #[cfg(not(feature = "entity-tags"))]
+            HashMap::new(),
         )
     }
 

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -416,6 +416,11 @@ impl Entity {
         self.attrs.get(attr).map(|v| v.as_ref())
     }
 
+    /// Get the value for the given tag, or `None` if not present
+    pub fn get_tag(&self, tag: &str) -> Option<&PartialValue> {
+        self.tags.get(tag).map(|v| v.as_ref())
+    }
+
     /// Is this `Entity` a descendant of `e` in the entity hierarchy?
     pub fn is_descendant_of(&self, e: &EntityUID) -> bool {
         self.ancestors.contains(e)
@@ -431,14 +436,29 @@ impl Entity {
         self.attrs.len()
     }
 
+    /// Get the number of tags on this entity
+    pub fn tags_len(&self) -> usize {
+        self.tags.len()
+    }
+
     /// Iterate over this entity's attribute names
     pub fn keys(&self) -> impl Iterator<Item = &SmolStr> {
         self.attrs.keys()
     }
 
+    /// Iterate over this entity's tag names
+    pub fn tag_keys(&self) -> impl Iterator<Item = &SmolStr> {
+        self.tags.keys()
+    }
+
     /// Iterate over this entity's attributes
     pub fn attrs(&self) -> impl Iterator<Item = (&SmolStr, &PartialValue)> {
         self.attrs.iter().map(|(k, v)| (k, v.as_ref()))
+    }
+
+    /// Iterate over this entity's tags
+    pub fn tags(&self) -> impl Iterator<Item = (&SmolStr, &PartialValue)> {
+        self.tags.iter().map(|(k, v)| (k, v.as_ref()))
     }
 
     /// Create an `Entity` with the given UID, no attributes, no parents, and no tags.
@@ -458,6 +478,13 @@ impl Entity {
         self.uid == other.uid && self.attrs == other.attrs && self.ancestors == other.ancestors
     }
 
+    /// Set the UID to the given value.
+    // Only used for convenience in some tests
+    #[cfg(test)]
+    pub fn set_uid(&mut self, uid: EntityUID) {
+        self.uid = uid;
+    }
+
     /// Set the given attribute to the given value.
     // Only used for convenience in some tests and when fuzzing
     #[cfg(any(test, fuzzing))]
@@ -469,6 +496,20 @@ impl Entity {
     ) -> Result<(), EvaluationError> {
         let val = RestrictedEvaluator::new(extensions).partial_interpret(val.as_borrowed())?;
         self.attrs.insert(attr, val.into());
+        Ok(())
+    }
+
+    /// Set the given tag to the given value.
+    // Only used for convenience in some tests and when fuzzing
+    #[cfg(any(test, fuzzing))]
+    pub fn set_tag(
+        &mut self,
+        tag: SmolStr,
+        val: RestrictedExpr,
+        extensions: &Extensions<'_>,
+    ) -> Result<(), EvaluationError> {
+        let val = RestrictedEvaluator::new(extensions).partial_interpret(val.as_borrowed())?;
+        self.tags.insert(tag, val.into());
         Ok(())
     }
 

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -366,8 +366,12 @@ impl<T> Expr<T> {
                     | BinaryOp::Eq
                     | BinaryOp::In
                     | BinaryOp::Less
-                    | BinaryOp::LessEq
-                    | BinaryOp::HasTag,
+                    | BinaryOp::LessEq,
+                ..
+            } => Some(Type::Bool),
+            #[cfg(feature = "entity-tags")]
+            ExprKind::BinaryApp {
+                op: BinaryOp::HasTag,
                 ..
             } => Some(Type::Bool),
             ExprKind::ExtensionFunctionApp { fn_name, .. } => extensions
@@ -381,6 +385,7 @@ impl<T> Expr<T> {
             // attribute.
             ExprKind::GetAttr { .. } => None,
             // similarly to `GetAttr`
+            #[cfg(feature = "entity-tags")]
             ExprKind::BinaryApp {
                 op: BinaryOp::GetTag,
                 ..
@@ -523,12 +528,14 @@ impl Expr {
 
     /// Create a `getTag` expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
+    #[cfg(feature = "entity-tags")]
     pub fn get_tag(expr: Expr, tag: Expr) -> Self {
         ExprBuilder::new().get_tag(expr, tag)
     }
 
     /// Create a `hasTag` expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
+    #[cfg(feature = "entity-tags")]
     pub fn has_tag(expr: Expr, tag: Expr) -> Self {
         ExprBuilder::new().has_tag(expr, tag)
     }
@@ -1104,6 +1111,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create a 'getTag' expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
+    #[cfg(feature = "entity-tags")]
     pub fn get_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::GetTag,
@@ -1114,6 +1122,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create a 'hasTag' expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
+    #[cfg(feature = "entity-tags")]
     pub fn has_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::HasTag,

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -56,11 +56,7 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
                 self.expression_stack.push(then_expr);
                 self.expression_stack.push(else_expr);
             }
-            ExprKind::And { left, right } => {
-                self.expression_stack.push(left);
-                self.expression_stack.push(right);
-            }
-            ExprKind::Or { left, right } => {
+            ExprKind::And { left, right } | ExprKind::Or { left, right } => {
                 self.expression_stack.push(left);
                 self.expression_stack.push(right);
             }
@@ -71,28 +67,20 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
                 self.expression_stack.push(arg1);
                 self.expression_stack.push(arg2);
             }
-            ExprKind::ExtensionFunctionApp { args, .. } => {
-                for arg in args.as_ref() {
-                    self.expression_stack.push(arg);
-                }
-            }
-            ExprKind::GetAttr { expr, attr: _ } => {
+            ExprKind::GetAttr { expr, attr: _ }
+            | ExprKind::HasAttr { expr, attr: _ }
+            | ExprKind::Like { expr, pattern: _ }
+            | ExprKind::Is {
+                expr,
+                entity_type: _,
+            } => {
                 self.expression_stack.push(expr);
             }
-            ExprKind::HasAttr { expr, attr: _ } => {
-                self.expression_stack.push(expr);
-            }
-            ExprKind::Like { expr, pattern: _ } => {
-                self.expression_stack.push(expr);
-            }
-            ExprKind::Set(elems) => {
-                self.expression_stack.extend(elems.as_ref());
+            ExprKind::ExtensionFunctionApp { args: exprs, .. } | ExprKind::Set(exprs) => {
+                self.expression_stack.extend(exprs.as_ref());
             }
             ExprKind::Record(map) => {
                 self.expression_stack.extend(map.values());
-            }
-            ExprKind::Is { expr, .. } => {
-                self.expression_stack.push(expr);
             }
         }
         Some(next_expr)

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -93,11 +93,13 @@ pub enum BinaryOp {
     /// Get a tag of an entity.
     ///
     /// First argument must have Entity type, second argument must have String type.
+    #[cfg(feature = "entity-tags")]
     GetTag,
 
     /// Does the given `expr` have the given `tag`?
     ///
     /// First argument must have Entity type, second argument must have String type.
+    #[cfg(feature = "entity-tags")]
     HasTag,
 }
 
@@ -123,7 +125,9 @@ impl std::fmt::Display for BinaryOp {
             BinaryOp::Contains => write!(f, "contains"),
             BinaryOp::ContainsAll => write!(f, "containsAll"),
             BinaryOp::ContainsAny => write!(f, "containsAny"),
+            #[cfg(feature = "entity-tags")]
             BinaryOp::GetTag => write!(f, "getTag"),
+            #[cfg(feature = "entity-tags")]
             BinaryOp::HasTag => write!(f, "hasTag"),
         }
     }

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -89,6 +89,16 @@ pub enum BinaryOp {
     ///
     /// Arguments must have Set type
     ContainsAny,
+
+    /// Get a tag of an entity.
+    ///
+    /// First argument must have Entity type, second argument must have String type.
+    GetTag,
+
+    /// Does the given `expr` have the given `tag`?
+    ///
+    /// First argument must have Entity type, second argument must have String type.
+    HasTag,
 }
 
 impl std::fmt::Display for UnaryOp {
@@ -113,6 +123,8 @@ impl std::fmt::Display for BinaryOp {
             BinaryOp::Contains => write!(f, "contains"),
             BinaryOp::ContainsAll => write!(f, "containsAll"),
             BinaryOp::ContainsAny => write!(f, "containsAny"),
+            BinaryOp::GetTag => write!(f, "getTag"),
+            BinaryOp::HasTag => write!(f, "hasTag"),
         }
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -2214,6 +2214,139 @@ mod test {
     }
 
     #[test]
+    fn entity_tags() {
+        let policy = r#"
+            permit(principal, action, resource)
+            when {
+                resource.hasTag("writeable")
+                && resource.getTag("writeable").contains(principal.group)
+                && principal.hasTag(context.foo)
+                && principal.getTag(context.foo) == 72
+            };
+        "#;
+        let cst = parser::text_to_cst::parse_policy(policy)
+            .unwrap()
+            .node
+            .unwrap();
+        let est: Policy = cst.try_into().unwrap();
+        let expected_json = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "All",
+                },
+                "action": {
+                    "op": "All",
+                },
+                "resource": {
+                    "op": "All",
+                },
+                "conditions": [
+                    {
+                        "kind": "when",
+                        "body": {
+                            "&&": {
+                                "left": {
+                                    "&&": {
+                                        "left": {
+                                            "&&": {
+                                                "left": {
+                                                    "hasTag": {
+                                                        "left": {
+                                                            "Var": "resource"
+                                                        },
+                                                        "right": {
+                                                            "Value": "writeable"
+                                                        }
+                                                    }
+                                                },
+                                                "right": {
+                                                    "contains": {
+                                                        "left": {
+                                                            "getTag": {
+                                                                "left": {
+                                                                    "Var": "resource"
+                                                                },
+                                                                "right": {
+                                                                    "Value": "writeable"
+                                                                }
+                                                            }
+                                                        },
+                                                        "right": {
+                                                            ".": {
+                                                                "left": {
+                                                                    "Var": "principal"
+                                                                },
+                                                                "attr": "group"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "right": {
+                                            "hasTag": {
+                                                "left": {
+                                                    "Var": "principal"
+                                                },
+                                                "right": {
+                                                    ".": {
+                                                        "left": {
+                                                            "Var": "context",
+                                                        },
+                                                        "attr": "foo"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                    }
+                                },
+                                "right": {
+                                    "==": {
+                                        "left": {
+                                            "getTag": {
+                                                "left": {
+                                                    "Var": "principal"
+                                                },
+                                                "right": {
+                                                    ".": {
+                                                        "left": {
+                                                            "Var": "context",
+                                                        },
+                                                        "attr": "foo"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "right": {
+                                            "Value": 72
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        );
+        assert_eq!(
+            serde_json::to_value(&est).unwrap(),
+            expected_json,
+            "\nExpected:\n{}\n\nActual:\n{}\n\n",
+            serde_json::to_string_pretty(&expected_json).unwrap(),
+            serde_json::to_string_pretty(&est).unwrap()
+        );
+        let old_est = est.clone();
+        let roundtripped = est_roundtrip(est);
+        assert_eq!(&old_est, &roundtripped);
+        let est = text_roundtrip(&old_est);
+        assert_eq!(&old_est, &est);
+
+        assert_eq!(ast_roundtrip(est.clone()), est);
+        assert_eq!(circular_roundtrip(est.clone()), est);
+    }
+
+    #[test]
     fn like_special_patterns() {
         let policy = r#"
         permit(principal, action, resource)

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -2342,7 +2342,9 @@ mod test {
         let est = text_roundtrip(&old_est);
         assert_eq!(&old_est, &est);
 
+        #[cfg(feature = "entity-tags")]
         assert_eq!(ast_roundtrip(est.clone()), est);
+        #[cfg(feature = "entity-tags")]
         assert_eq!(circular_roundtrip(est.clone()), est);
     }
 

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -78,6 +78,10 @@ pub enum FromJsonError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionType(#[from] parse_errors::InvalidActionType),
+    /// Returned when a policy uses entity tags, but the `entity-tags` feature is not enabled
+    #[cfg(not(feature = "entity-tags"))]
+    #[error("entity tags are not supported in this build; to use entity tags, you must enable the `entity-tags` experimental feature")]
+    UnsupportedEntityTags,
 }
 
 /// Errors arising while converting a policy set from its JSON representation (aka EST) into an AST

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -240,6 +240,22 @@ pub enum ExprNoExt {
         /// Right-hand argument (inside the `()`)
         right: Arc<Expr>,
     },
+    /// `getTag()`
+    #[serde(rename = "getTag")]
+    GetTag {
+        /// Left-hand argument (receiver)
+        left: Arc<Expr>,
+        /// Right-hand argument (inside the `()`)
+        right: Arc<Expr>,
+    },
+    /// `hasTag()`
+    #[serde(rename = "hasTag")]
+    HasTag {
+        /// Left-hand argument (receiver)
+        left: Arc<Expr>,
+        /// Right-hand argument (inside the `()`)
+        right: Arc<Expr>,
+    },
     /// Get-attribute
     #[serde(rename = ".")]
     GetAttr {
@@ -478,6 +494,22 @@ impl Expr {
         })
     }
 
+    /// `left.getTag(right)`
+    pub fn get_tag(left: Arc<Expr>, right: Expr) -> Self {
+        Expr::ExprNoExt(ExprNoExt::GetTag {
+            left,
+            right: Arc::new(right),
+        })
+    }
+
+    /// `left.hasTag(right)`
+    pub fn has_tag(left: Arc<Expr>, right: Expr) -> Self {
+        Expr::ExprNoExt(ExprNoExt::HasTag {
+            left,
+            right: Arc::new(right),
+        })
+    }
+
     /// `left.attr`
     pub fn get_attr(left: Expr, attr: SmolStr) -> Self {
         Expr::ExprNoExt(ExprNoExt::GetAttr {
@@ -633,6 +665,14 @@ impl Expr {
                 (*left).clone().try_into_ast(id.clone())?,
                 (*right).clone().try_into_ast(id)?,
             )),
+            Expr::ExprNoExt(ExprNoExt::GetTag { left, right }) => Ok(ast::Expr::get_tag(
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
+            )),
+            Expr::ExprNoExt(ExprNoExt::HasTag { left, right }) => Ok(ast::Expr::has_tag(
+                (*left).clone().try_into_ast(id.clone())?,
+                (*right).clone().try_into_ast(id)?,
+            )),
             Expr::ExprNoExt(ExprNoExt::GetAttr { left, attr }) => {
                 Ok(ast::Expr::get_attr((*left).clone().try_into_ast(id)?, attr))
             }
@@ -768,6 +808,8 @@ impl From<ast::Expr> for Expr {
                     ast::BinaryOp::Contains => Expr::contains(Arc::new(arg1), arg2),
                     ast::BinaryOp::ContainsAll => Expr::contains_all(Arc::new(arg1), arg2),
                     ast::BinaryOp::ContainsAny => Expr::contains_any(Arc::new(arg1), arg2),
+                    ast::BinaryOp::GetTag => Expr::get_tag(Arc::new(arg1), arg2),
+                    ast::BinaryOp::HasTag => Expr::has_tag(Arc::new(arg1), arg2),
                 }
             }
             ast::ExprKind::ExtensionFunctionApp { fn_name, args } => {
@@ -1216,6 +1258,14 @@ impl TryFrom<&Node<Option<cst::Member>>> for Expr {
                                     left,
                                     extract_single_argument(args, "containsAny()", &access.loc)?,
                                 )),
+                                "getTag" => Either::Right(Expr::get_tag(
+                                    left,
+                                    extract_single_argument(args, "getTag()", &access.loc)?,
+                                )),
+                                "hasTag" => Either::Right(Expr::has_tag(
+                                    left,
+                                    extract_single_argument(args, "hasTag()", &access.loc)?,
+                                )),
                                 _ => {
                                     // have to add the "receiver" argument as
                                     // first in the list for the method call
@@ -1513,6 +1563,14 @@ impl std::fmt::Display for ExprNoExt {
                 maybe_with_parens(f, left)?;
                 write!(f, ".containsAny({right})")
             }
+            ExprNoExt::GetTag { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, ".getTag({right})")
+            }
+            ExprNoExt::HasTag { left, right } => {
+                maybe_with_parens(f, left)?;
+                write!(f, ".hasTag({right})")
+            }
             ExprNoExt::GetAttr { left, attr } => {
                 maybe_with_parens(f, left)?;
                 write!(f, "[\"{}\"]", attr.escape_debug())
@@ -1629,6 +1687,8 @@ fn maybe_with_parens(f: &mut std::fmt::Formatter<'_>, expr: &Expr) -> std::fmt::
         Expr::ExprNoExt(ExprNoExt::Contains { .. }) |
         Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) |
         Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) |
+        Expr::ExprNoExt(ExprNoExt::GetTag { .. }) |
+        Expr::ExprNoExt(ExprNoExt::HasTag { .. }) |
         Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) |
         Expr::ExprNoExt(ExprNoExt::HasAttr { .. }) |
         Expr::ExprNoExt(ExprNoExt::Like { .. }) |

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -665,14 +665,20 @@ impl Expr {
                 (*left).clone().try_into_ast(id.clone())?,
                 (*right).clone().try_into_ast(id)?,
             )),
+            #[cfg(feature = "entity-tags")]
             Expr::ExprNoExt(ExprNoExt::GetTag { left, right }) => Ok(ast::Expr::get_tag(
                 (*left).clone().try_into_ast(id.clone())?,
                 (*right).clone().try_into_ast(id)?,
             )),
+            #[cfg(not(feature = "entity-tags"))]
+            Expr::ExprNoExt(ExprNoExt::GetTag { .. }) => Err(FromJsonError::UnsupportedEntityTags),
+            #[cfg(feature = "entity-tags")]
             Expr::ExprNoExt(ExprNoExt::HasTag { left, right }) => Ok(ast::Expr::has_tag(
                 (*left).clone().try_into_ast(id.clone())?,
                 (*right).clone().try_into_ast(id)?,
             )),
+            #[cfg(not(feature = "entity-tags"))]
+            Expr::ExprNoExt(ExprNoExt::HasTag { .. }) => Err(FromJsonError::UnsupportedEntityTags),
             Expr::ExprNoExt(ExprNoExt::GetAttr { left, attr }) => {
                 Ok(ast::Expr::get_attr((*left).clone().try_into_ast(id)?, attr))
             }
@@ -808,7 +814,9 @@ impl From<ast::Expr> for Expr {
                     ast::BinaryOp::Contains => Expr::contains(Arc::new(arg1), arg2),
                     ast::BinaryOp::ContainsAll => Expr::contains_all(Arc::new(arg1), arg2),
                     ast::BinaryOp::ContainsAny => Expr::contains_any(Arc::new(arg1), arg2),
+                    #[cfg(feature = "entity-tags")]
                     ast::BinaryOp::GetTag => Expr::get_tag(Arc::new(arg1), arg2),
+                    #[cfg(feature = "entity-tags")]
                     ast::BinaryOp::HasTag => Expr::has_tag(Arc::new(arg1), arg2),
                 }
             }
@@ -1687,10 +1695,10 @@ fn maybe_with_parens(f: &mut std::fmt::Formatter<'_>, expr: &Expr) -> std::fmt::
         Expr::ExprNoExt(ExprNoExt::Contains { .. }) |
         Expr::ExprNoExt(ExprNoExt::ContainsAll { .. }) |
         Expr::ExprNoExt(ExprNoExt::ContainsAny { .. }) |
-        Expr::ExprNoExt(ExprNoExt::GetTag { .. }) |
-        Expr::ExprNoExt(ExprNoExt::HasTag { .. }) |
         Expr::ExprNoExt(ExprNoExt::GetAttr { .. }) |
         Expr::ExprNoExt(ExprNoExt::HasAttr { .. }) |
+        Expr::ExprNoExt(ExprNoExt::GetTag { .. }) |
+        Expr::ExprNoExt(ExprNoExt::HasTag { .. }) |
         Expr::ExprNoExt(ExprNoExt::Like { .. }) |
         Expr::ExprNoExt(ExprNoExt::Is { .. }) |
         Expr::ExprNoExt(ExprNoExt::If { .. }) |

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1464,11 +1464,19 @@ pub mod test {
             )),
             Ok(Value::from(false))
         );
-        // hasTag on an entity that has tags, but not that one
+        // hasTag on an entity that has tags, but not that one (and no attrs exist)
         assert_eq!(
             eval.interpret_inline_policy(&Expr::has_tag(
                 Expr::val(EntityUID::with_eid("entity_with_tags")),
                 Expr::val("doesnotexist"),
+            )),
+            Ok(Value::from(false))
+        );
+        // hasTag on an entity that has tags, but not that one (but does have an attr of that name)
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags_and_attrs")),
+                Expr::val("address"),
             )),
             Ok(Value::from(false))
         );

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -532,6 +532,7 @@ impl<'e> Evaluator<'e> {
                         }
                     }
                     // GetTag and HasTag, which require an Entity on the left and a String on the right
+                    #[cfg(feature = "entity-tags")]
                     BinaryOp::GetTag | BinaryOp::HasTag => {
                         let uid = arg1.get_as_entity()?;
                         let tag = arg2.get_as_string()?;
@@ -820,7 +821,10 @@ impl<'e> Evaluator<'e> {
                             uid,
                             attr.clone(),
                             entity.keys(),
+                            #[cfg(feature = "entity-tags")]
                             entity.get_tag(attr).is_some(),
+                            #[cfg(not(feature = "entity-tags"))]
+                            false,
                             entity.attrs_len(),
                             source_loc.cloned(),
                         )
@@ -1047,6 +1051,7 @@ pub mod test {
             )
             .unwrap();
         let mut entity_with_tags = Entity::with_uid(EntityUID::with_eid("entity_with_tags"));
+        #[cfg(feature = "entity-tags")]
         entity_with_tags
             .set_tag(
                 "spoon".into(),
@@ -1056,6 +1061,7 @@ pub mod test {
             .unwrap();
         let mut entity_with_tags_and_attrs = entity_with_attrs.clone();
         entity_with_tags_and_attrs.set_uid(EntityUID::with_eid("entity_with_tags_and_attrs"));
+        #[cfg(feature = "entity-tags")]
         entity_with_tags_and_attrs
             .set_tag(
                 "spoon".into(),
@@ -1402,13 +1408,17 @@ pub mod test {
                 assert_eq!(&e.attr_or_tag, "spoon");
                 let available_attrs = e.available_attrs_or_tags;
                 assert_eq!(available_attrs.len(), 0);
-                expect_err(
-                    "",
-                    &report,
-                    &ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags"` does not have the attribute `spoon`"#)
+                #[cfg(feature = "entity-tags")]
+                let expected_error_message =
+                    ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags"` does not have the attribute `spoon`"#)
                         .help(r#"`test_entity_type::"entity_with_tags"` does not have any attributes; note that a tag (not an attribute) named `spoon` does exist"#)
-                        .build()
-                );
+                        .build();
+                #[cfg(not(feature = "entity-tags"))]
+                let expected_error_message =
+                    ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags"` does not have the attribute `spoon`"#)
+                        .help(r#"`test_entity_type::"entity_with_tags"` does not have any attributes"#)
+                        .build();
+                expect_err("", &report, &expected_error_message);
             }
         );
         // get_attr on an attr which does exist (and has integer type)
@@ -1452,6 +1462,7 @@ pub mod test {
     }
 
     #[test]
+    #[cfg(feature = "entity-tags")]
     fn interpret_entity_tags() {
         let request = basic_request();
         let entities = rich_entities();

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1016,6 +1016,7 @@ pub mod test {
     pub fn rich_entities() -> Entities {
         let entity_no_attrs_no_parents =
             Entity::with_uid(EntityUID::with_eid("entity_no_attrs_no_parents"));
+
         let mut entity_with_attrs = Entity::with_uid(EntityUID::with_eid("entity_with_attrs"));
         entity_with_attrs
             .set_attr("spoon".into(), RestrictedExpr::val(787), Extensions::none())
@@ -1050,6 +1051,8 @@ pub mod test {
                 Extensions::none(),
             )
             .unwrap();
+
+        #[cfg(feature = "entity-tags")]
         let mut entity_with_tags = Entity::with_uid(EntityUID::with_eid("entity_with_tags"));
         #[cfg(feature = "entity-tags")]
         entity_with_tags
@@ -1059,6 +1062,10 @@ pub mod test {
                 Extensions::none(),
             )
             .unwrap();
+
+        #[cfg(not(feature = "entity-tags"))]
+        let entity_with_tags = Entity::with_uid(EntityUID::with_eid("entity_with_tags"));
+
         let mut entity_with_tags_and_attrs = entity_with_attrs.clone();
         entity_with_tags_and_attrs.set_uid(EntityUID::with_eid("entity_with_tags_and_attrs"));
         #[cfg(feature = "entity-tags")]
@@ -1069,6 +1076,7 @@ pub mod test {
                 Extensions::none(),
             )
             .unwrap();
+
         let mut child = Entity::with_uid(EntityUID::with_eid("child"));
         let mut parent = Entity::with_uid(EntityUID::with_eid("parent"));
         let grandparent = Entity::with_uid(EntityUID::with_eid("grandparent"));
@@ -1083,6 +1091,7 @@ pub mod test {
         );
         child_diff_type.add_ancestor(parent.uid().clone());
         child_diff_type.add_ancestor(grandparent.uid().clone());
+
         Entities::from_entities(
             vec![
                 entity_no_attrs_no_parents,

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -531,6 +531,54 @@ impl<'e> Evaluator<'e> {
                             }
                         }
                     }
+                    // GetTag and HasTag, which require an Entity on the left and a String on the right
+                    BinaryOp::GetTag | BinaryOp::HasTag => {
+                        let uid = arg1.get_as_entity()?;
+                        let tag = arg2.get_as_string()?;
+                        match op {
+                            BinaryOp::GetTag => {
+                                match self.entities.entity(uid) {
+                                    Dereference::NoSuchEntity => {
+                                        // intentionally using the location of the euid (the LHS) and not the entire GetTag expression
+                                        Err(EvaluationError::entity_does_not_exist(
+                                            Arc::new(uid.clone()),
+                                            arg1.source_loc().cloned(),
+                                        ))
+                                    }
+                                    Dereference::Residual(r) => Ok(PartialValue::Residual(
+                                        Expr::get_tag(r, Expr::val(tag.clone())),
+                                    )),
+                                    Dereference::Data(entity) => entity
+                                        .get_tag(tag)
+                                        .ok_or_else(|| {
+                                            EvaluationError::entity_tag_does_not_exist(
+                                                Arc::new(uid.clone()),
+                                                tag.clone(),
+                                                entity.tag_keys(),
+                                                entity.get(tag).is_some(),
+                                                entity.tags_len(),
+                                                loc.cloned(), // intentionally using the location of the entire `GetTag` expression
+                                            )
+                                        })
+                                        .cloned(),
+                                }
+                            }
+                            BinaryOp::HasTag => match self.entities.entity(uid) {
+                                Dereference::NoSuchEntity => Ok(false.into()),
+                                Dereference::Residual(r) => Ok(PartialValue::Residual(
+                                    Expr::has_tag(r, Expr::val(tag.clone())),
+                                )),
+                                Dereference::Data(entity) => {
+                                    Ok(entity.get_tag(tag).is_some().into())
+                                }
+                            },
+                            // PANIC SAFETY `op` is checked to be one of these two above
+                            #[allow(clippy::unreachable)]
+                            _ => {
+                                unreachable!("Should have already checked that op was one of these")
+                            }
+                        }
+                    }
                 }
             }
             ExprKind::ExtensionFunctionApp { fn_name, args } => {
@@ -772,6 +820,7 @@ impl<'e> Evaluator<'e> {
                             uid,
                             attr.clone(),
                             entity.keys(),
+                            entity.get_tag(attr).is_some(),
                             entity.attrs_len(),
                             source_loc.cloned(),
                         )
@@ -911,6 +960,7 @@ pub mod test {
     use crate::{
         entities::{EntityJsonParser, NoEntitiesSchema, TCComputation},
         parser::{self, parse_expr, parse_policy_or_template, parse_policyset},
+        test_utils::{expect_err, ExpectedErrorMessageBuilder},
     };
 
     use cool_asserts::assert_matches;
@@ -968,6 +1018,13 @@ pub mod test {
             .unwrap();
         entity_with_attrs
             .set_attr(
+                "fork".into(),
+                RestrictedExpr::val("spoon"),
+                Extensions::none(),
+            )
+            .unwrap();
+        entity_with_attrs
+            .set_attr(
                 "tags".into(),
                 RestrictedExpr::set(vec![
                     RestrictedExpr::val("fun"),
@@ -989,6 +1046,23 @@ pub mod test {
                 Extensions::none(),
             )
             .unwrap();
+        let mut entity_with_tags = Entity::with_uid(EntityUID::with_eid("entity_with_tags"));
+        entity_with_tags
+            .set_tag(
+                "spoon".into(),
+                RestrictedExpr::val(-121),
+                Extensions::none(),
+            )
+            .unwrap();
+        let mut entity_with_tags_and_attrs = entity_with_attrs.clone();
+        entity_with_tags_and_attrs.set_uid(EntityUID::with_eid("entity_with_tags_and_attrs"));
+        entity_with_tags_and_attrs
+            .set_tag(
+                "spoon".into(),
+                RestrictedExpr::val(-121),
+                Extensions::none(),
+            )
+            .unwrap();
         let mut child = Entity::with_uid(EntityUID::with_eid("child"));
         let mut parent = Entity::with_uid(EntityUID::with_eid("parent"));
         let grandparent = Entity::with_uid(EntityUID::with_eid("grandparent"));
@@ -1007,6 +1081,8 @@ pub mod test {
             vec![
                 entity_no_attrs_no_parents,
                 entity_with_attrs,
+                entity_with_tags,
+                entity_with_tags_and_attrs,
                 child,
                 child_diff_type,
                 parent,
@@ -1290,20 +1366,49 @@ pub mod test {
             )),
             Ok(Value::from(true))
         );
-        // get_attr on an attr which doesn't exist
+        // get_attr on an attr which doesn't exist (and no tags exist)
         assert_matches!(
             eval.interpret_inline_policy(&Expr::get_attr(
                 Expr::val(EntityUID::with_eid("entity_with_attrs")),
                 "doesnotexist".into()
             )),
             Err(EvaluationError::EntityAttrDoesNotExist(e)) => {
+                let report = miette::Report::new(e.clone());
                 assert_eq!(e.entity.as_ref(), &EntityUID::with_eid("entity_with_attrs"));
-                assert_eq!(&e.attr, "doesnotexist");
-                let available_attrs = e.available_attrs;
-                assert_eq!(available_attrs.len(), 3);
+                assert_eq!(&e.attr_or_tag, "doesnotexist");
+                let available_attrs = e.available_attrs_or_tags;
+                assert_eq!(available_attrs.len(), 4);
                 assert!(available_attrs.contains(&"spoon".into()));
                 assert!(available_attrs.contains(&"address".into()));
                 assert!(available_attrs.contains(&"tags".into()));
+                expect_err(
+                    "",
+                    &report,
+                    &ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_attrs"` does not have the attribute `doesnotexist`"#)
+                        .help("available attributes: [address,fork,spoon,tags]")
+                        .build()
+                );
+            }
+        );
+        // get_attr on an attr which doesn't exist (but the corresponding tag does)
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::get_attr(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                "spoon".into()
+            )),
+            Err(EvaluationError::EntityAttrDoesNotExist(e)) => {
+                let report = miette::Report::new(e.clone());
+                assert_eq!(e.entity.as_ref(), &EntityUID::with_eid("entity_with_tags"));
+                assert_eq!(&e.attr_or_tag, "spoon");
+                let available_attrs = e.available_attrs_or_tags;
+                assert_eq!(available_attrs.len(), 0);
+                expect_err(
+                    "",
+                    &report,
+                    &ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags"` does not have the attribute `spoon`"#)
+                        .help(r#"`test_entity_type::"entity_with_tags"` does not have any attributes; note that a tag (not an attribute) named `spoon` does exist"#)
+                        .build()
+                );
             }
         );
         // get_attr on an attr which does exist (and has integer type)
@@ -1318,7 +1423,7 @@ pub mod test {
         assert_eq!(
             eval.interpret_inline_policy(&Expr::contains(
                 Expr::get_attr(
-                    Expr::val(EntityUID::with_eid("entity_with_attrs")),
+                    Expr::val(EntityUID::with_eid("entity_with_tags_and_attrs")),
                     "tags".into()
                 ),
                 Expr::val("useful")
@@ -1343,6 +1448,216 @@ pub mod test {
                 Arc::new(EntityUID::with_eid("doesnotexist")),
                 None
             ))
+        );
+    }
+
+    #[test]
+    fn interpret_entity_tags() {
+        let request = basic_request();
+        let entities = rich_entities();
+        let eval = Evaluator::new(request, &entities, Extensions::none());
+        // hasTag on an entity with no tags
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("entity_no_attrs_no_parents")),
+                Expr::val("doesnotexist"),
+            )),
+            Ok(Value::from(false))
+        );
+        // hasTag on an entity that has tags, but not that one
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::val("doesnotexist"),
+            )),
+            Ok(Value::from(false))
+        );
+        // hasTag where the response is true
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::val("spoon"),
+            )),
+            Ok(Value::from(true))
+        );
+        // hasTag, with a computed key, where the response is true
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::get_attr(
+                    Expr::val(EntityUID::with_eid("entity_with_tags_and_attrs")),
+                    "fork".into()
+                ),
+            )),
+            Ok(Value::from(true))
+        );
+        // getTag on a tag which doesn't exist (and no attrs exist)
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::val("doesnotexist"),
+            )),
+            Err(EvaluationError::EntityAttrDoesNotExist(e)) => {
+                let report = miette::Report::new(e.clone());
+                assert_eq!(e.entity.as_ref(), &EntityUID::with_eid("entity_with_tags"));
+                assert_eq!(&e.attr_or_tag, "doesnotexist");
+                let available_attrs = e.available_attrs_or_tags;
+                assert_eq!(available_attrs.len(), 1);
+                assert!(available_attrs.contains(&"spoon".into()));
+                expect_err(
+                    "",
+                    &report,
+                    &ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags"` does not have the tag `doesnotexist`"#)
+                        .help("available tags: [spoon]")
+                        .build()
+                );
+            }
+        );
+        // getTag on a tag which doesn't exist (but the corresponding attr does)
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags_and_attrs")),
+                Expr::val("address"),
+            )),
+            Err(EvaluationError::EntityAttrDoesNotExist(e)) => {
+                let report = miette::Report::new(e.clone());
+                assert_eq!(e.entity.as_ref(), &EntityUID::with_eid("entity_with_tags_and_attrs"));
+                assert_eq!(&e.attr_or_tag, "address");
+                let available_attrs = e.available_attrs_or_tags;
+                assert_eq!(available_attrs.len(), 1);
+                assert!(available_attrs.contains(&"spoon".into()));
+                expect_err(
+                    "",
+                    &report,
+                    &ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags_and_attrs"` does not have the tag `address`"#)
+                        .help("available tags: [spoon]; note that an attribute (not a tag) named `address` does exist")
+                        .build()
+                );
+            }
+        );
+        // getTag on a tag which does exist (and has integer type)
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::val("spoon"),
+            )),
+            Ok(Value::from(-121))
+        );
+        // getTag with a computed key on a tag which does exist
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::get_attr(
+                    Expr::val(EntityUID::with_eid("entity_with_attrs")),
+                    "fork".into()
+                ),
+            )),
+            Ok(Value::from(-121))
+        );
+        // getTag with a computed key on a tag which doesn't exist
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::get_attr(
+                    Expr::get_attr(
+                        Expr::val(EntityUID::with_eid("entity_with_attrs")),
+                        "address".into()
+                    ),
+                    "country".into()
+                ),
+            )),
+            Err(e) => {
+                expect_err(
+                    "",
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error(r#"`test_entity_type::"entity_with_tags"` does not have the tag `amazonia`"#)
+                        .help("available tags: [spoon]")
+                        .build(),
+                )
+            }
+        );
+        // hasTag on an entity which doesn't exist
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("doesnotexist")),
+                Expr::val("foo"),
+            )),
+            Ok(Value::from(false))
+        );
+        // getTag on an entity which doesn't exist
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("doesnotexist")),
+                Expr::val("foo"),
+            )),
+            Err(EvaluationError::entity_does_not_exist(
+                Arc::new(EntityUID::with_eid("doesnotexist")),
+                None
+            ))
+        );
+        // getTag on something that's not an entity
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::record([
+                    ("spoon".into(), Expr::val(78)),
+                ]).unwrap(),
+                Expr::val("spoon"),
+            )),
+            Err(e) => {
+                expect_err(
+                    "",
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error("type error: expected (entity of type `any_entity_type`), got record")
+                        .build()
+                );
+            }
+        );
+        // hasTag on something that's not an entity
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::record([
+                    ("spoon".into(), Expr::val(78)),
+                ]).unwrap(),
+                Expr::val("spoon"),
+            )),
+            Err(e) => {
+                expect_err(
+                    "",
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error("type error: expected (entity of type `any_entity_type`), got record")
+                        .build()
+                );
+            }
+        );
+        // getTag with a computed key that doesn't evaluate to a String
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::get_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::get_attr(Expr::val(EntityUID::with_eid("entity_with_attrs")), "spoon".into()),
+            )),
+            Err(e) => {
+                expect_err(
+                    "",
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error("type error: expected string, got long")
+                        .build()
+                );
+            }
+        );
+        // hasTag with a computed key that doesn't evaluate to a String
+        assert_matches!(
+            eval.interpret_inline_policy(&Expr::has_tag(
+                Expr::val(EntityUID::with_eid("entity_with_tags")),
+                Expr::get_attr(Expr::val(EntityUID::with_eid("entity_with_attrs")), "spoon".into()),
+            )),
+            Err(e) => {
+                expect_err(
+                    "",
+                    &miette::Report::new(e),
+                    &ExpectedErrorMessageBuilder::error("type error: expected string, got long")
+                        .build()
+                );
+            }
         );
     }
 
@@ -2100,6 +2415,7 @@ pub mod test {
             Arc::new(r#"Foo::"bar""#.parse().unwrap()),
             "foo".into(),
             expected_keys.iter(),
+            false,
             7,
             None,
         );

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -23,7 +23,7 @@ use smol_str::SmolStr;
 use std::sync::Arc;
 use thiserror::Error;
 
-// How many attrs will we store in an error before cutting off for performance reason
+// How many attrs or tags will we store in an error before cutting off for performance reason
 const TOO_MANY_ATTRS: usize = 5;
 
 /// Enumeration of the possible errors that can occur during evaluation
@@ -39,8 +39,8 @@ pub enum EvaluationError {
     #[diagnostic(transparent)]
     EntityDoesNotExist(#[from] evaluation_errors::EntityDoesNotExistError),
 
-    /// Tried to get an attribute, but the specified entity didn't
-    /// have that attribute
+    /// Tried to get an attribute or tag, but the specified entity didn't
+    /// have that attribute or tag
     #[error(transparent)]
     #[diagnostic(transparent)]
     EntityAttrDoesNotExist(#[from] evaluation_errors::EntityAttrDoesNotExistError),
@@ -166,22 +166,54 @@ impl EvaluationError {
     }
 
     /// Construct a [`EntityAttrDoesNotExist`] error
+    ///
+    /// `does_attr_exist_as_a_tag`: does `attr` exist on `entity` as a tag (rather than an attribute)
     pub(crate) fn entity_attr_does_not_exist<'a>(
         entity: Arc<EntityUID>,
         attr: SmolStr,
         available_attrs: impl IntoIterator<Item = &'a SmolStr>,
+        does_attr_exist_as_a_tag: bool,
         total_attrs: usize,
         source_loc: Option<Loc>,
     ) -> Self {
         evaluation_errors::EntityAttrDoesNotExistError {
             entity,
-            attr,
-            available_attrs: available_attrs
+            attr_or_tag: attr,
+            was_attr: true,
+            exists_the_other_kind: does_attr_exist_as_a_tag,
+            available_attrs_or_tags: available_attrs
                 .into_iter()
                 .take(TOO_MANY_ATTRS)
                 .cloned()
                 .collect::<Vec<_>>(),
-            total_attrs,
+            total_attrs_or_tags: total_attrs,
+            source_loc,
+        }
+        .into()
+    }
+
+    /// Construct an error for the case where an entity tag does not exist
+    ///
+    /// `does_tag_exist_as_an_attr`: does `tag` exist on `entity` as an attribute (rather than a tag)
+    pub(crate) fn entity_tag_does_not_exist<'a>(
+        entity: Arc<EntityUID>,
+        tag: SmolStr,
+        available_tags: impl IntoIterator<Item = &'a SmolStr>,
+        does_tag_exist_as_an_attr: bool,
+        total_tags: usize,
+        source_loc: Option<Loc>,
+    ) -> Self {
+        evaluation_errors::EntityAttrDoesNotExistError {
+            entity,
+            attr_or_tag: tag,
+            was_attr: false,
+            exists_the_other_kind: does_tag_exist_as_an_attr,
+            available_attrs_or_tags: available_tags
+                .into_iter()
+                .take(TOO_MANY_ATTRS)
+                .cloned()
+                .collect::<Vec<_>>(),
+            total_attrs_or_tags: total_tags,
             source_loc,
         }
         .into()
@@ -340,16 +372,21 @@ pub mod evaluation_errors {
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
-    #[error("`{entity}` does not have the attribute `{attr}`")]
+    #[error("`{entity}` does not have the {} `{attr_or_tag}`", if *.was_attr { "attribute" } else { "tag" })]
     pub struct EntityAttrDoesNotExistError {
         /// Entity that didn't have the attribute
         pub(crate) entity: Arc<EntityUID>,
-        /// Name of the attribute it didn't have
-        pub(crate) attr: SmolStr,
-        /// (First five) Available attributes on the entity
-        pub(crate) available_attrs: Vec<SmolStr>,
-        /// Total number of attributes on the entity
-        pub(crate) total_attrs: usize,
+        /// Name of the attribute or tag it didn't have
+        pub(crate) attr_or_tag: SmolStr,
+        /// Whether this was an attempted attribute access (`true`) or tag access (`false`)
+        pub(crate) was_attr: bool,
+        /// If `true`, this is a case where we tried accessing an attribute but
+        /// there's a tag of that name, or vice versa
+        pub(crate) exists_the_other_kind: bool,
+        /// (First five) Available attributes/tags on the entity, depending on `was_attr`
+        pub(crate) available_attrs_or_tags: Vec<SmolStr>,
+        /// Total number of attributes/tags on the entity, depending on `was_attr`
+        pub(crate) total_attrs_or_tags: usize,
         /// Source location
         pub(crate) source_loc: Option<Loc>,
     }
@@ -358,20 +395,43 @@ pub mod evaluation_errors {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            if self.available_attrs.is_empty() {
-                Some(Box::new("entity does not have any attributes"))
-            } else if self.available_attrs.len() == self.total_attrs {
-                Some(Box::new(format!(
-                    "Available attributes: {:?}",
-                    self.available_attrs
-                )))
+            let mut help_text = if self.available_attrs_or_tags.is_empty() {
+                format!(
+                    "`{}` does not have any {}",
+                    &self.entity,
+                    if self.was_attr { "attributes" } else { "tags" }
+                )
+            } else if self.available_attrs_or_tags.len() == self.total_attrs_or_tags {
+                format!(
+                    "available {}: [{}]",
+                    if self.was_attr { "attributes" } else { "tags" },
+                    self.available_attrs_or_tags.iter().join(",")
+                )
             } else {
-                Some(Box::new(format!(
-                    "available attributes: [{}, ... ({} more attributes) ]",
-                    self.available_attrs.iter().join(","),
-                    self.total_attrs - self.available_attrs.len()
-                )))
+                format!(
+                    "available {}: [{}, ... ({} more attributes) ]",
+                    if self.was_attr { "attributes" } else { "tags" },
+                    self.available_attrs_or_tags.iter().join(","),
+                    self.total_attrs_or_tags - self.available_attrs_or_tags.len()
+                )
+            };
+            if self.exists_the_other_kind {
+                help_text.push_str(&format!(
+                    "; note that {} (not {}) named `{}` does exist",
+                    if self.was_attr {
+                        "a tag"
+                    } else {
+                        "an attribute"
+                    },
+                    if self.was_attr {
+                        "an attribute"
+                    } else {
+                        "a tag"
+                    },
+                    self.attr_or_tag,
+                ));
             }
+            Some(Box::new(help_text))
         }
     }
 

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -195,6 +195,7 @@ impl EvaluationError {
     /// Construct an error for the case where an entity tag does not exist
     ///
     /// `does_tag_exist_as_an_attr`: does `tag` exist on `entity` as an attribute (rather than a tag)
+    #[cfg(feature = "entity-tags")]
     pub(crate) fn entity_tag_does_not_exist<'a>(
         entity: Arc<EntityUID>,
         tag: SmolStr,

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -614,10 +614,6 @@ mod tests {
     /// Tests parser+evaluator with builtin methods `containsAll()`, `hasTag()`, `getTag()`
     #[test]
     fn interpret_methods() {
-        let request = eval::test::basic_request();
-        let entities = eval::test::basic_entities();
-        let exts = Extensions::none();
-        let evaluator = eval::Evaluator::new(request, &entities, exts);
         // The below tests check not only that we get the expected `Value`, but
         // that it has the expected source location.
         // See note on this in the above test.
@@ -628,6 +624,11 @@ mod tests {
         "#;
         #[cfg(feature = "entity-tags")]
         {
+            let request = eval::test::basic_request();
+            let entities = eval::test::basic_entities();
+            let exts = Extensions::none();
+            let evaluator = eval::Evaluator::new(request, &entities, exts);
+
             let expr = parse_expr(src).unwrap();
             assert_matches!(evaluator.interpret_inline_policy(&expr), Err(e) => {
                 expect_err(

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -459,10 +459,16 @@ impl ast::UnreservedId {
                 .map(|arg| construct_method_contains_all(e, arg, loc.clone())),
             "containsAny" => extract_single_argument(args.into_iter(), "containsAny", loc)
                 .map(|arg| construct_method_contains_any(e, arg, loc.clone())),
+            #[cfg(feature = "entity-tags")]
             "getTag" => extract_single_argument(args.into_iter(), "getTag", loc)
                 .map(|arg| construct_method_getTag(e, arg, loc.clone())),
+            #[cfg(not(feature = "entity-tags"))]
+            "getTag" => Err(ToASTError::new(ToASTErrorKind::UnsupportedEntityTags, loc.clone()).into()),
+            #[cfg(feature = "entity-tags")]
             "hasTag" => extract_single_argument(args.into_iter(), "hasTag", loc)
                 .map(|arg| construct_method_hasTag(e, arg, loc.clone())),
+            #[cfg(not(feature = "entity-tags"))]
+            "hasTag" => Err(ToASTError::new(ToASTErrorKind::UnsupportedEntityTags, loc.clone()).into()),
             _ => {
                 if EXTENSION_STYLES.methods.contains(self) {
                     let args = NonEmpty {
@@ -1804,9 +1810,11 @@ fn construct_method_contains_any(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast:
         .with_source_loc(loc)
         .contains_any(e0, e1)
 }
+#[cfg(feature = "entity-tags")]
 fn construct_method_getTag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
     ast::ExprBuilder::new().with_source_loc(loc).get_tag(e0, e1)
 }
+#[cfg(feature = "entity-tags")]
 fn construct_method_hasTag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
     ast::ExprBuilder::new().with_source_loc(loc).has_tag(e0, e1)
 }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -459,6 +459,10 @@ impl ast::UnreservedId {
                 .map(|arg| construct_method_contains_all(e, arg, loc.clone())),
             "containsAny" => extract_single_argument(args.into_iter(), "containsAny", loc)
                 .map(|arg| construct_method_contains_any(e, arg, loc.clone())),
+            "getTag" => extract_single_argument(args.into_iter(), "getTag", loc)
+                .map(|arg| construct_method_getTag(e, arg, loc.clone())),
+            "hasTag" => extract_single_argument(args.into_iter(), "hasTag", loc)
+                .map(|arg| construct_method_hasTag(e, arg, loc.clone())),
             _ => {
                 if EXTENSION_STYLES.methods.contains(self) {
                     let args = NonEmpty {
@@ -1514,7 +1518,10 @@ impl ast::Name {
         if self.0.path.is_empty() {
             let id = self.basename();
             if EXTENSION_STYLES.methods.contains(&id)
-                || matches!(id.as_ref(), "contains" | "containsAll" | "containsAny")
+                || matches!(
+                    id.as_ref(),
+                    "contains" | "containsAll" | "containsAny" | "getTag" | "hasTag"
+                )
             {
                 return Err(ToASTError::new(
                     ToASTErrorKind::FunctionCallOnMethod(self.basename()),
@@ -1796,6 +1803,12 @@ fn construct_method_contains_any(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast:
     ast::ExprBuilder::new()
         .with_source_loc(loc)
         .contains_any(e0, e1)
+}
+fn construct_method_getTag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
+    ast::ExprBuilder::new().with_source_loc(loc).get_tag(e0, e1)
+}
+fn construct_method_hasTag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
+    ast::ExprBuilder::new().with_source_loc(loc).has_tag(e0, e1)
 }
 
 fn construct_ext_meth(n: UnreservedId, args: NonEmpty<ast::Expr>, loc: Loc) -> ast::Expr {

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -463,12 +463,16 @@ impl ast::UnreservedId {
             "getTag" => extract_single_argument(args.into_iter(), "getTag", loc)
                 .map(|arg| construct_method_getTag(e, arg, loc.clone())),
             #[cfg(not(feature = "entity-tags"))]
-            "getTag" => Err(ToASTError::new(ToASTErrorKind::UnsupportedEntityTags, loc.clone()).into()),
+            "getTag" => {
+                Err(ToASTError::new(ToASTErrorKind::UnsupportedEntityTags, loc.clone()).into())
+            }
             #[cfg(feature = "entity-tags")]
             "hasTag" => extract_single_argument(args.into_iter(), "hasTag", loc)
                 .map(|arg| construct_method_hasTag(e, arg, loc.clone())),
             #[cfg(not(feature = "entity-tags"))]
-            "hasTag" => Err(ToASTError::new(ToASTErrorKind::UnsupportedEntityTags, loc.clone()).into()),
+            "hasTag" => {
+                Err(ToASTError::new(ToASTErrorKind::UnsupportedEntityTags, loc.clone()).into())
+            }
             _ => {
                 if EXTENSION_STYLES.methods.contains(self) {
                     let args = NonEmpty {

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -371,6 +371,10 @@ pub enum ToASTErrorKind {
     #[error("when `is` and `in` are used together, `is` must come first")]
     #[diagnostic(help("try `_ is _ in _`"))]
     InvertedIsIn,
+    /// Returned when a policy uses entity tags, but the `entity-tags` feature is not enabled
+    #[cfg(not(feature = "entity-tags"))]
+    #[error("entity tags are not supported in this build; to use entity tags, you must enable the `entity-tags` experimental feature")]
+    UnsupportedEntityTags,
 }
 
 impl ToASTErrorKind {

--- a/cedar-policy-validator/src/entity_manifest.rs
+++ b/cedar-policy-validator/src/entity_manifest.rs
@@ -524,6 +524,7 @@ fn add_to_root_trie(
                 add_to_root_trie(root_trie, arg2, policy_id, should_load_all)?;
                 Ok(())
             }
+            #[cfg(feature = "entity-tags")]
             BinaryOp::GetTag | BinaryOp::HasTag => {
                 unimplemented!("interaction between RFCs 74 and 82")
             }

--- a/cedar-policy-validator/src/entity_manifest.rs
+++ b/cedar-policy-validator/src/entity_manifest.rs
@@ -524,6 +524,9 @@ fn add_to_root_trie(
                 add_to_root_trie(root_trie, arg2, policy_id, should_load_all)?;
                 Ok(())
             }
+            BinaryOp::GetTag | BinaryOp::HasTag => {
+                unimplemented!("interaction between RFCs 74 and 82")
+            }
         },
         ExprKind::ExtensionFunctionApp { fn_name: _, args } => {
             // WARNING: this code assumes that extension functions

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1417,6 +1417,10 @@ impl<'a> Typechecker<'a> {
                     })
                 })
             }
+
+            BinaryOp::GetTag | BinaryOp::HasTag => {
+                unimplemented!("validation for .getTag() and .hasTag() operations")
+            }
         }
     }
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1418,6 +1418,7 @@ impl<'a> Typechecker<'a> {
                 })
             }
 
+            #[cfg(feature = "entity-tags")]
             BinaryOp::GetTag | BinaryOp::HasTag => {
                 unimplemented!("validation for .getTag() and .hasTag() operations")
             }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,7 @@ Cedar Language Version: TBD
 ### Added
 
 - Implemented [RFC 82](https://github.com/cedar-policy/rfcs/pull/82), adding
-  entity tags to the Cedar language (#1204, #1207, more coming)
+  entity tags to the Cedar language under experimental flag `entity-tags` (#1204, #1207, more coming)
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)
   that provides the Entity Manifest: a data
   structure that describes what data is required to satisfy a

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -13,6 +13,8 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 Cedar Language Version: TBD
 
 ### Added
+- Implemented [RFC 82](https://github.com/cedar-policy/rfcs/pull/82), adding
+  entity tags to the Cedar language (#1204, more coming)
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)
   that provides the Entity Manifest: a data
   structure that describes what data is required to satisfy a

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,7 @@ Cedar Language Version: TBD
 ### Added
 
 - Implemented [RFC 82](https://github.com/cedar-policy/rfcs/pull/82), adding
-  entity tags to the Cedar language (#1204, more coming)
+  entity tags to the Cedar language (#1204, #1207, more coming)
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)
   that provides the Entity Manifest: a data
   structure that describes what data is required to satisfy a

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -47,7 +47,7 @@ corpus-timing = []
 # Enable all experimental features with `cargo build --features "experimental"`
 experimental = ["partial-eval", "permissive-validate", "partial-validate", "entity-manifest", "entity-tags"]
 entity-manifest = ["cedar-policy-validator/entity-manifest"]
-entity-tags = ["cedar-policy-validator/entity-tags"]
+entity-tags = ["cedar-policy-core/entity-tags", "cedar-policy-validator/entity-tags"]
 partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []
 partial-validate = ["cedar-policy-validator/partial-validate"]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -192,7 +192,7 @@ impl Entity {
         HashMap<String, RestrictedExpression>,
         HashSet<EntityUid>,
     ) {
-        let (uid, attrs, ancestors) = self.0.into_inner();
+        let (uid, attrs, ancestors, _) = self.0.into_inner();
 
         let attrs = attrs
             .into_iter()


### PR DESCRIPTION
## Description of changes

Handle `getTag` and `hasTag` operations in AST, EST, policy parser, and evaluator

## Issue #, if available

Part of [RFC 82](https://github.com/cedar-policy/rfcs/pull/82)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

