### PR TITLE
fix accepting `tags` as an attr name

### DIFF
--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -622,6 +622,18 @@ mod tests {
     }
 
     #[test]
+    fn attr_named_tags() {
+        let src = r#"
+            permit(principal, action, resource)
+            when {
+                resource.tags.contains({k: "foo", v: "bar"})
+            };
+        "#;
+        parse_policy_to_est_and_ast(None, src)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+    }
+
+    #[test]
     fn test_parse_policyset() {
         use crate::ast::PolicyID;
         let multiple_policies = r#"

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -72,6 +72,7 @@ lazy_static! {
             ("TYPE", "`type`"),
             ("SET", "`Set`"),
             ("IDENTIFIER", "identifier"),
+            ("TAGS", "`tags`"),
         ]),
         impossible_tokens: HashSet::new(),
         special_identifier_tokens: HashSet::from([
@@ -85,6 +86,7 @@ lazy_static! {
             "RESOURCE",
             "CONTEXT",
             "ATTRIBUTES",
+            "TAGS",
             "LONG",
             "STRING",
             "BOOL",

--- a/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
@@ -61,7 +61,6 @@ match {
     "entity" => ENTITY,
     "in" => IN,
     "type" => TYPE,
-    "tags" => TAGS,
     "Set" => SET,
     "appliesTo" => APPLIESTO,
     "principal" => PRINCIPAL,
@@ -69,6 +68,7 @@ match {
     "resource" => RESOURCE,
     "context" => CONTEXT,
     "attributes" => ATTRIBUTES,
+    "tags" => TAGS,
     "Long" => LONG,
     "String" => STRING,
     "Bool" => BOOL,
@@ -220,6 +220,8 @@ Ident: Node<Id> = {
         => Node::with_source_loc("context".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> ATTRIBUTES <r:@R>
         => Node::with_source_loc("attributes".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
+    <l:@L> TAGS <r:@R>
+        => Node::with_source_loc("tags".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> BOOL <r:@R>
         => Node::with_source_loc("Bool".parse().unwrap(), Loc::new(l..r, Arc::clone(src))),
     <l:@L> LONG <r:@R>

--- a/cedar-policy-validator/src/cedar_schema/test.rs
+++ b/cedar-policy-validator/src/cedar_schema/test.rs
@@ -35,7 +35,7 @@ mod demo_tests {
             err::{ToJsonSchemaError, NO_PR_HELP_MSG},
         },
         json_schema,
-        schema::test::collect_warnings,
+        schema::test::utils::collect_warnings,
         CedarSchemaError, RawName,
     };
 
@@ -1168,7 +1168,7 @@ mod translator_tests {
             to_json_schema::cedar_schema_to_json_schema,
         },
         json_schema,
-        schema::test::collect_warnings,
+        schema::test::utils::collect_warnings,
         types::{EntityLUB, EntityRecordKind, Primitive, Type},
         ValidatorSchema,
     };
@@ -2302,7 +2302,7 @@ mod common_type_references {
 #[cfg(test)]
 mod entity_tags {
     use crate::json_schema;
-    use crate::schema::test::collect_warnings;
+    use crate::schema::test::utils::collect_warnings;
     use cedar_policy_core::extensions::Extensions;
     use cool_asserts::assert_matches;
 

--- a/cedar-policy-validator/src/schema/test_579.rs
+++ b/cedar-policy-validator/src/schema/test_579.rs
@@ -60,7 +60,7 @@
 //! we only do the test for the more sensible one. (For instance, for 1a1, we
 //! only test an entity type reference, not a common type reference.)
 
-use super::{test::collect_warnings, SchemaWarning, ValidatorSchema};
+use super::{test::utils::collect_warnings, SchemaWarning, ValidatorSchema};
 use cedar_policy_core::extensions::Extensions;
 use cedar_policy_core::test_utils::{
     expect_err, ExpectedErrorMessage, ExpectedErrorMessageBuilder,


### PR DESCRIPTION
## Description of changes

Bugfix for unreleased code, specifically #1204.  1204 accidentally disallowed `tags` as an attribute name, which would be a breaking change.  This PR fixes that, and adds appropriate tests.  Also moves around a couple test utilities so that they can be used by the new test.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


