### PR TITLE
hide RFC 82 implementation behind entity-tags crate feature

### DIFF
--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -47,6 +47,7 @@ arbitrary = ["dep:arbitrary", "cedar-policy-core/arbitrary"]
 partial-validate = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 entity-manifest = []
+entity-tags = []
 
 [dev-dependencies]
 similar-asserts = "1.5.0"

--- a/cedar-policy-validator/src/err.rs
+++ b/cedar-policy-validator/src/err.rs
@@ -616,11 +616,15 @@ pub mod schema_errors {
 
     #[derive(Debug, Diagnostic, Error)]
     pub(crate) enum UnsupportedFeature {
+        #[cfg(not(feature = "partial-validate"))]
         #[error("records and entities with `additionalAttributes` are experimental, but the experimental `partial-validate` feature is not enabled")]
         OpenRecordsAndEntities,
         // Action attributes are allowed if `ActionBehavior` is `PermitAttributes`
         #[error("action declared with attributes: [{}]", .0.iter().join(", "))]
         ActionAttributes(Vec<String>),
+        #[cfg(not(feature = "entity-tags"))]
+        #[error("entity tags are not supported in this build; to use entity tags, you must enable the `entity-tags` experimental feature")]
+        EntityTags,
     }
 
     /// This error is thrown when `serde_json` fails to deserialize the JSON

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -22,7 +22,9 @@ use std::collections::HashSet;
 
 use cedar_policy_core::{ast::EntityType, transitive_closure::TCNode};
 
-use crate::types::{AttributeType, Attributes, OpenTag, Type};
+use crate::types::{AttributeType, Attributes, OpenTag};
+#[cfg(feature = "entity-tags")]
+use crate::types::Type;
 
 /// Contains entity type information for use by the validator. The contents of
 /// the struct are the same as the schema entity type structure, but the
@@ -50,6 +52,7 @@ pub struct ValidatorEntityType {
 
     /// Tag type for this entity type. `None` indicates that entities of this
     /// type are not allowed to have tags.
+    #[cfg(feature = "entity-tags")]
     pub(crate) tags: Option<Type>,
 }
 
@@ -72,6 +75,7 @@ impl ValidatorEntityType {
 
     /// Get the type of tags on this entity. `None` indicates that entities of
     /// this type are not allowed to have tags.
+    #[cfg(feature = "entity-tags")]
     pub fn tag_type(&self) -> Option<&Type> {
         self.tags.as_ref()
     }

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -45,8 +45,9 @@ corpus-timing = []
 
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
-experimental = ["partial-eval", "permissive-validate", "partial-validate", "entity-manifest"]
+experimental = ["partial-eval", "permissive-validate", "partial-validate", "entity-manifest", "entity-tags"]
 entity-manifest = ["cedar-policy-validator/entity-manifest"]
+entity-tags = ["cedar-policy-validator/entity-tags"]
 partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []
 partial-validate = ["cedar-policy-validator/partial-validate"]


### PR DESCRIPTION
## Description of changes

Hides the existing RFC 82 implementation code (#1204) behind an experimental feature flag, `entity-tags`.

This PR chooses to leave the parser grammar and JSON structures the same, and only report an error at the point we construct a `ValidatorSchema`. This enables us to have a much nicer error message if someone tries to use tags without enabling the feature.  It does mean that a lot of the "experimental" parser code is not deactivated when the feature is deactivated, but I think this is acceptable.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)


