### PR TITLE
handle RFC 82 entity tags in entity JSON parsing, including schema-based

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -466,7 +466,9 @@ mod json_parsing_tests {
         );
         let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        parser.from_json_value(v).unwrap();
+        parser
+            .from_json_value(v)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
     }
 
     #[test]
@@ -493,7 +495,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -531,7 +535,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -568,7 +574,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -609,7 +617,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -646,7 +656,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -685,7 +697,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -723,7 +737,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -748,7 +764,9 @@ mod json_parsing_tests {
             {"uid":{ "type" : "Test", "id" : "jeff" }, "attrs" : {}, "parents" : []},
             {"uid":{ "type" : "Test", "id" : "jeff" }, "attrs" : {}, "parents" : []}]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -767,7 +785,9 @@ mod json_parsing_tests {
         let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([{"uid":{ "type": "Test", "id": "alice" }, "attrs" : {}, "parents" : []}]);
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -820,7 +840,9 @@ mod json_parsing_tests {
                 },
             ]
         );
-        parser.from_json_value(json).expect("JSON is correct")
+        parser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
     }
 
     /// Ensure the initial conditions of the entities still hold
@@ -881,7 +903,7 @@ mod json_parsing_tests {
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let es = eparser
             .from_json_value(json)
-            .expect("JSON is correct")
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
             .partial();
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
@@ -930,13 +952,24 @@ mod json_parsing_tests {
                 },
                 "attrs": {},
                 "parents": []
+            },
+            {
+                "uid" : {
+                    "type" : "test_entity_type",
+                    "id" : "josephine"
+                },
+                "attrs": {},
+                "parents": [],
+                "tags": {}
             }
             ]
         );
 
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let es = eparser.from_json_value(json).expect("JSON is correct");
+        let es = eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
         // Double check transitive closure computation
@@ -1166,7 +1199,9 @@ mod json_parsing_tests {
 
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let es = eparser.from_json_value(json).expect("JSON is correct");
+        let es = eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
         assert_eq!(alice.get("bacon"), Some(&PartialValue::from("eggs")));
@@ -1255,7 +1290,9 @@ mod json_parsing_tests {
 
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let es = eparser.from_json_value(json).expect("JSON is correct");
+        let es = eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
 
         // check that all five entities exist
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
@@ -1692,15 +1729,26 @@ mod json_parsing_tests {
                         vec![RestrictedExpr::val("222.222.222.222")],
                     ),
                 ),
-            ]
-            .into_iter()
-            .collect(),
+            ],
             [
                 EntityUID::with_eid("parent1"),
                 EntityUID::with_eid("parent2"),
             ]
             .into_iter()
             .collect(),
+            #[cfg(feature = "entity-tags")]
+            [
+                // note that `foo` is also an attribute, with a different type
+                ("foo".into(), RestrictedExpr::val(2345)),
+                // note that `bar` is also an attribute, with the same type
+                ("bar".into(), RestrictedExpr::val(-1)),
+                // note that `pancakes` is not an attribute. Also note that, in
+                // this non-schema world, tags need not all have the same type.
+                (
+                    "pancakes".into(),
+                    RestrictedExpr::val(EntityUID::with_eid("pancakes")),
+                ),
+            ],
             Extensions::all_available(),
         )
         .unwrap();
@@ -1726,15 +1774,15 @@ mod json_parsing_tests {
                 // record literal that happens to look like an escape
                 "oops".into(),
                 RestrictedExpr::record([("__entity".into(), RestrictedExpr::val("hi"))]).unwrap(),
-            )]
-            .into_iter()
-            .collect(),
+            )],
             [
                 EntityUID::with_eid("parent1"),
                 EntityUID::with_eid("parent2"),
             ]
             .into_iter()
             .collect(),
+            #[cfg(feature = "entity-tags")]
+            [],
             Extensions::all_available(),
         )
         .unwrap();
@@ -1801,7 +1849,9 @@ mod json_parsing_tests {
         );
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        assert_matches!(eparser.from_json_value(json), Ok(_));
+        eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
     }
 
     /// test that duplicate keys in a record is an error
@@ -1935,6 +1985,7 @@ mod entities_tests {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod schema_based_parsing_tests {
+    use super::json::NullEntityTypeDescription;
     use super::*;
     use crate::extensions::Extensions;
     use crate::test_utils::*;
@@ -1944,7 +1995,7 @@ mod schema_based_parsing_tests {
     use std::collections::HashSet;
     use std::sync::Arc;
 
-    /// Mock schema impl used for these tests
+    /// Mock schema impl used for most of these tests
     struct MockSchema;
     impl Schema for MockSchema {
         type EntityTypeDescription = MockEmployeeDescription;
@@ -1991,7 +2042,45 @@ mod schema_based_parsing_tests {
         }
     }
 
-    /// Mock schema impl for the `Employee` type used in these tests
+    /// Mock schema impl with an entity type that doesn't have a tags declaration
+    struct MockSchemaNoTags;
+    impl Schema for MockSchemaNoTags {
+        type EntityTypeDescription = NullEntityTypeDescription;
+        type ActionEntityIterator = std::iter::Empty<Arc<Entity>>;
+        fn entity_type(&self, entity_type: &EntityType) -> Option<NullEntityTypeDescription> {
+            match entity_type.to_string().as_str() {
+                "Employee" => Some(NullEntityTypeDescription::new("Employee".parse().unwrap())),
+                _ => None,
+            }
+        }
+        fn action(&self, action: &EntityUID) -> Option<Arc<Entity>> {
+            match action.to_string().as_str() {
+                r#"Action::"view""# => Some(Arc::new(Entity::with_uid(
+                    r#"Action::"view""#.parse().expect("valid uid"),
+                ))),
+                _ => None,
+            }
+        }
+        fn entity_types_with_basename<'a>(
+            &'a self,
+            basename: &'a UnreservedId,
+        ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
+            match basename.as_ref() {
+                "Employee" => Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+                    basename.clone(),
+                )))),
+                "Action" => Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+                    basename.clone(),
+                )))),
+                _ => Box::new(std::iter::empty()),
+            }
+        }
+        fn action_entities(&self) -> Self::ActionEntityIterator {
+            std::iter::empty()
+        }
+    }
+
+    /// Mock schema impl for the `Employee` type used in most of these tests
     struct MockEmployeeDescription;
     impl EntityTypeDescription for MockEmployeeDescription {
         fn entity_type(&self) -> EntityType {
@@ -2056,6 +2145,13 @@ mod schema_based_parsing_tests {
             }
         }
 
+        #[cfg(feature = "entity-tags")]
+        fn tag_type(&self) -> Option<SchemaType> {
+            Some(SchemaType::Set {
+                element_ty: Box::new(SchemaType::String),
+            })
+        }
+
         fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
             Box::new(
                 [
@@ -2087,6 +2183,7 @@ mod schema_based_parsing_tests {
     /// JSON that should parse differently with and without the above schema
     #[test]
     fn with_and_without_schema() {
+        #[cfg(feature = "entity-tags")]
         let entitiesjson = json!(
             [
                 {
@@ -2110,7 +2207,38 @@ mod schema_based_parsing_tests {
                         "trust_score": "5.7",
                         "tricky": { "type": "Employee", "id": "34FB87" }
                     },
-                    "parents": []
+                    "parents": [],
+                    "tags": {
+                        "someTag": ["pancakes"],
+                    },
+                }
+            ]
+        );
+        #[cfg(not(feature = "entity-tags"))]
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": [],
                 }
             ]
         );
@@ -2121,7 +2249,7 @@ mod schema_based_parsing_tests {
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let parsed = eparser
             .from_json_value(entitiesjson.clone())
-            .expect("Should parse without error");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(parsed.iter().count(), 1);
         let parsed = parsed
             .entity(&r#"Employee::"12UA45""#.parse().unwrap())
@@ -2196,7 +2324,7 @@ mod schema_based_parsing_tests {
         );
         let parsed = eparser
             .from_json_value(entitiesjson)
-            .expect("Should parse without error");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(parsed.iter().count(), 1);
         let parsed = parsed
             .entity(&r#"Employee::"12UA45""#.parse().unwrap())
@@ -2205,6 +2333,15 @@ mod schema_based_parsing_tests {
             .get("isFullTime")
             .expect("isFullTime attr should exist");
         assert_eq!(is_full_time, &PartialValue::Value(Value::from(true)),);
+        #[cfg(feature = "entity-tags")]
+        let some_tag = parsed
+            .get_tag("someTag")
+            .expect("someTag attr should exist");
+        #[cfg(feature = "entity-tags")]
+        assert_eq!(
+            some_tag,
+            &PartialValue::Value(Value::set(["pancakes".into()], None))
+        );
         let num_direct_reports = parsed
             .get("numDirectReports")
             .expect("numDirectReports attr should exist");
@@ -2600,6 +2737,7 @@ mod schema_based_parsing_tests {
             );
         });
 
+        // this version with explicit __entity and __extn escapes should also pass
         let entitiesjson = json!(
             [
                 {
@@ -2629,7 +2767,64 @@ mod schema_based_parsing_tests {
         );
         let _ = eparser
             .from_json_value(entitiesjson)
-            .expect("this version with explicit __entity and __extn escapes should also pass");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+    }
+
+    /// tag has the wrong type
+    #[test]
+    fn type_mismatch_in_tag() {
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": [],
+                    "tags": {
+                        "someTag": "pancakes",
+                    }
+                }
+            ]
+        );
+        let eparser = EntityJsonParser::new(
+            Some(&MockSchema),
+            Extensions::all_available(),
+            TCComputation::ComputeNow,
+        );
+        #[cfg(feature = "entity-tags")]
+        let expected_error_msg =
+            ExpectedErrorMessageBuilder::error_starts_with("error during entity deserialization")
+                .source(r#"in tag `someTag` on `Employee::"12UA45"`, type mismatch: value was expected to have type [string], but it actually has type string: `"pancakes"`"#)
+                .build();
+        #[cfg(not(feature = "entity-tags"))]
+        let expected_error_msg =
+            ExpectedErrorMessageBuilder::error_starts_with("error during entity deserialization")
+                .source(r#"found a tag `someTag` on `Employee::"12UA45"`, but no tags should exist on `Employee::"12UA45"` according to the schema"#)
+                .build();
+        assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &expected_error_msg,
+            );
+        });
     }
 
     #[cfg(all(feature = "decimal", feature = "ipaddr"))]
@@ -2774,6 +2969,37 @@ mod schema_based_parsing_tests {
         });
     }
 
+    /// unexpected entity tag
+    #[test]
+    fn unexpected_entity_tag() {
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {},
+                    "parents": [],
+                    "tags": {
+                        "someTag": 12,
+                    }
+                }
+            ]
+        );
+        let eparser = EntityJsonParser::new(
+            Some(&MockSchemaNoTags),
+            Extensions::all_available(),
+            TCComputation::ComputeNow,
+        );
+        assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"found a tag `someTag` on `Employee::"12UA45"`, but no tags should exist on `Employee::"12UA45"` according to the schema"#)
+                    .build()
+            );
+        });
+    }
+
     #[cfg(all(feature = "decimal", feature = "ipaddr"))]
     /// Test that involves parents of wrong types
     #[test]
@@ -2902,7 +3128,7 @@ mod schema_based_parsing_tests {
         );
         let entities = eparser
             .from_json_value(entitiesjson)
-            .expect("should parse sucessfully");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(entities.iter().count(), 1);
         let expected_uid = r#"Action::"view""#.parse().expect("valid uid");
         let parsed_entity = match entities.entity(&expected_uid) {
@@ -3160,6 +3386,11 @@ mod schema_based_parsing_tests {
                 }
             }
 
+            #[cfg(feature = "entity-tags")]
+            fn tag_type(&self) -> Option<SchemaType> {
+                None
+            }
+
             fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
                 Box::new(
                     ["isFullTime", "department", "manager"]
@@ -3197,7 +3428,7 @@ mod schema_based_parsing_tests {
         );
         let parsed = eparser
             .from_json_value(entitiesjson)
-            .expect("Should parse without error");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(parsed.iter().count(), 1);
         let parsed = parsed
             .entity(&r#"XYZCorp::Employee::"12UA45""#.parse().unwrap())

--- a/cedar-policy-core/src/entities/conformance/err.rs
+++ b/cedar-policy-core/src/entities/conformance/err.rs
@@ -22,6 +22,10 @@ use smol_str::SmolStr;
 use thiserror::Error;
 
 /// Errors raised when entities do not conform to the schema
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Diagnostic, Error)]
 #[non_exhaustive]
 pub enum EntitySchemaConformanceError {
@@ -29,6 +33,10 @@ pub enum EntitySchemaConformanceError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnexpectedEntityAttr(UnexpectedEntityAttr),
+    /// Encountered tag, but no tags should exist on entities of this type
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnexpectedEntityTag(UnexpectedEntityTag),
     /// Didn't encounter attribute that should exist
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -69,6 +77,13 @@ impl EntitySchemaConformanceError {
         Self::UnexpectedEntityAttr(UnexpectedEntityAttr {
             uid,
             attr: attr.into(),
+        })
+    }
+
+    pub(crate) fn unexpected_entity_tag(uid: EntityUID, tag: impl Into<SmolStr>) -> Self {
+        Self::UnexpectedEntityTag(UnexpectedEntityTag {
+            uid,
+            tag: tag.into(),
         })
     }
 
@@ -122,6 +137,10 @@ impl EntitySchemaConformanceError {
 /// Error looking up an extension function. This error can occur when
 /// checking entity conformance because that may require getting information
 /// about any extension functions referenced in entity attribute values.
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("in attribute `{attr}` on `{uid}`, {err}")]
 pub struct ExtensionFunctionLookup {
@@ -136,6 +155,10 @@ pub struct ExtensionFunctionLookup {
 
 /// Encountered an action whose definition doesn't precisely match the
 /// schema's declaration of that action
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("definition of action `{uid}` does not match its schema declaration")]
 #[diagnostic(help(
@@ -147,6 +170,10 @@ pub struct ActionDeclarationMismatch {
 }
 
 /// Encountered an action which was not declared in the schema
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("found action entity `{uid}`, but it was not declared as an action in the schema")]
 pub struct UndeclaredAction {
@@ -155,6 +182,10 @@ pub struct UndeclaredAction {
 }
 
 /// Found an ancestor of a type that's not allowed for that entity
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error(
     "`{uid}` is not allowed to have an ancestor of type `{ancestor_ty}` according to the schema"
@@ -167,6 +198,10 @@ pub struct InvalidAncestorType {
 }
 
 /// Encountered attribute that shouldn't exist on entities of this type
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("attribute `{attr}` on `{uid}` should not exist according to the schema")]
 pub struct UnexpectedEntityAttr {
@@ -174,7 +209,25 @@ pub struct UnexpectedEntityAttr {
     attr: SmolStr,
 }
 
+/// Encountered tag, but no tags should exist on entities of this type
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "found a tag `{tag}` on `{uid}`, but no tags should exist on `{uid}` according to the schema"
+)]
+pub struct UnexpectedEntityTag {
+    uid: EntityUID,
+    tag: SmolStr,
+}
+
 /// Didn't encounter attribute that should exist
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("expected entity `{uid}` to have attribute `{attr}`, but it does not")]
 pub struct MissingRequiredEntityAttr {
@@ -182,10 +235,14 @@ pub struct MissingRequiredEntityAttr {
     attr: SmolStr,
 }
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("in attribute `{attr}` on `{uid}`, {err}")]
 /// The given attribute on the given entity had a different type than the
 /// schema indicated
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
+#[derive(Debug, Error, Diagnostic)]
+#[error("in attribute `{attr}` on `{uid}`, {err}")]
 pub struct TypeMismatch {
     uid: EntityUID,
     attr: SmolStr,
@@ -195,6 +252,10 @@ pub struct TypeMismatch {
 
 /// Encountered an entity of a type which is not declared in the schema.
 /// Note that this error is only used for non-Action entity types.
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error)]
 #[error("entity `{uid}` has type `{}` which is not declared in the schema", .uid.entity_type())]
 pub struct UnexpectedEntityTypeError {

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -59,7 +59,7 @@ pub struct EntityJson {
     #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
     #[serde(default)]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson"))]
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson>"))]
     // the annotation covers duplicates in this `HashMap` itself, while the `JsonValueWithNoDuplicateKeys` covers duplicates in any records contained in tag values (including recursively)
     tags: HashMap<SmolStr, JsonValueWithNoDuplicateKeys>,
 }

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -56,6 +56,12 @@ pub struct EntityJson {
     attrs: HashMap<SmolStr, JsonValueWithNoDuplicateKeys>,
     /// Parents of the entity, specified in any form accepted by `EntityUidJson`
     parents: Vec<EntityUidJson>,
+    #[serde_as(as = "serde_with::MapPreventDuplicates<_,_>")]
+    #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[cfg_attr(feature = "wasm", tsify(type = "Record<string, CedarValueJson"))]
+    // the annotation covers duplicates in this `HashMap` itself, while the `JsonValueWithNoDuplicateKeys` covers duplicates in any records contained in tag values (including recursively)
+    tags: HashMap<SmolStr, JsonValueWithNoDuplicateKeys>,
 }
 
 /// Struct used to parse entities from JSON.
@@ -341,6 +347,57 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                 }
             })
             .collect::<Result<_, JsonDeserializationError>>()?;
+        let tags: HashMap<SmolStr, RestrictedExpr> = ejson
+            .tags
+            .into_iter()
+            .map(|(k, v)| match &entity_schema_info {
+                EntitySchemaInfo::NoSchema => Ok((
+                    k.clone(),
+                    vparser.val_into_restricted_expr(v.into(), None, || {
+                        JsonDeserializationErrorContext::EntityTag {
+                            uid: uid.clone(),
+                            tag: k.clone(),
+                        }
+                    })?,
+                )),
+                EntitySchemaInfo::NonAction(desc) => {
+                    // Depending on the expected type, we may parse the contents
+                    // of the tag differently.
+                    #[cfg(feature = "entity-tags")]
+                    {
+                        let rexpr = match desc.tag_type() {
+                            // `None` indicates no tags should exist -- see docs on
+                            // the `tag_type()` trait method
+                            None => {
+                                return Err(JsonDeserializationError::EntitySchemaConformance(
+                                    EntitySchemaConformanceError::unexpected_entity_tag(
+                                        uid.clone(),
+                                        k,
+                                    ),
+                                ));
+                            }
+                            Some(expected_ty) => vparser.val_into_restricted_expr(
+                                v.into(),
+                                Some(&expected_ty),
+                                || JsonDeserializationErrorContext::EntityTag {
+                                    uid: uid.clone(),
+                                    tag: k.clone(),
+                                },
+                            )?,
+                        };
+                        Ok((k, rexpr))
+                    }
+                    #[cfg(not(feature = "entity-tags"))]
+                    {
+                        // without the `entity-tags` feature, no schemas specify tags,
+                        // so any tag that appears is necessarily a conformance error
+                        Err(JsonDeserializationError::EntitySchemaConformance(
+                            EntitySchemaConformanceError::unexpected_entity_tag(uid.clone(), k),
+                        ))
+                    }
+                }
+            })
+            .collect::<Result<_, JsonDeserializationError>>()?;
         let is_parent_allowed = |parent_euid: &EntityUID| {
             // full validation isn't done in this function (see doc comments on
             // this function), but we do need to do the following check which
@@ -373,7 +430,18 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
                 })
             })
             .collect::<Result<_, JsonDeserializationError>>()?;
-        Ok(Entity::new(uid, attrs, parents, self.extensions)?)
+        #[cfg(not(feature = "entity-tags"))]
+        if !tags.is_empty() {
+            return Err(JsonDeserializationError::UnsupportedEntityTags);
+        }
+        Ok(Entity::new(
+            uid,
+            attrs,
+            parents,
+            #[cfg(feature = "entity-tags")]
+            tags,
+            self.extensions,
+        )?)
     }
 }
 
@@ -382,29 +450,39 @@ impl EntityJson {
     ///
     /// (for the reverse transformation, use `EntityJsonParser`)
     pub fn from_entity(entity: &Entity) -> Result<Self, JsonSerializationError> {
+        let serialize_kpvalue = |(k, pvalue): (&SmolStr, &PartialValue)| -> Result<_, _> {
+            match pvalue {
+                PartialValue::Value(value) => {
+                    let cedarvaluejson = CedarValueJson::from_value(value.clone())?;
+                    Ok((k.clone(), serde_json::to_value(cedarvaluejson)?.into()))
+                }
+                PartialValue::Residual(expr) => match BorrowedRestrictedExpr::new(expr) {
+                    Ok(expr) => {
+                        let cedarvaluejson = CedarValueJson::from_expr(expr)?;
+                        Ok((k.clone(), serde_json::to_value(cedarvaluejson)?.into()))
+                    }
+                    Err(_) => Err(JsonSerializationError::residual(expr.clone())),
+                },
+            }
+        };
         Ok(Self {
             // for now, we encode `uid` and `parents` using an implied `__entity` escape
             uid: EntityUidJson::ImplicitEntityEscape(TypeAndId::from(entity.uid())),
             attrs: entity
                 .attrs()
-                .map(|(k, pvalue)| match pvalue {
-                    PartialValue::Value(value) => {
-                        let cedarvaluejson = CedarValueJson::from_value(value.clone())?;
-                        Ok((k.clone(), serde_json::to_value(cedarvaluejson)?.into()))
-                    }
-                    PartialValue::Residual(expr) => match BorrowedRestrictedExpr::new(expr) {
-                        Ok(expr) => {
-                            let cedarvaluejson = CedarValueJson::from_expr(expr)?;
-                            Ok((k.clone(), serde_json::to_value(cedarvaluejson)?.into()))
-                        }
-                        Err(_) => Err(JsonSerializationError::residual(expr.clone())),
-                    },
-                })
+                .map(serialize_kpvalue)
                 .collect::<Result<_, JsonSerializationError>>()?,
             parents: entity
                 .ancestors()
                 .map(|euid| EntityUidJson::ImplicitEntityEscape(TypeAndId::from(euid.clone())))
                 .collect(),
+            #[cfg(feature = "entity-tags")]
+            tags: entity
+                .tags()
+                .map(serialize_kpvalue)
+                .collect::<Result<_, JsonSerializationError>>()?,
+            #[cfg(not(feature = "entity-tags"))]
+            tags: HashMap::new(),
         })
     }
 }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -127,6 +127,10 @@ pub enum JsonDeserializationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     ReservedName(#[from] ReservedNameError),
+    /// Returned when entities have tags, but the `entity-tags` feature is not enabled
+    #[cfg(not(feature = "entity-tags"))]
+    #[error("entity tags are not supported in this build; to use entity tags, you must enable the `entity-tags` experimental feature")]
+    UnsupportedEntityTags,
 }
 
 impl JsonDeserializationError {
@@ -460,6 +464,13 @@ pub enum JsonDeserializationErrorContext {
         /// Attribute where the error occurred
         attr: SmolStr,
     },
+    /// The error occurred while deserializing the tag `tag` of an entity.
+    EntityTag {
+        /// Entity where the error occurred
+        uid: EntityUID,
+        /// Tag where the error occurred
+        tag: SmolStr,
+    },
     /// The error occurred while deserializing the `parents` field of an entity.
     EntityParents {
         /// Entity where the error occurred
@@ -558,6 +569,7 @@ impl std::fmt::Display for JsonDeserializationErrorContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EntityAttribute { uid, attr } => write!(f, "in attribute `{attr}` on `{uid}`"),
+            Self::EntityTag { uid, tag } => write!(f, "in tag `{tag}` on `{uid}`"),
             Self::EntityParents { uid } => write!(f, "in parents field of `{uid}`"),
             Self::EntityUid => write!(f, "in uid field of <unknown entity>"),
             Self::Context => write!(f, "while parsing context"),

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -122,6 +122,12 @@ pub trait EntityTypeDescription {
     /// Returning `None` indicates that attribute should not exist.
     fn attr_type(&self, attr: &str) -> Option<SchemaType>;
 
+    /// If this entity has tags, what type should the tags be?
+    ///
+    /// Returning `None` indicates that no tags should exist for this entity type.
+    #[cfg(feature = "entity-tags")]
+    fn tag_type(&self) -> Option<SchemaType>;
+
     /// Get the names of all the required attributes for this entity type.
     fn required_attrs<'s>(&'s self) -> Box<dyn Iterator<Item = SmolStr> + 's>;
 
@@ -134,10 +140,10 @@ pub trait EntityTypeDescription {
 }
 
 /// Simple type that implements `EntityTypeDescription` by expecting no
-/// attributes to exist
+/// attributes, tags, or parents to exist
 #[derive(Debug, Clone)]
 pub struct NullEntityTypeDescription {
-    /// null description for this type
+    /// null description for this entity typename
     ty: EntityType,
 }
 impl EntityTypeDescription for NullEntityTypeDescription {
@@ -145,6 +151,10 @@ impl EntityTypeDescription for NullEntityTypeDescription {
         self.ty.clone()
     }
     fn attr_type(&self, _attr: &str) -> Option<SchemaType> {
+        None
+    }
+    #[cfg(feature = "entity-tags")]
+    fn tag_type(&self) -> Option<SchemaType> {
         None
     }
     fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
@@ -155,5 +165,11 @@ impl EntityTypeDescription for NullEntityTypeDescription {
     }
     fn open_attributes(&self) -> bool {
         false
+    }
+}
+impl NullEntityTypeDescription {
+    /// Create a new [`NullEntityTypeDescription`] for the given entity typename
+    pub fn new(ty: EntityType) -> Self {
+        Self { ty }
     }
 }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -2421,6 +2421,8 @@ pub mod test {
             r#"Foo::"bar""#.parse().unwrap(),
             attrs.clone(),
             HashSet::new(),
+            #[cfg(feature = "entity-tags")]
+            [],
             Extensions::none(),
         )
         .unwrap();

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -135,6 +135,22 @@ impl entities::EntityTypeDescription for EntityTypeDescription {
         Some(core_schema_type)
     }
 
+    #[cfg(feature = "entity-tags")]
+    fn tag_type(&self) -> Option<entities::SchemaType> {
+        let tag_type: &crate::types::Type = self.validator_type.tag_type()?;
+        // This converts a type from a schema into the representation of schema
+        // types used by core. `tag_type` is taken from a `ValidatorEntityType`
+        // which was constructed from a schema.
+        // PANIC SAFETY: see above
+        #[allow(clippy::expect_used)]
+        let core_schema_type: entities::SchemaType = tag_type
+            .clone()
+            .try_into()
+            .expect("failed to convert validator type into Core SchemaType");
+        debug_assert!(tag_type.is_consistent_with(&core_schema_type));
+        Some(core_schema_type)
+    }
+
     fn required_attrs<'s>(&'s self) -> Box<dyn Iterator<Item = SmolStr> + 's> {
         Box::new(
             self.validator_type

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2565,8 +2565,10 @@ pub(crate) mod test {
             view_photo.unwrap(),
             &Entity::new(
                 action_uid,
-                HashMap::from([("attr".into(), RestrictedExpr::val("foo"))]),
+                [("attr".into(), RestrictedExpr::val("foo"))],
                 HashSet::new(),
+                #[cfg(feature = "entity-tags")]
+                [],
                 Extensions::none(),
             )
             .unwrap(),

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -769,7 +769,8 @@ impl ActionFragment<ConditionalName, ConditionalName> {
                 .map_err(|err| {
                     ActionAttrEvalError(EntityAttrEvaluationError {
                         uid: action_id.clone(),
-                        attr: k.clone(),
+                        attr_or_tag: k.clone(),
+                        was_attr: true,
                         err,
                     })
                 })?;

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -65,7 +65,7 @@ use std::str::FromStr;
 pub struct Entity(ast::Entity);
 
 impl Entity {
-    /// Create a new `Entity` with this Uid, attributes, and parents.
+    /// Create a new `Entity` with this Uid, attributes, and parents (and no tags).
     ///
     /// Attribute values are specified here as "restricted expressions".
     /// See docs on `RestrictedExpression`
@@ -95,16 +95,15 @@ impl Entity {
         // the `Entities` object is created
         Ok(Self(ast::Entity::new(
             uid.into(),
-            attrs
-                .into_iter()
-                .map(|(k, v)| (SmolStr::from(k), v.0))
-                .collect(),
+            attrs.into_iter().map(|(k, v)| (SmolStr::from(k), v.0)),
             parents.into_iter().map(EntityUid::into).collect(),
+            #[cfg(feature = "entity-tags")]
+            [],
             Extensions::all_available(),
         )?))
     }
 
-    /// Create a new `Entity` with this Uid, parents, and no attributes.
+    /// Create a new `Entity` with this Uid, parents, and no attributes or tags.
     /// This is the same as `Self::new` except the attributes are empty, and therefore it can
     /// return `Self` instead of `Result<Self>`
     pub fn new_empty_attrs(uid: EntityUid, parents: HashSet<EntityUid>) -> Self {


### PR DESCRIPTION
## Description of changes

Handles entity tags (RFC 82) in entity JSON parsing, including schema-based entity JSON parsing.  

## Issue #, if available

[RFC 82](https://github.com/cedar-policy/rfcs/blob/emina/entity-tags/text/0082-entity-tags.md)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

Changelog update added with a previous PR.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

