### PR TITLE
support hasTag() and getTag() in the validator

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,8 @@ I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choos
 - [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
 - [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)
 
+I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
+
+- [ ] Does not require updates because my change does not impact the Cedar language specification.
+- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
+- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -466,7 +466,9 @@ mod json_parsing_tests {
         );
         let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        parser.from_json_value(v).unwrap();
+        parser
+            .from_json_value(v)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
     }
 
     #[test]
@@ -493,7 +495,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -531,7 +535,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -568,7 +574,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -609,7 +617,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -646,7 +656,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -685,7 +697,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -723,7 +737,9 @@ mod json_parsing_tests {
             }
         ]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -748,7 +764,9 @@ mod json_parsing_tests {
             {"uid":{ "type" : "Test", "id" : "jeff" }, "attrs" : {}, "parents" : []},
             {"uid":{ "type" : "Test", "id" : "jeff" }, "attrs" : {}, "parents" : []}]);
 
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -767,7 +785,9 @@ mod json_parsing_tests {
         let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let new = serde_json::json!([{"uid":{ "type": "Test", "id": "alice" }, "attrs" : {}, "parents" : []}]);
-        let addl_entities = parser.iter_from_json_value(new).unwrap();
+        let addl_entities = parser
+            .iter_from_json_value(new)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -820,7 +840,9 @@ mod json_parsing_tests {
                 },
             ]
         );
-        parser.from_json_value(json).expect("JSON is correct")
+        parser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
     }
 
     /// Ensure the initial conditions of the entities still hold
@@ -881,7 +903,7 @@ mod json_parsing_tests {
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let es = eparser
             .from_json_value(json)
-            .expect("JSON is correct")
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
             .partial();
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
@@ -930,13 +952,24 @@ mod json_parsing_tests {
                 },
                 "attrs": {},
                 "parents": []
+            },
+            {
+                "uid" : {
+                    "type" : "test_entity_type",
+                    "id" : "josephine"
+                },
+                "attrs": {},
+                "parents": [],
+                "tags": {}
             }
             ]
         );
 
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let es = eparser.from_json_value(json).expect("JSON is correct");
+        let es = eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
         // Double check transitive closure computation
@@ -1166,7 +1199,9 @@ mod json_parsing_tests {
 
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let es = eparser.from_json_value(json).expect("JSON is correct");
+        let es = eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
 
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
         assert_eq!(alice.get("bacon"), Some(&PartialValue::from("eggs")));
@@ -1255,7 +1290,9 @@ mod json_parsing_tests {
 
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        let es = eparser.from_json_value(json).expect("JSON is correct");
+        let es = eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
 
         // check that all five entities exist
         let alice = es.entity(&EntityUID::with_eid("alice")).unwrap();
@@ -1692,15 +1729,26 @@ mod json_parsing_tests {
                         vec![RestrictedExpr::val("222.222.222.222")],
                     ),
                 ),
-            ]
-            .into_iter()
-            .collect(),
+            ],
             [
                 EntityUID::with_eid("parent1"),
                 EntityUID::with_eid("parent2"),
             ]
             .into_iter()
             .collect(),
+            #[cfg(feature = "entity-tags")]
+            [
+                // note that `foo` is also an attribute, with a different type
+                ("foo".into(), RestrictedExpr::val(2345)),
+                // note that `bar` is also an attribute, with the same type
+                ("bar".into(), RestrictedExpr::val(-1)),
+                // note that `pancakes` is not an attribute. Also note that, in
+                // this non-schema world, tags need not all have the same type.
+                (
+                    "pancakes".into(),
+                    RestrictedExpr::val(EntityUID::with_eid("pancakes")),
+                ),
+            ],
             Extensions::all_available(),
         )
         .unwrap();
@@ -1726,15 +1774,15 @@ mod json_parsing_tests {
                 // record literal that happens to look like an escape
                 "oops".into(),
                 RestrictedExpr::record([("__entity".into(), RestrictedExpr::val("hi"))]).unwrap(),
-            )]
-            .into_iter()
-            .collect(),
+            )],
             [
                 EntityUID::with_eid("parent1"),
                 EntityUID::with_eid("parent2"),
             ]
             .into_iter()
             .collect(),
+            #[cfg(feature = "entity-tags")]
+            [],
             Extensions::all_available(),
         )
         .unwrap();
@@ -1801,7 +1849,9 @@ mod json_parsing_tests {
         );
         let eparser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
-        assert_matches!(eparser.from_json_value(json), Ok(_));
+        eparser
+            .from_json_value(json)
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
     }
 
     /// test that duplicate keys in a record is an error
@@ -1935,6 +1985,7 @@ mod entities_tests {
 #[allow(clippy::panic)]
 #[cfg(test)]
 mod schema_based_parsing_tests {
+    use super::json::NullEntityTypeDescription;
     use super::*;
     use crate::extensions::Extensions;
     use crate::test_utils::*;
@@ -1944,7 +1995,7 @@ mod schema_based_parsing_tests {
     use std::collections::HashSet;
     use std::sync::Arc;
 
-    /// Mock schema impl used for these tests
+    /// Mock schema impl used for most of these tests
     struct MockSchema;
     impl Schema for MockSchema {
         type EntityTypeDescription = MockEmployeeDescription;
@@ -1991,7 +2042,45 @@ mod schema_based_parsing_tests {
         }
     }
 
-    /// Mock schema impl for the `Employee` type used in these tests
+    /// Mock schema impl with an entity type that doesn't have a tags declaration
+    struct MockSchemaNoTags;
+    impl Schema for MockSchemaNoTags {
+        type EntityTypeDescription = NullEntityTypeDescription;
+        type ActionEntityIterator = std::iter::Empty<Arc<Entity>>;
+        fn entity_type(&self, entity_type: &EntityType) -> Option<NullEntityTypeDescription> {
+            match entity_type.to_string().as_str() {
+                "Employee" => Some(NullEntityTypeDescription::new("Employee".parse().unwrap())),
+                _ => None,
+            }
+        }
+        fn action(&self, action: &EntityUID) -> Option<Arc<Entity>> {
+            match action.to_string().as_str() {
+                r#"Action::"view""# => Some(Arc::new(Entity::with_uid(
+                    r#"Action::"view""#.parse().expect("valid uid"),
+                ))),
+                _ => None,
+            }
+        }
+        fn entity_types_with_basename<'a>(
+            &'a self,
+            basename: &'a UnreservedId,
+        ) -> Box<dyn Iterator<Item = EntityType> + 'a> {
+            match basename.as_ref() {
+                "Employee" => Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+                    basename.clone(),
+                )))),
+                "Action" => Box::new(std::iter::once(EntityType::from(Name::unqualified_name(
+                    basename.clone(),
+                )))),
+                _ => Box::new(std::iter::empty()),
+            }
+        }
+        fn action_entities(&self) -> Self::ActionEntityIterator {
+            std::iter::empty()
+        }
+    }
+
+    /// Mock schema impl for the `Employee` type used in most of these tests
     struct MockEmployeeDescription;
     impl EntityTypeDescription for MockEmployeeDescription {
         fn entity_type(&self) -> EntityType {
@@ -2056,6 +2145,13 @@ mod schema_based_parsing_tests {
             }
         }
 
+        #[cfg(feature = "entity-tags")]
+        fn tag_type(&self) -> Option<SchemaType> {
+            Some(SchemaType::Set {
+                element_ty: Box::new(SchemaType::String),
+            })
+        }
+
         fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
             Box::new(
                 [
@@ -2087,6 +2183,7 @@ mod schema_based_parsing_tests {
     /// JSON that should parse differently with and without the above schema
     #[test]
     fn with_and_without_schema() {
+        #[cfg(feature = "entity-tags")]
         let entitiesjson = json!(
             [
                 {
@@ -2110,7 +2207,38 @@ mod schema_based_parsing_tests {
                         "trust_score": "5.7",
                         "tricky": { "type": "Employee", "id": "34FB87" }
                     },
-                    "parents": []
+                    "parents": [],
+                    "tags": {
+                        "someTag": ["pancakes"],
+                    },
+                }
+            ]
+        );
+        #[cfg(not(feature = "entity-tags"))]
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": [],
                 }
             ]
         );
@@ -2121,7 +2249,7 @@ mod schema_based_parsing_tests {
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
         let parsed = eparser
             .from_json_value(entitiesjson.clone())
-            .expect("Should parse without error");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(parsed.iter().count(), 1);
         let parsed = parsed
             .entity(&r#"Employee::"12UA45""#.parse().unwrap())
@@ -2196,7 +2324,7 @@ mod schema_based_parsing_tests {
         );
         let parsed = eparser
             .from_json_value(entitiesjson)
-            .expect("Should parse without error");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(parsed.iter().count(), 1);
         let parsed = parsed
             .entity(&r#"Employee::"12UA45""#.parse().unwrap())
@@ -2205,6 +2333,15 @@ mod schema_based_parsing_tests {
             .get("isFullTime")
             .expect("isFullTime attr should exist");
         assert_eq!(is_full_time, &PartialValue::Value(Value::from(true)),);
+        #[cfg(feature = "entity-tags")]
+        let some_tag = parsed
+            .get_tag("someTag")
+            .expect("someTag attr should exist");
+        #[cfg(feature = "entity-tags")]
+        assert_eq!(
+            some_tag,
+            &PartialValue::Value(Value::set(["pancakes".into()], None))
+        );
         let num_direct_reports = parsed
             .get("numDirectReports")
             .expect("numDirectReports attr should exist");
@@ -2600,6 +2737,7 @@ mod schema_based_parsing_tests {
             );
         });
 
+        // this version with explicit __entity and __extn escapes should also pass
         let entitiesjson = json!(
             [
                 {
@@ -2629,7 +2767,64 @@ mod schema_based_parsing_tests {
         );
         let _ = eparser
             .from_json_value(entitiesjson)
-            .expect("this version with explicit __entity and __extn escapes should also pass");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+    }
+
+    /// tag has the wrong type
+    #[test]
+    fn type_mismatch_in_tag() {
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {
+                        "isFullTime": true,
+                        "numDirectReports": 3,
+                        "department": "Sales",
+                        "manager": { "type": "Employee", "id": "34FB87" },
+                        "hr_contacts": [
+                            { "type": "HR", "id": "aaaaa" },
+                            { "type": "HR", "id": "bbbbb" }
+                        ],
+                        "json_blob": {
+                            "inner1": false,
+                            "inner2": "-*/",
+                            "inner3": { "innerinner": { "type": "Employee", "id": "09AE76" }},
+                        },
+                        "home_ip": "222.222.222.101",
+                        "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
+                        "trust_score": "5.7",
+                        "tricky": { "type": "Employee", "id": "34FB87" }
+                    },
+                    "parents": [],
+                    "tags": {
+                        "someTag": "pancakes",
+                    }
+                }
+            ]
+        );
+        let eparser = EntityJsonParser::new(
+            Some(&MockSchema),
+            Extensions::all_available(),
+            TCComputation::ComputeNow,
+        );
+        #[cfg(feature = "entity-tags")]
+        let expected_error_msg =
+            ExpectedErrorMessageBuilder::error_starts_with("error during entity deserialization")
+                .source(r#"in tag `someTag` on `Employee::"12UA45"`, type mismatch: value was expected to have type [string], but it actually has type string: `"pancakes"`"#)
+                .build();
+        #[cfg(not(feature = "entity-tags"))]
+        let expected_error_msg =
+            ExpectedErrorMessageBuilder::error_starts_with("error during entity deserialization")
+                .source(r#"found a tag `someTag` on `Employee::"12UA45"`, but no tags should exist on `Employee::"12UA45"` according to the schema"#)
+                .build();
+        assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &expected_error_msg,
+            );
+        });
     }
 
     #[cfg(all(feature = "decimal", feature = "ipaddr"))]
@@ -2774,6 +2969,37 @@ mod schema_based_parsing_tests {
         });
     }
 
+    /// unexpected entity tag
+    #[test]
+    fn unexpected_entity_tag() {
+        let entitiesjson = json!(
+            [
+                {
+                    "uid": { "type": "Employee", "id": "12UA45" },
+                    "attrs": {},
+                    "parents": [],
+                    "tags": {
+                        "someTag": 12,
+                    }
+                }
+            ]
+        );
+        let eparser = EntityJsonParser::new(
+            Some(&MockSchemaNoTags),
+            Extensions::all_available(),
+            TCComputation::ComputeNow,
+        );
+        assert_matches!(eparser.from_json_value(entitiesjson.clone()), Err(e) => {
+            expect_err(
+                &entitiesjson,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error during entity deserialization")
+                    .source(r#"found a tag `someTag` on `Employee::"12UA45"`, but no tags should exist on `Employee::"12UA45"` according to the schema"#)
+                    .build()
+            );
+        });
+    }
+
     #[cfg(all(feature = "decimal", feature = "ipaddr"))]
     /// Test that involves parents of wrong types
     #[test]
@@ -2902,7 +3128,7 @@ mod schema_based_parsing_tests {
         );
         let entities = eparser
             .from_json_value(entitiesjson)
-            .expect("should parse sucessfully");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(entities.iter().count(), 1);
         let expected_uid = r#"Action::"view""#.parse().expect("valid uid");
         let parsed_entity = match entities.entity(&expected_uid) {
@@ -3160,6 +3386,11 @@ mod schema_based_parsing_tests {
                 }
             }
 
+            #[cfg(feature = "entity-tags")]
+            fn tag_type(&self) -> Option<SchemaType> {
+                None
+            }
+
             fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
                 Box::new(
                     ["isFullTime", "department", "manager"]
@@ -3197,7 +3428,7 @@ mod schema_based_parsing_tests {
         );
         let parsed = eparser
             .from_json_value(entitiesjson)
-            .expect("Should parse without error");
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
         assert_eq!(parsed.iter().count(), 1);
         let parsed = parsed
             .entity(&r#"XYZCorp::Employee::"12UA45""#.parse().unwrap())

--- a/cedar-policy-core/src/entities/conformance/err.rs
+++ b/cedar-policy-core/src/entities/conformance/err.rs
@@ -22,6 +22,10 @@ use smol_str::SmolStr;
 use thiserror::Error;
 
 /// Errors raised when entities do not conform to the schema
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Diagnostic, Error)]
 #[non_exhaustive]
 pub enum EntitySchemaConformanceError {
@@ -29,6 +33,10 @@ pub enum EntitySchemaConformanceError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnexpectedEntityAttr(UnexpectedEntityAttr),
+    /// Encountered tag, but no tags should exist on entities of this type
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnexpectedEntityTag(UnexpectedEntityTag),
     /// Didn't encounter attribute that should exist
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -69,6 +77,13 @@ impl EntitySchemaConformanceError {
         Self::UnexpectedEntityAttr(UnexpectedEntityAttr {
             uid,
             attr: attr.into(),
+        })
+    }
+
+    pub(crate) fn unexpected_entity_tag(uid: EntityUID, tag: impl Into<SmolStr>) -> Self {
+        Self::UnexpectedEntityTag(UnexpectedEntityTag {
+            uid,
+            tag: tag.into(),
         })
     }
 
@@ -122,6 +137,10 @@ impl EntitySchemaConformanceError {
 /// Error looking up an extension function. This error can occur when
 /// checking entity conformance because that may require getting information
 /// about any extension functions referenced in entity attribute values.
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("in attribute `{attr}` on `{uid}`, {err}")]
 pub struct ExtensionFunctionLookup {
@@ -136,6 +155,10 @@ pub struct ExtensionFunctionLookup {
 
 /// Encountered an action whose definition doesn't precisely match the
 /// schema's declaration of that action
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("definition of action `{uid}` does not match its schema declaration")]
 #[diagnostic(help(
@@ -147,6 +170,10 @@ pub struct ActionDeclarationMismatch {
 }
 
 /// Encountered an action which was not declared in the schema
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("found action entity `{uid}`, but it was not declared as an action in the schema")]
 pub struct UndeclaredAction {
@@ -155,6 +182,10 @@ pub struct UndeclaredAction {
 }
 
 /// Found an ancestor of a type that's not allowed for that entity
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error(
     "`{uid}` is not allowed to have an ancestor of type `{ancestor_ty}` according to the schema"
@@ -167,6 +198,10 @@ pub struct InvalidAncestorType {
 }
 
 /// Encountered attribute that shouldn't exist on entities of this type
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("attribute `{attr}` on `{uid}` should not exist according to the schema")]
 pub struct UnexpectedEntityAttr {
@@ -174,7 +209,25 @@ pub struct UnexpectedEntityAttr {
     attr: SmolStr,
 }
 
+/// Encountered tag, but no tags should exist on entities of this type
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "found a tag `{tag}` on `{uid}`, but no tags should exist on `{uid}` according to the schema"
+)]
+pub struct UnexpectedEntityTag {
+    uid: EntityUID,
+    tag: SmolStr,
+}
+
 /// Didn't encounter attribute that should exist
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error, Diagnostic)]
 #[error("expected entity `{uid}` to have attribute `{attr}`, but it does not")]
 pub struct MissingRequiredEntityAttr {
@@ -182,10 +235,14 @@ pub struct MissingRequiredEntityAttr {
     attr: SmolStr,
 }
 
-#[derive(Debug, Error, Diagnostic)]
-#[error("in attribute `{attr}` on `{uid}`, {err}")]
 /// The given attribute on the given entity had a different type than the
 /// schema indicated
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
+#[derive(Debug, Error, Diagnostic)]
+#[error("in attribute `{attr}` on `{uid}`, {err}")]
 pub struct TypeMismatch {
     uid: EntityUID,
     attr: SmolStr,
@@ -195,6 +252,10 @@ pub struct TypeMismatch {
 
 /// Encountered an entity of a type which is not declared in the schema.
 /// Note that this error is only used for non-Action entity types.
+//
+// CAUTION: this type is publicly exported in `cedar-policy`.
+// Don't make fields `pub`, don't make breaking changes, and use caution
+// when adding public methods.
 #[derive(Debug, Error)]
 #[error("entity `{uid}` has type `{}` which is not declared in the schema", .uid.entity_type())]
 pub struct UnexpectedEntityTypeError {

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -127,6 +127,10 @@ pub enum JsonDeserializationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     ReservedName(#[from] ReservedNameError),
+    /// Returned when entities have tags, but the `entity-tags` feature is not enabled
+    #[cfg(not(feature = "entity-tags"))]
+    #[error("entity tags are not supported in this build; to use entity tags, you must enable the `entity-tags` experimental feature")]
+    UnsupportedEntityTags,
 }
 
 impl JsonDeserializationError {
@@ -460,6 +464,13 @@ pub enum JsonDeserializationErrorContext {
         /// Attribute where the error occurred
         attr: SmolStr,
     },
+    /// The error occurred while deserializing the tag `tag` of an entity.
+    EntityTag {
+        /// Entity where the error occurred
+        uid: EntityUID,
+        /// Tag where the error occurred
+        tag: SmolStr,
+    },
     /// The error occurred while deserializing the `parents` field of an entity.
     EntityParents {
         /// Entity where the error occurred
@@ -558,6 +569,7 @@ impl std::fmt::Display for JsonDeserializationErrorContext {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::EntityAttribute { uid, attr } => write!(f, "in attribute `{attr}` on `{uid}`"),
+            Self::EntityTag { uid, tag } => write!(f, "in tag `{tag}` on `{uid}`"),
             Self::EntityParents { uid } => write!(f, "in parents field of `{uid}`"),
             Self::EntityUid => write!(f, "in uid field of <unknown entity>"),
             Self::Context => write!(f, "while parsing context"),

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -122,6 +122,12 @@ pub trait EntityTypeDescription {
     /// Returning `None` indicates that attribute should not exist.
     fn attr_type(&self, attr: &str) -> Option<SchemaType>;
 
+    /// If this entity has tags, what type should the tags be?
+    ///
+    /// Returning `None` indicates that no tags should exist for this entity type.
+    #[cfg(feature = "entity-tags")]
+    fn tag_type(&self) -> Option<SchemaType>;
+
     /// Get the names of all the required attributes for this entity type.
     fn required_attrs<'s>(&'s self) -> Box<dyn Iterator<Item = SmolStr> + 's>;
 
@@ -134,10 +140,10 @@ pub trait EntityTypeDescription {
 }
 
 /// Simple type that implements `EntityTypeDescription` by expecting no
-/// attributes to exist
+/// attributes, tags, or parents to exist
 #[derive(Debug, Clone)]
 pub struct NullEntityTypeDescription {
-    /// null description for this type
+    /// null description for this entity typename
     ty: EntityType,
 }
 impl EntityTypeDescription for NullEntityTypeDescription {
@@ -145,6 +151,10 @@ impl EntityTypeDescription for NullEntityTypeDescription {
         self.ty.clone()
     }
     fn attr_type(&self, _attr: &str) -> Option<SchemaType> {
+        None
+    }
+    #[cfg(feature = "entity-tags")]
+    fn tag_type(&self) -> Option<SchemaType> {
         None
     }
     fn required_attrs(&self) -> Box<dyn Iterator<Item = SmolStr>> {
@@ -155,5 +165,11 @@ impl EntityTypeDescription for NullEntityTypeDescription {
     }
     fn open_attributes(&self) -> bool {
         false
+    }
+}
+impl NullEntityTypeDescription {
+    /// Create a new [`NullEntityTypeDescription`] for the given entity typename
+    pub fn new(ty: EntityType) -> Self {
+        Self { ty }
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -299,8 +299,8 @@ impl From<ast::Template> for Policy {
     }
 }
 
-impl From<ast::Expr> for Clause {
-    fn from(expr: ast::Expr) -> Clause {
+impl<T: Clone> From<ast::Expr<T>> for Clause {
+    fn from(expr: ast::Expr<T>) -> Clause {
         Clause::When(expr.into())
     }
 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -769,8 +769,8 @@ impl Expr {
     }
 }
 
-impl From<ast::Expr> for Expr {
-    fn from(expr: ast::Expr) -> Expr {
+impl<T: Clone> From<ast::Expr<T>> for Expr {
+    fn from(expr: ast::Expr<T>) -> Expr {
         match expr.into_expr_kind() {
             ast::ExprKind::Lit(lit) => lit.into(),
             ast::ExprKind::Var(var) => var.into(),

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -2421,6 +2421,8 @@ pub mod test {
             r#"Foo::"bar""#.parse().unwrap(),
             attrs.clone(),
             HashSet::new(),
+            #[cfg(feature = "entity-tags")]
+            [],
             Extensions::none(),
         )
         .unwrap();

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -135,6 +135,22 @@ impl entities::EntityTypeDescription for EntityTypeDescription {
         Some(core_schema_type)
     }
 
+    #[cfg(feature = "entity-tags")]
+    fn tag_type(&self) -> Option<entities::SchemaType> {
+        let tag_type: &crate::types::Type = self.validator_type.tag_type()?;
+        // This converts a type from a schema into the representation of schema
+        // types used by core. `tag_type` is taken from a `ValidatorEntityType`
+        // which was constructed from a schema.
+        // PANIC SAFETY: see above
+        #[allow(clippy::expect_used)]
+        let core_schema_type: entities::SchemaType = tag_type
+            .clone()
+            .try_into()
+            .expect("failed to convert validator type into Core SchemaType");
+        debug_assert!(tag_type.is_consistent_with(&core_schema_type));
+        Some(core_schema_type)
+    }
+
     fn required_attrs<'s>(&'s self) -> Box<dyn Iterator<Item = SmolStr> + 's> {
         Box::new(
             self.validator_type

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -170,6 +170,7 @@ pub enum ValidationError {
     /// this is ever returned, please file an issue)
     #[error(transparent)]
     #[diagnostic(transparent)]
+    #[cfg(feature = "entity-tags")] // have to write this because, as of this writing, without this feature InternalInvariantViolation is never used, so that causes a warning which fails CI
     InternalInvariantViolation(#[from] validation_errors::InternalInvariantViolation),
 }
 

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -166,6 +166,11 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     HierarchyNotRespected(#[from] validation_errors::HierarchyNotRespected),
+    /// Returned when an internal invariant is violated (should not happen; if
+    /// this is ever returned, please file an issue)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InternalInvariantViolation(#[from] validation_errors::InternalInvariantViolation),
 }
 
 impl ValidationError {
@@ -327,7 +332,6 @@ impl ValidationError {
 
     pub(crate) fn wrong_number_args(
         source_loc: Option<Loc>,
-
         policy_id: PolicyID,
         expected: usize,
         actual: usize,
@@ -372,7 +376,6 @@ impl ValidationError {
 
     pub(crate) fn hierarchy_not_respected(
         source_loc: Option<Loc>,
-
         policy_id: PolicyID,
         in_lhs: Option<EntityType>,
         in_rhs: Option<EntityType>,
@@ -382,6 +385,17 @@ impl ValidationError {
             policy_id,
             in_lhs,
             in_rhs,
+        }
+        .into()
+    }
+
+    pub(crate) fn internal_invariant_violation(
+        source_loc: Option<Loc>,
+        policy_id: PolicyID,
+    ) -> Self {
+        validation_errors::InternalInvariantViolation {
+            source_loc,
+            policy_id,
         }
         .into()
     }

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -22,14 +22,14 @@ use thiserror::Error;
 
 use std::collections::BTreeSet;
 
-use cedar_policy_core::ast::{EntityType, PolicyID};
 #[cfg(feature = "entity-tags")]
 use cedar_policy_core::ast::Expr;
+use cedar_policy_core::ast::{EntityType, PolicyID};
 use cedar_policy_core::parser::Loc;
 
-use crate::types::Type;
 #[cfg(feature = "entity-tags")]
 use crate::types::EntityLUB;
+use crate::types::Type;
 
 pub mod validation_errors;
 pub mod validation_warnings;

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -170,7 +170,7 @@ pub enum ValidationError {
     /// this is ever returned, please file an issue)
     #[error(transparent)]
     #[diagnostic(transparent)]
-    #[cfg(feature = "entity-tags")] // have to write this because, as of this writing, without this feature InternalInvariantViolation is never used, so that causes a warning which fails CI
+    #[cfg_attr(not(feature = "entity-tags"), allow(dead_code))]
     InternalInvariantViolation(#[from] validation_errors::InternalInvariantViolation),
 }
 
@@ -390,6 +390,7 @@ impl ValidationError {
         .into()
     }
 
+    #[cfg_attr(not(feature = "entity-tags"), allow(dead_code))]
     pub(crate) fn internal_invariant_violation(
         source_loc: Option<Loc>,
         policy_id: PolicyID,

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -483,6 +483,27 @@ impl Diagnostic for NonLitExtConstructor {
     }
 }
 
+/// Returned when an internal invariant is violated (should not happen; if
+/// this is ever returned, please file an issue)
+#[derive(Debug, Clone, Hash, Eq, PartialEq, Error)]
+#[error("internal invariant violated")]
+pub struct InternalInvariantViolation {
+    /// Source location
+    pub source_loc: Option<Loc>,
+    /// Policy ID where the error occurred
+    pub policy_id: PolicyID,
+}
+
+impl Diagnostic for InternalInvariantViolation {
+    impl_diagnostic_from_source_loc_opt_field!(source_loc);
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        Some(Box::new(
+            "please file an issue at <https://github.com/cedar-policy/cedar/issues> including the schema and policy for which you observed the issue"
+        ))
+    }
+}
+
 /// Contains more detailed information about an attribute access when it occurs
 /// on an entity type expression or on the `context` variable. Track a `Vec` of
 /// attributes rather than a single attribute so that on `principal.foo.bar` can

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2565,8 +2565,10 @@ pub(crate) mod test {
             view_photo.unwrap(),
             &Entity::new(
                 action_uid,
-                HashMap::from([("attr".into(), RestrictedExpr::val("foo"))]),
+                [("attr".into(), RestrictedExpr::val("foo"))],
                 HashSet::new(),
+                #[cfg(feature = "entity-tags")]
+                [],
                 Extensions::none(),
             )
             .unwrap(),

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -769,7 +769,8 @@ impl ActionFragment<ConditionalName, ConditionalName> {
                 .map_err(|err| {
                     ActionAttrEvalError(EntityAttrEvaluationError {
                         uid: action_id.clone(),
-                        attr: k.clone(),
+                        attr_or_tag: k.clone(),
+                        was_attr: true,
                         err,
                     })
                 })?;

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1435,9 +1435,7 @@ impl<'a> Typechecker<'a> {
                     arg1,
                     Type::any_entity_reference(),
                     type_errors,
-                    |actual| match actual {
-                        _ => None,
-                    },
+                    |_| None,
                 )
                 .then_typecheck(|expr_ty_arg1, _| {
                     self.expect_type(

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -812,7 +812,8 @@ impl<'a> Typechecker<'a> {
                                 // evaluate to `true` when the attribute is
                                 // present).
                                 if ty.is_required
-                                    || prior_capability.contains(&Capability::new(expr, attr))
+                                    || prior_capability
+                                        .contains(&Capability::new_attribute(expr, attr.clone()))
                                 {
                                     TypecheckAnswer::success(annot_expr)
                                 } else {
@@ -904,8 +905,8 @@ impl<'a> Typechecker<'a> {
                                 // However, we can make an exception when the attribute
                                 // access of the expression is already in the prior capability,
                                 // which means the entity must exist.
-                                let in_prior_capability =
-                                    prior_capability.contains(&Capability::new(expr, attr));
+                                let in_prior_capability = prior_capability
+                                    .contains(&Capability::new_attribute(expr, attr.clone()));
                                 let type_of_has = if exists_in_store || in_prior_capability {
                                     Type::singleton_boolean(true)
                                 } else {
@@ -915,7 +916,10 @@ impl<'a> Typechecker<'a> {
                                     ExprBuilder::with_data(Some(type_of_has))
                                         .with_same_source_loc(e)
                                         .has_attr(typ_expr_actual, attr.clone()),
-                                    CapabilitySet::singleton(Capability::new(expr, attr)),
+                                    CapabilitySet::singleton(Capability::new_attribute(
+                                        expr,
+                                        attr.clone(),
+                                    )),
                                 )
                             }
                             // This is where capability information is generated. If
@@ -931,7 +935,9 @@ impl<'a> Typechecker<'a> {
                                     // type `true` if it occurs after the attribute
                                     // access of the expression is already in the
                                     // prior capability.
-                                    if prior_capability.contains(&Capability::new(expr, attr)) {
+                                    if prior_capability
+                                        .contains(&Capability::new_attribute(expr, attr.clone()))
+                                    {
                                         Type::singleton_boolean(true)
                                     } else {
                                         Type::primitive_boolean()
@@ -939,7 +945,10 @@ impl<'a> Typechecker<'a> {
                                 ))
                                 .with_same_source_loc(e)
                                 .has_attr(typ_expr_actual, attr.clone()),
-                                CapabilitySet::singleton(Capability::new(expr, attr)),
+                                CapabilitySet::singleton(Capability::new_attribute(
+                                    expr,
+                                    attr.clone(),
+                                )),
                             ),
                             None => TypecheckAnswer::success(
                                 ExprBuilder::with_data(Some(
@@ -1419,8 +1428,178 @@ impl<'a> Typechecker<'a> {
             }
 
             #[cfg(feature = "entity-tags")]
-            BinaryOp::GetTag | BinaryOp::HasTag => {
-                unimplemented!("validation for .getTag() and .hasTag() operations")
+            BinaryOp::HasTag => self
+                .expect_type(
+                    request_env,
+                    prior_capability,
+                    arg1,
+                    Type::any_entity_reference(),
+                    type_errors,
+                    |actual| match actual {
+                        _ => None,
+                    },
+                )
+                .then_typecheck(|expr_ty_arg1, _| {
+                    self.expect_type(
+                        request_env,
+                        prior_capability,
+                        arg2,
+                        Type::primitive_string(),
+                        type_errors,
+                        |_| None,
+                    )
+                    .then_typecheck(|expr_ty_arg2, _| {
+                        let Some(Type::EntityOrRecord(kind)) = expr_ty_arg1.data() else {
+                            // should be unreachable, as we already typechecked that this matches
+                            // `Type::any_entity_reference()`, but to be safe we can return this
+                            // reasonable failure instead of `unreachable!()`
+                            return TypecheckAnswer::fail(
+                                ExprBuilder::new()
+                                    .with_same_source_loc(bin_expr)
+                                    .has_tag(expr_ty_arg1, expr_ty_arg2),
+                            );
+                        };
+                        let type_of_has = match self.tag_types(kind) {
+                            Ok(tag_types) if tag_types.is_empty() => {
+                                // impossible for the type to have any tags, thus the `has` will always be `False`
+                                Type::singleton_boolean(false)
+                            }
+                            Err(()) => {
+                                // Not an entity type; should be unreachable, as we already typechecked
+                                // that this matches `Type::any_entity_reference()`, but to be safe we
+                                // can just treat this like the case above, no tags are possible
+                                Type::singleton_boolean(false)
+                            }
+                            _ => Type::primitive_boolean(),
+                        };
+                        TypecheckAnswer::success_with_capability(
+                            ExprBuilder::with_data(Some(type_of_has))
+                                .with_same_source_loc(bin_expr)
+                                .binary_app(BinaryOp::HasTag, expr_ty_arg1, expr_ty_arg2),
+                            CapabilitySet::singleton(Capability::new_borrowed_tag(arg1, &arg2)),
+                        )
+                    })
+                }),
+
+            #[cfg(feature = "entity-tags")]
+            BinaryOp::GetTag => {
+                self.expect_type(
+                    request_env,
+                    prior_capability,
+                    arg1,
+                    Type::any_entity_reference(),
+                    type_errors,
+                    |actual| match actual {
+                        _ => None,
+                    },
+                )
+                .then_typecheck(|expr_ty_arg1, _| {
+                    self.expect_type(
+                        request_env,
+                        prior_capability,
+                        arg2,
+                        Type::primitive_string(),
+                        type_errors,
+                        |_| None,
+                    )
+                    .then_typecheck(|expr_ty_arg2, _| {
+                        let Some(Type::EntityOrRecord(kind)) = expr_ty_arg1.data() else {
+                            // should be unreachable, as we already typechecked that this matches
+                            // `Type::any_entity_reference()`, but to be safe we can return this
+                            // reasonable failure instead of `unreachable!()`
+                            return TypecheckAnswer::fail(
+                                ExprBuilder::new()
+                                    .with_same_source_loc(bin_expr)
+                                    .get_tag(expr_ty_arg1, expr_ty_arg2),
+                            );
+                        };
+                        if prior_capability.contains(&Capability::new_borrowed_tag(arg1, &arg2)) {
+                            // Determine the set of possible tag types for this access.
+                            let tag_types = match self.tag_types(kind) {
+                                Ok(tag_types) => tag_types,
+                                Err(()) => {
+                                    // `kind` was not an entity type.
+                                    // should be unreachable, as we already typechecked that this matches
+                                    // `Type::any_entity_reference()`, but to be safe we can return this
+                                    // reasonable failure instead of `unreachable!()`
+                                    return TypecheckAnswer::fail(
+                                        ExprBuilder::new()
+                                            .with_same_source_loc(bin_expr)
+                                            .get_tag(expr_ty_arg1, expr_ty_arg2),
+                                    );
+                                }
+                            };
+                            if tag_types.is_empty() {
+                                // no entities in the LUB are allowed to have tags.
+                                // This is a somewhat weird case where we did do a `has` check (we
+                                // already confirmed farther above that we have the capability for
+                                // this tag), but the entity type(s) we're operating on just can't
+                                // have tags.
+                                let entity_ty = match kind {
+                                    EntityRecordKind::Entity(lub) => lub.get_single_entity(),
+                                    EntityRecordKind::AnyEntity => None,
+                                    EntityRecordKind::ActionEntity { name, .. } => Some(name),
+                                    EntityRecordKind::Record { .. } => None,
+                                };
+                                type_errors.push(ValidationError::no_tags_allowed(
+                                    bin_expr.source_loc().cloned(),
+                                    self.policy_id.clone(),
+                                    entity_ty.cloned(),
+                                ));
+                                TypecheckAnswer::fail(
+                                    ExprBuilder::new()
+                                        .with_same_source_loc(bin_expr)
+                                        .get_tag(expr_ty_arg1, expr_ty_arg2),
+                                )
+                            } else {
+                                // one or more entities in the LUB are allowed to have tags.
+                                // compute the LUB of all the relevant tag types, and assign that
+                                // as the type.
+                                let tag_type = match Type::reduce_to_least_upper_bound(
+                                    &self.schema,
+                                    tag_types.clone(),
+                                    self.mode,
+                                ) {
+                                    Ok(ty) => ty,
+                                    Err(e) => {
+                                        type_errors.push(ValidationError::incompatible_types(
+                                            bin_expr.source_loc().cloned(),
+                                            self.policy_id.clone(),
+                                            tag_types.into_iter().cloned(),
+                                            e,
+                                            LubContext::GetTag,
+                                        ));
+                                        return TypecheckAnswer::fail(
+                                            ExprBuilder::new()
+                                                .with_same_source_loc(bin_expr)
+                                                .get_tag(expr_ty_arg1, expr_ty_arg2),
+                                        );
+                                    }
+                                };
+                                TypecheckAnswer::success(
+                                    ExprBuilder::with_data(Some(tag_type))
+                                        .with_same_source_loc(bin_expr)
+                                        .get_tag(expr_ty_arg1, expr_ty_arg2),
+                                )
+                            }
+                        } else {
+                            type_errors.push(ValidationError::unsafe_tag_access(
+                                bin_expr.source_loc().cloned(),
+                                self.policy_id.clone(),
+                                match kind {
+                                    EntityRecordKind::Entity(lub) => Some(lub.clone()),
+                                    _ => None,
+                                },
+                                expr_ty_arg2.clone(),
+                            ));
+                            TypecheckAnswer::fail(
+                                ExprBuilder::new()
+                                    .with_same_source_loc(bin_expr)
+                                    .get_tag(expr_ty_arg1, expr_ty_arg2),
+                            )
+                        }
+                    })
+                })
             }
         }
     }
@@ -1508,6 +1687,37 @@ impl<'a> Typechecker<'a> {
                 // type than boolean.
                 Type::primitive_boolean()
             }
+        }
+    }
+
+    /// Get the set of types that are possible tag types for `kind`.
+    ///
+    /// If `kind` is not an entity type (e.g., a record type), this returns `Err`.
+    /// If `kind` is an entity type without a `tags` declaration, this returns
+    /// `Ok` with the empty set.
+    ///
+    /// If `kind` is a LUB containing some entity types that have tags and some
+    /// that do not, this ignores the entity types that do not; we just assume
+    /// the access is not on one of those entity types.
+    #[cfg(feature = "entity-tags")]
+    fn tag_types<'s>(&'s self, kind: &EntityRecordKind) -> Result<HashSet<&'s Type>, ()> {
+        use crate::schema::ValidatorEntityType;
+        match kind {
+            EntityRecordKind::Entity(lub) => Ok(lub
+                .iter()
+                .filter_map(|ety| {
+                    self.schema
+                        .get_entity_type(ety)
+                        .and_then(ValidatorEntityType::tag_type)
+                })
+                .collect()),
+            EntityRecordKind::AnyEntity => Ok(self
+                .schema
+                .entity_types()
+                .filter_map(|(_, vety)| vety.tag_type())
+                .collect()),
+            EntityRecordKind::ActionEntity { .. } => Ok(HashSet::new()), // currently, action entities cannot be declared with tags in the schema
+            EntityRecordKind::Record { .. } => Err(()),
         }
     }
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1449,8 +1449,11 @@ impl<'a> Typechecker<'a> {
                     .then_typecheck(|expr_ty_arg2, _| {
                         let Some(Type::EntityOrRecord(kind)) = expr_ty_arg1.data() else {
                             // should be unreachable, as we already typechecked that this matches
-                            // `Type::any_entity_reference()`, but to be safe we can return this
-                            // reasonable failure instead of `unreachable!()`
+                            // `Type::any_entity_reference()`
+                            type_errors.push(ValidationError::internal_invariant_violation(
+                                bin_expr.source_loc().cloned(),
+                                self.policy_id.clone(),
+                            ));
                             return TypecheckAnswer::fail(
                                 ExprBuilder::new()
                                     .with_same_source_loc(bin_expr)
@@ -1464,9 +1467,16 @@ impl<'a> Typechecker<'a> {
                             }
                             Err(()) => {
                                 // Not an entity type; should be unreachable, as we already typechecked
-                                // that this matches `Type::any_entity_reference()`, but to be safe we
-                                // can just treat this like the case above, no tags are possible
-                                Type::singleton_boolean(false)
+                                // that this matches `Type::any_entity_reference()`
+                                type_errors.push(ValidationError::internal_invariant_violation(
+                                    bin_expr.source_loc().cloned(),
+                                    self.policy_id.clone(),
+                                ));
+                                return TypecheckAnswer::fail(
+                                    ExprBuilder::new()
+                                        .with_same_source_loc(bin_expr)
+                                        .has_tag(expr_ty_arg1, expr_ty_arg2),
+                                );
                             }
                             _ => Type::primitive_boolean(),
                         };
@@ -1503,8 +1513,11 @@ impl<'a> Typechecker<'a> {
                     .then_typecheck(|expr_ty_arg2, _| {
                         let Some(Type::EntityOrRecord(kind)) = expr_ty_arg1.data() else {
                             // should be unreachable, as we already typechecked that this matches
-                            // `Type::any_entity_reference()`, but to be safe we can return this
-                            // reasonable failure instead of `unreachable!()`
+                            // `Type::any_entity_reference()`
+                            type_errors.push(ValidationError::internal_invariant_violation(
+                                bin_expr.source_loc().cloned(),
+                                self.policy_id.clone(),
+                            ));
                             return TypecheckAnswer::fail(
                                 ExprBuilder::new()
                                     .with_same_source_loc(bin_expr)
@@ -1518,8 +1531,13 @@ impl<'a> Typechecker<'a> {
                                 Err(()) => {
                                     // `kind` was not an entity type.
                                     // should be unreachable, as we already typechecked that this matches
-                                    // `Type::any_entity_reference()`, but to be safe we can return this
-                                    // reasonable failure instead of `unreachable!()`
+                                    // `Type::any_entity_reference()`
+                                    type_errors.push(
+                                        ValidationError::internal_invariant_violation(
+                                            bin_expr.source_loc().cloned(),
+                                            self.policy_id.clone(),
+                                        ),
+                                    );
                                     return TypecheckAnswer::fail(
                                         ExprBuilder::new()
                                             .with_same_source_loc(bin_expr)

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1447,18 +1447,30 @@ impl<'a> Typechecker<'a> {
                         |_| None,
                     )
                     .then_typecheck(|expr_ty_arg2, _| {
-                        let Some(Type::EntityOrRecord(kind)) = expr_ty_arg1.data() else {
-                            // should be unreachable, as we already typechecked that this matches
-                            // `Type::any_entity_reference()`
-                            type_errors.push(ValidationError::internal_invariant_violation(
-                                bin_expr.source_loc().cloned(),
-                                self.policy_id.clone(),
-                            ));
-                            return TypecheckAnswer::fail(
-                                ExprBuilder::new()
-                                    .with_same_source_loc(bin_expr)
-                                    .has_tag(expr_ty_arg1, expr_ty_arg2),
-                            );
+                        let kind = match expr_ty_arg1.data() {
+                            Some(Type::EntityOrRecord(kind)) => kind,
+                            None => {
+                                // should have already reported an error in this case.
+                                // just return a failure.
+                                return TypecheckAnswer::fail(
+                                    ExprBuilder::new()
+                                        .with_same_source_loc(bin_expr)
+                                        .has_tag(expr_ty_arg1, expr_ty_arg2),
+                                );
+                            }
+                            _ => {
+                                // should be unreachable, as we already typechecked that this matches
+                                // `Type::any_entity_reference()`
+                                type_errors.push(ValidationError::internal_invariant_violation(
+                                    bin_expr.source_loc().cloned(),
+                                    self.policy_id.clone(),
+                                ));
+                                return TypecheckAnswer::fail(
+                                    ExprBuilder::new()
+                                        .with_same_source_loc(bin_expr)
+                                        .has_tag(expr_ty_arg1, expr_ty_arg2),
+                                );
+                            }
                         };
                         let type_of_has = match self.tag_types(kind) {
                             Ok(tag_types) if tag_types.is_empty() => {
@@ -1511,18 +1523,30 @@ impl<'a> Typechecker<'a> {
                         |_| None,
                     )
                     .then_typecheck(|expr_ty_arg2, _| {
-                        let Some(Type::EntityOrRecord(kind)) = expr_ty_arg1.data() else {
-                            // should be unreachable, as we already typechecked that this matches
-                            // `Type::any_entity_reference()`
-                            type_errors.push(ValidationError::internal_invariant_violation(
-                                bin_expr.source_loc().cloned(),
-                                self.policy_id.clone(),
-                            ));
-                            return TypecheckAnswer::fail(
-                                ExprBuilder::new()
-                                    .with_same_source_loc(bin_expr)
-                                    .get_tag(expr_ty_arg1, expr_ty_arg2),
-                            );
+                        let kind = match expr_ty_arg1.data() {
+                            Some(Type::EntityOrRecord(kind)) => kind,
+                            None => {
+                                // should have already reported an error in this case.
+                                // just return a failure.
+                                return TypecheckAnswer::fail(
+                                    ExprBuilder::new()
+                                        .with_same_source_loc(bin_expr)
+                                        .get_tag(expr_ty_arg1, expr_ty_arg2),
+                                );
+                            }
+                            _ => {
+                                // should be unreachable, as we already typechecked that this matches
+                                // `Type::any_entity_reference()`
+                                type_errors.push(ValidationError::internal_invariant_violation(
+                                    bin_expr.source_loc().cloned(),
+                                    self.policy_id.clone(),
+                                ));
+                                return TypecheckAnswer::fail(
+                                    ExprBuilder::new()
+                                        .with_same_source_loc(bin_expr)
+                                        .get_tag(expr_ty_arg1, expr_ty_arg2),
+                                );
+                            }
                         };
                         if prior_capability.contains(&Capability::new_borrowed_tag(arg1, &arg2)) {
                             // Determine the set of possible tag types for this access.

--- a/cedar-policy-validator/src/typecheck/test.rs
+++ b/cedar-policy-validator/src/typecheck/test.rs
@@ -30,5 +30,6 @@ mod optional_attributes;
 mod partial;
 mod policy;
 mod strict;
+mod tags;
 mod type_annotation;
 mod unspecified_entity;

--- a/cedar-policy-validator/src/typecheck/test/tags.rs
+++ b/cedar-policy-validator/src/typecheck/test/tags.rs
@@ -21,7 +21,8 @@
 #![cfg(feature = "entity-tags")]
 
 use super::test_utils::{
-    assert_exactly_one_diagnostic, assert_policy_typecheck_fails, assert_policy_typecheck_warns, assert_policy_typechecks
+    assert_exactly_one_diagnostic, assert_policy_typecheck_fails, assert_policy_typecheck_warns,
+    assert_policy_typechecks,
 };
 use cedar_policy_core::{
     ast::PolicyID,
@@ -326,10 +327,12 @@ fn tags_on_actions() {
     expect_err(
         src,
         &miette::Report::new(error),
-        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unable to guarantee safety of access to tag `"foo"`"#)
-            .help(r#"try testing for the tag's presence with `.hasTag("foo") && ..`"#)
-            .exactly_one_underline(r#"action.getTag("foo")"#)
-            .build(),
+        &ExpectedErrorMessageBuilder::error(
+            r#"for policy `0`, unable to guarantee safety of access to tag `"foo"`"#,
+        )
+        .help(r#"try testing for the tag's presence with `.hasTag("foo") && ..`"#)
+        .exactly_one_underline(r#"action.getTag("foo")"#)
+        .build(),
     );
 }
 

--- a/cedar-policy-validator/src/typecheck/test/tags.rs
+++ b/cedar-policy-validator/src/typecheck/test/tags.rs
@@ -1,0 +1,315 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Contains tests for defining entity tags and typechecking their
+//! access using the ability added by capabilities.
+// GRCOV_STOP_COVERAGE
+
+#![cfg(feature = "entity-tags")]
+
+use super::test_utils::{
+    assert_exactly_one_diagnostic, assert_policy_typecheck_fails, assert_policy_typechecks,
+};
+use cedar_policy_core::{
+    ast::PolicyID,
+    parser::parse_policy,
+    test_utils::{expect_err, ExpectedErrorMessageBuilder},
+};
+use cool_asserts::assert_matches;
+
+fn schema_with_tags() -> &'static str {
+    r#"
+        entity E tags String;
+        entity F { foo: String, opt?: String } tags Set<String>;
+        entity Blank;
+        action A1 appliesTo {
+            principal: [E],
+            resource: [F],
+        };
+        action A2 appliesTo {
+            principal: [F],
+            resource: [E],
+        };
+        action A3 appliesTo {
+            principal: [E, F],
+            resource: [E, F],
+        };
+        action A4 appliesTo {
+            principal: [E],
+            resource: [Blank],
+        };
+    "#
+}
+
+#[test]
+fn tag_access_success() {
+    // constant-keys case
+    let policy = parse_policy(
+        Some(PolicyID::from_string("0")),
+        r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.hasTag("foo") && principal.getTag("foo") == "foo"
+        };
+        "#,
+    )
+    .unwrap();
+    assert_policy_typechecks(schema_with_tags(), policy);
+
+    // computed-keys case
+    let policy = parse_policy(
+        Some(PolicyID::from_string("0")),
+        r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.hasTag(resource.foo) && principal.getTag(resource.foo) == "foo"
+        };
+        "#,
+    )
+    .unwrap();
+    assert_policy_typechecks(schema_with_tags(), policy);
+}
+
+#[test]
+fn tag_access_missing_has_check() {
+    // constant-keys case
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.getTag("foo") == "foo"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unable to guarantee safety of access to tag `"foo"` on entity type `E`"#)
+            .help(r#"try testing for the tag's presence with `.hasTag("foo") && ..`"#)
+            .exactly_one_underline(r#"principal.getTag("foo")"#)
+            .build(),
+    );
+
+    // computed-keys case
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.getTag(resource.foo) == "foo"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unable to guarantee safety of access to tag `resource["foo"]` on entity type `E`"#)
+            .help(r#"try testing for the tag's presence with `.hasTag(resource["foo"]) && ..`"#)
+            .exactly_one_underline(r#"principal.getTag(resource.foo)"#)
+            .build(),
+    );
+}
+
+#[test]
+fn tag_access_type_error() {
+    // constant-keys case
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.hasTag("foo") && principal.getTag("foo").contains("bar")
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unexpected type: expected Set<__cedar::internal::Any> but saw String"#)
+            .help("try using `like` to examine the contents of a string")
+            .exactly_one_underline(r#"principal.getTag("foo").contains("bar")"#)
+            .build(),
+    );
+
+    // computed-keys case
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.hasTag(resource.foo) && principal.getTag(resource.foo).contains("bar")
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unexpected type: expected Set<__cedar::internal::Any> but saw String"#)
+            .help("try using `like` to examine the contents of a string")
+            .exactly_one_underline(r#"principal.getTag(resource.foo).contains("bar")"#)
+            .build(),
+    );
+
+    // works for one principal type this action applies to, but not for all
+    let src = r#"
+        permit(principal, action == Action::"A3", resource) when {
+            principal.hasTag("foo") && principal.getTag("foo") == "bar"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"the types String and Set<String> are not compatible"#)
+            .help("for policy `0`, both operands to a `==` expression must have compatible types. Types must be exactly equal to be compatible")
+            .exactly_one_underline(r#"principal.getTag("foo") == "bar""#)
+            .build(),
+    );
+
+    // works for one action this policy applies to, but not for all
+    let src = r#"
+        permit(principal, action in [Action::"A1", Action::"A2"], resource) when {
+            principal.hasTag("foo") && principal.getTag("foo") == "bar"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"the types String and Set<String> are not compatible"#)
+            .help("for policy `0`, both operands to a `==` expression must have compatible types. Types must be exactly equal to be compatible")
+            .exactly_one_underline(r#"principal.getTag("foo") == "bar""#)
+            .build(),
+    );
+}
+
+#[test]
+fn no_tags_allowed() {
+    // .hasTag() on an entity with no tags is allowed
+    let src = r#"
+        permit(principal, action == Action::"A4", resource) when {
+            resource.hasTag("foo")
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    assert_policy_typechecks(schema_with_tags(), policy);
+
+    // .getTag() on an entity with no tags is not allowed
+    let src = r#"
+        permit(principal, action == Action::"A4", resource) when {
+            resource.getTag("foo") == "bar"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unable to guarantee safety of access to tag `"foo"` on entity type `Blank`"#)
+            .help(r#"try testing for the tag's presence with `.hasTag("foo") && ..`"#)
+            .exactly_one_underline(r#"resource.getTag("foo")"#)
+            .build(),
+    );
+
+    // .getTag() on an entity with no tags _is_ allowed if guarded by an
+    // appropriate `.hasTag()` check, because of short-circuiting
+    let src = r#"
+        permit(principal, action == Action::"A4", resource) when {
+            resource.hasTag("foo") && resource.getTag("foo") == "bar"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    assert_policy_typechecks(schema_with_tags(), policy);
+}
+
+/// having a capability for attribute "foo" doesn't let you access tag "foo", and vice versa
+#[test]
+fn mixed_tags_and_attrs() {
+    // have attr capability, try to access tag
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            resource has opt && resource.getTag("opt").contains("foo")
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unable to guarantee safety of access to tag `"opt"` on entity type `F`"#)
+            .help(r#"try testing for the tag's presence with `.hasTag("opt") && ..`"#)
+            .exactly_one_underline(r#"resource.getTag("opt").contains("foo")"#) // why does the `.contains("foo")` part get underlined?
+            .build(),
+    );
+
+    // have tag capability, try to access attr
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            resource.hasTag("opt") && resource.opt == "foo"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    let errors = assert_policy_typecheck_fails(schema_with_tags(), policy);
+    let error = assert_exactly_one_diagnostic(errors);
+    expect_err(
+        src,
+        &miette::Report::new(error),
+        &ExpectedErrorMessageBuilder::error(r#"for policy `0`, unable to guarantee safety of access to optional attribute `opt` on entity type `F`"#)
+            .help(r#"try testing for the attribute's presence with `e has opt && ..`"#)
+            .exactly_one_underline("resource.opt")
+            .build(),
+    );
+
+    // gaining a capability for an attr doesn't wipe out your capability for the tag
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            resource.hasTag("opt") && resource has opt && resource.getTag("opt").contains("bar")
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    assert_policy_typechecks(schema_with_tags(), policy);
+
+    // gaining a capability for a tag doesn't wipe out your capability for the attr
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            resource has opt && resource.hasTag("opt") && resource.opt == "bar"
+        };
+    "#;
+    let policy = parse_policy(Some(PolicyID::from_string("0")), src).unwrap();
+    assert_policy_typechecks(schema_with_tags(), policy);
+}
+
+/// Not a test of tag functionality itself, but just double-checking that
+/// although tags support computed keys (as evidenced by above tests),
+/// attributes do not
+#[test]
+fn computed_attribute_fails() {
+    let src = r#"
+        permit(principal, action == Action::"A1", resource) when {
+            principal.hasTag("foo") && resource[principal.getTag("foo")] == "bar"
+        };
+    "#;
+    assert_matches!(parse_policy(Some(PolicyID::from_string("0")), src), Err(e) => {
+        expect_err(
+            src,
+            &miette::Report::new(e),
+            &ExpectedErrorMessageBuilder::error(r#"invalid string literal: principal.getTag("foo")"#)
+                .exactly_one_underline(r#"principal.getTag("foo")"#)
+                .build()
+        )
+    });
+}

--- a/cedar-policy-validator/src/types/capability.rs
+++ b/cedar-policy-validator/src/types/capability.rs
@@ -59,9 +59,9 @@ impl<'a> CapabilitySet<'a> {
 pub struct Capability<'a> {
     /// For this expression
     on_expr: ExprShapeOnly<'a, ()>,
-    /// This attribute is known to exist on that expression
+    /// This attribute or tag is known to exist on that expression
     ///
-    /// This expression represents the attribute name. It should have type string.
+    /// This expression represents the attribute or tag name. It should have type string.
     /// Often this is a string constant, but in the case of tags it can be an expression.
     attribute_or_tag: ExprShapeOnly<'a, ()>,
     /// Is `attribute_or_tag` an attribute name or a tag name

--- a/cedar-policy-validator/src/types/capability.rs
+++ b/cedar-policy-validator/src/types/capability.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+use smol_str::SmolStr;
 use std::collections::HashSet;
 
 use cedar_policy_core::ast::{Expr, ExprShapeOnly};
@@ -57,18 +58,52 @@ impl<'a> CapabilitySet<'a> {
 #[derive(Hash, Eq, PartialEq, Debug, Clone)]
 pub struct Capability<'a> {
     /// For this expression
-    on_expr: ExprShapeOnly<'a>,
+    on_expr: ExprShapeOnly<'a, ()>,
     /// This attribute is known to exist on that expression
-    attribute: &'a str,
+    ///
+    /// This expression represents the attribute name. It should have type string.
+    /// Often, but not necessarily, this is a string constant.
+    attribute_or_tag: ExprShapeOnly<'a, ()>,
+    /// Is `attribute_or_tag` an attribute name or a tag name
+    kind: CapabilityKind,
+}
+
+#[derive(Hash, Eq, PartialEq, Debug, Clone, Copy)]
+enum CapabilityKind {
+    /// This capability is for accessing attributes
+    Attribute,
+    /// This capability is for accessing tags
+    Tag,
 }
 
 impl<'a> Capability<'a> {
     /// Construct a new [`Capability`] stating that the attribute `attribute` is
     /// known to exist for the expression `on_expr`
-    pub fn new(on_expr: &'a Expr, attribute: &'a str) -> Self {
+    pub fn new_attribute(on_expr: &'a Expr<()>, attribute: SmolStr) -> Self {
         Self {
-            on_expr: ExprShapeOnly::new(on_expr),
-            attribute,
+            on_expr: ExprShapeOnly::new_from_borrowed(on_expr),
+            attribute_or_tag: ExprShapeOnly::new_from_owned(Expr::val(attribute)),
+            kind: CapabilityKind::Attribute,
+        }
+    }
+
+    /// Construct a new [`Capability`] stating that the tag `tag` is
+    /// known to exist for the expression `on_expr`
+    pub fn new_borrowed_tag(on_expr: &'a Expr<()>, tag: &'a Expr<()>) -> Self {
+        Self {
+            on_expr: ExprShapeOnly::new_from_borrowed(on_expr),
+            attribute_or_tag: ExprShapeOnly::new_from_borrowed(tag),
+            kind: CapabilityKind::Tag,
+        }
+    }
+
+    /// Construct a new [`Capability`] stating that the tag `tag` is
+    /// known to exist for the expression `on_expr`
+    pub fn new_owned_tag(on_expr: &'a Expr<()>, tag: Expr<()>) -> Self {
+        Self {
+            on_expr: ExprShapeOnly::new_from_borrowed(on_expr),
+            attribute_or_tag: ExprShapeOnly::new_from_owned(tag),
+            kind: CapabilityKind::Tag,
         }
     }
 }

--- a/cedar-policy-validator/src/types/capability.rs
+++ b/cedar-policy-validator/src/types/capability.rs
@@ -62,7 +62,7 @@ pub struct Capability<'a> {
     /// This attribute is known to exist on that expression
     ///
     /// This expression represents the attribute name. It should have type string.
-    /// Often, but not necessarily, this is a string constant.
+    /// Often this is a string constant, but in the case of tags it can be an expression.
     attribute_or_tag: ExprShapeOnly<'a, ()>,
     /// Is `attribute_or_tag` an attribute name or a tag name
     kind: CapabilityKind,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,7 @@ Cedar Language Version: TBD
 ### Added
 
 - Implemented [RFC 82](https://github.com/cedar-policy/rfcs/pull/82), adding
-  entity tags to the Cedar language under experimental flag `entity-tags` (#1204, #1207, more coming)
+  entity tags to the Cedar language under experimental flag `entity-tags` (#1204, #1207, #1213, #1218)
 - Implemented [RFC 74](https://github.com/cedar-policy/rfcs/pull/74): A new experimental API (`compute_entity_manifest`)
   that provides the Entity Manifest: a data
   structure that describes what data is required to satisfy a

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -65,7 +65,7 @@ use std::str::FromStr;
 pub struct Entity(ast::Entity);
 
 impl Entity {
-    /// Create a new `Entity` with this Uid, attributes, and parents.
+    /// Create a new `Entity` with this Uid, attributes, and parents (and no tags).
     ///
     /// Attribute values are specified here as "restricted expressions".
     /// See docs on `RestrictedExpression`
@@ -95,16 +95,15 @@ impl Entity {
         // the `Entities` object is created
         Ok(Self(ast::Entity::new(
             uid.into(),
-            attrs
-                .into_iter()
-                .map(|(k, v)| (SmolStr::from(k), v.0))
-                .collect(),
+            attrs.into_iter().map(|(k, v)| (SmolStr::from(k), v.0)),
             parents.into_iter().map(EntityUid::into).collect(),
+            #[cfg(feature = "entity-tags")]
+            [],
             Extensions::all_available(),
         )?))
     }
 
-    /// Create a new `Entity` with this Uid, parents, and no attributes.
+    /// Create a new `Entity` with this Uid, parents, and no attributes or tags.
     /// This is the same as `Self::new` except the attributes are empty, and therefore it can
     /// return `Self` instead of `Result<Self>`
     pub fn new_empty_attrs(uid: EntityUid, parents: HashSet<EntityUid>) -> Self {

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -416,6 +416,11 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     HierarchyNotRespected(#[from] validation_errors::HierarchyNotRespected),
+    /// Returned when an internal invariant is violated (should not happen; if
+    /// this is ever returned, please file an issue)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InternalInvariantViolation(#[from] validation_errors::InternalInvariantViolation),
 }
 
 impl ValidationError {
@@ -439,6 +444,7 @@ impl ValidationError {
             Self::EmptySetForbidden(e) => e.policy_id(),
             Self::NonLitExtConstructor(e) => e.policy_id(),
             Self::HierarchyNotRespected(e) => e.policy_id(),
+            Self::InternalInvariantViolation(e) => e.policy_id(),
         }
     }
 }
@@ -493,6 +499,9 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
             }
             cedar_policy_validator::ValidationError::HierarchyNotRespected(e) => {
                 Self::HierarchyNotRespected(e.into())
+            }
+            cedar_policy_validator::ValidationError::InternalInvariantViolation(e) => {
+                Self::InternalInvariantViolation(e.into())
             }
         }
     }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -375,6 +375,16 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     UnsafeOptionalAttributeAccess(#[from] validation_errors::UnsafeOptionalAttributeAccess),
+    /// The typechecker could not conclude that an access to a tag was safe.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    #[cfg(feature = "entity-tags")]
+    UnsafeTagAccess(#[from] validation_errors::UnsafeTagAccess),
+    /// `.getTag()` on an entity type which cannot have tags according to the schema.
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    #[cfg(feature = "entity-tags")]
+    NoTagsAllowed(#[from] validation_errors::NoTagsAllowed),
     /// Undefined extension function.
     #[error(transparent)]
     #[diagnostic(transparent)]
@@ -414,6 +424,10 @@ impl ValidationError {
             Self::IncompatibleTypes(e) => e.policy_id(),
             Self::UnsafeAttributeAccess(e) => e.policy_id(),
             Self::UnsafeOptionalAttributeAccess(e) => e.policy_id(),
+            #[cfg(feature = "entity-tags")]
+            Self::UnsafeTagAccess(e) => e.policy_id(),
+            #[cfg(feature = "entity-tags")]
+            Self::NoTagsAllowed(e) => e.policy_id(),
             Self::UndefinedFunction(e) => e.policy_id(),
             Self::WrongNumberArguments(e) => e.policy_id(),
             Self::FunctionArgumentValidation(e) => e.policy_id(),
@@ -448,6 +462,14 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
             }
             cedar_policy_validator::ValidationError::UnsafeOptionalAttributeAccess(e) => {
                 Self::UnsafeOptionalAttributeAccess(e.into())
+            }
+            #[cfg(feature = "entity-tags")]
+            cedar_policy_validator::ValidationError::UnsafeTagAccess(e) => {
+                Self::UnsafeTagAccess(e.into())
+            }
+            #[cfg(feature = "entity-tags")]
+            cedar_policy_validator::ValidationError::NoTagsAllowed(e) => {
+                Self::NoTagsAllowed(e.into())
             }
             cedar_policy_validator::ValidationError::UndefinedFunction(e) => {
                 Self::UndefinedFunction(e.into())

--- a/cedar-policy/src/api/err/validation_errors.rs
+++ b/cedar-policy/src/api/err/validation_errors.rs
@@ -63,6 +63,10 @@ wrap_core_error!(UnexpectedType);
 wrap_core_error!(IncompatibleTypes);
 wrap_core_error!(UnsafeAttributeAccess);
 wrap_core_error!(UnsafeOptionalAttributeAccess);
+#[cfg(feature = "entity-tags")]
+wrap_core_error!(UnsafeTagAccess);
+#[cfg(feature = "entity-tags")]
+wrap_core_error!(NoTagsAllowed);
 wrap_core_error!(UndefinedFunction);
 wrap_core_error!(WrongNumberArguments);
 wrap_core_error!(FunctionArgumentValidation);

--- a/cedar-policy/src/api/err/validation_errors.rs
+++ b/cedar-policy/src/api/err/validation_errors.rs
@@ -73,3 +73,4 @@ wrap_core_error!(FunctionArgumentValidation);
 wrap_core_error!(HierarchyNotRespected);
 wrap_core_error!(EmptySetForbidden);
 wrap_core_error!(NonLitExtConstructor);
+wrap_core_error!(InternalInvariantViolation);


### PR DESCRIPTION
## Description of changes

Support `.hasTag()` and `.getTag()` (RFC 82) in the validator.

## Issue #, if available

[RFC 82](https://github.com/cedar-policy/rfcs/blob/emina/entity-tags/text/0082-entity-tags.md)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

