### PR TITLE
Tweak constructor to avoid re-building attrs Map

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -386,18 +386,20 @@ impl Entity {
     ///
     /// Unlike in `Entity::new()`, in this constructor, attributes are expressed
     /// as `PartialValue`.
+    ///
+    /// Callers should consider directly using [`Entity::new_with_attr_partial_value_serialized_as_expr`]
+    /// if they would call this method by first building a map, as it will
+    /// deconstruct and re-build the map perhaps unnecessarily.
     pub fn new_with_attr_partial_value(
         uid: EntityUID,
-        attrs: HashMap<SmolStr, PartialValue>,
+        attrs: impl IntoIterator<Item = (SmolStr, PartialValue)>,
         ancestors: HashSet<EntityUID>,
     ) -> Self {
-        Entity {
+        Self::new_with_attr_partial_value_serialized_as_expr(
             uid,
-            attrs: attrs.into_iter().map(|(k, v)| (k, v.into())).collect(), // TODO(#540): can we do this without disassembling and reassembling the HashMap
+            attrs.into_iter().map(|(k, v)| (k, v.into())).collect(),
             ancestors,
-            #[cfg(feature = "entity-tags")]
-            tags: BTreeMap::new(),
-        }
+        )
     }
 
     /// Create a new `Entity` with this UID, attributes, and ancestors (and no tags)

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2010,9 +2010,7 @@ mod schema_based_parsing_tests {
             match action.to_string().as_str() {
                 r#"Action::"view""# => Some(Arc::new(Entity::new_with_attr_partial_value(
                     action.clone(),
-                    [(SmolStr::from("foo"), PartialValue::from(34))]
-                        .into_iter()
-                        .collect(),
+                    [(SmolStr::from("foo"), PartialValue::from(34))],
                     [r#"Action::"readOnly""#.parse().expect("valid uid")]
                         .into_iter()
                         .collect(),

--- a/cedar-policy-core/src/entities/json/schema.rs
+++ b/cedar-policy-core/src/entities/json/schema.rs
@@ -18,7 +18,7 @@ use super::SchemaType;
 use crate::ast::{Entity, EntityType, EntityUID};
 use crate::entities::{Name, UnreservedId};
 use smol_str::SmolStr;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Trait for `Schema`s that can inform the parsing of Entity JSON data
@@ -95,7 +95,7 @@ impl Schema for AllEntitiesNoAttrsSchema {
     fn action(&self, action: &EntityUID) -> Option<Arc<Entity>> {
         Some(Arc::new(Entity::new_with_attr_partial_value(
             action.clone(),
-            HashMap::new(),
+            [],
             HashSet::new(),
         )))
     }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -2486,7 +2486,7 @@ pub(crate) mod test {
         let view_photo = actions.entity(&action_uid);
         assert_eq!(
             view_photo.unwrap(),
-            &Entity::new_with_attr_partial_value(action_uid, HashMap::new(), HashSet::new())
+            &Entity::new_with_attr_partial_value(action_uid, [], HashSet::new())
         );
     }
 
@@ -2520,7 +2520,7 @@ pub(crate) mod test {
             view_photo_entity.unwrap(),
             &Entity::new_with_attr_partial_value(
                 view_photo_uid,
-                HashMap::new(),
+                [],
                 HashSet::from([view_uid.clone(), read_uid.clone()])
             )
         );
@@ -2528,17 +2528,13 @@ pub(crate) mod test {
         let view_entity = actions.entity(&view_uid);
         assert_eq!(
             view_entity.unwrap(),
-            &Entity::new_with_attr_partial_value(
-                view_uid,
-                HashMap::new(),
-                HashSet::from([read_uid.clone()])
-            )
+            &Entity::new_with_attr_partial_value(view_uid, [], HashSet::from([read_uid.clone()]))
         );
 
         let read_entity = actions.entity(&read_uid);
         assert_eq!(
             read_entity.unwrap(),
-            &Entity::new_with_attr_partial_value(read_uid, HashMap::new(), HashSet::new())
+            &Entity::new_with_attr_partial_value(read_uid, [], HashSet::new())
         );
     }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -122,7 +122,7 @@ impl Entity {
         // the `Entities` object is created
         Self(ast::Entity::new_with_attr_partial_value(
             uid.into(),
-            HashMap::new(),
+            [],
             parents.into_iter().map(EntityUid::into).collect(),
         ))
     }


### PR DESCRIPTION
## Description of changes

Fix #540 

Avoid building a map twice in some cases by having the constructor take an `impl IntoIterator<Item = (SmolStr, PartialValue)>` instead of `HashMap`. There also already exists `new_with_attr_partial_value_serialized_as_expr` which can be called to avoid re-building when the `attrs` are already a `BTreeMap`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
