### PR TITLE
Add support for annotations without explicit value

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1170,43 +1170,11 @@ pub struct Annotation {
     /// Annotation value. `None` for annotations without a value, i.e., `@foo`.
     /// An annotation without a value should be treated as equivalent to the
     /// value being `""`. This interpretation is implemented by the `AsRef<str>`
-    /// impl an `val` method below.
-    val: Option<SmolStr>,
+    /// impl below.
+    pub val: Option<SmolStr>,
     /// Source location. Note this is the location of _the entire key-value
     /// pair_ for the annotation, not just `val` above
-    loc: Option<Loc>,
-}
-
-impl Annotation {
-    /// Construct a new annotation.
-    pub fn new(val: Option<SmolStr>, loc: Option<Loc>) -> Self {
-        Self { val, loc }
-    }
-
-    /// Get the annotation value, treating an annotation without a value as
-    /// being equivalent to the value `""`.
-    pub fn val(&self) -> &str {
-        self.as_ref()
-    }
-
-    /// Get the annotation value, returning `None` for annotations without a
-    /// value. We generally want to treat this as equivalent to `""`, but we
-    /// occasionally want a lossless representation.
-    pub fn raw_val(&self) -> Option<&SmolStr> {
-        self.val.as_ref()
-    }
-
-    /// Get the annotation value, returning `None` for annotations without a
-    /// value. We generally want to treat this as equivalent to `""`, but we
-    /// occasionally want a lossless representation.
-    pub fn into_raw_val(self) -> Option<SmolStr> {
-        self.val
-    }
-
-    /// Get the location for the whole annotation (not just the value).
-    pub fn loc(&self) -> Option<&Loc> {
-        self.loc.as_ref()
-    }
+    pub loc: Option<Loc>,
 }
 
 impl AsRef<str> for Annotation {

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1170,11 +1170,43 @@ pub struct Annotation {
     /// Annotation value. `None` for annotations without a value, i.e., `@foo`.
     /// An annotation without a value should be treated as equivalent to the
     /// value being `""`. This interpretation is implemented by the `AsRef<str>`
-    /// impl below.
-    pub val: Option<SmolStr>,
+    /// impl an `val` method below.
+    val: Option<SmolStr>,
     /// Source location. Note this is the location of _the entire key-value
     /// pair_ for the annotation, not just `val` above
-    pub loc: Option<Loc>,
+    loc: Option<Loc>,
+}
+
+impl Annotation {
+    /// Construct a new annotation.
+    pub fn new(val: Option<SmolStr>, loc: Option<Loc>) -> Self {
+        Self { val, loc }
+    }
+
+    /// Get the annotation value, treating an annotation without a value as
+    /// being equivalent to the value `""`.
+    pub fn val(&self) -> &str {
+        self.as_ref()
+    }
+
+    /// Get the annotation value, returning `None` for annotations without a
+    /// value. We generally want to treat this as equivalent to `""`, but we
+    /// occasionally want a lossless representation.
+    pub fn raw_val(&self) -> Option<&SmolStr> {
+        self.val.as_ref()
+    }
+
+    /// Get the annotation value, returning `None` for annotations without a
+    /// value. We generally want to treat this as equivalent to `""`, but we
+    /// occasionally want a lossless representation.
+    pub fn into_raw_val(self) -> Option<SmolStr> {
+        self.val
+    }
+
+    /// Get the location for the whole annotation (not just the value).
+    pub fn loc(&self) -> Option<&Loc> {
+        self.loc.as_ref()
+    }
 }
 
 impl AsRef<str> for Annotation {

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1085,7 +1085,11 @@ impl From<StaticPolicy> for TemplateBody {
 impl std::fmt::Display for TemplateBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.annotations.iter() {
-            writeln!(f, "@{}(\"{}\")", k, v.val.escape_debug())?
+            write!(f, "@{k}")?;
+            if let Some(v) = &v.val {
+                write!(f, "(\"{}\")", v.escape_debug())?;
+            }
+            writeln!(f)?;
         }
         write!(
             f,
@@ -1163,8 +1167,11 @@ impl From<BTreeMap<AnyId, Annotation>> for Annotations {
 /// Struct which holds the value of a particular annotation
 #[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, PartialOrd, Ord)]
 pub struct Annotation {
-    /// Annotation value
-    pub val: SmolStr,
+    /// Annotation value. `None` for annotations without a value, i.e., `@foo`.
+    /// An annotation without a value should be treated as equivalent to the
+    /// value being `""`. This interpretation is implemented by the `AsRef<str>`
+    /// impl below.
+    pub val: Option<SmolStr>,
     /// Source location. Note this is the location of _the entire key-value
     /// pair_ for the annotation, not just `val` above
     pub loc: Option<Loc>,
@@ -1172,7 +1179,7 @@ pub struct Annotation {
 
 impl AsRef<str> for Annotation {
     fn as_ref(&self) -> &str {
-        &self.val
+        self.val.as_ref().map(SmolStr::as_str).unwrap_or("")
     }
 }
 
@@ -1704,7 +1711,11 @@ impl ActionConstraint {
 impl std::fmt::Display for StaticPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.0.annotations.iter() {
-            writeln!(f, "@{}(\"{}\")", k, v.val.escape_debug())?
+            write!(f, "@{k}")?;
+            if let Some(v) = &v.val {
+                write!(f, "(\"{}\")", v.escape_debug())?;
+            }
+            writeln!(f)?;
         }
         write!(
             f,

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1086,7 +1086,7 @@ impl std::fmt::Display for TemplateBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.annotations.iter() {
             write!(f, "@{k}")?;
-            if let Some(v) = &v.val {
+            if let Some(v) = &v.raw_val {
                 write!(f, "(\"{}\")", v.escape_debug())?;
             }
             writeln!(f)?;
@@ -1171,7 +1171,7 @@ pub struct Annotation {
     /// An annotation without a value should be treated as equivalent to the
     /// value being `""`. This interpretation is implemented by the `AsRef<str>`
     /// impl an `val` method below.
-    val: Option<SmolStr>,
+    raw_val: Option<SmolStr>,
     /// Source location. Note this is the location of _the entire key-value
     /// pair_ for the annotation, not just `val` above
     loc: Option<Loc>,
@@ -1180,7 +1180,7 @@ pub struct Annotation {
 impl Annotation {
     /// Construct a new annotation.
     pub fn new(val: Option<SmolStr>, loc: Option<Loc>) -> Self {
-        Self { val, loc }
+        Self { raw_val: val, loc }
     }
 
     /// Get the annotation value, treating an annotation without a value as
@@ -1193,14 +1193,14 @@ impl Annotation {
     /// value. We generally want to treat this as equivalent to `""`, but we
     /// occasionally want a lossless representation.
     pub fn raw_val(&self) -> Option<&SmolStr> {
-        self.val.as_ref()
+        self.raw_val.as_ref()
     }
 
     /// Get the annotation value, returning `None` for annotations without a
     /// value. We generally want to treat this as equivalent to `""`, but we
     /// occasionally want a lossless representation.
     pub fn into_raw_val(self) -> Option<SmolStr> {
-        self.val
+        self.raw_val
     }
 
     /// Get the location for the whole annotation (not just the value).
@@ -1211,7 +1211,7 @@ impl Annotation {
 
 impl AsRef<str> for Annotation {
     fn as_ref(&self) -> &str {
-        self.val.as_ref().map(SmolStr::as_str).unwrap_or("")
+        self.raw_val.as_ref().map(SmolStr::as_str).unwrap_or("")
     }
 }
 
@@ -1744,7 +1744,7 @@ impl std::fmt::Display for StaticPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.0.annotations.iter() {
             write!(f, "@{k}")?;
-            if let Some(v) = &v.val {
+            if let Some(v) = &v.raw_val {
                 write!(f, "(\"{}\")", v.escape_debug())?;
             }
             writeln!(f)?;

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1085,7 +1085,7 @@ impl From<StaticPolicy> for TemplateBody {
 impl std::fmt::Display for TemplateBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.annotations.iter() {
-            writeln!(f, "@{k}(\"{}\")", v.val.escape_debug())?;
+            writeln!(f, "@{}(\"{}\")", k, v.val.escape_debug())?
         }
         write!(
             f,
@@ -1717,7 +1717,7 @@ impl ActionConstraint {
 impl std::fmt::Display for StaticPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.0.annotations.iter() {
-            writeln!(f, "@{k}(\"{}\")", v.val.escape_debug())?;
+            writeln!(f, "@{}(\"{}\")", k, v.val.escape_debug())?
         }
         write!(
             f,

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1086,7 +1086,7 @@ impl std::fmt::Display for TemplateBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.annotations.iter() {
             write!(f, "@{k}")?;
-            if let Some(v) = &v.raw_val {
+            if let Some(v) = &v.val {
                 write!(f, "(\"{}\")", v.escape_debug())?;
             }
             writeln!(f)?;
@@ -1171,7 +1171,7 @@ pub struct Annotation {
     /// An annotation without a value should be treated as equivalent to the
     /// value being `""`. This interpretation is implemented by the `AsRef<str>`
     /// impl an `val` method below.
-    raw_val: Option<SmolStr>,
+    val: Option<SmolStr>,
     /// Source location. Note this is the location of _the entire key-value
     /// pair_ for the annotation, not just `val` above
     loc: Option<Loc>,
@@ -1180,7 +1180,7 @@ pub struct Annotation {
 impl Annotation {
     /// Construct a new annotation.
     pub fn new(val: Option<SmolStr>, loc: Option<Loc>) -> Self {
-        Self { raw_val: val, loc }
+        Self { val, loc }
     }
 
     /// Get the annotation value, treating an annotation without a value as
@@ -1193,14 +1193,14 @@ impl Annotation {
     /// value. We generally want to treat this as equivalent to `""`, but we
     /// occasionally want a lossless representation.
     pub fn raw_val(&self) -> Option<&SmolStr> {
-        self.raw_val.as_ref()
+        self.val.as_ref()
     }
 
     /// Get the annotation value, returning `None` for annotations without a
     /// value. We generally want to treat this as equivalent to `""`, but we
     /// occasionally want a lossless representation.
     pub fn into_raw_val(self) -> Option<SmolStr> {
-        self.raw_val
+        self.val
     }
 
     /// Get the location for the whole annotation (not just the value).
@@ -1211,7 +1211,7 @@ impl Annotation {
 
 impl AsRef<str> for Annotation {
     fn as_ref(&self) -> &str {
-        self.raw_val.as_ref().map(SmolStr::as_str).unwrap_or("")
+        self.val.as_ref().map(SmolStr::as_str).unwrap_or("")
     }
 }
 
@@ -1744,7 +1744,7 @@ impl std::fmt::Display for StaticPolicy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.0.annotations.iter() {
             write!(f, "@{k}")?;
-            if let Some(v) = &v.raw_val {
+            if let Some(v) = &v.val {
                 write!(f, "(\"{}\")", v.escape_debug())?;
             }
             writeln!(f)?;

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -172,10 +172,7 @@ impl TryFrom<cst::Policy> for Policy {
             action: action.into(),
             resource: resource.into(),
             conditions,
-            annotations: annotations
-                .into_iter()
-                .map(|(k, v)| (k, v.into_raw_val()))
-                .collect(),
+            annotations: annotations.into_iter().map(|(k, v)| (k, v.val)).collect(),
         })
     }
 }
@@ -265,7 +262,7 @@ impl Policy {
             None,
             self.annotations
                 .into_iter()
-                .map(|(key, val)| (key, ast::Annotation::new(val, None)))
+                .map(|(key, val)| (key, ast::Annotation { val, loc: None }))
                 .collect(),
             self.effect,
             self.principal.try_into()?,
@@ -311,7 +308,7 @@ impl From<ast::Policy> for Policy {
             conditions: vec![ast.non_scope_constraints().clone().into()],
             annotations: ast
                 .annotations()
-                .map(|(k, v)| (k.clone(), v.raw_val().cloned()))
+                .map(|(k, v)| (k.clone(), v.val.clone()))
                 .collect(),
         }
     }
@@ -328,7 +325,7 @@ impl From<ast::Template> for Policy {
             conditions: vec![ast.non_scope_constraints().clone().into()],
             annotations: ast
                 .annotations()
-                .map(|(k, v)| (k.clone(), v.raw_val().cloned()))
+                .map(|(k, v)| (k.clone(), v.val.clone()))
                 .collect(),
         }
     }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -140,7 +140,10 @@ impl TryFrom<cst::Policy> for Policy {
             action: action.into(),
             resource: resource.into(),
             conditions,
-            annotations: annotations.into_iter().map(|(k, v)| (k, v.val)).collect(),
+            annotations: annotations
+                .into_iter()
+                .map(|(k, v)| (k, v.into_raw_val()))
+                .collect(),
         })
     }
 }
@@ -230,7 +233,7 @@ impl Policy {
             None,
             self.annotations
                 .into_iter()
-                .map(|(key, val)| (key, ast::Annotation { val, loc: None }))
+                .map(|(key, val)| (key, ast::Annotation::new(val, None)))
                 .collect(),
             self.effect,
             self.principal.try_into()?,
@@ -276,7 +279,7 @@ impl From<ast::Policy> for Policy {
             conditions: vec![ast.non_scope_constraints().clone().into()],
             annotations: ast
                 .annotations()
-                .map(|(k, v)| (k.clone(), v.val.clone()))
+                .map(|(k, v)| (k.clone(), v.raw_val().cloned()))
                 .collect(),
         }
     }
@@ -293,7 +296,7 @@ impl From<ast::Template> for Policy {
             conditions: vec![ast.non_scope_constraints().clone().into()],
             annotations: ast
                 .annotations()
-                .map(|(k, v)| (k.clone(), v.val.clone()))
+                .map(|(k, v)| (k.clone(), v.raw_val().cloned()))
                 .collect(),
         }
     }

--- a/cedar-policy-core/src/parser/cst.rs
+++ b/cedar-policy-core/src/parser/cst.rs
@@ -31,7 +31,7 @@ pub struct Annotation {
     /// key
     pub key: Node<Ident>,
     /// value
-    pub value: Node<Str>,
+    pub value: Option<Node<Str>>,
 }
 
 /// Literal strings

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -365,10 +365,8 @@ impl Node<Option<cst::Annotation>> {
         let (k, v) = flatten_tuple_2(maybe_key, maybe_value)?;
         Ok((
             k,
-            ast::Annotation {
-                val: v,
-                loc: Some(self.loc.clone()), // self's loc, not the loc of the value alone; see comments on ast::Annotation
-            },
+            // self's loc, not the loc of the value alone; see comments on ast::Annotation
+            ast::Annotation::new(v, Some(self.loc.clone())),
         ))
     }
 }
@@ -2428,7 +2426,7 @@ mod tests {
         assert_matches!(
             policy.annotation(&ast::AnyId::new_unchecked("anno")),
             Some(annotation) => {
-                assert_eq!(annotation.val, None);
+                assert_eq!(annotation.raw_val(), None);
                 assert_eq!(annotation.as_ref(), "");
             }
         );
@@ -2455,14 +2453,14 @@ mod tests {
         assert_matches!(
             policy.annotation(&ast::AnyId::new_unchecked("foo")),
             Some(annotation) => {
-                assert_eq!(annotation.val, None);
+                assert_eq!(annotation.raw_val(), None);
                 assert_eq!(annotation.as_ref(), "");
             }
         );
         assert_matches!(
             policy.annotation(&ast::AnyId::new_unchecked("bar")),
             Some(annotation) => {
-                assert_eq!(annotation.val, None);
+                assert_eq!(annotation.raw_val(), None);
                 assert_eq!(annotation.as_ref(), "");
             }
         );

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -365,8 +365,10 @@ impl Node<Option<cst::Annotation>> {
         let (k, v) = flatten_tuple_2(maybe_key, maybe_value)?;
         Ok((
             k,
-            // self's loc, not the loc of the value alone; see comments on ast::Annotation
-            ast::Annotation::new(v, Some(self.loc.clone())),
+            ast::Annotation {
+                val: v,
+                loc: Some(self.loc.clone()), // self's loc, not the loc of the value alone; see comments on ast::Annotation
+            },
         ))
     }
 }
@@ -2426,7 +2428,7 @@ mod tests {
         assert_matches!(
             policy.annotation(&ast::AnyId::new_unchecked("anno")),
             Some(annotation) => {
-                assert_eq!(annotation.raw_val(), None);
+                assert_eq!(annotation.val, None);
                 assert_eq!(annotation.as_ref(), "");
             }
         );
@@ -2453,14 +2455,14 @@ mod tests {
         assert_matches!(
             policy.annotation(&ast::AnyId::new_unchecked("foo")),
             Some(annotation) => {
-                assert_eq!(annotation.raw_val(), None);
+                assert_eq!(annotation.val, None);
                 assert_eq!(annotation.as_ref(), "");
             }
         );
         assert_matches!(
             policy.annotation(&ast::AnyId::new_unchecked("bar")),
             Some(annotation) => {
-                assert_eq!(annotation.raw_val(), None);
+                assert_eq!(annotation.val, None);
                 assert_eq!(annotation.as_ref(), "");
             }
         );

--- a/cedar-policy-core/src/parser/fmt.rs
+++ b/cedar-policy-core/src/parser/fmt.rs
@@ -116,7 +116,10 @@ impl fmt::Display for Policy {
 
 impl fmt::Display for Annotation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "@{}({})", View(&self.key), View(&self.value))
+        match self.value.as_ref() {
+            Some(value) => write!(f, "@{}({})", View(&self.key), View(value)),
+            None => write!(f, "@{}", View(&self.key)),
+        }
     }
 }
 

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -98,7 +98,7 @@ pub Policies: Node<Option<cst::Policies>> = {
 
 // Annotations := {'@' Ident '(' String ')'}
 Annotation: Node<Option<cst::Annotation>> = {
-    <l:@L> "@" <key:AnyIdent> "(" <value:Str> ")" <r:@R> => Node::with_source_loc(Some(cst::Annotation{key,value}), Loc::new(l..r, Arc::clone(src)))
+    <l:@L> "@" <key:AnyIdent> <value: ("(" <Str> ")")?> <r:@R> => Node::with_source_loc(Some(cst::Annotation{key,value}), Loc::new(l..r, Arc::clone(src)))
 }
 
 // Policy := "label" ('permit' | 'forbid') '(' {VariableDef} ')' {Cond} ;

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1012,7 +1012,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_annotations() {
+    fn policy_annotations_ok() {
         let policies = assert_parse_succeeds(
             parse_policies,
             r#"
@@ -1032,7 +1032,10 @@ mod tests {
                 .len(),
             4
         );
+    }
 
+    #[test]
+    fn policy_annotations_bad_id() {
         let src = r#"
             @bad-annotation("bad") permit (principal, action, resource);
         "#;
@@ -1041,10 +1044,42 @@ mod tests {
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `-`")
-                .exactly_one_underline_with_label("-", "expected `(`")
+                .exactly_one_underline_with_label("-", "expected `(`, `@`, or identifier")
                 .build(),
         );
 
+        let src = r#"
+            @hi mom("this should be invalid")
+            permit(principal, action, resource);
+        "#;
+        let errs = assert_parse_fails(parse_policies, src);
+        expect_exactly_one_error(
+            src,
+            &errs,
+            &ExpectedErrorMessageBuilder::error("unexpected token `\"this should be invalid\"`")
+                .exactly_one_underline_with_label(
+                    "\"this should be invalid\"",
+                    "expected `)` or identifier",
+                )
+                .build(),
+        );
+
+        let src = r#"
+            @hi+mom("this should be invalid")
+            permit(principal, action, resource);
+        "#;
+        let errs = assert_parse_fails(parse_policies, src);
+        expect_exactly_one_error(
+            src,
+            &errs,
+            &ExpectedErrorMessageBuilder::error("unexpected token `+`")
+                .exactly_one_underline_with_label("+", "expected `(`, `@`, or identifier")
+                .build(),
+        );
+    }
+
+    #[test]
+    fn policy_annotations_bad_val() {
         let src = r#"
             @bad_annotation("bad","annotation") permit (principal, action, resource);
         "#;
@@ -1054,6 +1089,18 @@ mod tests {
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `,`")
                 .exactly_one_underline_with_label(",", "expected `)`")
+                .build(),
+        );
+
+        let src = r#"
+            @bad_annotation() permit (principal, action, resource);
+        "#;
+        let errs = assert_parse_fails(parse_policies, src);
+        expect_exactly_one_error(
+            src,
+            &errs,
+            &ExpectedErrorMessageBuilder::error("unexpected token `)`")
+                .exactly_one_underline_with_label(")", "expected string literal")
                 .build(),
         );
 
@@ -1068,7 +1115,10 @@ mod tests {
                 .exactly_one_underline_with_label("bad_annotation", "expected string literal")
                 .build(),
         );
+    }
 
+    #[test]
+    fn policy_annotation_bad_position() {
         let src = r#"
             permit (@comment("your name here") principal, action, resource);
         "#;
@@ -1078,32 +1128,6 @@ mod tests {
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `@`")
                 .exactly_one_underline_with_label("@", "expected `)` or identifier")
-                .build(),
-        );
-
-        let src = r#"
-            @hi mom("this should be invalid")
-            permit(principal, action, resource);
-        "#;
-        let errs = assert_parse_fails(parse_policies, src);
-        expect_exactly_one_error(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `mom`")
-                .exactly_one_underline_with_label("mom", "expected `(`")
-                .build(),
-        );
-
-        let src = r#"
-            @hi+mom("this should be invalid")
-            permit(principal, action, resource);
-        "#;
-        let errs = assert_parse_fails(parse_policies, src);
-        expect_exactly_one_error(
-            src,
-            &errs,
-            &ExpectedErrorMessageBuilder::error("unexpected token `+`")
-                .exactly_one_underline_with_label("+", "expected `(`")
                 .build(),
         );
     }

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1038,12 +1038,9 @@ mod tests {
     fn policy_annotations_no_value_ok() {
         let policy = assert_parse_succeeds(
             parse_policy,
-            r#"@foo permit (principal, action, resource); "#,
+            r#"@foo permit (principal, action, resource);"#,
         );
         let annotation = policy.annotations.first().unwrap().as_inner().unwrap();
-
-        // The CST distinguishes the between `None` and empty string case, so we
-        // test this in addition to no-value tests on the AST.
         assert_eq!(annotation.value, None);
         assert_eq!(
             annotation.key.as_inner().unwrap().to_string(),

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1035,6 +1035,24 @@ mod tests {
     }
 
     #[test]
+    fn policy_annotations_no_value_ok() {
+        let policy = assert_parse_succeeds(
+            parse_policy,
+            r#"@foo permit (principal, action, resource); "#,
+        );
+        let annotation = policy.annotations.first().unwrap().as_inner().unwrap();
+
+        // The CST distinguishes the between `None` and empty string case, so we
+        // test this in addition to no-value tests on the AST.
+        assert_eq!(annotation.value, None);
+        assert_eq!(
+            annotation.key.as_inner().unwrap().to_string(),
+            "foo".to_string()
+        );
+        assert_eq!(policy.annotations.len(), 1);
+    }
+
+    #[test]
     fn policy_annotations_bad_id() {
         let src = r#"
             @bad-annotation("bad") permit (principal, action, resource);

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -741,8 +741,6 @@ impl Doc for Node<Option<Annotation>> {
                 );
                 lp_doc.append(val_doc).append(rp_doc)
             }
-            // A space is necessary so the annotation id doesn't run into the
-            // policy effect.
             None => RcDoc::hardline(),
         };
 

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -68,10 +68,10 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
         }
         let (f_anno, anno) = (
             f_p.annotations()
-                .map(|(k, v)| (k, &v.val))
+                .map(|(k, v)| (k, v.raw_val()))
                 .collect::<std::collections::BTreeMap<_, _>>(),
             p.annotations()
-                .map(|(k, v)| (k, &v.val))
+                .map(|(k, v)| (k, v.raw_val()))
                 .collect::<std::collections::BTreeMap<_, _>>(),
         );
         if f_anno != anno {

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -68,10 +68,10 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
         }
         let (f_anno, anno) = (
             f_p.annotations()
-                .map(|(k, v)| (k, v.raw_val()))
+                .map(|(k, v)| (k, &v.val))
                 .collect::<std::collections::BTreeMap<_, _>>(),
             p.annotations()
-                .map(|(k, v)| (k, v.raw_val()))
+                .map(|(k, v)| (k, &v.val))
                 .collect::<std::collections::BTreeMap<_, _>>(),
         );
         if f_anno != anno {

--- a/cedar-policy-formatter/tests/annotations.cedar
+++ b/cedar-policy-formatter/tests/annotations.cedar
@@ -1,0 +1,49 @@
+@id("foo")
+permit (principal, action, resource);
+
+@id("
+foo
+
+bar
+")
+permit (principal, action, resource);
+
+@shadow_mode
+permit (principal, action, resource);
+
+@shadow_mode("")
+permit (principal, action, resource);
+
+@shadow_mode // shadow mode is on
+permit (principal, action, resource);
+
+@shadow_mode("") // shadow mode is also on
+permit (principal, action, resource);
+
+@foo@bar@baz("buz") permit(principal, action, resource);
+
+// foo
+@foo@bar
+// baz buz
+@baz("buz")
+// also biz
+@biz
+permit (principal, action, resource);
+
+@//1
+//2
+shadow_mode//3
+//4
+permit (principal, action, resource);
+
+@//5
+//6
+shadow_mode//7
+//8
+(//9
+//10
+""//11
+//12
+)//13
+//14
+permit (principal, action, resource);

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@annotations.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@annotations.cedar.snap
@@ -1,0 +1,58 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/annotations.cedar
+---
+@id("foo")
+permit (principal, action, resource);
+
+@id("
+foo
+
+bar
+")
+permit (principal, action, resource);
+
+@shadow_mode
+permit (principal, action, resource);
+
+@shadow_mode("")
+permit (principal, action, resource);
+
+@shadow_mode // shadow mode is on
+permit (principal, action, resource);
+
+@shadow_mode("") // shadow mode is also on
+permit (principal, action, resource);
+
+@foo
+@bar
+@baz("buz")
+permit (principal, action, resource);
+
+// foo
+@foo
+@bar
+// baz buz
+@baz("buz")
+// also biz
+@biz
+permit (principal, action, resource);
+
+@ //1
+//2
+shadow_mode //3
+//4
+permit (principal, action, resource);
+
+@ //5
+//6
+shadow_mode //7
+//8
+( //9
+//10
+"" //11
+//12
+) //13
+//14
+permit (principal, action, resource);

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -10,10 +10,12 @@ The "Cedar Language Version" refers to the language version as documented in the
 Starting with version 3.2.4, changes marked with a star (*) are _language breaking changes_, meaning that they have the potential to affect users of Cedar, beyond users of the `cedar-policy` Rust crate. Changes marked with a star change the behavior of a Cedar parser, the authorization engine, or policy validator.
 
 ## [Unreleased]
-Cedar Language Version: TBD
+Cedar Language Version: 4.1
 
 ### Added
 
+- Annotations without explicit values. It is now possible to write an annotation `@my_annotation` as
+  short-hand for `@my_annotation("")` (#1231).
 - Added `get_entity_literals` API (#1149).
 - Implemented [RFC 82](https://github.com/cedar-policy/rfcs/pull/82), adding
   entity tags to the Cedar language under experimental flag `entity-tags` (#1204, #1207, #1213, #1218)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -10,7 +10,7 @@ The "Cedar Language Version" refers to the language version as documented in the
 Starting with version 3.2.4, changes marked with a star (*) are _language breaking changes_, meaning that they have the potential to affect users of Cedar, beyond users of the `cedar-policy` Rust crate. Changes marked with a star change the behavior of a Cedar parser, the authorization engine, or policy validator.
 
 ## [Unreleased]
-Cedar Language Version: 4.1
+Cedar Language Version: TBD
 
 ### Added
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,7 +16,7 @@ Cedar Language Version: TBD
 
 - Added `sub_entity_literals` API (#1233).
 - Annotations without explicit values. It is now possible to write an annotation `@my_annotation` as
-  short-hand for `@my_annotation("")` (#1231).
+  short-hand for `@my_annotation("")` (#1231, resolving #1031).
 
 ## [4.1.0] - 2024-09-30
 Cedar Language Version: 4.0

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2073,7 +2073,10 @@ impl PolicySet {
         self.policies.get(id)
     }
 
-    /// Extract annotation data from a `Policy` by its `PolicyId` and annotation key
+    /// Extract annotation data from a `Policy` by its `PolicyId` and annotation key.
+    /// If the annotation is present without an explicit value (e.g., `@annotation`),
+    /// then this function returns `Some("")`. It returns `None` only when the
+    /// annotation is not present.
     pub fn annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .get(id.as_ref())?
@@ -2082,6 +2085,9 @@ impl PolicySet {
     }
 
     /// Extract annotation data from a `Template` by its `PolicyId` and annotation key.
+    /// If the annotation is present without an explicit value (e.g., `@annotation`),
+    /// then this function returns `Some("")`. It returns `None` only when the
+    /// annotation is not present.
     pub fn template_annotation(&self, id: &PolicyId, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .get_template(id.as_ref())?
@@ -2400,7 +2406,10 @@ impl Template {
         self.ast.effect()
     }
 
-    /// Get an annotation value of this `Template`
+    /// Get an annotation value of this `Template`.
+    /// If the annotation is present without an explicit value (e.g., `@annotation`),
+    /// then this function returns `Some("")`. It returns `None` only when the
+    /// annotation is not present.
     pub fn annotation(&self, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .annotation(&key.as_ref().parse().ok()?)
@@ -2408,6 +2417,8 @@ impl Template {
     }
 
     /// Iterate through annotation data of this `Template` as key-value pairs
+    /// Annotations which do not have an explicit value (e.g., `@annotation`),
+    /// are included in the iterator with the value `""`.
     pub fn annotations(&self) -> impl Iterator<Item = (&str, &str)> {
         self.ast
             .annotations()
@@ -2698,6 +2709,9 @@ impl Policy {
     }
 
     /// Get an annotation value of this template-linked or static policy
+    /// If the annotation is present without an explicit value (e.g., `@annotation`),
+    /// then this function returns `Some("")`. It returns `None` only when the
+    /// annotation is not present.
     pub fn annotation(&self, key: impl AsRef<str>) -> Option<&str> {
         self.ast
             .annotation(&key.as_ref().parse().ok()?)
@@ -2705,6 +2719,8 @@ impl Policy {
     }
 
     /// Iterate through annotation data of this template-linked or static policy
+    /// Annotations which do not have an explicit value (e.g., `@annotation`),
+    /// are included in the iterator with the value `""`.
     pub fn annotations(&self) -> impl Iterator<Item = (&str, &str)> {
         self.ast
             .annotations()

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -4155,7 +4155,7 @@ mod issue_618 {
         round_trip(r#"permit(principal, action, resource) when { principal["\n"] };"#);
         round_trip(r#"permit(principal, action, resource) when { {"\n": 0} };"#);
         round_trip(
-            r#"@annotation("\n") 
+            r#"@annotation("\n")
 permit(principal, action, resource) when { {"\n": 0} };"#,
         );
     }

--- a/cedar-policy/tests/public_interface.rs
+++ b/cedar-policy/tests/public_interface.rs
@@ -416,6 +416,30 @@ fn policy_annotations() {
 }
 
 #[test]
+fn policy_annotation_without_value() {
+    let p: Policy = r#"@anno permit(principal, action, resource);"#.parse().unwrap();
+    assert_eq!(p.annotation("anno"), Some(""));
+    assert_eq!(p.annotations().next(), Some(("anno", "")));
+
+    // and on templates
+    let t: Template = r#"@tanno permit(principal == ?principal, action, resource);"#
+        .parse()
+        .unwrap();
+    let t = t.new_id(PolicyId::new("new_template_id"));
+    assert_eq!(t.annotation("tanno"), Some(""));
+    assert_eq!(t.annotations().next(), Some(("tanno", "")));
+
+    // and on policy sets
+    let pid = p.id().clone();
+    let tid = t.id().clone();
+    let mut s = PolicySet::new();
+    s.add(p).unwrap();
+    s.add_template(t).unwrap();
+    assert_eq!(s.annotation(&pid, "anno"), Some(""));
+    assert_eq!(s.template_annotation(&tid, "tanno"), Some(""));
+}
+
+#[test]
 fn change_ids() {
     let ps: PolicySet = r#"
         @id("first")


### PR DESCRIPTION
## Description of changes

Adds support for annotations like `@foo` as sugar for `@foo("")`.

Will require a small DRT update to account for the change in data structures. Will also require a small change to the docs to note that this syntax is also allowed. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
