### PR TITLE
[main] bump version numbers to 4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ overflow-checks = true
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)
 rust-version = "1.77"
-version = "4.0.0"
+version = "4.1.0"
 homepage = "https://cedarpolicy.com"
 keywords = ["cedar", "authorization", "policy", "security"]
 categories = ["compilers", "config"]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { version = "=4.0.0", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=4.0.0", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=4.1.0", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=4.1.0", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
 logos = "0.14.0"
 itertools = "0.13"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
@@ -52,7 +52,7 @@ entity-tags = []
 [dev-dependencies]
 similar-asserts = "1.5.0"
 cool_asserts = "2.0"
-cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core", features = ["test-util"] }
+cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core", features = ["test-util"] }
 miette = { version = "7.1.0", features = ["fancy"] }
 
 [build-dependencies]

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace = true
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.0.0", path = "../cedar-policy-validator" }
-cedar-policy-formatter = { version = "=4.0.0", path = "../cedar-policy-formatter" }
+cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.1.0", path = "../cedar-policy-validator" }
+cedar-policy-formatter = { version = "=4.1.0", path = "../cedar-policy-formatter" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -64,7 +64,7 @@ miette = { version = "7.1.0", features = ["fancy"] }
 cool_asserts = "2.0"
 criterion = "0.5"
 globset = "0.4"
-cedar-policy-core = { version = "=4.0.0", features = [
+cedar-policy-core = { version = "=4.1.0", features = [
     "test-util",
 ], path = "../cedar-policy-core" }
 # NON-CRYPTOGRAPHIC random number generators

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -5959,7 +5959,7 @@ mod version_tests {
 
     #[test]
     fn test_sdk_version() {
-        assert_eq!(get_sdk_version().to_string(), "4.0.0");
+        assert_eq!(get_sdk_version().to_string(), "4.1.0");
     }
 
     #[test]

--- a/cedar-testing/Cargo.toml
+++ b/cedar-testing/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cedar-policy = { version = "=4.0.0", path = "../cedar-policy" }
-cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.0.0", path = "../cedar-policy-validator" }
+cedar-policy = { version = "=4.1.0", path = "../cedar-policy" }
+cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.1.0", path = "../cedar-policy-validator" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 exclude = ['/build']
 
 [dependencies]
-cedar-policy = { version = "=4.0.0", path = "../cedar-policy", features = ["wasm"] }
-cedar-policy-core = { version = "=4.0.0", path = "../cedar-policy-core", features = ["wasm"] }
-cedar-policy-formatter = { version = "=4.0.0", path = "../cedar-policy-formatter" }
-cedar-policy-validator = { version = "=4.0.0", path = "../cedar-policy-validator", features = ["wasm"] }
+cedar-policy = { version = "=4.1.0", path = "../cedar-policy", features = ["wasm"] }
+cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core", features = ["wasm"] }
+cedar-policy-formatter = { version = "=4.1.0", path = "../cedar-policy-formatter" }
+cedar-policy-validator = { version = "=4.1.0", path = "../cedar-policy-validator", features = ["wasm"] }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
## Description of changes

Cherry-picks #1245 to `main`.  Seems like `main` should have its version number set to at least 4.1 if not higher.
