### PR TITLE
Document error message and documentation conventions in markdown file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,7 @@ In the (rarer) case that your PR is to a `release/X.Y.Z` branch rather than `mai
 ## Review Process
 
 We deeply appreciate everyone who takes the time to make a contribution. We will review all contributions as quickly as possible. As a reminder, [opening an issue](https://github.com/cedar-policy/cedar/issues) discussing your change before you make it is the best way to smooth the PR process. This will prevent a rejection because someone else is already working on the problem, or because the solution is incompatible with the architectural direction.
+Also take a minute to review our [style guide](style_guide.md). Most of this is handled by automated tooling, but there are a few conventions around documentation and error messages you should review before making a larger contribution.
 
 During the PR process, expect that there will be some back-and-forth. Please try to respond to comments in a timely fashion, and if you don't wish to continue with the PR, let us know. If a PR takes too many iterations for its complexity or size, we may reject it. Additionally, if you stop responding we may close the PR as abandoned. In either case, if you feel this was done in error, please add a comment on the PR.
 

--- a/style_guide.md
+++ b/style_guide.md
@@ -37,7 +37,7 @@ For example, `#[non_exhaustive]` should never be used for `EvaluationError` or o
 The enum itself, and also each of the member structs, should implement `miette::Diagnostic` and `thiserror::Error`.
 Both of these should be automatically derived when possible, and the `#[error(...)]` macro should be used to generate `Display` implementations.
 For more complex error it is occasionally easier to manually implement `Display`.
-Manual implementation of `miette::Diagnostic` is less common, but is occasionally necessary to work around limitations in derive macro.
+Manual implementation of `miette::Diagnostic` is less common, but is occasionally necessary to work around limitations in the derive macro.
 We use a [module of internal macros](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-core/src/error_macros.rs) to help in these situations.
 
 By ensuring the internal structs have private fields we are free to change details in the error without making a breaking change to our API.

--- a/style_guide.md
+++ b/style_guide.md
@@ -1,33 +1,33 @@
 # Cedar Style Guide
 
 Cedar relies on automated tooling for the majority of its code style enforcement.
-Code must be formatted as enforced by `cargo fmt`, there may not be any `unsafe` code, `cargo check` must not report any warnings, and `cargo clippy` must not report any errors (clippy warnings are acceptable).
-These are all enforced in our GitHub actions workflows, so any violation will be reported to you upon opening a pull request.
+Code must be formatted as enforced by `cargo fmt`, there must not be any `unsafe` code, `cargo check` must not report any warnings, and `cargo clippy` must not report any errors (clippy warnings are acceptable).
+These are all enforced in our GitHub Actions workflows, so any violation will be reported to you upon opening a pull request.
 
 The rest of this guide describes some aspects of style which are not automatically enforced.
 
 ## Conventions for Cedar Documentation
 
 Everything publicly exported from `cedar-policy` (functions, types, modules, etc.) must be documented with a doc comment (a comment delimited by `///`).
-There is no minimum standard for length of documentation. A comment may be as short as a single sentence fragment.
+There is no minimum standard for the length of documentation. A comment may be as short as a single sentence fragment.
 
 **Capitalization:** Doc comments (sentence fragments or otherwise) should always begin with a capital letter.
 
-**Punctuation:** Sentence fragments (e.g., ``Errors that can occur when adding to a `PolicySet` ``) do not need a period, but 
-proper sentences (e.g. ``There was a duplicate `PolicyId` encountered in either the set of templates or the set of policies.``) do. 
+**Punctuation:** Sentence fragments (e.g., ``Errors that can occur when adding to a `PolicySet` ``) do not need a period, but
+proper sentences (e.g., ``There was a duplicate `PolicyId` encountered in either the set of templates or the set of policies.``) do.
 In the case of a mixture of sentence fragments and full sentences, use periods.
 
-**Invariants:** We often documents internal invariants in our code with `// INVARIANT: ` comments.
+**Invariants:** We often document internal invariants in our code with `// INVARIANT: ` comments.
 These invariants should not generally be included in doc comments, i.e., they should start with `//` instead of `///`.
 
-**Other:** When describing an identifier, use “id”, not “Id” or “ID” (applies to both doc strings and error messages).
+**Other:** When describing an identifier, use "id", not "Id" or "ID" (applies to both doc strings and error messages).
 
 ## Conventions for Cedar Errors
 
 ### Error Types
 
-Methods that can return errors should return a `Result` type where the error type is a public enum. 
-Each variant of that enum should be either another error enum or a single struct with private field(s). 
+Methods that can return errors should return a `Result` type where the error type is a public enum.
+Each variant of that enum should be either another error enum or a single struct with private field(s).
 The structs for a particular error enum are typically gathered into a submodule.
 The names of all error enums and structs should end in `Error`, but each variant of an error enum should not end in `Error`.
 
@@ -36,11 +36,11 @@ For example, `#[non_exhaustive]` should never be used for `EvaluationError` or o
 
 The enum itself, and also each of the member structs, should implement `miette::Diagnostic` and `thiserror::Error`.
 Both of these should be automatically derived when possible, and the `#[error(...)]` macro should be used to generate `Display` implementations.
-For more complex error it is occasionally easier to manually implement `Display`.
-Manual implementation of `miette::Diagnostic` is less common, but is occasionally necessary to work around limitations in the derive macro.
-We use a [module of internal macros](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-core/src/error_macros.rs) to help in these situations.
+For more complex errors, it is occasionally easier to manually implement `Display`.
+Manual implementation of `miette::Diagnostic` is less common but is occasionally necessary to work around limitations in the derive macro.
+We use [a module of internal macros](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-core/src/error_macros.rs) to help in these situations.
 
-By ensuring the internal structs have private fields we are free to change details in the error without making a breaking change to our API.
+By ensuring the internal structs have private fields, we are free to change details in the error without making a breaking change to our API.
 The enum and all member structs may also provide additional public methods to expose certain details.
 We are generally conservative in what we expose this way to make future changes to our error types easier.
 
@@ -86,19 +86,17 @@ See [issue #745](https://github.com/cedar-policy/cedar/issues/745) for further d
 
 Error type documentation follows the same conventions as documentation on other types.
 Each error needs to be documented twice (once on the enum variant and again on the struct).
-To avoid duplicating large comments we prefer to place detailed documentation on the enum variant with a shorter comment on the struct.
+To avoid duplicating large comments, we prefer to place detailed documentation on the enum variant with a shorter comment on the struct.
 
 ### Error Messages
 
 * Single-sentence error messages should not use capitalization or periods.
-  If multiple sentences are needed then use grammatical capitalization and punctuation only on the message’s interior.
-  Example: `wrong number of arguments in extension function application. Expected {}, got {}`" (note the initial lowercase letter and lack of final period).
-* Strongly consider breaking multi-sentences error messages into a main error message together with a [help message](https://docs.rs/miette/latest/miette/#-help-text) and [labeled snippets](https://docs.rs/miette/latest/miette/#-snippets).
+  If multiple sentences are needed, then use grammatical capitalization and punctuation only on the message's interior.
+  Example: `wrong number of arguments in extension function application. Expected {}, got {}` (note the initial lowercase letter and lack of final period).
+* Strongly consider breaking multi-sentence error messages into a main error message together with a [help message](https://docs.rs/miette/latest/miette/#-help-text) and [labeled snippets](https://docs.rs/miette/latest/miette/#-snippets).
   These should independently follow the recommendations for error message punctuation and capitalization.
-* User-provided input (e.g. attributes, entity uids, policy ids) should be surrounded with backticks or be placed after a colon at the end of the message.
-  Use of backticks is preferred.
-  Examples: ``undeclared action `foo` ``, `undeclared entity type(s): {"Foo"}`
+* User-provided input (e.g., attributes, entity uids, policy ids) should be surrounded with backticks or be placed after a colon at the end of the message. Use of backticks is preferred. Examples: ``undeclared action `foo` ``, `undeclared entity type(s): {"Foo"}`.
 * Whenever possible, include a [source span](https://docs.rs/miette/latest/miette/#-snippets) indicating where in the input the error occurred. Consider if this span adequately replaces any verbatim copies of user-provided input included in the error message.
-* Related error messages should be concatenated with colons. Example: ``error occurred while evaluating policy `policy0`: `User::"alive"` does not have the attribute `foo` ``"
+* Related error messages should be concatenated with colons. Example: ``error occurred while evaluating policy `policy0`: `User::"alive"` does not have the attribute `foo` ``.
 * Error messages should not refer to specific Rust type names (like `PolicyId`), preferring to refer to generic Cedar concepts (like policy id). Remember that these errors will be viewed by Cedar users who may never interact directly with the Rust library.
 * Error messages must not include line breaks.

--- a/style_guide.md
+++ b/style_guide.md
@@ -9,13 +9,13 @@ The rest of this guide describes some aspects of style which are not automatical
 ## Conventions for Cedar Documentation
 
 Everything publicly exported from `cedar-policy` (functions, types, modules, etc.) must be documented with a doc comment (a comment delimited by `///`).
-There is no minimum standard for length of documentation. A comment be as short as a single sentence fragment.
+There is no minimum standard for length of documentation. A comment may be as short as a single sentence fragment.
 
 **Capitalization:** Doc comments (sentence fragments or otherwise) should always begin with a capital letter.
 
 **Punctuation:** Sentence fragments (e.g., ``Errors that can occur when adding to a `PolicySet` ``) do not need a period, but 
 proper sentences (e.g. ``There was a duplicate `PolicyId` encountered in either the set of templates or the set of policies.``) do. 
-Use periods in the case of a mixture of sentence fragments and full sentences, use periods.
+In the case of a mixture of sentence fragments and full sentences, use periods.
 
 **Invariants:** We often documents internal invariants in our code with `// INVARIANT: ` comments.
 These invariants should not generally be included in doc comments, i.e., they should start with `//` instead of `///`.
@@ -26,21 +26,21 @@ These invariants should not generally be included in doc comments, i.e., they sh
 
 ### Error Types
 
-Methods that can return errors return a `Result` type where the error type is a public enum. 
-Each variant of that enum is either another error enum or a single struct with private field(s). 
+Methods that can return errors should return a `Result` type where the error type is a public enum. 
+Each variant of that enum should be either another error enum or a single struct with private field(s). 
 The structs for a particular error enum are typically gathered into a submodule.
 The names of all error enums and structs should end in `Error`, but each variant of an error enum should not end in `Error`.
 
 Error enums are often annotated with `#[non_exhaustive]`, though we omit this annotation when we feel callers _should_ have their build break when we introduce new error variants.
 For example, `#[non_exhaustive]` should never be used for `EvaluationError` or other errors that are returned from the `is_authorized` API, but parsing and validation errors generally should be `#[non_exhaustive]`.
 
-The enum itself, and also each of the member structs, all implement `miette::Diagnostic` and `thiserror::Error`.
+The enum itself, and also each of the member structs, should implement `miette::Diagnostic` and `thiserror::Error`.
 Both of these should be automatically derived when possible, and the `#[error(...)]` macro should be used to generate `Display` implementations.
 For more complex error it is occasionally easier to manually implement `Display`.
 Manual implementation of `miette::Diagnostic` is less common, but is occasionally necessary to work around limitations in derive macro.
 We use a [module of internal macros](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-core/src/error_macros.rs) to help in these situations.
 
-By ensuring the internal structs have private fields we are free to track more details in the error without making a breaking change to our API.
+By ensuring the internal structs have private fields we are free to change details in the error without making a breaking change to our API.
 The enum and all member structs may also provide additional public methods to expose certain details.
 We are generally conservative in what we expose this way to make future changes to our error types easier.
 
@@ -90,7 +90,7 @@ To avoid duplicating large comments we prefer to place detailed documentation on
 
 ### Error Messages
 
-* Single-sentence error messages should not use capitalization and periods.
+* Single-sentence error messages should not use capitalization or periods.
   If multiple sentences are needed then use grammatical capitalization and punctuation only on the message’s interior.
   Example: `wrong number of arguments in extension function application. Expected {}, got {}`" (note the initial lowercase letter and lack of final period).
 * Strongly consider breaking multi-sentences error messages into a main error message together with a [help message](https://docs.rs/miette/latest/miette/#-help-text) and [labeled snippets](https://docs.rs/miette/latest/miette/#-snippets).
@@ -100,5 +100,5 @@ To avoid duplicating large comments we prefer to place detailed documentation on
   Examples: ``undeclared action `foo` ``, `undeclared entity type(s): {"Foo"}`
 * Whenever possible, include a [source span](https://docs.rs/miette/latest/miette/#-snippets) indicating where in the input the error occurred. Consider if this span adequately replaces any verbatim copies of user-provided input included in the error message.
 * Related error messages should be concatenated with colons. Example: ``error occurred while evaluating policy `policy0`: `User::"alive"` does not have the attribute `foo` ``"
-* Error messages should not refer to specific Rust type names (like PolicyId), preferring to refer to generic Cedar concepts (like policy id). Remember that these errors will be viewed by Cedar users who may never interact directly with the Rust library.
+* Error messages should not refer to specific Rust type names (like `PolicyId`), preferring to refer to generic Cedar concepts (like policy id). Remember that these errors will be viewed by Cedar users who may never interact directly with the Rust library.
 * Error messages must not include line breaks.

--- a/style_guide.md
+++ b/style_guide.md
@@ -1,0 +1,104 @@
+# Cedar Style Guide
+
+Cedar relies on automated tooling for the majority of its code style enforcement.
+Code must be formatted as enforced by `cargo fmt`, there may not be any `unsafe` code, `cargo check` must not report any warnings, and `cargo clippy` must not report any errors (clippy warnings are acceptable).
+These are all enforced in our GitHub actions workflows, so any violation will be reported to you upon opening a pull request.
+
+The rest of this guide describes some aspects of style which are not automatically enforced.
+
+## Conventions for Cedar Documentation
+
+Everything publicly exported from `cedar-policy` (functions, types, modules, etc.) must be documented with a doc comment (a comment delimited by `///`).
+There is no minimum standard for length of documentation. A comment be as short as a single sentence fragment.
+
+**Capitalization:** Doc comments (sentence fragments or otherwise) should always begin with a capital letter.
+
+**Punctuation:** Sentence fragments (e.g., ``Errors that can occur when adding to a `PolicySet` ``) do not need a period, but 
+proper sentences (e.g. ``There was a duplicate `PolicyId` encountered in either the set of templates or the set of policies.``) do. 
+Use periods in the case of a mixture of sentence fragments and full sentences, use periods.
+
+**Invariants:** We often documents internal invariants in our code with `// INVARIANT: ` comments.
+These invariants should not generally be included in doc comments, i.e., they should start with `//` instead of `///`.
+
+**Other:** When describing an identifier, use “id”, not “Id” or “ID” (applies to both doc strings and error messages).
+
+## Conventions for Cedar Errors
+
+### Error Types
+
+Methods that can return errors return a `Result` type where the error type is a public enum. 
+Each variant of that enum is either another error enum or a single struct with private field(s). 
+The structs for a particular error enum are typically gathered into a submodule.
+The names of all error enums and structs should end in `Error`, but each variant of an error enum should not end in `Error`.
+
+Error enums are often annotated with `#[non_exhaustive]`, though we omit this annotation when we feel callers _should_ have their build break when we introduce new error variants.
+For example, `#[non_exhaustive]` should never be used for `EvaluationError` or other errors that are returned from the `is_authorized` API, but parsing and validation errors generally should be `#[non_exhaustive]`.
+
+The enum itself, and also each of the member structs, all implement `miette::Diagnostic` and `thiserror::Error`.
+Both of these should be automatically derived when possible, and the `#[error(...)]` macro should be used to generate `Display` implementations.
+For more complex error it is occasionally easier to manually implement `Display`.
+Manual implementation of `miette::Diagnostic` is less common, but is occasionally necessary to work around limitations in derive macro.
+We use a [module of internal macros](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-core/src/error_macros.rs) to help in these situations.
+
+By ensuring the internal structs have private fields we are free to track more details in the error without making a breaking change to our API.
+The enum and all member structs may also provide additional public methods to expose certain details.
+We are generally conservative in what we expose this way to make future changes to our error types easier.
+
+For example, `RequestValidationError` is an enum with each variant containing a struct like `UndeclaredActionError`.
+
+```rust
+/// The request does not conform to the schema
+#[derive(Debug, Diagnostic, Error)]
+#[non_exhaustive]
+pub enum RequestValidationError {
+    /// Request action is not declared in the schema
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UndeclaredAction(#[from] request_validation_errors::UndeclaredActionError),
+
+    // more error variants...
+}
+
+/// Error subtypes for [`RequestValidationError`]
+pub mod request_validation_errors {
+    /// Request action is not declared in the schema
+    #[derive(Debug, Diagnostic, Error)]
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    pub struct UndeclaredActionError(
+        #[from] cedar_policy_validator::request_validation_errors::UndeclaredActionError,
+    );
+
+    impl UndeclaredActionError {
+        /// The action which was not declared in the schema
+        pub fn action(&self) -> &EntityUid {
+            RefCast::ref_cast(self.0.action())
+        }
+    }
+
+    // more error structs...
+}
+```
+
+See [issue #745](https://github.com/cedar-policy/cedar/issues/745) for further discussion and alternatives considered.
+
+### Error Documentation
+
+Error type documentation follows the same conventions as documentation on other types.
+Each error needs to be documented twice (once on the enum variant and again on the struct).
+To avoid duplicating large comments we prefer to place detailed documentation on the enum variant with a shorter comment on the struct.
+
+### Error Messages
+
+* Single-sentence error messages should not use capitalization and periods.
+  If multiple sentences are needed then use grammatical capitalization and punctuation only on the message’s interior.
+  Example: `wrong number of arguments in extension function application. Expected {}, got {}`" (note the initial lowercase letter and lack of final period).
+* Strongly consider breaking multi-sentences error messages into a main error message together with a [help message](https://docs.rs/miette/latest/miette/#-help-text) and [labeled snippets](https://docs.rs/miette/latest/miette/#-snippets).
+  These should independently follow the recommendations for error message punctuation and capitalization.
+* User-provided input (e.g. attributes, entity uids, policy ids) should be surrounded with backticks or be placed after a colon at the end of the message.
+  Use of backticks is preferred.
+  Examples: ``undeclared action `foo` ``, `undeclared entity type(s): {"Foo"}`
+* Whenever possible, include a [source span](https://docs.rs/miette/latest/miette/#-snippets) indicating where in the input the error occurred. Consider if this span adequately replaces any verbatim copies of user-provided input included in the error message.
+* Related error messages should be concatenated with colons. Example: ``error occurred while evaluating policy `policy0`: `User::"alive"` does not have the attribute `foo` ``"
+* Error messages should not refer to specific Rust type names (like PolicyId), preferring to refer to generic Cedar concepts (like policy id). Remember that these errors will be viewed by Cedar users who may never interact directly with the Rust library.
+* Error messages must not include line breaks.


### PR DESCRIPTION
## Description of changes

Aggregate content from an internal wiki and discussion on #745 to document error and docs conventions. Some minor tweaks based on my understanding of our current practice.

Please comment with any other code style conventions we follow and should document. I probably won't incorporate them into this PR unless they directly relate to errors/docs, but it'd be good to get anything else written down.  

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
