### PR TITLE
Track comments as slices in formatter

### DIFF
--- a/cedar-policy-formatter/src/pprint/config.rs
+++ b/cedar-policy-formatter/src/pprint/config.rs
@@ -33,7 +33,7 @@ impl Default for Config {
 }
 
 #[derive(Debug)]
-pub struct Context<'a> {
+pub struct Context<'a, 'src> {
     pub config: &'a Config,
-    pub tokens: Vec<WrappedToken>,
+    pub tokens: Vec<WrappedToken<'src>>,
 }

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -24,18 +24,18 @@ use super::token::Comment;
 /// The trait to convert a CST to a RcDoc
 pub trait Doc {
     /// Convert a type implementing this trait to a `RcDoc`.
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>>;
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>>;
 }
 
 impl Doc for Ident {
     // An Ident's doc is itself.
-    fn to_doc(&self, _context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, _context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(RcDoc::as_string(self))
     }
 }
 
 impl Doc for Node<Option<VariableDef>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let vd = self.as_inner()?;
         let start_comment = get_comment_at_start(self.loc.span, &mut context.tokens)?;
         let var_doc = vd.variable.as_inner()?.to_doc(context)?;
@@ -92,7 +92,7 @@ impl Doc for Node<Option<VariableDef>> {
 }
 
 impl Doc for Node<Option<Cond>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let cond = self.as_inner()?;
         let lb_comment = get_comment_after_end(cond.cond.loc.span, &mut context.tokens)?;
         let rb_comment = get_comment_at_end(self.loc.span, &mut context.tokens)?;
@@ -156,15 +156,15 @@ impl Doc for Node<Option<Cond>> {
 }
 
 impl Doc for Node<Option<Expr>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         match self.as_inner()?.expr.as_ref() {
             ExprData::If(c, t, e) => {
-                fn pp_group<'n>(
-                    s: &'n str,
-                    c: Comment,
-                    e: &'n Node<Option<Expr>>,
-                    context: &mut Context<'_>,
-                ) -> RcDoc<'n> {
+                fn pp_group<'src>(
+                    s: &'src str,
+                    c: Comment<'src>,
+                    e: &Node<Option<Expr>>,
+                    context: &mut Context<'_, 'src>,
+                ) -> RcDoc<'src> {
                     add_comment(RcDoc::text(s), c, RcDoc::nil()).append(
                         RcDoc::line()
                             .append(e.to_doc(context))
@@ -189,7 +189,7 @@ impl Doc for Node<Option<Expr>> {
 }
 
 impl Doc for Node<Option<Or>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
         let extended = &e.extended;
@@ -209,7 +209,7 @@ impl Doc for Node<Option<Or>> {
 }
 
 impl Doc for Node<Option<And>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
         let extended = &e.extended;
@@ -229,7 +229,7 @@ impl Doc for Node<Option<And>> {
 }
 
 impl Doc for Node<Option<Relation>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         match e {
             Relation::Common { initial, extended } => {
@@ -320,13 +320,13 @@ impl Doc for Node<Option<Relation>> {
 }
 
 impl Doc for AddOp {
-    fn to_doc(&self, _: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, _context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(RcDoc::as_string(self))
     }
 }
 
 impl Doc for Node<Option<Add>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
         let extended = &e.extended;
@@ -356,13 +356,13 @@ impl Doc for Node<Option<Add>> {
 }
 
 impl Doc for MultOp {
-    fn to_doc(&self, _: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, __context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(RcDoc::as_string(self))
     }
 }
 
 impl Doc for Node<Option<Mult>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         let initial = &e.initial;
         let extended = &e.extended;
@@ -392,7 +392,7 @@ impl Doc for Node<Option<Mult>> {
 }
 
 impl Doc for Node<Option<Unary>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         if let Some(op) = e.op {
             match op {
@@ -433,7 +433,7 @@ impl Doc for Node<Option<Unary>> {
 }
 
 impl Doc for Member {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let item_doc = self.item.to_doc(context)?;
         Some(
             item_doc
@@ -450,7 +450,7 @@ impl Doc for Member {
 }
 
 impl Doc for Node<Option<RecInit>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         let key_doc = e.0.to_doc(context)?;
         let value_doc = e.1.to_doc(context)?;
@@ -468,7 +468,7 @@ impl Doc for Node<Option<RecInit>> {
 }
 
 impl Doc for Node<Option<Name>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         let path = &e.path;
         let n = &e.name;
@@ -506,7 +506,7 @@ impl Doc for Node<Option<Name>> {
 }
 
 impl Doc for Node<Option<Str>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         // Note: the input string may contain newlines, but `utils::create_multiline_doc`
         // _cannot_ be used here because this function will change indentation
@@ -520,7 +520,7 @@ impl Doc for Node<Option<Str>> {
 }
 
 impl Doc for Node<Option<Ref>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         match self.as_inner()? {
             Ref::Uid { path, eid } => Some(
                 path.to_doc(context)?
@@ -537,7 +537,7 @@ impl Doc for Node<Option<Ref>> {
 }
 
 impl Doc for Node<Option<Literal>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(add_comment(
             RcDoc::as_string(self.as_inner()?),
             get_comment_at_start(self.loc.span, &mut context.tokens)?,
@@ -547,7 +547,7 @@ impl Doc for Node<Option<Literal>> {
 }
 
 impl Doc for Node<Option<Slot>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(add_comment(
             RcDoc::as_string(self.as_inner()?),
             get_comment_at_start(self.loc.span, &mut context.tokens)?,
@@ -557,7 +557,7 @@ impl Doc for Node<Option<Slot>> {
 }
 
 impl Doc for Node<Option<Primary>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         match e {
             Primary::Literal(lit) => lit.to_doc(context),
@@ -649,7 +649,7 @@ impl Doc for Node<Option<Primary>> {
 }
 
 impl Doc for Node<Option<MemAccess>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let e = self.as_inner()?;
         match e {
             MemAccess::Field(f) => Some(
@@ -718,7 +718,7 @@ impl Doc for Node<Option<MemAccess>> {
 }
 
 impl Doc for Node<Option<Annotation>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let annotation = self.as_inner()?;
         let id_doc = annotation.key.to_doc(context);
         let at_doc = add_comment(
@@ -749,7 +749,7 @@ impl Doc for Node<Option<Annotation>> {
 }
 
 impl Doc for Node<Option<Ident>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(add_comment(
             self.as_inner()?.to_doc(context)?,
             get_comment_at_start(self.loc.span, &mut context.tokens)?,
@@ -759,7 +759,7 @@ impl Doc for Node<Option<Ident>> {
 }
 
 impl Doc for Node<Option<Policy>> {
-    fn to_doc(&self, context: &mut Context<'_>) -> Option<RcDoc<'_>> {
+    fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let policy = self.as_inner()?;
 
         let anno_doc = RcDoc::intersperse(

--- a/cedar-policy-formatter/src/pprint/lexer.rs
+++ b/cedar-policy-formatter/src/pprint/lexer.rs
@@ -22,7 +22,9 @@ use logos::Logos;
 /// Tokenize the input, associating with each token a leading and trailing
 /// comment if they are present. Also returns a string containing any comments
 /// that may be present at the end of input after all tokens are consumed.
-pub fn get_token_stream(input: &str) -> Option<(Vec<WrappedToken>, String)> {
+pub fn get_token_stream(
+    input: &str,
+) -> Option<(Vec<WrappedToken<'_>>, impl Iterator<Item = &str>)> {
     let mut tokens = Token::lexer(input).spanned();
 
     let Some(mut current_token) = tokens.next() else {

--- a/cedar-policy-formatter/src/pprint/token.rs
+++ b/cedar-policy-formatter/src/pprint/token.rs
@@ -16,7 +16,6 @@
 
 // PANIC SAFETY: there's little we can do about Logos.
 #![allow(clippy::indexing_slicing)]
-use itertools::Itertools;
 use logos::{Logos, Span};
 use smol_str::SmolStr;
 use std::fmt::{self, Display};
@@ -31,50 +30,58 @@ pub(crate) mod regex_constants {
     }
 }
 
-pub fn get_comment(text: &str) -> String {
-    let mut comment = regex_constants::COMMENT
+pub fn get_comment(text: &str) -> impl Iterator<Item = &str> + std::fmt::Debug {
+    regex_constants::COMMENT
         .find_iter(text)
-        .map(|c| c.as_str().trim_end())
-        .join("\n");
-    if comment.is_empty() {
-        comment
-    } else {
-        comment.push('\n');
-        comment
-    }
+        .map(|c| c.as_str().trim())
 }
 
 // Represent Cedar comments
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct Comment {
-    leading_comment: String,
-    trailing_comment: String,
+pub struct Comment<'src> {
+    leading_comment: Vec<&'src str>,
+    trailing_comment: &'src str,
 }
 
-impl Comment {
-    pub fn new(leading_comment: &str, trailing_comment: &str) -> Self {
+impl<'src> Comment<'src> {
+    pub fn new(leading_comment: &'src str, trailing_comment: &'src str) -> Self {
         Self {
-            leading_comment: get_comment(leading_comment),
-            trailing_comment: get_comment(trailing_comment),
+            leading_comment: get_comment(leading_comment).collect(),
+            // The trailing comments must not have line breaks, so we don't need
+            // to find comments with regex matching. If the trimmed string is
+            // empty, then there was no comment.
+            trailing_comment: trailing_comment.trim(),
         }
     }
 
-    pub fn leading_comment(&self) -> &str {
+    pub fn leading_comment(&self) -> &Vec<&'src str> {
         &self.leading_comment
     }
 
-    pub fn trailing_comment(&self) -> &str {
-        &self.trailing_comment
+    pub fn trailing_comment(&self) -> &'src str {
+        self.trailing_comment
+    }
+
+    fn format_leading_comment(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for comment_line in itertools::Itertools::intersperse(self.leading_comment.iter(), &"\n") {
+            write!(f, "{comment_line}")?;
+        }
+        if !self.leading_comment.is_empty() {
+            writeln!(f)?;
+        }
+        Ok(())
+    }
+
+    fn format_trailing_comment(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.trailing_comment)
     }
 }
 
-impl Display for Comment {
+impl Display for Comment<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.leading_comment.is_empty() {
-            self.trailing_comment.fmt(f)
-        } else {
-            write!(f, "{}\n{}", self.leading_comment, self.trailing_comment)
-        }
+        self.format_leading_comment(f)?;
+        self.format_trailing_comment(f)?;
+        Ok(())
     }
 }
 
@@ -296,14 +303,14 @@ impl fmt::Display for Token {
 // A wrapper for token span (i.e., (Token, Span))
 // We use this wrapper for easier processing of comments
 #[derive(Debug, Clone, PartialEq)]
-pub struct WrappedToken {
+pub struct WrappedToken<'src> {
     pub token: Token,
-    pub comment: Comment,
+    pub comment: Comment<'src>,
     pub span: Span,
 }
 
-impl WrappedToken {
-    pub fn new(token: Token, span: Span, comment: Comment) -> Self {
+impl<'src> WrappedToken<'src> {
+    pub fn new(token: Token, span: Span, comment: Comment<'src>) -> Self {
         Self {
             token,
             comment,
@@ -316,16 +323,16 @@ impl WrappedToken {
     }
 
     fn clear_trailing_comment(&mut self) {
-        self.comment.trailing_comment.clear();
+        self.comment.trailing_comment = "";
     }
 
-    pub fn consume_leading_comment(&mut self) -> String {
+    pub fn consume_leading_comment(&mut self) -> Vec<&'src str> {
         let comment = self.comment.leading_comment.clone();
         self.clear_leading_comment();
         comment
     }
 
-    pub fn consume_comment(&mut self) -> Comment {
+    pub fn consume_comment(&mut self) -> Comment<'src> {
         let comment = self.comment.clone();
         self.clear_leading_comment();
         self.clear_trailing_comment();
@@ -333,12 +340,11 @@ impl WrappedToken {
     }
 }
 
-impl Display for WrappedToken {
+impl Display for WrappedToken<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}{} {}",
-            self.comment.leading_comment, self.token, self.comment.trailing_comment
-        )
+        self.comment.format_leading_comment(f)?;
+        write!(f, "{} ", self.token)?;
+        self.comment.format_trailing_comment(f)?;
+        Ok(())
     }
 }

--- a/cedar-policy-formatter/src/pprint/token.rs
+++ b/cedar-policy-formatter/src/pprint/token.rs
@@ -54,7 +54,7 @@ impl<'src> Comment<'src> {
         }
     }
 
-    pub fn leading_comment(&self) -> &Vec<&'src str> {
+    pub fn leading_comment(&self) -> &[&'src str] {
         &self.leading_comment
     }
 

--- a/cedar-policy-formatter/tests/comment_trailing_whitespace.cedar
+++ b/cedar-policy-formatter/tests/comment_trailing_whitespace.cedar
@@ -1,0 +1,29 @@
+// Tests that trailing spaces are correctly removed at the end of comment lines.
+
+// ___WARNING___ Some editors will automaticaly trim trailing whitespace, but
+// this file expliciclty tests formatter behavior in this case. When making
+// changes to this file check that the comments still have trailing whitespace.
+
+// There is a space at the end of this line 
+permit (principal, action, resource);
+
+// No space here
+// But there is one here 
+permit (principal, action, resource);
+
+// No space here
+ // Leading space before this comment
+// A tab character here:	
+permit (principal, action, resource);
+
+permit (principal, // Trailing comment Space 
+// Leading comment Space  
+// Leading comment Space   
+// Leading comment Space    
+action, resource);
+
+// end of file comment with space 
+// on these lines 
+
+// trailing whitespace on the last line is ignored by insta, so we test that 
+// case as part of `test_add_trailing_newline` in `fmt.rs` 

--- a/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@comment_trailing_whitespace.cedar.snap
+++ b/cedar-policy-formatter/tests/snapshots/cedar_policy_formatter__pprint__fmt__tests__format_files@comment_trailing_whitespace.cedar.snap
@@ -1,0 +1,30 @@
+---
+source: cedar-policy-formatter/src/pprint/fmt.rs
+expression: formatted
+input_file: cedar-policy-formatter/tests/comment_trailing_whitespace.cedar
+---
+// Tests that trailing spaces are correctly removed at the end of comment lines.
+// ___WARNING___ Some editors will automaticaly trim trailing whitespace, but
+// this file expliciclty tests formatter behavior in this case. When making
+// changes to this file check that the comments still have trailing whitespace.
+// There is a space at the end of this line
+permit (principal, action, resource);
+
+// No space here
+// But there is one here
+permit (principal, action, resource);
+
+// No space here
+// Leading space before this comment
+// A tab character here:
+permit (principal, action, resource);
+
+permit (principal, // Trailing comment Space
+  // Leading comment Space
+  // Leading comment Space
+  // Leading comment Space
+  action, resource);
+// end of file comment with space
+// on these lines
+// trailing whitespace on the last line is ignored by insta, so we test that
+// case as part of `test_add_trailing_newline` in `fmt.rs`


### PR DESCRIPTION
## Description of changes

fun change to the formatter. Insted of storing comments as owned strings we can store slices into the original source code. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
