### PR TITLE
Suggest obvious fix when action id includes type

### DIFF
--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -19,6 +19,7 @@
 
 use miette::Diagnostic;
 use thiserror::Error;
+use validation_errors::UnrecognizedActionIdHelp;
 
 use std::collections::BTreeSet;
 
@@ -195,13 +196,13 @@ impl ValidationError {
 
         policy_id: PolicyID,
         actual_action_id: String,
-        suggested_action_id: Option<String>,
+        unrecognized_action_id_help: Option<UnrecognizedActionIdHelp>,
     ) -> Self {
         validation_errors::UnrecognizedActionId {
             source_loc,
             policy_id,
             actual_action_id,
-            suggested_action_id,
+            unrecognized_action_id_help,
         }
         .into()
     }

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -196,13 +196,13 @@ impl ValidationError {
 
         policy_id: PolicyID,
         actual_action_id: String,
-        unrecognized_action_id_help: Option<UnrecognizedActionIdHelp>,
+        hint: Option<UnrecognizedActionIdHelp>,
     ) -> Self {
         validation_errors::UnrecognizedActionId {
             source_loc,
             policy_id,
             actual_action_id,
-            unrecognized_action_id_help,
+            hint,
         }
         .into()
     }

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -133,7 +133,10 @@ pub fn unrecognized_action_id_help(
         ))
     } else {
         // Otherwise, suggest using another id
-        let euids_strs = schema.known_action_ids().map(ToString::to_string).collect::<Vec<_>>();
+        let euids_strs = schema
+            .known_action_ids()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
         fuzzy_search(euid.eid().as_ref(), &euids_strs)
             .map(UnrecognizedActionIdHelp::SuggestAlternative)
     }

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -70,18 +70,17 @@ pub struct UnrecognizedActionId {
     pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
-    /// Action Id seen in the policy.
+    /// Action Id seen in the policy
     pub actual_action_id: String,
-    /// An action id from the schema that the user might reasonably have
-    /// intended to write.
-    pub unrecognized_action_id_help: Option<UnrecognizedActionIdHelp>,
+    /// Hint for resolving the error
+    pub hint: Option<UnrecognizedActionIdHelp>,
 }
 
 impl Diagnostic for UnrecognizedActionId {
     impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        self.unrecognized_action_id_help
+        self.hint
             .as_ref()
             .map(|help| Box::new(help) as Box<dyn std::fmt::Display>)
     }
@@ -108,8 +107,8 @@ pub fn unrecognized_action_id_help(
     let eid_with_type = format!("Action::{}", eid_str);
     let eid_with_type_and_quotes = format!("Action::\"{}\"", eid_str);
     let maybe_id_with_type = schema.known_action_ids().find(|euid| {
-        let eid_string = <Eid as AsRef<str>>::as_ref(euid.eid()).to_string();
-        eid_string.contains(&eid_with_type) || eid_string.contains(&eid_with_type_and_quotes)
+        let eid = <Eid as AsRef<str>>::as_ref(euid.eid());
+        eid.contains(&eid_with_type) || eid.contains(&eid_with_type_and_quotes)
     });
     if let Some(id) = maybe_id_with_type {
         // In that case, let the user know about it

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -81,15 +81,9 @@ impl Diagnostic for UnrecognizedActionId {
     impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-        match &self.unrecognized_action_id_help {
-            Some(UnrecognizedActionIdHelp::AvoidActionTypeInActionId(s)) => Some(Box::new(
-                format!("did you intend to include the type in action `{s}`?"),
-            )),
-            Some(UnrecognizedActionIdHelp::SuggestAlternative(s)) => {
-                Some(Box::new(format!("did you mean `{s}`?")))
-            }
-            None => None,
-        }
+        self.unrecognized_action_id_help
+            .as_ref()
+            .map(|help| Box::new(help) as Box<dyn std::fmt::Display>)
     }
 }
 
@@ -97,20 +91,11 @@ impl Diagnostic for UnrecognizedActionId {
 #[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]
 pub enum UnrecognizedActionIdHelp {
     /// Draw attention to action id including action type (e.g., `Action::"Action::view"`)
+    #[error("did you intend to include the type in action `{0}`?")]
     AvoidActionTypeInActionId(String),
     /// Suggest an alternative action
+    #[error("did you mean `{0}`?")]
     SuggestAlternative(String),
-}
-
-impl std::fmt::Display for UnrecognizedActionIdHelp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::AvoidActionTypeInActionId(s) => {
-                write!(f, "the action id {s} is similar but includes the type")
-            }
-            Self::SuggestAlternative(s) => write!(f, "the action id {s} may be an alternative"),
-        }
-    }
 }
 
 /// Determine the help to offer in the presence of an unrecognized action id error.

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -81,8 +81,12 @@ impl Diagnostic for UnrecognizedActionId {
 
     fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
         match &self.unrecognized_action_id_help {
-            Some(UnrecognizedActionIdHelp::AvoidActionTypeInActionId(s)) => Some(Box::new(format!("did you intend to include the type in action `{s}`?"))),
-            Some(UnrecognizedActionIdHelp::SuggestAlternative(s)) => Some(Box::new(format!("did you mean `{s}`?"))),
+            Some(UnrecognizedActionIdHelp::AvoidActionTypeInActionId(s)) => Some(Box::new(
+                format!("did you intend to include the type in action `{s}`?"),
+            )),
+            Some(UnrecognizedActionIdHelp::SuggestAlternative(s)) => {
+                Some(Box::new(format!("did you mean `{s}`?")))
+            }
             None => None,
         }
     }
@@ -100,27 +104,38 @@ pub enum UnrecognizedActionIdHelp {
 impl std::fmt::Display for UnrecognizedActionIdHelp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::AvoidActionTypeInActionId(s) => write!(f, "the action id {s} is similar but includes the type"),
+            Self::AvoidActionTypeInActionId(s) => {
+                write!(f, "the action id {s} is similar but includes the type")
+            }
             Self::SuggestAlternative(s) => write!(f, "the action id {s} may be an alternative"),
         }
     }
 }
 
 /// Determine the help to offer in the presence of an unrecognized action id error.
-pub fn unrecognized_action_id_help(euid: &EntityUID, euids: &[&EntityUID]) -> Option<UnrecognizedActionIdHelp> {
+pub fn unrecognized_action_id_help(
+    euid: &EntityUID,
+    euids: &[&EntityUID],
+) -> Option<UnrecognizedActionIdHelp> {
     // Check if the user has included the type (i.e., `Action::`) in the action id
     let eid_with_type = format!("Action::{}", <Eid as AsRef<str>>::as_ref(euid.eid()));
-    let maybe_id_with_type = euids.iter().find(|euid| <Eid as AsRef<str>>::as_ref(euid.eid()).to_string().contains(&eid_with_type));
+    let maybe_id_with_type = euids.iter().find(|euid| {
+        <Eid as AsRef<str>>::as_ref(euid.eid())
+            .to_string()
+            .contains(&eid_with_type)
+    });
     if let Some(id) = maybe_id_with_type {
         // In that case, let the user know about it
-        Some(UnrecognizedActionIdHelp::AvoidActionTypeInActionId(id.to_string()))
+        Some(UnrecognizedActionIdHelp::AvoidActionTypeInActionId(
+            id.to_string(),
+        ))
     } else {
         // Otherwise, suggest using another id
         let euids_strs = euids.iter().map(ToString::to_string).collect::<Vec<_>>();
-        fuzzy_search(euid.eid().as_ref(), &euids_strs).map(UnrecognizedActionIdHelp::SuggestAlternative)
+        fuzzy_search(euid.eid().as_ref(), &euids_strs)
+            .map(UnrecognizedActionIdHelp::SuggestAlternative)
     }
 }
-
 
 /// Structure containing details about an invalid action application error.
 #[derive(Debug, Clone, Error, Hash, Eq, PartialEq)]

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -213,6 +213,7 @@ mod test {
 
     use crate::types::Type;
     use crate::Result;
+    use crate::validation_errors::UnrecognizedActionIdHelp;
 
     use super::*;
     use cedar_policy_core::{

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -290,7 +290,7 @@ mod test {
             Some(Loc::new(45..60, Arc::from(policy_a_src))),
             PolicyID::from_string("pola"),
             "Action::\"actin\"".to_string(),
-            Some("Action::\"action\"".to_string()),
+            Some(UnrecognizedActionIdHelp::SuggestAlternative("Action::\"action\"".to_string())),
         );
 
         assert!(!result.validation_passed());

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -212,8 +212,8 @@ mod test {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::types::Type;
-    use crate::Result;
     use crate::validation_errors::UnrecognizedActionIdHelp;
+    use crate::Result;
 
     use super::*;
     use cedar_policy_core::{
@@ -291,7 +291,9 @@ mod test {
             Some(Loc::new(45..60, Arc::from(policy_a_src))),
             PolicyID::from_string("pola"),
             "Action::\"actin\"".to_string(),
-            Some(UnrecognizedActionIdHelp::SuggestAlternative("Action::\"action\"".to_string())),
+            Some(UnrecognizedActionIdHelp::SuggestAlternative(
+                "Action::\"action\"".to_string(),
+            )),
         );
 
         assert!(!result.validation_passed());

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -27,7 +27,9 @@ use cedar_policy_core::{
 use std::{collections::HashSet, sync::Arc};
 
 use crate::{
-    expr_iterator::{policy_entity_type_names, policy_entity_uids}, validation_errors::unrecognized_action_id_help, ValidationError
+    expr_iterator::{policy_entity_type_names, policy_entity_uids},
+    validation_errors::unrecognized_action_id_help,
+    ValidationError,
 };
 
 use super::{fuzzy_match::fuzzy_search, schema::*, Validator};
@@ -75,10 +77,7 @@ impl Validator {
     ) -> impl Iterator<Item = ValidationError> + 'a {
         // Valid action id names that will be used to generate suggestions if an
         // action id is not found
-        let known_action_ids = self
-            .schema
-            .known_action_ids()
-            .collect::<Vec<_>>();
+        let known_action_ids = self.schema.known_action_ids().collect::<Vec<_>>();
         policy_entity_uids(template).filter_map(move |euid| {
             let entity_type = euid.entity_type();
             if entity_type.is_action() && !self.schema.is_known_action_id(euid) {

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -27,8 +27,7 @@ use cedar_policy_core::{
 use std::{collections::HashSet, sync::Arc};
 
 use crate::{
-    expr_iterator::{policy_entity_type_names, policy_entity_uids},
-    ValidationError,
+    expr_iterator::{policy_entity_type_names, policy_entity_uids}, validation_errors::unrecognized_action_id_help, ValidationError
 };
 
 use super::{fuzzy_match::fuzzy_search, schema::*, Validator};
@@ -79,7 +78,6 @@ impl Validator {
         let known_action_ids = self
             .schema
             .known_action_ids()
-            .map(ToString::to_string)
             .collect::<Vec<_>>();
         policy_entity_uids(template).filter_map(move |euid| {
             let entity_type = euid.entity_type();
@@ -88,7 +86,7 @@ impl Validator {
                     euid.loc().cloned(),
                     template.id().clone(),
                     euid.to_string(),
-                    fuzzy_search(euid.eid().as_ref(), known_action_ids.as_slice()),
+                    unrecognized_action_id_help(euid, &known_action_ids),
                 ))
             } else {
                 None

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -77,7 +77,6 @@ impl Validator {
     ) -> impl Iterator<Item = ValidationError> + 'a {
         // Valid action id names that will be used to generate suggestions if an
         // action id is not found
-        let known_action_ids = self.schema.known_action_ids().collect::<Vec<_>>();
         policy_entity_uids(template).filter_map(move |euid| {
             let entity_type = euid.entity_type();
             if entity_type.is_action() && !self.schema.is_known_action_id(euid) {
@@ -85,7 +84,7 @@ impl Validator {
                     euid.loc().cloned(),
                     template.id().clone(),
                     euid.to_string(),
-                    unrecognized_action_id_help(euid, &known_action_ids),
+                    unrecognized_action_id_help(euid, &self.schema),
                 ))
             } else {
                 None

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -23,6 +23,11 @@ Cedar Language Version: TBD
   Cedar request. To use this API you must enable the `entity-manifest` feature flag.
 - Added public APIs to get language and SDK version numbers (#1219).
 
+### Changed
+
+- The validator provides a more specific hint when an action ID cannot be found
+  and the same action ID with `Action::` has been defined.
+
 ### Fixed
 
 - The formatter will now consistently add a trailing newline. (resolving #1217)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -26,7 +26,7 @@ Cedar Language Version: TBD
 ### Changed
 
 - The validator provides a more specific hint when an action ID cannot be found
-  and the same action ID with `Action::` has been defined.
+  and the same action ID with `Action::` has been defined (#1258, resolving #166)
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

This PR extends the validation of action IDs so that we detect cases in which the user may have mistakenly included the entity type (i.e., `"Action::"`) in the action ID. In that case, we don't suggest another action ID like we used to, but instead draw attention to the fact that the action ID was defined with the entity type in its name. This avoids misleading the user when the fix is much simpler.

Resolves #166 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
