### PR TITLE
Reorganize `to_expr_or_special` for `cst::Member`

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1131,6 +1131,14 @@ impl Node<Option<cst::Member>> {
     /// Construct an attribute access or method call on an expression. This also
     /// handles function calls, but a function call of an arbitrary expression
     /// is always an error.
+    ///
+    /// The input `head` is an arbitrary expression, while `next` and `tail` are
+    /// togther a non-empty list of accesses applied to that expression.
+    ///
+    /// Returns a tuple where the first element is the expression built for the
+    /// `next` access applied to `head`, and the second element is the new tail of
+    /// acessors. In most cases, `tail` is returned unmodified, but in the method
+    /// call case we need to pull off the `Call` element containing the arguments.
     fn build_expr_accessor<'a>(
         &self,
         head: ast::Expr,


### PR DESCRIPTION
## Description of changes

This method has always struck me as unnecessarily complex. This PR tries to simplify it by observing that most of the cases can only occur on the first iteration of the loop. On the first iteration, we might have an access on a name (`foo.bar`),  variable (`principal.bar`), string-literal (`"foo".bar`) or expression (`(principal.foo).bar`), but on all subsequent iterations we can only have the expression case. The string literal case was identical to the expression case, so these can share code.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
