### PR TITLE
Fix JSON schema parsing error mesage on error in nested types

### DIFF
--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -1080,11 +1080,6 @@ impl<'de, N: Deserialize<'de> + From<RawName>> Visitor<'de> for TypeVisitor<N> {
     {
         use TypeFields::{AdditionalAttributes, Attributes, Element, Name, Type as TypeField};
 
-        // We keep field values wrapped in a `Result` initially so that we do
-        // not report errors due the contents of a field when the field is not
-        // expected for a particular type variant. We instead report that the
-        // field so not exist at all, so that the schema author can delete the
-        // field without wasting time fixing errors in the value.
         let mut type_name: Option<SmolStr> = None;
         let mut element: Option<Type<N>> = None;
         let mut attributes: Option<AttributesTypeMap> = None;

--- a/cedar-policy-validator/src/json_schema.rs
+++ b/cedar-policy-validator/src/json_schema.rs
@@ -2027,7 +2027,7 @@ mod test {
     #[test]
     fn schema_file_unexpected_malformed_attribute() {
         let src = serde_json::json!(
-        {
+        { "": {
             "entityTypes": {
                 "User": {
                     "shape": {
@@ -2044,7 +2044,7 @@ mod test {
                 }
             },
             "actions": {}
-        });
+        }});
         let schema = ValidatorSchema::from_json_value(src, Extensions::all_available());
         assert_matches!(schema, Err(e) => {
             expect_err(
@@ -2100,7 +2100,6 @@ mod test {
                             "type": "Record",
                             "attributes": {
                                  "foo": { "type": "Entity", "name": "b" },
-                                 "bar": { "type": "Set", "element": "Long" },
                                  "baz": { "type": "Record",
                                     "attributes": {
                                         // Parsing should fail here instead of continuing and failing on the `"b"` as in #417
@@ -2120,7 +2119,7 @@ mod test {
             expect_err(
                 "",
                 &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error(r#"unknown field `z`, expected one of `type`, `element`, `attributes`, `additionalAttributes`, `name`"#).build()
+                &ExpectedErrorMessageBuilder::error(r#"invalid type: string "Boolean", expected struct TypeOfAttribute"#).build()
             );
         });
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ## [Unreleased]
 Cedar Language Version: TBD
 
+### Fixed
+
+- Some misleading parser errors for JSON schema with mistakes in nested attribute definitions (#1270, resolving #417)
+
 ## [4.2.0] - 2024-10-07
 Cedar Language version: 4.1
 


### PR DESCRIPTION
## Description of changes

Fix #417. This avoid an extremely confusing error message (see issue for details).

The code removed here was originally intended to improve errors messages on errors in nested attribute by delaying reporting of these error until we know the attribute is required, but this didn't actually work and the errors are even worse than the would be without this code.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
