### PR TITLE
Suggest function in unknown extension function errors

### DIFF
--- a/cedar-policy-core/src/fuzzy_match.rs
+++ b/cedar-policy-core/src/fuzzy_match.rs
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+//! This module provides the fuzzy matching utility used to make suggestions
+//! when encountering unknown values in entities, functions, etc.
+
 /// Fuzzy string matching using the Levenshtein distance algorithm
 pub fn fuzzy_search(key: &str, lst: &[impl AsRef<str>]) -> Option<String> {
     if key.is_empty() || lst.is_empty() {
@@ -30,7 +33,8 @@ pub fn fuzzy_search(key: &str, lst: &[impl AsRef<str>]) -> Option<String> {
         Some(t.1.to_owned())
     }
 }
-pub fn levenshtein_distance(word1: &str, word2: &str) -> usize {
+
+fn levenshtein_distance(word1: &str, word2: &str) -> usize {
     let w1 = word1.chars().collect::<Vec<_>>();
     let w2 = word2.chars().collect::<Vec<_>>();
     let word1_length = w1.len() + 1;

--- a/cedar-policy-core/src/fuzzy_match.rs
+++ b/cedar-policy-core/src/fuzzy_match.rs
@@ -19,6 +19,16 @@
 
 /// Fuzzy string matching using the Levenshtein distance algorithm
 pub fn fuzzy_search(key: &str, lst: &[impl AsRef<str>]) -> Option<String> {
+    fuzzy_search_limited(key, lst, None)
+}
+
+/// Fuzzy string matching using the Levenshtein distance algorithm, with an
+/// option to limit matching up to some distance.
+pub fn fuzzy_search_limited(
+    key: &str,
+    lst: &[impl AsRef<str>],
+    max_distance: Option<usize>,
+) -> Option<String> {
     if key.is_empty() || lst.is_empty() {
         None
     } else {
@@ -30,7 +40,12 @@ pub fn fuzzy_search(key: &str, lst: &[impl AsRef<str>]) -> Option<String> {
                 acc
             }
         });
-        Some(t.1.to_owned())
+
+        if let Some(threshold) = max_distance {
+            (t.0 <= threshold).then_some(t.1.to_owned())
+        } else {
+            Some(t.1.to_owned())
+        }
     }
 }
 

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -33,6 +33,7 @@ mod error_macros;
 pub mod est;
 pub mod evaluator;
 pub mod extensions;
+pub mod fuzzy_match;
 pub mod jsonvalue;
 pub mod parser;
 pub mod transitive_closure;

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -44,7 +44,7 @@ use crate::ast::{
     PrincipalOrResourceConstraint, ResourceConstraint, UnreservedId,
 };
 use crate::est::extract_single_argument;
-use crate::fuzzy_match::fuzzy_search;
+use crate::fuzzy_match::fuzzy_search_limited;
 use itertools::Either;
 use nonempty::NonEmpty;
 use smol_str::{SmolStr, ToSmolStr};
@@ -1510,8 +1510,13 @@ impl ast::Name {
             Ok(construct_ext_func(self, args, loc))
         } else {
             fn suggest_function(name: &ast::Name, funs: &HashSet<&ast::Name>) -> Option<String> {
+                const SUGGEST_FUNCTION_MAX_DISTANCE: usize = 3;
                 let fnames = funs.iter().map(ToString::to_string).collect::<Vec<_>>();
-                let suggested_function = fuzzy_search(&name.to_string(), fnames.as_slice());
+                let suggested_function = fuzzy_search_limited(
+                    &name.to_string(),
+                    fnames.as_slice(),
+                    Some(SUGGEST_FUNCTION_MAX_DISTANCE),
+                );
                 suggested_function.map(|f| format!("did you mean `{f}`?"))
             }
             let hint = suggest_function(&self, &EXTENSION_STYLES.functions);

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -300,8 +300,14 @@ pub enum ToASTErrorKind {
     #[error("`{0}` is not a valid method")]
     UnknownMethod(ast::UnreservedId),
     /// Returned when a policy attempts to call a function that does not exist
-    #[error("`{0}` is not a valid function")]
-    UnknownFunction(ast::Name),
+    #[error("`{id}` is not a valid function")]
+    UnknownFunction {
+        /// The user-provided function id
+        id: ast::Name,
+        /// The hint to resolve the error
+        #[help]
+        hint: Option<String>,
+    },
     /// Returned when a policy attempts to write an entity literal
     #[error("invalid entity literal: {0}")]
     #[diagnostic(help("entity literals should have a form like `Namespace::User::\"alice\"`"))]

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -22,9 +22,9 @@ use thiserror::Error;
 use std::fmt::Display;
 use std::ops::{Add, Neg};
 
+use cedar_policy_core::fuzzy_match::fuzzy_search;
 use cedar_policy_core::impl_diagnostic_from_source_loc_opt_field;
 use cedar_policy_core::parser::Loc;
-use cedar_policy_core::fuzzy_match::fuzzy_search;
 
 use std::collections::BTreeSet;
 

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -24,13 +24,13 @@ use std::ops::{Add, Neg};
 
 use cedar_policy_core::impl_diagnostic_from_source_loc_opt_field;
 use cedar_policy_core::parser::Loc;
+use cedar_policy_core::fuzzy_match::fuzzy_search;
 
 use std::collections::BTreeSet;
 
 use cedar_policy_core::ast::{Eid, EntityType, EntityUID, Expr, ExprKind, PolicyID, Var};
 use cedar_policy_core::parser::join_with_conjunction;
 
-use crate::fuzzy_match::fuzzy_search;
 use crate::types::{EntityLUB, EntityRecordKind, RequestEnv, Type};
 use crate::ValidatorSchema;
 use itertools::Itertools;

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -48,7 +48,6 @@ pub use diagnostics::*;
 mod expr_iterator;
 mod extension_schema;
 mod extensions;
-mod fuzzy_match;
 mod rbac;
 mod schema;
 pub use schema::*;

--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -21,6 +21,7 @@ use cedar_policy_core::{
         self, ActionConstraint, EntityReference, EntityUID, Policy, PolicyID, PrincipalConstraint,
         PrincipalOrResourceConstraint, ResourceConstraint, SlotEnv, Template,
     },
+    fuzzy_match::fuzzy_search,
     parser::Loc,
 };
 
@@ -32,7 +33,7 @@ use crate::{
     ValidationError,
 };
 
-use super::{fuzzy_match::fuzzy_search, schema::*, Validator};
+use super::{schema::*, Validator};
 
 impl Validator {
     /// Generate `UnrecognizedEntityType` error for every entity type in the

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -20,7 +20,6 @@
 use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 
 use cedar_policy_core::{
-    fuzzy_match::fuzzy_search,
     ast::{
         EntityAttrEvaluationError, EntityType, EntityUID, InternalName, Name,
         PartialValueSerializedAsExpr, UnreservedId,
@@ -28,6 +27,7 @@ use cedar_policy_core::{
     entities::{json::err::JsonDeserializationErrorContext, CedarValueJson},
     evaluator::RestrictedEvaluator,
     extensions::Extensions,
+    fuzzy_match::fuzzy_search,
 };
 use itertools::Itertools;
 use nonempty::{nonempty, NonEmpty};

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -20,6 +20,7 @@
 use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 
 use cedar_policy_core::{
+    fuzzy_match::fuzzy_search,
     ast::{
         EntityAttrEvaluationError, EntityType, EntityUID, InternalName, Name,
         PartialValueSerializedAsExpr, UnreservedId,
@@ -35,7 +36,6 @@ use smol_str::{SmolStr, ToSmolStr};
 use super::{internal_name_to_entity_type, AllDefs, ValidatorApplySpec};
 use crate::{
     err::{schema_errors::*, SchemaError},
-    fuzzy_match::fuzzy_search,
     json_schema::{self, CommonTypeId},
     types::{AttributeType, Attributes, OpenTag, Type},
     ActionBehavior, ConditionalName, RawName, ReferenceType,

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -28,7 +28,6 @@ use std::{borrow::Cow, collections::HashSet, iter::zip};
 use crate::{
     extension_schema::ExtensionFunctionType,
     extensions::ExtensionSchemas,
-    fuzzy_match::fuzzy_search,
     schema::ValidatorSchema,
     types::{
         AttributeType, Capability, CapabilitySet, EntityRecordKind, OpenTag, Primitive, RequestEnv,
@@ -42,6 +41,7 @@ use cedar_policy_core::ast::{
     BinaryOp, EntityType, EntityUID, Expr, ExprBuilder, ExprKind, Literal, Name, PolicyID,
     PrincipalOrResourceConstraint, SlotId, Template, UnaryOp, Var,
 };
+use cedar_policy_core::fuzzy_match::fuzzy_search;
 
 #[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -12,6 +12,11 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ## [Unreleased]
 Cedar Language Version: TBD
 
+### Changed
+
+- The error associated with parsing a non-existent extension function additionally
+  includes a suggestion based on available extension functions (#1279, resolving #332).
+
 ### Fixed
 
 - Some misleading parser errors for JSON schema with mistakes in nested attribute definitions (#1270, resolving #417)

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,7 @@ Cedar Language Version: TBD
 ### Changed
 
 - The error associated with parsing a non-existent extension function additionally
-  includes a suggestion based on available extension functions (#1279, resolving #332).
+  includes a suggestion based on available extension functions (#1280, resolving #332).
 
 ### Fixed
 

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6214,7 +6214,6 @@ mod version_tests {
 mod reserved_keywords_in_policies {
     use super::*;
     use cool_asserts::assert_matches;
-    use lazy_static::lazy_static;
 
     const RESERVED_IDENTS: [&str; 9] = [
         "true", "false", "if", "then", "else", "in", "like", "has", "is",
@@ -6230,31 +6229,6 @@ mod reserved_keywords_in_policies {
         "when",
         "unless",
     ];
-
-    lazy_static! {
-        static ref FUNCTION_SUGGESTIONS: HashMap<&'static str, &'static str> = {
-            let mut map = HashMap::with_capacity(OTHER_SPECIAL_IDENTS.len());
-            map.insert("principal", "decimal");
-            map.insert("action", "decimal");
-            #[cfg(not(feature = "experimental"))]
-            {
-                map.insert("resource", "decimal");
-                map.insert("context", "decimal");
-                map.insert("forbid", "decimal");
-                map.insert("when", "decimal");
-            }
-            #[cfg(feature = "experimental")]
-            {
-                map.insert("resource", "unknown");
-                map.insert("context", "unknown");
-                map.insert("forbid", "unknown");
-                map.insert("when", "unknown");
-            }
-            map.insert("permit", "decimal");
-            map.insert("unless", "decimal");
-            map
-        };
-    }
 
     const RESERVED_IDENT_MSG: fn(&str) -> String =
         |id| format!("this identifier is reserved and cannot be used: {id}");
@@ -6469,12 +6443,10 @@ mod reserved_keywords_in_policies {
         }
 
         for id in OTHER_SPECIAL_IDENTS.into_iter() {
-            let suggestion = FUNCTION_SUGGESTIONS[id];
-            assert_invalid_expression_with_help(
+            assert_invalid_expression(
                 format!("extension::function::{id}(\"foo\")"),
                 format!("`extension::function::{id}` is not a valid function"),
                 format!("extension::function::{id}(\"foo\")"),
-                format!("did you mean `{suggestion}`?"),
             );
             assert_invalid_expression(
                 format!("context.{id}(1)"),

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6443,10 +6443,12 @@ mod reserved_keywords_in_policies {
         }
 
         for id in OTHER_SPECIAL_IDENTS.into_iter() {
-            assert_invalid_expression(
+            // Note: We always get `decimal` as the suggestion
+            assert_invalid_expression_with_help(
                 format!("extension::function::{id}(\"foo\")"),
                 format!("`extension::function::{id}` is not a valid function"),
                 format!("extension::function::{id}(\"foo\")"),
+                format!("did you mean `decimal`?"),
             );
             assert_invalid_expression(
                 format!("context.{id}(1)"),


### PR DESCRIPTION
## Description of changes

This PR extends unknown function errors with a hint that suggests the closest function from the ones available based on the fuzzy string matching algorithm used to make similar suggestions. With this change, the example in #332 now also shows the help message ``Did you mean `ip`?`` in its diagnostics.

Resolves #332 

## Callouts

This PR does not deal with #246, a similar request for methods instead of functions. But I'm planning on fixing it right after this one's cleared.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.

