### PR TITLE
Fix long first paragraphs in docs and deny clippy warning

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1633,8 +1633,9 @@ impl Schema {
     }
 }
 
-/// Contains the result of policy validation. The result includes the list of
-/// issues found by validation and whether validation succeeds or fails.
+/// Contains the result of policy validation.
+///
+/// The result includes the list of issues found by validation and whether validation succeeds or fails.
 /// Validation succeeds if there are no fatal errors. There may still be
 /// non-fatal warnings present when validation passes.
 #[derive(Debug)]
@@ -1782,8 +1783,9 @@ impl Diagnostic for ValidationResult {
     }
 }
 
-/// Scan a set of policies for potentially confusing/obfuscating text. These
-/// checks are also provided through [`Validator::validate`] which provides more
+/// Scan a set of policies for potentially confusing/obfuscating text.
+///
+/// These checks are also provided through [`Validator::validate`] which provides more
 /// comprehensive error detection, but this function can be used to check for
 /// confusable strings without defining a schema.
 pub fn confusable_string_checker<'a>(
@@ -3992,6 +3994,7 @@ impl std::fmt::Display for EvalResult {
 }
 
 /// Evaluates an expression.
+///
 /// If evaluation results in an error (e.g., attempting to access a non-existent Entity or Record,
 /// passing the wrong number of arguments to a function etc.), that error is returned as a String
 pub fn eval_expression(

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -913,6 +913,7 @@ pub struct Response {
 }
 
 /// A partially evaluated authorization response.
+///
 /// Splits the results into several categories: satisfied, false, and residual for each policy effect.
 /// Also tracks all the errors that were encountered during evaluation.
 #[doc = include_str!("../experimental_warning.md")]
@@ -4442,6 +4443,7 @@ action CreateList in Create appliesTo {
 }
 
 /// Given a schema and policy set, compute an entity manifest.
+///
 /// The policies must validate against the schema in strict mode,
 /// otherwise an error is returned.
 /// The manifest describes the data required to answer requests

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -843,6 +843,7 @@ impl From<est::PolicySetFromJsonError> for PolicySetError {
 
 /// Represents one or more [`ParseError`]s encountered when parsing a policy or
 /// expression.
+///
 /// By default, the `Diagnostic` and `Error` implementations will only print the
 /// first error. If you want to see all errors, use `.iter()` or `.into_iter()`.
 #[derive(Debug, Diagnostic, Error)]

--- a/cedar-policy/src/lib.rs
+++ b/cedar-policy/src/lib.rs
@@ -32,7 +32,8 @@
     rustdoc::invalid_rust_codeblocks,
     rustdoc::bare_urls,
     clippy::doc_markdown,
-    clippy::doc_lazy_continuation
+    clippy::doc_lazy_continuation,
+    clippy::too_long_first_doc_paragraph
 )]
 #![allow(
     clippy::needless_doctest_main,


### PR DESCRIPTION
## Description of changes

Applies a new clippy suggestion for nicer docs and adds this new lint to our list `deny` lints.

See https://rust-lang.github.io/rust-clippy/rust-1.82.0/index.html#/too_long_first_doc_paragraph

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
