### PR TITLE
Fix expected error message in deserialization test

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -4149,7 +4149,7 @@ mod test {
             );
             assert_panics!(
                 serde_json::from_value::<Policy>(bad).unwrap(),
-                includes("unknown variant `is`, expected one of `All`, `==`, `in`"),
+                includes("unknown variant `is`, expected one of `All`, `all`, `==`, `in`"),
             );
         }
 


### PR DESCRIPTION
## Description of changes

This PR resolves a CI issue first seen in #1280 where we fail an `assert_panics!` macro because the expected error doesn't match the one we pass. That's because in a [more recent version of serde](https://github.com/serde-rs/serde/releases/tag/v1.0.211) the variant aliases are also shown in the error message.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
