### PR TITLE
Suggest method in unknown extension method errors

### DIFF
--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -297,8 +297,14 @@ pub enum ToASTErrorKind {
     #[error("attempted to call `{0}.{1}(...)`, but `{0}` does not have any methods")]
     NoMethods(ast::Name, ast::UnreservedId),
     /// Returned when a policy attempts to call a method that does not exist
-    #[error("`{0}` is not a valid method")]
-    UnknownMethod(ast::UnreservedId),
+    #[error("`{id}` is not a valid method")]
+    UnknownMethod {
+        /// The user-provided method id
+        id: ast::UnreservedId,
+        /// The hint to resolve the error
+        #[help]
+        hint: Option<String>,
+    },
     /// Returned when a policy attempts to call a function that does not exist
     #[error("`{id}` is not a valid function")]
     UnknownFunction {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -20,6 +20,8 @@ Cedar Language Version: TBD
 
 - The error associated with parsing a non-existent extension function additionally
   includes a suggestion based on available extension functions (#1280, resolving #332).
+- The error associated with parsing a non-existent extension method additionally
+  includes a suggestion based on available extension functions (#1289, resolving #246).
 
 ### Fixed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -21,7 +21,7 @@ Cedar Language Version: TBD
 - The error associated with parsing a non-existent extension function additionally
   includes a suggestion based on available extension functions (#1280, resolving #332).
 - The error associated with parsing a non-existent extension method additionally
-  includes a suggestion based on available extension functions (#1289, resolving #246).
+  includes a suggestion based on available extension methods (#1289, resolving #246).
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

This PR extends unknown method errors with a hint that suggests the closest method from the ones available based on the fuzzy string matching algorithm used to make similar suggestions. This recommendation uses the "limited" version of the fuzzy matching algorithm to avoid suggestions which wouldn't be too helpful. To put it simply, this PR is like #1280 but for methods.

Resolves #246 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
