### PR TITLE
Generate actions HashMap at ValidatorSchema instantiation

### DIFF
--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -40,10 +40,7 @@ impl<'a> CoreSchema<'a> {
     /// Create a new `CoreSchema` for the given `ValidatorSchema`
     pub fn new(schema: &'a ValidatorSchema) -> Self {
         Self {
-            actions: schema
-                .action_entities_iter()
-                .map(|e| (e.uid().clone(), Arc::new(e)))
-                .collect(),
+            actions: schema.actions.clone(),
             schema,
         }
     }

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -19,7 +19,7 @@ use cedar_policy_core::extensions::{ExtensionFunctionLookupError, Extensions};
 use cedar_policy_core::{ast, entities};
 use miette::Diagnostic;
 use smol_str::SmolStr;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -27,20 +27,13 @@ use thiserror::Error;
 #[derive(Debug)]
 pub struct CoreSchema<'a> {
     /// Contains all the information
-    schema: &'a ValidatorSchema,
-    /// For easy lookup, this is a map from action name to `Entity` object
-    /// for each action in the schema. This information is contained in the
-    /// `ValidatorSchema`, but not efficient to extract -- getting the `Entity`
-    /// from the `ValidatorSchema` is O(N) as of this writing, but with this
-    /// cache it's O(1).
-    actions: HashMap<ast::EntityUID, Arc<ast::Entity>>,
+    schema: &'a ValidatorSchema
 }
 
 impl<'a> CoreSchema<'a> {
     /// Create a new `CoreSchema` for the given `ValidatorSchema`
     pub fn new(schema: &'a ValidatorSchema) -> Self {
         Self {
-            actions: schema.actions.clone(),
             schema,
         }
     }
@@ -55,7 +48,7 @@ impl<'a> entities::Schema for CoreSchema<'a> {
     }
 
     fn action(&self, action: &ast::EntityUID) -> Option<Arc<ast::Entity>> {
-        self.actions.get(action).cloned()
+        self.schema.actions.get(action).cloned()
     }
 
     fn entity_types_with_basename<'b>(
@@ -76,7 +69,7 @@ impl<'a> entities::Schema for CoreSchema<'a> {
     }
 
     fn action_entities(&self) -> Self::ActionEntityIterator {
-        self.actions.values().map(Arc::clone).collect()
+        self.schema.actions.values().map(Arc::clone).collect()
     }
 }
 

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 use crate::{ValidatorEntityType, ValidatorSchema};
 use cedar_policy_core::extensions::{ExtensionFunctionLookupError, Extensions};
 use cedar_policy_core::{ast, entities};
 use miette::Diagnostic;
 use smol_str::SmolStr;
+use std::collections::hash_map::Values;
 use std::collections::HashSet;
+use std::iter::Cloned;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -27,21 +28,19 @@ use thiserror::Error;
 #[derive(Debug)]
 pub struct CoreSchema<'a> {
     /// Contains all the information
-    schema: &'a ValidatorSchema
+    schema: &'a ValidatorSchema,
 }
 
 impl<'a> CoreSchema<'a> {
     /// Create a new `CoreSchema` for the given `ValidatorSchema`
     pub fn new(schema: &'a ValidatorSchema) -> Self {
-        Self {
-            schema,
-        }
+        Self { schema }
     }
 }
 
 impl<'a> entities::Schema for CoreSchema<'a> {
     type EntityTypeDescription = EntityTypeDescription;
-    type ActionEntityIterator = Vec<Arc<ast::Entity>>;
+    type ActionEntityIterator = Cloned<Values<'a, ast::EntityUID, Arc<ast::Entity>>>;
 
     fn entity_type(&self, entity_type: &ast::EntityType) -> Option<EntityTypeDescription> {
         EntityTypeDescription::new(self.schema, entity_type)
@@ -69,7 +68,7 @@ impl<'a> entities::Schema for CoreSchema<'a> {
     }
 
     fn action_entities(&self) -> Self::ActionEntityIterator {
-        self.schema.actions.values().map(Arc::clone).collect()
+        self.schema.actions.values().cloned()
     }
 }
 

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -856,9 +856,7 @@ impl ValidatorSchema {
     pub fn action_entities(&self) -> std::result::Result<Entities, EntitiesError> {
         let extensions = Extensions::all_available();
         Entities::from_entities(
-            self.actions
-                .values()
-                .map(|entity| entity.as_ref().clone()),
+            self.actions.values().map(|entity| entity.as_ref().clone()),
             None::<&cedar_policy_core::entities::NoEntitiesSchema>, // we don't want to tell `Entities::from_entities()` to add the schema's action entities, that would infinitely recurse
             TCComputation::AssumeAlreadyComputed,
             extensions,

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -858,8 +858,7 @@ impl ValidatorSchema {
         Entities::from_entities(
             self.actions
                 .values()
-                .map(|entity| entity.as_ref().clone())
-                .collect::<Vec<Entity>>(),
+                .map(|entity| entity.as_ref().clone()),
             None::<&cedar_policy_core::entities::NoEntitiesSchema>, // we don't want to tell `Entities::from_entities()` to add the schema's action entities, that would infinitely recurse
             TCComputation::AssumeAlreadyComputed,
             extensions,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,8 +22,8 @@ Cedar Language Version: TBD
   includes a suggestion based on available extension functions (#1280, resolving #332).
 - The error associated with parsing a non-existent extension method additionally
   includes a suggestion based on available extension methods (#1289, resolving #246).
-- Extract action graph inversion from CoreSchema to ValidatorSchema instantiation to
-  improve schema validation speeds. (#1290, as part of resolving #1285)
+- Extract action graph inversion from `CoreSchema` to `ValidatorSchema` instantiation
+  to improve schema validation speeds. (#1290, as part of resolving #1285)
 
 ### Fixed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -20,6 +20,8 @@ Cedar Language Version: TBD
 
 - The error associated with parsing a non-existent extension function additionally
   includes a suggestion based on available extension functions (#1280, resolving #332).
+- Extract action graph inversion from CoreSchema to ValidatorSchema instantiation to
+  improve schema validation speeds. (#1290, as part of resolving #1285)
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

This change fixes part of the issues identified in #1285 by pulling up the expensive action inversion from CoreSchema construction to ValidatorSchema construction, which is only done once per Schema.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)


I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
