### PR TITLE
Speed Improvement: Make incoming entities Arc<Entities> like schema entities

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -30,6 +30,7 @@ use serde_with::{serde_as, TryFromInto};
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::str::FromStr;
+use std::sync::Arc;
 use thiserror::Error;
 
 /// The entity type that Actions must have
@@ -646,6 +647,25 @@ impl TCNode<EntityUID> for Entity {
 
     fn add_edge_to(&mut self, k: EntityUID) {
         self.add_ancestor(k)
+    }
+
+    fn out_edges(&self) -> Box<dyn Iterator<Item = &EntityUID> + '_> {
+        Box::new(self.ancestors())
+    }
+
+    fn has_edge_to(&self, e: &EntityUID) -> bool {
+        self.is_descendant_of(e)
+    }
+}
+
+impl TCNode<EntityUID> for Arc<Entity> {
+    fn get_key(&self) -> EntityUID {
+        self.uid().clone()
+    }
+
+    fn add_edge_to(&mut self, k: EntityUID) {
+        // Use Arc::make_mut to get a mutable reference to the inner value
+        Arc::make_mut(self).add_ancestor(k)
     }
 
     fn out_edges(&self) -> Box<dyn Iterator<Item = &EntityUID> + '_> {

--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -773,6 +773,13 @@ impl From<&Entity> for proto::Entity {
     }
 }
 
+#[cfg(feature = "protobufs")]
+impl From<&Arc<Entity>> for proto::Entity {
+    fn from(v: &Arc<Entity>) -> Self {
+        Self::from(v.as_ref())
+    }
+}
+
 /// `PartialValue`, but serialized as a `RestrictedExpr`.
 ///
 /// (Extension values can't be directly serialized, but can be serialized as

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -323,7 +323,9 @@ impl Entities {
 }
 
 /// Create a map from EntityUids to Entities, erroring if there are any duplicates
-fn create_entity_map(es: impl Iterator<Item = Arc<Entity>>) -> Result<HashMap<EntityUID, Arc<Entity>>> {
+fn create_entity_map(
+    es: impl Iterator<Item = Arc<Entity>>,
+) -> Result<HashMap<EntityUID, Arc<Entity>>> {
     let mut map = HashMap::new();
     for e in es {
         match map.entry(e.uid().clone()) {
@@ -345,9 +347,7 @@ impl IntoIterator for Entities {
     >;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.entities
-            .into_values()
-            .map(Arc::unwrap_or_clone)
+        self.entities.into_values().map(Arc::unwrap_or_clone)
     }
 }
 
@@ -369,7 +369,11 @@ impl From<&proto::Entities> for Entities {
     // PANIC SAFETY: experimental feature
     #[allow(clippy::expect_used)]
     fn from(v: &proto::Entities) -> Self {
-        let entities: Vec<Arc<Entity>> = v.entities.iter().map(|e| Arc::new(Entity::from(e))).collect();
+        let entities: Vec<Arc<Entity>> = v
+            .entities
+            .iter()
+            .map(|e| Arc::new(Entity::from(e)))
+            .collect();
 
         #[cfg(not(feature = "partial-eval"))]
         let result = Entities::new();
@@ -3546,13 +3550,16 @@ pub mod protobuf_tests {
         let attrs = (1..=7)
             .map(|id| (format!("{id}").into(), RestrictedExpr::val(true)))
             .collect::<HashMap<SmolStr, _>>();
-        let entity: Arc<Entity> = Arc::new(Entity::new(
-            r#"Foo::"bar""#.parse().unwrap(),
-            attrs.clone(),
-            HashSet::new(),
-            BTreeMap::new(),
-            &Extensions::none(),
-        ).unwrap());
+        let entity: Arc<Entity> = Arc::new(
+            Entity::new(
+                r#"Foo::"bar""#.parse().unwrap(),
+                attrs.clone(),
+                HashSet::new(),
+                BTreeMap::new(),
+                &Extensions::none(),
+            )
+            .unwrap(),
+        );
         let mut entities2: Entities = Entities::new();
         entities2 = entities2
             .add_entities(
@@ -3568,13 +3575,16 @@ pub mod protobuf_tests {
         );
 
         // Two Element Test
-        let entity2: Arc<Entity> = Arc::new(Entity::new(
-            r#"Bar::"foo""#.parse().unwrap(),
-            attrs.clone(),
-            HashSet::new(),
-            BTreeMap::new(),
-            &Extensions::none(),
-        ).unwrap());
+        let entity2: Arc<Entity> = Arc::new(
+            Entity::new(
+                r#"Bar::"foo""#.parse().unwrap(),
+                attrs.clone(),
+                HashSet::new(),
+                BTreeMap::new(),
+                &Extensions::none(),
+            )
+            .unwrap(),
+        );
         let mut entities3: Entities = Entities::new();
         entities3 = entities3
             .add_entities(

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -369,7 +369,7 @@ impl From<&proto::Entities> for Entities {
     // PANIC SAFETY: experimental feature
     #[allow(clippy::expect_used)]
     fn from(v: &proto::Entities) -> Self {
-        let entities: Vec<Entity> = v.entities.iter().map(Entity::from).collect();
+        let entities: Vec<Arc<Entity>> = v.entities.iter().map(|e| Arc::new(Entity::from(e))).collect();
 
         #[cfg(not(feature = "partial-eval"))]
         let result = Entities::new();
@@ -3546,14 +3546,13 @@ pub mod protobuf_tests {
         let attrs = (1..=7)
             .map(|id| (format!("{id}").into(), RestrictedExpr::val(true)))
             .collect::<HashMap<SmolStr, _>>();
-        let entity: Entity = Entity::new(
+        let entity: Arc<Entity> = Arc::new(Entity::new(
             r#"Foo::"bar""#.parse().unwrap(),
             attrs.clone(),
             HashSet::new(),
             BTreeMap::new(),
             &Extensions::none(),
-        )
-        .unwrap();
+        ).unwrap());
         let mut entities2: Entities = Entities::new();
         entities2 = entities2
             .add_entities(
@@ -3569,14 +3568,13 @@ pub mod protobuf_tests {
         );
 
         // Two Element Test
-        let entity2: Entity = Entity::new(
+        let entity2: Arc<Entity> = Arc::new(Entity::new(
             r#"Bar::"foo""#.parse().unwrap(),
             attrs.clone(),
             HashSet::new(),
             BTreeMap::new(),
             &Extensions::none(),
-        )
-        .unwrap();
+        ).unwrap());
         let mut entities3: Entities = Entities::new();
         entities3 = entities3
             .add_entities(

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -125,7 +125,7 @@ impl Entities {
     /// responsible for ensuring that TC and DAG hold before calling this method.
     pub fn add_entities(
         mut self,
-        collection: impl IntoIterator<Item = Entity>,
+        collection: impl IntoIterator<Item = Arc<Entity>>,
         schema: Option<&impl Schema>,
         tc_computation: TCComputation,
         extensions: &Extensions<'_>,
@@ -140,7 +140,7 @@ impl Entities {
                     return Err(EntitiesError::duplicate(entity.uid().clone()))
                 }
                 hash_map::Entry::Vacant(vacant_entry) => {
-                    vacant_entry.insert(Arc::new(entity));
+                    vacant_entry.insert(entity);
                 }
             }
         }
@@ -174,7 +174,7 @@ impl Entities {
         tc_computation: TCComputation,
         extensions: &Extensions<'_>,
     ) -> Result<Self> {
-        let mut entity_map = create_entity_map(entities.into_iter())?;
+        let mut entity_map = create_entity_map(entities.into_iter().map(Arc::new))?;
         if let Some(schema) = schema {
             // Validate non-action entities against schema.
             // We do this before adding the actions, because we trust the
@@ -323,13 +323,13 @@ impl Entities {
 }
 
 /// Create a map from EntityUids to Entities, erroring if there are any duplicates
-fn create_entity_map(es: impl Iterator<Item = Entity>) -> Result<HashMap<EntityUID, Arc<Entity>>> {
+fn create_entity_map(es: impl Iterator<Item = Arc<Entity>>) -> Result<HashMap<EntityUID, Arc<Entity>>> {
     let mut map = HashMap::new();
     for e in es {
         match map.entry(e.uid().clone()) {
             hash_map::Entry::Occupied(_) => return Err(EntitiesError::duplicate(e.uid().clone())),
             hash_map::Entry::Vacant(v) => {
-                v.insert(Arc::new(e));
+                v.insert(e);
             }
         };
     }
@@ -553,7 +553,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -593,7 +594,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -632,7 +634,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,
@@ -675,7 +678,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -714,7 +718,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -755,7 +760,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -795,7 +801,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let es = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -822,7 +829,8 @@ mod json_parsing_tests {
 
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let err = simple_entities(&parser)
             .add_entities(
                 addl_entities,
@@ -843,7 +851,8 @@ mod json_parsing_tests {
         let new = serde_json::json!([{"uid":{ "type": "Test", "id": "alice" }, "attrs" : {}, "parents" : []}]);
         let addl_entities = parser
             .iter_from_json_value(new)
-            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)));
+            .unwrap_or_else(|e| panic!("{:?}", &miette::Report::new(e)))
+            .map(Arc::new);
         let err = simple_entities(&parser).add_entities(
             addl_entities,
             None::<&NoEntitiesSchema>,

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -339,14 +339,15 @@ fn create_entity_map(es: impl Iterator<Item = Arc<Entity>>) -> Result<HashMap<En
 impl IntoIterator for Entities {
     type Item = Entity;
 
-    type IntoIter = std::vec::IntoIter<Entity>;
+    type IntoIter = std::iter::Map<
+        std::collections::hash_map::IntoValues<EntityUID, Arc<Entity>>,
+        fn(Arc<Entity>) -> Entity,
+    >;
 
     fn into_iter(self) -> Self::IntoIter {
         self.entities
             .into_values()
             .map(Arc::unwrap_or_clone)
-            .collect::<Vec<Entity>>()
-            .into_iter()
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -55,10 +55,10 @@ use miette::Diagnostic;
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
-use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Read;
 use std::str::FromStr;
+use std::sync::Arc;
 
 // PANIC SAFETY: `CARGO_PKG_VERSION` should return a valid SemVer version string
 #[allow(clippy::unwrap_used)]
@@ -447,8 +447,7 @@ impl Entities {
             Extensions::all_available(),
             cedar_policy_core::entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser.iter_from_json_str(json)?
-        .map(Arc::new);
+        let new_entities = eparser.iter_from_json_str(json)?.map(Arc::new);
         Ok(Self(self.0.add_entities(
             new_entities,
             schema.as_ref(),
@@ -486,8 +485,7 @@ impl Entities {
             Extensions::all_available(),
             cedar_policy_core::entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser.iter_from_json_value(json)?
-        .map(Arc::new);
+        let new_entities = eparser.iter_from_json_value(json)?.map(Arc::new);
         Ok(Self(self.0.add_entities(
             new_entities,
             schema.as_ref(),
@@ -526,8 +524,7 @@ impl Entities {
             Extensions::all_available(),
             cedar_policy_core::entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser.iter_from_json_file(json)?
-            .map(Arc::new);
+        let new_entities = eparser.iter_from_json_file(json)?.map(Arc::new);
         Ok(Self(self.0.add_entities(
             new_entities,
             schema.as_ref(),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -55,6 +55,7 @@ use miette::Diagnostic;
 use ref_cast::RefCast;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
+use std::sync::Arc;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Read;
 use std::str::FromStr;
@@ -407,7 +408,7 @@ impl Entities {
     ) -> Result<Self, EntitiesError> {
         Ok(Self(
             self.0.add_entities(
-                entities.into_iter().map(|e| e.0),
+                entities.into_iter().map(|e| Arc::new(e.0)),
                 schema
                     .map(|s| cedar_policy_validator::CoreSchema::new(&s.0))
                     .as_ref(),
@@ -446,7 +447,8 @@ impl Entities {
             Extensions::all_available(),
             cedar_policy_core::entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser.iter_from_json_str(json)?;
+        let new_entities = eparser.iter_from_json_str(json)?
+        .map(Arc::new);
         Ok(Self(self.0.add_entities(
             new_entities,
             schema.as_ref(),
@@ -484,7 +486,8 @@ impl Entities {
             Extensions::all_available(),
             cedar_policy_core::entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser.iter_from_json_value(json)?;
+        let new_entities = eparser.iter_from_json_value(json)?
+        .map(Arc::new);
         Ok(Self(self.0.add_entities(
             new_entities,
             schema.as_ref(),
@@ -523,7 +526,8 @@ impl Entities {
             Extensions::all_available(),
             cedar_policy_core::entities::TCComputation::ComputeNow,
         );
-        let new_entities = eparser.iter_from_json_file(json)?;
+        let new_entities = eparser.iter_from_json_file(json)?
+            .map(Arc::new);
         Ok(Self(self.0.add_entities(
             new_entities,
             schema.as_ref(),


### PR DESCRIPTION
## Description of changes
This provides a 3x speedup based on local benchmarking with a large schema that has big action entity hierarchy relationships. Today Entities.entities is a HashMap of `<EntityUID, Entity>`. When from_entities brings in the entities and actions from a given schema, it currently relies on `Arc::unwrap_or_clone`, which frequently ends up being clone. For a large set of very interrelated Actions, this repeated clone becomes expensive.

Changing Entities.entities to be a HashMap of `<EntityUID, Arc<Entity>>` allows us to keep the clone cheap, and Arc'ing the incoming Entities becomes cheap as well.

Changing the interface of the HashMap means altering what create_entities_map returns, adding an implementation of TCNode for `Arc<Entity>`, and udpating how IntoIterator works to return values from the Arc's.

## Issue #, if available
This contributes to 1285.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.