### PR TITLE
Dependabot: Grouped updates for all dependency types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    # Update all explicitly defined dependencies
+    allow:
+      - dependency-type: "all"
+    # Group all updates into one pull request
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description of changes

Extends the Dependabot settings to:
 - Group all updates into one PR (more details [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/customizing-dependency-updates#grouping-dependabot-updates-into-one-pull-request))
 - Allow updates for all dependency types. If I'm not mistaken, this should result in updates for both `Cargo.toml` and `Cargo.lock` files even for transitive dependencies (more details [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file))

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
