### PR TITLE
Improve least upper bound tests

### DIFF
--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1781,21 +1781,18 @@ mod test {
         assert_eq!(
             Type::least_upper_bound(&schema, &lhs, &rhs, mode),
             lub,
-            "assert_least_upper_bound({:?}, {:?}, {:?})",
-            lhs,
-            rhs,
-            lub
+            "assert_least_upper_bound({lhs:?}, {rhs:?}, {lub:?}, {mode:?})",
         );
 
         if let Ok(lub_ty) = &lub {
             // Also assert that types are subtypes of the LUB
             assert!(
                 Type::is_subtype(&schema, &lhs, &lub_ty, mode),
-                "{lhs:?} </: {lub_ty:?}"
+                "{lhs:?} </: ({mode:?}) {lub_ty:?}"
             );
             assert!(
                 Type::is_subtype(&schema, &rhs, &lub_ty, mode),
-                "{rhs:?} </: {lub_ty:?}"
+                "{rhs:?} </: ({mode:?}) {lub_ty:?}"
             );
 
             // Permissive LUB should be the same as strict when the strict LUB is defined.
@@ -1807,7 +1804,6 @@ mod test {
             assert_least_upper_bound(schema, ValidationMode::Strict, lhs, rhs, lub);
         }
     }
-
     #[track_caller] // report the caller's location as the location of the panic, not the location in this function
     fn assert_entity_lub(
         schema: ValidatorSchema,
@@ -1825,7 +1821,7 @@ mod test {
                     .map(|s| s.parse().expect("Expected valid entity type name."))
                     .collect::<BTreeSet<_>>(),
                 entity_lub.lub_elements,
-                "Incorrect entity types composing LUB."
+                "Incorrect entity types composing LUB for {mode:?}."
             );
             assert_eq!(
                 Attributes::with_attributes(
@@ -1838,18 +1834,18 @@ mod test {
                         .collect::<BTreeMap<_, _>>()
                 ),
                 entity_lub.get_attribute_types(&schema),
-                "Incorrect computed record type for LUB."
+                "Incorrect computed record type for LUB for {mode:?}."
             );
         });
 
         // Also assert that types are subtypes of the LUB
         assert!(
             Type::is_subtype(&schema, &lhs, lub.as_ref().unwrap(), mode),
-            "{lhs:?} </: {lub:?}"
+            "{lhs:?} </: ({mode:?}) {lub:?}"
         );
         assert!(
             Type::is_subtype(&schema, &rhs, lub.as_ref().unwrap(), mode),
-            "{rhs:?} </: {lub:?}"
+            "{rhs:?} </: ({mode:?}) {lub:?}"
         );
 
         // Permissive LUB should be the same as strict when the strict LUB is defined.
@@ -2447,8 +2443,9 @@ mod test {
             Ok(action_view_ty.clone()),
         );
 
-        // This test case seems a little odd, but the types don't actually only
-        // track the entity type, not the id, so the `Action::"edit"` type is actually identical.
+        // This test case seems a little odd, but the types actually only track
+        // the entity type, not the id, so the `Action::"edit"` type is
+        // identical to `Action::"view"`.
         assert_least_upper_bound(
             action_schema(),
             ValidationMode::Strict,

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -2211,6 +2211,17 @@ mod test {
 
         assert_least_upper_bound(
             ValidatorSchema::empty(),
+            ValidationMode::Strict,
+            Type::closed_record_with_required_attributes([("a".into(), Type::True)]),
+            Type::closed_record_with_required_attributes([("a".into(), Type::False)]),
+            Ok(Type::closed_record_with_required_attributes([(
+                "a".into(),
+                Type::primitive_boolean(),
+            )])),
+        );
+
+        assert_least_upper_bound(
+            ValidatorSchema::empty(),
             ValidationMode::Permissive,
             Type::closed_record_with_required_attributes([
                 ("foo".into(), Type::False),
@@ -2308,6 +2319,77 @@ mod test {
                 ),
             ]),
             Err(LubHelp::AttributeQualifier),
+        );
+
+        assert_least_upper_bound(
+            ValidatorSchema::empty(),
+            ValidationMode::Permissive,
+            Type::closed_record_with_attributes([
+                (
+                    "foo".into(),
+                    AttributeType::new(Type::primitive_long(), false),
+                ),
+                (
+                    "bar".into(),
+                    AttributeType::new(Type::primitive_long(), false),
+                ),
+            ]),
+            Type::closed_record_with_attributes([
+                (
+                    "foo".into(),
+                    AttributeType::new(Type::primitive_long(), true),
+                ),
+                (
+                    "baz".into(),
+                    AttributeType::new(Type::primitive_long(), false),
+                ),
+            ]),
+            Ok(Type::open_record_with_attributes([(
+                "foo".into(),
+                AttributeType::new(Type::primitive_long(), false),
+            )])),
+        );
+        assert_least_upper_bound(
+            ValidatorSchema::empty(),
+            ValidationMode::Strict,
+            Type::closed_record_with_attributes([
+                (
+                    "foo".into(),
+                    AttributeType::new(Type::primitive_long(), false),
+                ),
+                (
+                    "bar".into(),
+                    AttributeType::new(Type::primitive_long(), false),
+                ),
+            ]),
+            Type::closed_record_with_attributes([
+                (
+                    "foo".into(),
+                    AttributeType::new(Type::primitive_long(), true),
+                ),
+                (
+                    "baz".into(),
+                    AttributeType::new(Type::primitive_long(), false),
+                ),
+            ]),
+            Err(LubHelp::RecordWidth),
+        );
+
+        assert_least_upper_bound(
+            ValidatorSchema::empty(),
+            ValidationMode::Strict,
+            Type::open_record_with_attributes([(
+                "foo".into(),
+                AttributeType::new(Type::False, true),
+            )]),
+            Type::closed_record_with_attributes([(
+                "foo".into(),
+                AttributeType::new(Type::True, true),
+            )]),
+            Ok(Type::open_record_with_attributes([(
+                "foo".into(),
+                AttributeType::new(Type::primitive_boolean(), true),
+            )])),
         );
 
         assert_least_upper_bound(


### PR DESCRIPTION
## Description of changes

Update tests for least upper bounds computation in the validator. 

* The existing tests only tested the permissive mode LUB, I've updated them to also test strict mode.
* The tests for action entity LUB were not actually exercising the action entity specific code. They constructed entity-types with the type name `Action`, but the validator has a specific `ActionEntity` type that was not tested.
* Added an assertion to check that types are subtypes of their least upper bound, uncovering a bug where `Action ⊔ Action = Action`, but `Action` was not a subtype of `Action`. Since the LUB computation was still correct, this does not effect typechecking.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
