### PR TITLE
Add benchmark for 1284

### DIFF
--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -89,6 +89,10 @@ harness = false
 name = "extension_fn_validation"
 harness = false
 
+[[bench]]
+name = "deeply_nested_est"
+harness = false
+
 [package.metadata.docs.rs]
 features = ["experimental"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/cedar-policy/benches/deeply_nested_est.rs
+++ b/cedar-policy/benches/deeply_nested_est.rs
@@ -196,8 +196,8 @@ pub fn deeply_nested_est(c: &mut Criterion) {
     c.bench_function("Policy::from_json", |b| {
         b.iter(|| {
             let _ = Policy::from_json(
-              None,
-              black_box(serde_json::from_str(black_box(json_str)).unwrap()),
+                None,
+                black_box(serde_json::from_str(black_box(json_str)).unwrap()),
             );
         })
     });

--- a/cedar-policy/benches/deeply_nested_est.rs
+++ b/cedar-policy/benches/deeply_nested_est.rs
@@ -1,0 +1,207 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use cedar_policy::Policy;
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+// PANIC SAFETY: benchmarking
+#[allow(clippy::unwrap_used)]
+pub fn deeply_nested_est(c: &mut Criterion) {
+    let json_str = r#"
+        {
+            "conditions": [
+              {
+                "kind": "unless",
+                "body": {
+                  "==": {
+                    "left": {
+                      "is": [
+                        {
+                          ">": [
+                            {
+                              "==": {
+                                "left": {
+                                  "is": [
+                                    {
+                                      "+": [
+                                        {
+                                          ">": [
+                                            {
+                                              "is": [
+                                                {
+                                                  "[>": [
+                                                    {},
+                                                    {
+                                                      ">=": {
+                                                        "left": {
+                                                          "icieaticPHHcPoHtmcPolissaticPolicHHH&HHHs": [],
+                                                          "QtsaPolizciessatcPolicieHHHs": [
+                                                            {
+                                                              "==": {
+                                                                "left": {
+                                                                  "is": [
+                                                                    {
+                                                                      ">": [
+                                                                        {
+                                                                          "==": {
+                                                                            "left": {
+                                                                              "is": [
+                                                                                {
+                                                                                  "+": [
+                                                                                    {
+                                                                                      ">": [
+                                                                                        {
+                                                                                          "is": [
+                                                                                            {
+                                                                                              "[>": [
+                                                                                                {},
+                                                                                                {
+                                                                                                  ">=": {
+                                                                                                    "left": {
+                                                                                                      "HHHHhHcPolictempHHHHmpHH:HHHHs": [],
+                                                                                                      "QstaticPolicieaticPHHcPoHsieaticPHHcPoHtmcPolissaticPolicHHH&HHHs": [],
+                                                                                                      "QtsaPolizciessatcPolicieHHHs": [
+                                                                                                        {
+                                                                                                          "==": {
+                                                                                                            "left": {
+                                                                                                              "is": [
+                                                                                                                {
+                                                                                                                  ">": [
+                                                                                                                    {
+                                                                                                                      "==": {
+                                                                                                                        "left": {
+                                                                                                                          "is": [
+                                                                                                                            {
+                                                                                                                              "+": [
+                                                                                                                                {
+                                                                                                                                  ">": [
+                                                                                                                                    {
+                                                                                                                                      "is": [
+                                                                                                                                        {
+                                                                                                                                          "[>": [
+                                                                                                                                            {},
+                                                                                                                                            {
+                                                                                                                                              ">=": {
+                                                                                                                                                "left": {
+                                                                                                                                                  "HHHHhHcPolictempHHHHmpHH:HHHHs": [],
+                                                                                                                                                  "QstaticPolicieaticPHHcPoHsaticPolicieaticPHHcPoHsieaticPHHcPoHtmcPolissaticPolicHHH&HHHs": [],
+                                                                                                                                                  "QtsaPolizciessatcPolicieHHHs": [ ],
+                                                                                                                                                  "Q?tHHHHHHHHHHHHmplates": {},
+                                                                                                                                                  "": {},
+                                                                                                                                                  "XtLHHHHHHHHHHHHHps2  \temHHclictempHHHHHHHs": [],
+                                                                                                                                                  "QstatncPlictempHHHHHHHs": [],
+                                                                                                                                                  "QstatncPolicieaticPHHHQstatmcPolicHHHHHHs": [],
+                                                                                                                                                  "QstaPoliciessaticPolicHHHHHHs": [],
+                                                                                                                                                  "QtsassatcPolicieHHHs": [],
+                                                                                                                                                  "Q?tHHHHHHHHHHHHHHHHHHHmplates": {},
+                                                                                                                                                  "XtLHHHHHHHHHHHHHHct]is": [ ]
+                                                                                                                                                }
+                                                                                                                                              }
+                                                                                                                                            }
+                                                                                                                                          ]
+                                                                                                                                        }
+                                                                                                                                      ]
+                                                                                                                                    }
+                                                                                                                                  ]
+                                                                                                                                },
+                                                                                                                                "-"
+                                                                                                                              ]
+                                                                                                                            }
+                                                                                                                          ]
+                                                                                                                        }
+                                                                                                                      }
+                                                                                                                    }
+                                                                                                                  ]
+                                                                                                                }
+                                                                                                              ]
+                                                                                                            }
+                                                                                                          }
+                                                                                                        }
+                                                                                                      ],
+                                                                                                      "Q?tHHHHHHHHHHHHmplates": {},
+                                                                                                      "": {},
+                                                                                                      "XtLHHHHHHHHHHHHHps2  \temHHclictempHHHHHHHs": [],
+                                                                                                      "QstatncPol$cieaticPHHHQstatmcPolicHHHHHHs": [],
+                                                                                                      "QstaPmliciessaticPolicHHHHHHs": [],
+                                                                                                      "QtsassatcPolicieHHHs": [],
+                                                                                                      "Q?tHHHHHHHHHHHHHHHHHHHmplates": {},
+                                                                                                      "XtLHHHHHHHHHHHHHHct]is": [ ]
+                                                                                                    }
+                                                                                                  }
+                                                                                                }
+                                                                                              ]
+                                                                                            }
+                                                                                          ]
+                                                                                        }
+                                                                                      ]
+                                                                                    },
+                                                                                    "-"
+                                                                                  ]
+                                                                                }
+                                                                              ]
+                                                                            }
+                                                                          }
+                                                                        }
+                                                                      ]
+                                                                    }
+                                                                  ]
+                                                                }
+                                                              }
+                                                            }
+                                                          ],
+                                                          "Q?tHHHHHHHHHHHHmplates": {},
+                                                          "": {},
+                                                          "XtLHHHHHHHHHHHHHps2  \temHHct]is": [ ]
+                                                        }
+                                                      }
+                                                    }
+                                                  ]
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        },
+                                        "-"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ]
+          }
+    "#;
+
+    c.bench_function("Policy::from_json", |b| {
+        b.iter(|| {
+            let _ = Policy::from_json(
+              None,
+              black_box(serde_json::from_str(black_box(json_str)).unwrap()),
+            );
+        })
+    });
+}
+
+criterion_group!(benches, deeply_nested_est);
+criterion_main!(benches);


### PR DESCRIPTION
## Description of changes

Adds another criterion benchmark, this one demonstrating the problem in #1284.  That way we can evaluate potential (full or partial) fixes to #1284 by how much they improve this benchmark.  Here are the current results on my machine:

```
Policy::from_json       time:   [3.3987 s 3.3995 s 3.4004 s]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  4 (4.00%) high severe
```
Takes about 3.4s to execute the benchmark once, confirming the finding in #1284; this is much too long.

## Issue #, if available

#1284 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
