### PR TITLE
improve performance of deserializing invalid json policies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ resolver = "2"
 [profile.release]
 overflow-checks = true
 
+[profile.bench]
+overflow-checks = true
+debug = "line-tables-only"  # this adds more debug symbols/info to the binary than the default for `release` (which is `none`)
+
 # Keys that packages can inherit
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -4489,7 +4489,7 @@ mod test {
 
 #[cfg(test)]
 mod issue_891 {
-    use crate::est::{self, FromJsonError};
+    use crate::est;
     use cool_asserts::assert_matches;
     use serde_json::json;
 
@@ -4513,8 +4513,9 @@ mod issue_891 {
     #[test]
     fn invalid_extension_func() {
         let src = est_json_with_body(json!( { "ow4": [ { "Var": "principal" } ] }));
-        let est: est::Policy = serde_json::from_value(src).expect("est JSON should deserialize");
-        assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtensionFunction(n)) if n == "ow4".parse().unwrap());
+        assert_matches!(serde_json::from_value::<est::Policy>(src), Err(e) => {
+            assert!(e.to_string().starts_with("unknown variant `ow4`, expected one of `Value`, `Var`, "), "e was: {e}");
+        });
 
         let src = est_json_with_body(json!(
             {
@@ -4529,8 +4530,9 @@ mod issue_891 {
                 }
             }
         ));
-        let est: est::Policy = serde_json::from_value(src).expect("est JSON should deserialize");
-        assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtensionFunction(n)) if n == "ownerOrEqual".parse().unwrap());
+        assert_matches!(serde_json::from_value::<est::Policy>(src), Err(e) => {
+            assert!(e.to_string().starts_with("unknown variant `ownerOrEqual`, expected one of `Value`, `Var`, "), "e was: {e}");
+        });
 
         let src = est_json_with_body(json!(
             {
@@ -4544,8 +4546,9 @@ mod issue_891 {
                 }
             }
         ));
-        let est: est::Policy = serde_json::from_value(src).expect("est JSON should deserialize");
-        assert_matches!(est.try_into_ast_policy(None), Err(FromJsonError::UnknownExtensionFunction(n)) if n == "resorThanOrEqual".parse().unwrap());
+        assert_matches!(serde_json::from_value::<est::Policy>(src), Err(e) => {
+            assert!(e.to_string().starts_with("unknown variant `resorThanOrEqual`, expected one of `Value`, `Var`, "), "e was: {e}");
+        });
     }
 }
 

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3433,6 +3433,47 @@ mod test {
                             },
                             "-": {
                                 "left": {
+                                    "Value": 8
+                                },
+                                "right": {
+                                    "Value": 2
+                                }
+                            },
+                        }
+                    }
+                ]
+            }
+        );
+        assert_matches!(serde_json::from_value::<Policy>(bad), Err(e) => {
+            assert_eq!(e.to_string(), "expression map shouldn't have two keys");
+        });
+
+        let bad = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "All"
+                },
+                "action": {
+                    "op": "All"
+                },
+                "resource": {
+                    "op": "All"
+                },
+                "conditions": [
+                    {
+                        "kind": "when",
+                        "body": {
+                            "+": {
+                                "left": {
+                                    "Value": 3
+                                },
+                                "right": {
+                                    "Value": 4
+                                }
+                            },
+                            "-": {
+                                "left": {
                                     "Value": 2
                                 },
                                 "right": {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3445,7 +3445,7 @@ mod test {
             }
         );
         assert_matches!(serde_json::from_value::<Policy>(bad), Err(e) => {
-            assert_eq!(e.to_string(), "expression map shouldn't have two keys");
+            assert_eq!(e.to_string(), "JSON object representing an `Expr` should have only one key, but found two keys: `+` and `-`");
         });
 
         let bad = json!(

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3403,9 +3403,9 @@ mod test {
                 ]
             }
         );
-        let est: Policy = serde_json::from_value(bad).unwrap();
-        let ast: Result<ast::Policy, _> = est.try_into_ast_policy(None);
-        assert_matches!(ast, Err(FromJsonError::MissingOperator));
+        assert_matches!(serde_json::from_value::<Policy>(bad), Err(e) => {
+            assert_eq!(e.to_string(), "empty map is not a valid expression");
+        });
 
         let bad = json!(
             {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -85,7 +85,7 @@ impl<'de> Deserialize<'de> for Expr {
                     None => (),
                     Some(k2) => {
                         let k2: SmolStr = k2;
-                        return Err(serde::de::Error::custom(format!("JSON object representing an Expr should have only one key, but found two keys: `{k}` and `{k2}`")));
+                        return Err(serde::de::Error::custom(format!("JSON object representing an `Expr` should have only one key, but found two keys: `{k}` and `{k2}`")));
                     }
                 };
                 match k.as_str() {


### PR DESCRIPTION
## Description of changes

Replaces the derived `Deserialize` implementation for `est::Expr` with a custom one, resulting in greatly improved performance on the #1284 benchmark (see #1307).  Should be a performance improvement for a wide variety of invalid `est::Expr`s.  Hopefully not a slowdown for the happy path, that is, valid `est::Expr`s.

On my machine, the new numbers for the #1284 benchmark are:
```
Policy::from_json       time:   [107.54 µs 107.61 µs 107.70 µs]
                        change: [-99.997% -99.997% -99.997%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe
```

That is, performance has improved from about 3.4s to execute once, to about 108 µs.

## Issue #, if available

Fixes #1284.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
