### PR TITLE
update to thiserror 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arbitrary"
@@ -319,7 +319,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "thiserror",
+ "thiserror 2.0.3",
  "tsify",
  "wasm-bindgen",
 ]
@@ -340,7 +340,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ dependencies = [
  "serde_with",
  "smol_str",
  "stacker",
- "thiserror",
+ "thiserror 2.0.3",
  "tsify",
  "wasm-bindgen",
 ]
@@ -410,7 +410,7 @@ dependencies = [
  "similar-asserts",
  "smol_str",
  "stacker",
- "thiserror",
+ "thiserror 2.0.3",
  "tsify",
  "unicode-security",
  "wasm-bindgen",
@@ -1323,7 +1323,7 @@ dependencies = [
  "supports-unicode",
  "terminal_size",
  "textwrap",
- "thiserror",
+ "thiserror 1.0.67",
  "unicode-width",
 ]
 
@@ -2138,7 +2138,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2248,7 +2248,16 @@ version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3c6efbfc763e64eb85c11c25320f0737cb7364c4b6336db90aa9ebe27a0bbd"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.67",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -2256,6 +2265,17 @@ name = "thiserror-impl"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b607164372e89797d78b8e23a6d67d5d1038c1c65efd52e1389ef8b77caba2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2619,7 +2639,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 miette = { version = "7.1.0", features = ["fancy"] }
-thiserror = "1.0"
+thiserror = "2.0"
 semver = "1.0.23"
 
 [features]

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -22,7 +22,7 @@ either = "1.8"
 itertools = "0.13"
 ref-cast = "1.0"
 rustc_lexer = "0.1"
-thiserror = "1.0"
+thiserror = "2.0"
 smol_str = { version = "0.3", features = ["serde"] }
 stacker = "0.1.15"
 arbitrary = { version = "1", features = ["derive"], optional = true }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -338,7 +338,11 @@ impl LinkingError {
     }
 }
 
-fn describe_arity_error(unbound_values: &[SlotId], extra_values: &[SlotId], fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+fn describe_arity_error(
+    unbound_values: &[SlotId],
+    extra_values: &[SlotId],
+    fmt: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
     match (unbound_values.len(), extra_values.len()) {
         // PANIC SAFETY 0,0 case is not an error
         #[allow(clippy::unreachable)]

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -303,7 +303,7 @@ impl std::fmt::Display for Template {
 pub enum LinkingError {
     /// An error with the slot arguments provided
     // INVARIANT: `unbound_values` and `extra_values` can't both be empty
-    #[error("{}", describe_arity_error(.unbound_values, .extra_values))]
+    #[error(fmt = describe_arity_error)]
     ArityError {
         /// Error for when some Slots were not provided values
         unbound_values: Vec<SlotId>,
@@ -338,14 +338,14 @@ impl LinkingError {
     }
 }
 
-fn describe_arity_error(unbound_values: &[SlotId], extra_values: &[SlotId]) -> String {
+fn describe_arity_error(unbound_values: &[SlotId], extra_values: &[SlotId], fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     match (unbound_values.len(), extra_values.len()) {
         // PANIC SAFETY 0,0 case is not an error
         #[allow(clippy::unreachable)]
         (0,0) => unreachable!(),
-        (_unbound, 0) => format!("the following slots were not provided as arguments: {}", unbound_values.iter().join(",")),
-        (0, _extra) => format!("the following slots were provided as arguments, but did not exist in the template: {}", extra_values.iter().join(",")),
-        (_unbound, _extra) => format!("the following slots were not provided as arguments: {}. The following slots were provided as arguments, but did not exist in the template: {}", unbound_values.iter().join(","), extra_values.iter().join(","))
+        (_unbound, 0) => write!(fmt, "the following slots were not provided as arguments: {}", unbound_values.iter().join(",")),
+        (0, _extra) => write!(fmt, "the following slots were provided as arguments, but did not exist in the template: {}", extra_values.iter().join(",")),
+        (_unbound, _extra) => write!(fmt, "the following slots were not provided as arguments: {}. The following slots were provided as arguments, but did not exist in the template: {}", unbound_values.iter().join(","), extra_values.iter().join(",")),
     }
 }
 

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1436,7 +1436,10 @@ impl TryFrom<&Node<Option<cst::Member>>> for Expr {
                     item = match item {
                         Either::Left(name) => {
                             return Err(node
-                                .to_ast_err(ToASTErrorKind::InvalidAccess { lhs: name, field: id.to_smolstr() })
+                                .to_ast_err(ToASTErrorKind::InvalidAccess {
+                                    lhs: name,
+                                    field: id.to_smolstr(),
+                                })
                                 .into())
                         }
                         Either::Right(expr) => Either::Right(Expr::get_attr(expr, id.to_smolstr())),

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1436,7 +1436,7 @@ impl TryFrom<&Node<Option<cst::Member>>> for Expr {
                     item = match item {
                         Either::Left(name) => {
                             return Err(node
-                                .to_ast_err(ToASTErrorKind::InvalidAccess(name, id.to_smolstr()))
+                                .to_ast_err(ToASTErrorKind::InvalidAccess { lhs: name, field: id.to_smolstr() })
                                 .into())
                         }
                         Either::Right(expr) => Either::Right(Expr::get_attr(expr, id.to_smolstr())),
@@ -1505,7 +1505,10 @@ impl TryFrom<&Node<Option<cst::Member>>> for Expr {
                     item = match item {
                         Either::Left(name) => {
                             return Err(node
-                                .to_ast_err(ToASTErrorKind::InvalidIndex(name, s))
+                                .to_ast_err(ToASTErrorKind::InvalidIndex {
+                                    lhs: name,
+                                    field: s,
+                                })
                                 .into())
                         }
                         Either::Right(expr) => Either::Right(Expr::get_attr(expr, s)),

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1274,16 +1274,19 @@ impl Node<Option<cst::Member>> {
                 // attribute access on an arbitrary name - error
                 (Name { name, .. }, [Field(f), ..]) => {
                     return Err(self
-                        .to_ast_err(ToASTErrorKind::InvalidAccess(
-                            name.clone(),
-                            f.to_string().into(),
-                        ))
+                        .to_ast_err(ToASTErrorKind::InvalidAccess {
+                            lhs: name.clone(),
+                            field: f.to_smolstr(),
+                        })
                         .into());
                 }
                 // index style attribute access on an arbitrary name - error
                 (Name { name, .. }, [Index(i), ..]) => {
                     return Err(self
-                        .to_ast_err(ToASTErrorKind::InvalidIndex(name.clone(), i.clone()))
+                        .to_ast_err(ToASTErrorKind::InvalidIndex {
+                            lhs: name.clone(),
+                            field: i.clone(),
+                        })
                         .into());
                 }
 

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -323,11 +323,21 @@ pub enum ToASTErrorKind {
     #[error("function calls must be of the form `<name>(arg1, arg2, ...)`")]
     ExpressionCall,
     /// Returned when a policy attempts to access the fields of a value with no fields
-    #[error("invalid member access `{0}.{1}`, `{0}` has no fields or methods")]
-    InvalidAccess(ast::Name, SmolStr),
+    #[error("invalid member access `{lhs}.{field}`, `{lhs}` has no fields or methods")]
+    InvalidAccess {
+        /// what we attempted to access a field of
+        lhs: ast::Name,
+        /// field we attempted to access
+        field: SmolStr,
+    },
     /// Returned when a policy attempts to index on a fields of a value with no fields
-    #[error("invalid indexing expression `{0}[\"{}\"]`, `{0}` has no fields", .1.escape_debug())]
-    InvalidIndex(ast::Name, SmolStr),
+    #[error("invalid indexing expression `{lhs}[\"{}\"]`, `{lhs}` has no fields", .field.escape_debug())]
+    InvalidIndex {
+        /// what we attempted to access a field of
+        lhs: ast::Name,
+        /// field we attempted to access
+        field: SmolStr,
+    },
     /// Returned when the contents of an indexing expression is not a string literal
     #[error("the contents of an index expression must be a string literal")]
     NonStringIndex,

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
 miette = "7.1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 itertools = "0.13"
 ref-cast = "1.0"
 unicode-security = "0.1.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 lalrpop-util = { version = "0.22.0", features = ["lexer"] }
 itertools = "0.13"
 miette = "7.1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 smol_str = { version = "0.3", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true }
 serde_with = "3.3.0"


### PR DESCRIPTION
## Description of changes

Updates all crates in this repo to `thiserror` 2.0.  Adjust for one small breaking change, and take advantage of one small new feature.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
