### PR TITLE
Update version to 4.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,12 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.92"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
-
-[[package]]
 name = "arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,12 +256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
-
-[[package]]
 name = "cargo-lock"
 version = "10.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,7 +284,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
@@ -326,7 +314,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-cli"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -345,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-core"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "arbitrary",
  "cool_asserts",
@@ -356,8 +344,6 @@ dependencies = [
  "lazy_static",
  "miette",
  "nonempty",
- "prost",
- "prost-build",
  "ref-cast",
  "regex",
  "rustc_lexer",
@@ -374,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "cedar-policy-core",
  "insta",
@@ -389,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-validator"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "arbitrary",
  "cedar-policy-core",
@@ -400,8 +386,6 @@ dependencies = [
  "lazy_static",
  "miette",
  "nonempty",
- "prost",
- "prost-build",
  "ref-cast",
  "serde",
  "serde-wasm-bindgen",
@@ -418,7 +402,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-testing"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -433,7 +417,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-wasm"
-version = "4.1.0"
+version = "4.2.2"
 dependencies = [
  "cargo-lock",
  "cedar-policy",
@@ -1364,12 +1348,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bec4598fddb13cc7b528819e697852653252b760f1228b7642679bf2ff2cd07"
 
 [[package]]
-name = "multimap"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1587,16 +1565,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,59 +1600,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "prost"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
-dependencies = [
- "bytes",
- "heck",
- "itertools 0.13.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn",
- "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
-dependencies = [
- "anyhow",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
-dependencies = [
- "prost",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ overflow-checks = true
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)
 rust-version = "1.77"
-version = "4.2.1"
+version = "4.2.2"
 homepage = "https://cedarpolicy.com"
 keywords = ["cedar", "authorization", "policy", "security"]
 categories = ["compilers", "config"]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { version = "=4.2.1", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=4.2.1", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=4.2.2", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=4.2.2", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.2.1", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.2.2", path = "../cedar-policy-core" }
 pretty = "0.12.1"
 logos = "0.14.0"
 itertools = "0.13"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.2.1", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.2.2", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
@@ -52,7 +52,7 @@ entity-manifest = []
 [dev-dependencies]
 similar-asserts = "1.5.0"
 cool_asserts = "2.0"
-cedar-policy-core = { version = "=4.2.1", path = "../cedar-policy-core", features = ["test-util"] }
+cedar-policy-core = { version = "=4.2.2", path = "../cedar-policy-core", features = ["test-util"] }
 miette = { version = "7.1.0", features = ["fancy"] }
 
 [build-dependencies]

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace = true
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=4.2.1", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.2.1", path = "../cedar-policy-validator" }
-cedar-policy-formatter = { version = "=4.2.1", path = "../cedar-policy-formatter" }
+cedar-policy-core = { version = "=4.2.2", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.2.2", path = "../cedar-policy-validator" }
+cedar-policy-formatter = { version = "=4.2.2", path = "../cedar-policy-formatter" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -64,7 +64,7 @@ miette = { version = "7.1.0", features = ["fancy"] }
 cool_asserts = "2.0"
 criterion = "0.5"
 globset = "0.4"
-cedar-policy-core = { version = "=4.2.1", features = [
+cedar-policy-core = { version = "=4.2.2", features = [
     "test-util",
 ], path = "../cedar-policy-core" }
 # NON-CRYPTOGRAPHIC random number generators

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6202,7 +6202,7 @@ mod version_tests {
 
     #[test]
     fn test_sdk_version() {
-        assert_eq!(get_sdk_version().to_string(), "4.2.1");
+        assert_eq!(get_sdk_version().to_string(), "4.2.2");
     }
 
     #[test]

--- a/cedar-testing/Cargo.toml
+++ b/cedar-testing/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cedar-policy = { version = "=4.2.1", path = "../cedar-policy" }
-cedar-policy-core = { version = "=4.2.1", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.2.1", path = "../cedar-policy-validator" }
+cedar-policy = { version = "=4.2.2", path = "../cedar-policy" }
+cedar-policy-core = { version = "=4.2.2", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.2.2", path = "../cedar-policy-validator" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 exclude = ['/build']
 
 [dependencies]
-cedar-policy = { version = "=4.2.1", path = "../cedar-policy", features = ["wasm"] }
-cedar-policy-core = { version = "=4.2.1", path = "../cedar-policy-core", features = ["wasm"] }
-cedar-policy-formatter = { version = "=4.2.1", path = "../cedar-policy-formatter" }
-cedar-policy-validator = { version = "=4.2.1", path = "../cedar-policy-validator", features = ["wasm"] }
+cedar-policy = { version = "=4.2.2", path = "../cedar-policy", features = ["wasm"] }
+cedar-policy-core = { version = "=4.2.2", path = "../cedar-policy-core", features = ["wasm"] }
+cedar-policy-formatter = { version = "=4.2.2", path = "../cedar-policy-formatter" }
+cedar-policy-validator = { version = "=4.2.2", path = "../cedar-policy-validator", features = ["wasm"] }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
## Description of changes

This PR updates the version to 4.2.2 in preparation for its release.

There are a bunch of dependencies being removed. I'm guessing that's because the changes to the `Cargo.lock` file were not committed after reverting #1277 on the release branch.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
