### PR TITLE
tell dependabot not to update url dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,6 @@ updates:
       rust-dependencies:
         patterns:
           - "*"
+    # Ignore (do not update) some dependencies
+    ignore:
+      - dependency-name: "url"  # see notes in cedar-wasm/Cargo.toml


### PR DESCRIPTION
## Description of changes

I think this is the right syntax.

For reasoning why this change, see the notes in cedar-wasm/Cargo.toml: 
> Lock `url` (dependencies of cargo-lock) to 2.5.2 because they may introduce a dependency on a crate licensed under the Unicode 3.0 license in a future minor version, and we do not have explicit legal aproval to use that license.
