### PR TITLE
derives `Clone` on a bunch more of our types

### DIFF
--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -40,7 +40,7 @@ pub use partial_response::ErrorState;
 pub use partial_response::PartialResponse;
 
 /// Authorizer
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Authorizer {
     /// Cedar `Extension`s which will be used during requests to this `Authorizer`
     extensions: &'static Extensions<'static>,

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -40,7 +40,7 @@ pub use partial_response::ErrorState;
 pub use partial_response::PartialResponse;
 
 /// Authorizer
-#[derive(Debug, Clone)]
+#[derive(Clone)] // `Debug` implemented manually below
 pub struct Authorizer {
     /// Cedar `Extension`s which will be used during requests to this `Authorizer`
     extensions: &'static Extensions<'static>,

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -40,6 +40,7 @@ pub use partial_response::ErrorState;
 pub use partial_response::PartialResponse;
 
 /// Authorizer
+#[derive(Clone)]
 pub struct Authorizer {
     /// Cedar `Extension`s which will be used during requests to this `Authorizer`
     extensions: &'static Extensions<'static>,

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -128,7 +128,7 @@ impl From<&proto::ValidationMode> for ValidationMode {
 
 /// Structure containing the context needed for policy validation. This is
 /// currently only the `EntityType`s and `ActionType`s from a single schema.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Validator {
     schema: ValidatorSchema,
 }

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -76,7 +76,7 @@ pub enum ActionBehavior {
 
 /// A `ValidatorSchemaFragment` consists of any number (even 0) of
 /// `ValidatorNamespaceDef`s.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidatorSchemaFragment<N, A>(Vec<ValidatorNamespaceDef<N, A>>);
 
 impl TryInto<ValidatorSchemaFragment<ConditionalName, ConditionalName>>

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -66,7 +66,7 @@ use crate::{
 ///
 /// `A` is like `N`, but `A` governs typenames in `appliesTo` fields, while
 /// `N` governs all other type references.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidatorNamespaceDef<N, A> {
     /// The (fully-qualified) name of the namespace this is a definition of, or
     /// `None` if this is a definition for the empty namespace.
@@ -266,7 +266,7 @@ impl ValidatorNamespaceDef<ConditionalName, ConditionalName> {
 /// [`json_schema::Type`]s (values in the map), entity/common type references may or
 /// may not be fully qualified yet, depending on `N`; see notes on
 /// [`json_schema::Type`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CommonTypeDefs<N> {
     pub(super) defs: HashMap<InternalName, json_schema::Type<N>>,
 }
@@ -371,7 +371,7 @@ impl CommonTypeDefs<ConditionalName> {
 /// different schema fragment).
 ///
 /// All [`EntityType`] keys in this map are declared in this schema fragment.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EntityTypesDef<N> {
     pub(super) defs: HashMap<EntityType, EntityTypeFragment<N>>,
 }
@@ -440,7 +440,7 @@ impl EntityTypesDef<ConditionalName> {
 /// reference undeclared entity/common types. Furthermore, entity/common type
 /// references in `parents`, `attributes`, and `tags` may or may not be fully
 /// qualified yet, depending on `N`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EntityTypeFragment<N> {
     /// Description of the attribute types for this entity type.
     ///
@@ -562,7 +562,7 @@ impl EntityTypeFragment<ConditionalName> {
 /// types. All action entities are required to use a single `Action` entity
 /// type. However, the action entity type may be namespaced, so an action entity
 /// may have a fully qualified entity type `My::Namespace::Action`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ActionsDef<N, A> {
     pub(super) actions: HashMap<EntityUID, ActionFragment<N, A>>,
 }
@@ -636,7 +636,7 @@ impl ActionsDef<ConditionalName, ConditionalName> {
 ///
 /// `A` is used for typenames in `applies_to`, and `N` is used for all other
 /// type references.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ActionFragment<N, A> {
     /// The type of the context record for this action. This may contain
     /// references to common types which have not yet been resolved/inlined

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3412,7 +3412,7 @@ pub struct RequestBuilder<S> {
 /// A marker type that indicates [`Schema`] is not set for a request
 #[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct UnsetSchema;
 
 #[cfg(feature = "partial-eval")]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -763,7 +763,7 @@ impl IntoIterator for Entities {
 
 /// Authorizer object, which provides responses to authorization queries
 #[repr(transparent)]
-#[derive(Debug, RefCast)]
+#[derive(Debug, Clone, RefCast)]
 pub struct Authorizer(authorizer::Authorizer);
 
 impl Default for Authorizer {
@@ -1237,7 +1237,7 @@ impl From<ValidationMode> for cedar_policy_validator::ValidationMode {
 
 /// Validator object, which provides policy validation and typechecking.
 #[repr(transparent)]
-#[derive(Debug, RefCast)]
+#[derive(Debug, Clone, RefCast)]
 pub struct Validator(cedar_policy_validator::Validator);
 
 impl Validator {
@@ -1281,7 +1281,7 @@ impl Validator {
 
 /// Contains all the type information used to construct a `Schema` that can be
 /// used to validate a policy.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SchemaFragment {
     value: cedar_policy_validator::ValidatorSchemaFragment<
         cedar_policy_validator::ConditionalName,
@@ -1640,7 +1640,7 @@ impl Schema {
 /// The result includes the list of issues found by validation and whether validation succeeds or fails.
 /// Validation succeeds if there are no fatal errors. There may still be
 /// non-fatal warnings present when validation passes.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidationResult {
     validation_errors: Vec<ValidationError>,
     validation_warnings: Vec<ValidationWarning>,
@@ -3399,7 +3399,7 @@ impl FromStr for RestrictedExpression {
 /// for partial evaluation.
 #[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RequestBuilder<S> {
     principal: ast::EntityUIDEntry,
     action: ast::EntityUIDEntry,
@@ -3412,7 +3412,7 @@ pub struct RequestBuilder<S> {
 /// A marker type that indicates [`Schema`] is not set for a request
 #[doc = include_str!("../experimental_warning.md")]
 #[cfg(feature = "partial-eval")]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UnsetSchema;
 
 #[cfg(feature = "partial-eval")]
@@ -3525,7 +3525,7 @@ impl RequestBuilder<&Schema> {
 /// It represents an authorization request asking the question, "Can this
 /// principal take this action on this resource in this context?"
 #[repr(transparent)]
-#[derive(Debug, RefCast)]
+#[derive(Debug, Clone, RefCast)]
 pub struct Request(pub(crate) ast::Request);
 
 impl Request {
@@ -3860,7 +3860,7 @@ impl std::fmt::Display for Context {
 }
 
 /// Result of Evaluation
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum EvalResult {
     /// Boolean value
     Bool(bool),
@@ -3880,7 +3880,7 @@ pub enum EvalResult {
 }
 
 /// Sets of Cedar values
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Set(BTreeSet<EvalResult>);
 
 impl Set {
@@ -3906,7 +3906,7 @@ impl Set {
 }
 
 /// A record of Cedar values
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Record(BTreeMap<String, EvalResult>);
 
 impl Record {


### PR DESCRIPTION
Many of these maybe _shouldn't_ have to be cloned, but there's no reason not to derive `Clone`, and maybe it enables some more threading usecases for our users or something