### PR TITLE
Don't warn on ascii idents

### DIFF
--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -487,11 +487,13 @@ impl ValidationWarning {
         source_loc: Option<Loc>,
         policy_id: PolicyID,
         id: impl Into<String>,
+        confusable_character: char,
     ) -> Self {
         validation_warnings::ConfusableIdentifier {
             source_loc,
             policy_id,
             id: id.into(),
+            confusable_character,
         }
         .into()
     }

--- a/cedar-policy-validator/src/diagnostics/validation_warnings.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_warnings.rs
@@ -100,7 +100,11 @@ impl Diagnostic for MixedScriptIdentifier {
 
 /// Warning for identifiers containing confusable characters
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
-#[error("for policy `{policy_id}`, identifier `{id}` contains the character `{}` which falls outside of the General Security Profile for Identifiers", .confusable_character.escape_debug())]
+#[error(
+    "for policy `{policy_id}`, identifier `{}` contains the character `{}` which is not a printable ASCII character and falls outside of the General Security Profile for Identifiers",
+    .id.escape_debug(),
+    .confusable_character.escape_debug()
+)]
 pub struct ConfusableIdentifier {
     /// Source location
     pub source_loc: Option<Loc>,

--- a/cedar-policy-validator/src/diagnostics/validation_warnings.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_warnings.rs
@@ -100,7 +100,7 @@ impl Diagnostic for MixedScriptIdentifier {
 
 /// Warning for identifiers containing confusable characters
 #[derive(Debug, Clone, PartialEq, Error, Eq, Hash)]
-#[error("for policy `{policy_id}`, identifier `{id}` contains characters that fall outside of the General Security Profile for Identifiers")]
+#[error("for policy `{policy_id}`, identifier `{id}` contains the character `{}` which falls outside of the General Security Profile for Identifiers", .confusable_character.escape_debug())]
 pub struct ConfusableIdentifier {
     /// Source location
     pub source_loc: Option<Loc>,
@@ -108,6 +108,8 @@ pub struct ConfusableIdentifier {
     pub policy_id: PolicyID,
     /// Identifier containing confusable characters
     pub id: String,
+    /// The specific character we're not happy about
+    pub confusable_character: char,
 }
 
 impl Diagnostic for ConfusableIdentifier {

--- a/cedar-policy-validator/src/str_checks.rs
+++ b/cedar-policy-validator/src/str_checks.rs
@@ -78,11 +78,15 @@ fn permissable_ident(
             policy_id.clone(),
             s,
         ))
-    } else if !s.chars().all(|c| c.identifier_allowed()) {
+    } else if let Some(c) = s
+        .chars()
+        .find(|c| !c.is_ascii_graphic() && !c.identifier_allowed())
+    {
         Some(ValidationWarning::confusable_identifier(
             loc.cloned(),
             policy_id.clone(),
             s,
+            c,
         ))
     } else if !s.is_single_script() {
         Some(ValidationWarning::mixed_script_identifier(
@@ -119,7 +123,9 @@ mod test {
     use cedar_policy_core::{
         ast::PolicySet,
         parser::{parse_policy, Loc},
+        test_utils::{expect_err, ExpectedErrorMessageBuilder},
     };
+    use cool_asserts::assert_matches;
     use std::sync::Arc;
     #[test]
     fn strs() {
@@ -148,14 +154,52 @@ mod test {
             permissable_ident(None, &PolicyID::from_string("0"), "test"),
             None
         );
-        match permissable_ident(None, &PolicyID::from_string("0"), "is​Admin") {
-            Some(ValidationWarning::ConfusableIdentifier(_)) => (),
-            o => panic!("should have produced ConfusableIdentifier: {:?}", o),
-        };
-        match permissable_ident(None, &PolicyID::from_string("0"), "say_һello") {
-            Some(ValidationWarning::MixedScriptIdentifier(_)) => (),
-            o => panic!("should have produced MixedScriptIdentifier: {:?}", o),
-        };
+        assert_eq!(
+            permissable_ident(
+                None,
+                &PolicyID::from_string("0"),
+                "https://www.example.com/test?foo=bar&bar=baz#buz"
+            ),
+            None
+        );
+        assert_eq!(
+            permissable_ident(
+                None,
+                &PolicyID::from_string("0"),
+                "http://example.com/query{firstName}-{lastName}"
+            ),
+            None
+        );
+        assert_eq!(
+            permissable_ident(
+                None,
+                &PolicyID::from_string("0"),
+                "example_user+1@example.com"
+            ),
+            None
+        );
+
+        assert_matches!(permissable_ident(None, &PolicyID::from_string("0"), "is​Admin"), Some(warning) => {
+            expect_err(
+                "",
+                &miette::Report::new(warning),
+                &ExpectedErrorMessageBuilder::error(r#"for policy `0`, identifier `is​Admin` contains the character `\u{200b}` which falls outside of the General Security Profile for Identifiers"#)
+                    .build());
+        });
+        assert_matches!(permissable_ident(None, &PolicyID::from_string("0"), "🍌"), Some(warning) => {
+            expect_err(
+                "",
+                &miette::Report::new(warning),
+                &ExpectedErrorMessageBuilder::error(r#"for policy `0`, identifier `🍌` contains the character `🍌` which falls outside of the General Security Profile for Identifiers"#)
+                    .build());
+        });
+        assert_matches!(permissable_ident(None, &PolicyID::from_string("0"), "say_һello") , Some(warning) => {
+            expect_err(
+                "",
+                &miette::Report::new(warning),
+                &ExpectedErrorMessageBuilder::error(r#"for policy `0`, identifier `say_һello` contains mixed scripts"#)
+                    .build());
+        });
     }
 
     #[test]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -19,6 +19,11 @@ Cedar Language Version: TBD
 - Added protobuf and JSON generation code to `cedar-policy-cli`.
 - Added a new get helper method to Context that allows easy extraction of generic values from the context by key. This method simplifies the common use case of retrieving values from Context objects.
 
+### Changed
+
+- Stopped emitting warnings for identifiers containing certain printable ASCII
+  characters (e.g., `/` and `:`) (#1336, resolving #621)
+
 ## [4.2.2] - 2024-11-11
 Cedar Language version: 4.1
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -522,23 +522,30 @@ pub mod validation_warnings;
 #[derive(Debug, Clone, Error, Diagnostic)]
 #[non_exhaustive]
 pub enum ValidationWarning {
-    /// A string contains mixed scripts. Different scripts can contain visually similar characters which may be confused for each other.
+    /// A string contains a mix of characters for different scripts (e.g., latin
+    /// and cyrillic alphabets). Different scripts can contain visually similar
+    /// characters which may be confused for each other.
     #[diagnostic(transparent)]
     #[error(transparent)]
     MixedScriptString(#[from] validation_warnings::MixedScriptString),
-    /// A string contains BIDI control characters. These can be used to create crafted pieces of code that obfuscate true control flow.
+    /// A string contains bidirectional text control characters. These can be used to create crafted pieces of code that obfuscate true control flow.
     #[diagnostic(transparent)]
     #[error(transparent)]
     BidiCharsInString(#[from] validation_warnings::BidiCharsInString),
-    /// An id contains BIDI control characters. These can be used to create crafted pieces of code that obfuscate true control flow.
+    /// An id contains bidirectional text control characters. These can be used to create crafted pieces of code that obfuscate true control flow.
     #[diagnostic(transparent)]
     #[error(transparent)]
     BidiCharsInIdentifier(#[from] validation_warnings::BidiCharsInIdentifier),
-    /// An id contains mixed scripts. This can cause characters to be confused for each other.
+    /// An id contains a mix of characters for different scripts (e.g., latin and
+    /// cyrillic alphabets). Different scripts can contain visually similar
+    /// characters which may be confused for each other.
     #[diagnostic(transparent)]
     #[error(transparent)]
     MixedScriptIdentifier(#[from] validation_warnings::MixedScriptIdentifier),
-    /// An id contains characters that fall outside of the General Security Profile for Identifiers. We recommend adhering to this if possible. See Unicode® Technical Standard #39 for more info.
+    /// An id contains characters that is not a [graphical ASCII character](https://doc.rust-lang.org/std/primitive.char.html#method.is_ascii_graphic),
+    /// not the space character (`U+0020`), and falls outside of the General
+    /// Security Profile for Identifiers. We recommend adhering to this if
+    /// possible. See [Unicode® Technical Standard #39](https://unicode.org/reports/tr39/#General_Security_Profile) for more information.
     #[diagnostic(transparent)]
     #[error(transparent)]
     ConfusableIdentifier(#[from] validation_warnings::ConfusableIdentifier),


### PR DESCRIPTION
This still warns on ascii control characters and any non-ascii characters we previosly warned about.

Fixes #621 

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
