### PR TITLE
simplify protobuf for tags in schema

### DIFF
--- a/cedar-policy-validator/protobuf_schema/Validator.proto
+++ b/cedar-policy-validator/protobuf_schema/Validator.proto
@@ -116,9 +116,7 @@ message AttributeType {
 }
 
 message Tag {
-    oneof optional_type {
-        Type type = 1;
-    }
+    Type optional_type = 1;
 }
 
 enum ValidationMode {

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -106,7 +106,7 @@ impl TCNode<EntityType> for ValidatorEntityType {
 impl From<&ValidatorEntityType> for proto::ValidatorEntityType {
     fn from(v: &ValidatorEntityType) -> Self {
         let tags = v.tags.as_ref().map(|tags| proto::Tag {
-            optional_type: Some(proto::tag::OptionalType::Type(proto::Type::from(tags))),
+            optional_type: Some(proto::Type::from(tags)),
         });
         Self {
             name: Some(ast::proto::EntityType::from(&v.name)),
@@ -128,10 +128,7 @@ impl From<&proto::ValidatorEntityType> for ValidatorEntityType {
     #[allow(clippy::expect_used)]
     fn from(v: &proto::ValidatorEntityType) -> Self {
         let tags = match &v.tags {
-            Some(tags) => match &tags.optional_type {
-                Some(proto::tag::OptionalType::Type(ty)) => Some(Type::from(ty)),
-                _ => None,
-            },
+            Some(tags) => tags.optional_type.as_ref().map(Type::from),
             None => None,
         };
         Self {


### PR DESCRIPTION
Simplifies the protobuf declaration for the `tags` field in schemas.

Possibly a breaking change for anyone using the protobuf representation of schemas that contain tag declarations.  Protobufs is an experimental feature though, so this kind of breaking change should be expected.