### PR TITLE
Expose protobufs in public API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -312,6 +312,7 @@ dependencies = [
  "nonempty",
  "oorandom",
  "proptest",
+ "prost",
  "ref-cast",
  "semver",
  "serde",

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -41,7 +41,7 @@ wasm-bindgen = { version = "0.2.82", optional = true }
 chrono = { version = "0.4.38", optional = true, default-features = false}
 
 # protobuf dependency
-prost = { version = "0.13.3", optional = true }
+prost = { version = "0.13", optional = true }
 
 [features]
 # by default, enable all Cedar extensions
@@ -64,7 +64,7 @@ protobufs = ["dep:prost", "dep:prost-build"]
 [build-dependencies]
 lalrpop = "0.22.0"
 # protobuf dependency
-prost-build = { version = "0.13.3", optional = true }
+prost-build = { version = "0.13", optional = true }
 
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -619,6 +619,15 @@ impl From<&proto::LiteralPolicy> for LiteralPolicy {
 }
 
 #[cfg(feature = "protobufs")]
+impl TryFrom<&proto::LiteralPolicy> for Policy {
+    type Error = ReificationError;
+    fn try_from(policy: &proto::LiteralPolicy) -> Result<Self, Self::Error> {
+        // TODO: do we need to provide a nonempty `templates` argument to `.reify()`
+        LiteralPolicy::from(policy).reify(&HashMap::new())
+    }
+}
+
+#[cfg(feature = "protobufs")]
 impl From<&LiteralPolicy> for proto::LiteralPolicy {
     fn from(v: &LiteralPolicy) -> Self {
         let template_id_str: &str = v.template_id.as_ref();

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -521,6 +521,11 @@ impl PolicySet {
         self.links.values()
     }
 
+    /// Consume the `PolicySet`, producing an iterator of all the policies in it
+    pub fn into_policies(self) -> impl Iterator<Item = Policy> {
+        self.links.into_values()
+    }
+
     /// Iterate over everything stored as template, including static policies.
     /// Ie: all_templates() should equal templates() ++ static_policies().map(|p| p.template())
     pub fn all_templates(&self) -> impl Iterator<Item = &Template> {

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -33,7 +33,7 @@ tsify = { version = "0.4.5", optional = true }
 wasm-bindgen = { version = "0.2.82", optional = true }
 
 # protobuf dependency
-prost = { version = "0.13.3", optional = true }
+prost = { version = "0.13", optional = true }
 
 [features]
 # by default, enable all Cedar extensions
@@ -63,7 +63,7 @@ miette = { version = "7.1.0", features = ["fancy"] }
 [build-dependencies]
 lalrpop = "0.22.0"
 # protobuf dependency
-prost-build = { version = "0.13.3", optional = true }
+prost-build = { version = "0.13", optional = true }
 
 [lints]
 workspace = true

--- a/cedar-policy-validator/protobuf_schema/Validator.proto
+++ b/cedar-policy-validator/protobuf_schema/Validator.proto
@@ -102,8 +102,8 @@ message EntityRecordKind {
 }
 
 enum OpenTag {
-        OpenAttributes = 0;
-        ClosedAttributes = 1;
+    OpenAttributes = 0;
+    ClosedAttributes = 1;
 }
 
 message Attributes {

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -25,6 +25,7 @@ smol_str = { version = "0.3", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true }
 serde_with = "3.3.0"
 nonempty = "0.10"
+prost = { version = "0.13", optional = true }
 
 # wasm dependencies
 serde-wasm-bindgen = { version = "0.6", optional = true }
@@ -52,7 +53,7 @@ entity-manifest = ["cedar-policy-validator/entity-manifest"]
 partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []
 partial-validate = ["cedar-policy-validator/partial-validate"]
-protobufs = ["cedar-policy-validator/protobufs", "cedar-policy-core/protobufs"]
+protobufs = ["dep:prost", "cedar-policy-validator/protobufs", "cedar-policy-core/protobufs"]
 level-validate = ["cedar-policy-validator/level-validate"]
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2019,6 +2019,7 @@ impl PolicySet {
     }
 
     /// Build the [`PolicySet`] from just the AST information
+    #[cfg_attr(not(feature = "protobufs"), allow(dead_code))]
     fn from_ast(ast: ast::PolicySet) -> Result<Self, PolicySetError> {
         Self::from_policies(ast.into_policies().map(Policy::from_ast))
     }
@@ -2687,6 +2688,7 @@ impl Template {
         })
     }
 
+    #[cfg_attr(not(feature = "protobufs"), allow(dead_code))]
     fn from_ast(ast: ast::Template) -> Self {
         Self {
             lossless: LosslessPolicy::Est(ast.clone().into()),

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -83,6 +83,55 @@ pub(crate) mod version {
     }
 }
 
+/// Private functions to support implementing the `Protobuf` trait on various types
+#[cfg(feature = "protobufs")]
+mod proto {
+    use std::default::Default;
+
+    /// Encode `thing` into `buf` using the protobuf format `M`
+    ///
+    /// `Err` is only returned if `buf` has insufficient space.
+    #[allow(dead_code)] // experimental feature, we might have use for this one in the future
+    pub(super) fn encode<M: prost::Message>(
+        thing: impl Into<M>,
+        buf: &mut impl prost::bytes::BufMut,
+    ) -> Result<(), prost::EncodeError> {
+        thing.into().encode(buf)
+    }
+
+    /// Encode `thing` into a freshly-allocated buffer using the protobuf format `M`
+    pub(super) fn encode_to_vec<M: prost::Message>(thing: impl Into<M>) -> Vec<u8> {
+        thing.into().encode_to_vec()
+    }
+
+    /// Decode something of type `T` from `buf` using the protobuf format `M`
+    pub(super) fn decode<M: prost::Message + Default, T: for<'a> From<&'a M>>(
+        buf: impl prost::bytes::Buf,
+    ) -> Result<T, prost::DecodeError> {
+        M::decode(buf).map(|m| T::from(&m))
+    }
+
+    /// Decode something of type `T` from `buf` using the protobuf format `M`
+    pub(super) fn try_decode<
+        M: prost::Message + Default,
+        E,
+        T: for<'a> TryFrom<&'a M, Error = E>,
+    >(
+        buf: impl prost::bytes::Buf,
+    ) -> Result<Result<T, E>, prost::DecodeError> {
+        M::decode(buf).map(|m| T::try_from(&m))
+    }
+}
+
+/// Trait allowing serializing and deserializing in protobuf format
+#[cfg(feature = "protobufs")]
+pub trait Protobuf: Sized {
+    /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
+    fn encode(&self) -> Vec<u8>;
+    /// Decode the binary data in `buf`, producing something of type `Self`
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError>;
+}
+
 /// Entity datatype
 #[repr(transparent)]
 #[derive(Debug, Clone, PartialEq, Eq, RefCast, Hash)]
@@ -309,6 +358,16 @@ impl Entity {
 impl std::fmt::Display for Entity {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+#[cfg(feature = "protobufs")]
+impl Protobuf for Entity {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::Entity>(&self.0)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<ast::proto::Entity, _>(buf).map(Self)
     }
 }
 
@@ -758,6 +817,16 @@ impl IntoIterator for Entities {
         Self::IntoIter {
             inner: self.0.into_iter(),
         }
+    }
+}
+
+#[cfg(feature = "protobufs")]
+impl Protobuf for Entities {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::Entities>(&self.0)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<ast::proto::Entities, _>(buf).map(Self)
     }
 }
 
@@ -1635,6 +1704,16 @@ impl Schema {
     }
 }
 
+#[cfg(feature = "protobufs")]
+impl Protobuf for Schema {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<cedar_policy_validator::proto::ValidatorSchema>(&self.0)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<cedar_policy_validator::proto::ValidatorSchema, _>(buf).map(Self)
+    }
+}
+
 /// Contains the result of policy validation.
 ///
 /// The result includes the list of issues found by validation and whether validation succeeds or fails.
@@ -1829,6 +1908,16 @@ impl std::fmt::Display for EntityNamespace {
     }
 }
 
+#[cfg(feature = "protobufs")]
+impl Protobuf for EntityNamespace {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::Name>(&self.0)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<ast::proto::Name, _>(buf).map(Self)
+    }
+}
+
 /// Represents a set of `Policy`s
 #[derive(Debug, Clone, Default)]
 pub struct PolicySet {
@@ -1925,6 +2014,11 @@ impl PolicySet {
             policies,
             templates,
         })
+    }
+
+    /// Build the [`PolicySet`] from just the AST information
+    pub fn from_ast(ast: ast::PolicySet) -> Result<Self, PolicySetError> {
+        Self::from_policies(ast.into_policies().map(Policy::from_ast))
     }
 
     /// Deserialize the [`PolicySet`] from a JSON string
@@ -2271,6 +2365,23 @@ impl std::fmt::Display for PolicySet {
     }
 }
 
+#[cfg(feature = "protobufs")]
+impl Protobuf for PolicySet {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::LiteralPolicySet>(&self.ast)
+    }
+    // PANIC SAFETY: experimental feature
+    #[allow(clippy::expect_used)]
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        let ast = proto::try_decode::<ast::proto::LiteralPolicySet, _, _>(buf)?
+            .expect("proto-encoded policy set should be a valid policy set");
+        Ok(
+            PolicySet::from_ast(ast)
+                .expect("proto-encoded policy set should be a valid policy set"),
+        )
+    }
+}
+
 /// Given a [`PolicyId`] and a [`Policy`], determine if the policy represents a static policy or a
 /// link
 fn is_static_or_link(
@@ -2574,6 +2685,13 @@ impl Template {
         })
     }
 
+    fn from_ast(ast: ast::Template) -> Self {
+        Self {
+            lossless: LosslessPolicy::Est(ast.clone().into()),
+            ast,
+        }
+    }
+
     /// Get the JSON representation of this `Template`.
     pub fn to_json(&self) -> Result<serde_json::Value, PolicyToJsonError> {
         let est = self.lossless.est()?;
@@ -2600,6 +2718,16 @@ impl FromStr for Template {
 
     fn from_str(src: &str) -> Result<Self, Self::Err> {
         Self::parse(None, src)
+    }
+}
+
+#[cfg(feature = "protobufs")]
+impl Protobuf for Template {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::TemplateBody>(&self.ast)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<ast::proto::TemplateBody, _>(buf).map(Self::from_ast)
     }
 }
 
@@ -3076,7 +3204,10 @@ impl Policy {
     /// create the `Policy` from the policy text, CST, or EST instead, as the
     /// conversion to AST is lossy. ESTs for policies generated by this method
     /// will reflect the AST and not the original policy syntax.
-    #[cfg_attr(not(feature = "partial-eval"), allow(unused))]
+    #[cfg_attr(
+        not(any(feature = "partial-eval", feature = "protobufs")),
+        allow(unused)
+    )]
     pub(crate) fn from_ast(ast: ast::Policy) -> Self {
         let text = ast.to_string(); // assume that pretty-printing is faster than `est::Policy::from(ast.clone())`; is that true?
         Self {
@@ -3104,6 +3235,21 @@ impl FromStr for Policy {
     /// a new id.
     fn from_str(policy: &str) -> Result<Self, Self::Err> {
         Self::parse(None, policy)
+    }
+}
+
+#[cfg(feature = "protobufs")]
+impl Protobuf for Policy {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::LiteralPolicy>(&self.ast)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        // PANIC SAFETY: experimental feature
+        #[allow(clippy::expect_used)]
+        Ok(Self::from_ast(
+            proto::try_decode::<ast::proto::LiteralPolicy, _, ast::Policy>(buf)?
+                .expect("protobuf-encoded policy should be a valid policy"),
+        ))
     }
 }
 
@@ -3273,6 +3419,16 @@ impl FromStr for Expression {
         ast::Expr::from_str(expression)
             .map(Expression)
             .map_err(Into::into)
+    }
+}
+
+#[cfg(feature = "protobufs")]
+impl Protobuf for Expression {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::Expr>(&self.0)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<ast::proto::Expr, _>(buf).map(Self)
     }
 }
 
@@ -3596,6 +3752,16 @@ impl Request {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
             ast::EntityUIDEntry::Unknown { .. } => None,
         }
+    }
+}
+
+#[cfg(feature = "protobufs")]
+impl Protobuf for Request {
+    fn encode(&self) -> Vec<u8> {
+        proto::encode_to_vec::<ast::proto::Request>(&self.0)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        proto::decode::<ast::proto::Request, _>(buf).map(Self)
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2019,7 +2019,7 @@ impl PolicySet {
     }
 
     /// Build the [`PolicySet`] from just the AST information
-    pub fn from_ast(ast: ast::PolicySet) -> Result<Self, PolicySetError> {
+    fn from_ast(ast: ast::PolicySet) -> Result<Self, PolicySetError> {
         Self::from_policies(ast.into_policies().map(Policy::from_ast))
     }
 


### PR DESCRIPTION
## Description of changes

To date, the protobuf serialization/deserialization experimental feature is only available to direct consumers of cedar-policy-core and cedar-policy-validator, and callers are required to manually call `from()` / `into()` to convert into the appropriate struct in `cedar_policy_core::ast::proto` or `cedar_policy_validator::proto`. 

This PR introduces a new `Protobuf` trait, exposed in our public API (guarded by the `protobufs` feature flag, of course), which allows consumers of the public API to serialize/deserialize various public-API types like `Policy` and `Schema` using protobufs.  All necessary conversions are performed under-the-hood, and the types in the `proto` modules are not exposed publicly.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
