### PR TITLE
followup performance optimization to 1308

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -23,6 +23,7 @@ use crate::entities::json::{
 use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use crate::parser::cst::{self, Ident};
+use crate::parser::cst_to_ast;
 use crate::parser::err::{ParseErrors, ToASTError, ToASTErrorKind};
 use crate::parser::unescape::to_unescaped_string;
 use crate::parser::util::flatten_tuple_2;
@@ -89,24 +90,19 @@ impl<'de> Deserialize<'de> for Expr {
                         return Err(serde::de::Error::custom(format!("JSON object representing an `Expr` should have only one key, but found two keys: `{k}` and `{k2}`")));
                     }
                 };
-                match ast::Name::parse_unqualified_name(&k)
-                    .map(|name| name.is_known_extension_func_name())
-                {
-                    Ok(true) => {
-                        // `k` is the name of an extension function. We assume that no such keys
-                        // are valid keys for `ExprNoExt`, so we must parse as an `ExtFuncCall`.
-                        let obj = serde_json::json!({ k: v });
-                        let extfunccall =
-                            serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
-                        Ok(Expr::ExtFuncCall(extfunccall))
-                    }
-                    _ => {
-                        // not a valid extension function, so we expect it to work for `ExprNoExt`.
-                        let obj = serde_json::json!({ k: v });
-                        let exprnoext =
-                            serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
-                        Ok(Expr::ExprNoExt(exprnoext))
-                    }
+                if cst_to_ast::is_known_extension_func_str(k.clone()) {
+                    // `k` is the name of an extension function or method. We assume that
+                    // no such keys are valid keys for `ExprNoExt`, so we must parse as an
+                    // `ExtFuncCall`.
+                    let obj = serde_json::json!({ k: v });
+                    let extfunccall = serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
+                    Ok(Expr::ExtFuncCall(extfunccall))
+                } else {
+                    // not a valid extension function or method, so we expect it
+                    // to work for `ExprNoExt`.
+                    let obj = serde_json::json!({ k: v });
+                    let exprnoext = serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
+                    Ok(Expr::ExprNoExt(exprnoext))
                 }
             }
         }
@@ -965,7 +961,7 @@ impl Expr {
                                 errs,
                             )
                         })?;
-                        if !fn_name.is_known_extension_func_name() {
+                        if !cst_to_ast::is_known_extension_func_name(&fn_name) {
                             return Err(FromJsonError::UnknownExtensionFunction(fn_name));
                         }
                         Ok(ast::Expr::call_extension_fn(

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -95,13 +95,15 @@ impl<'de> Deserialize<'de> for Expr {
                     // no such keys are valid keys for `ExprNoExt`, so we must parse as an
                     // `ExtFuncCall`.
                     let obj = serde_json::json!({ k: v });
-                    let extfunccall = serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
+                    let extfunccall =
+                        serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
                     Ok(Expr::ExtFuncCall(extfunccall))
                 } else {
                     // not a valid extension function or method, so we expect it
                     // to work for `ExprNoExt`.
                     let obj = serde_json::json!({ k: v });
-                    let exprnoext = serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
+                    let exprnoext =
+                        serde_json::from_value(obj).map_err(serde::de::Error::custom)?;
                     Ok(Expr::ExprNoExt(exprnoext))
                 }
             }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -90,7 +90,7 @@ impl<'de> Deserialize<'de> for Expr {
                         return Err(serde::de::Error::custom(format!("JSON object representing an `Expr` should have only one key, but found two keys: `{k}` and `{k2}`")));
                     }
                 };
-                if cst_to_ast::is_known_extension_func_str(k.clone()) {
+                if cst_to_ast::is_known_extension_func_str(&k) {
                     // `k` is the name of an extension function or method. We assume that
                     // no such keys are valid keys for `ExprNoExt`, so we must parse as an
                     // `ExtFuncCall`.

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -19,7 +19,7 @@
 /// Concrete Syntax Tree def used as parser first pass
 pub mod cst;
 /// Step two: convert CST to package AST
-mod cst_to_ast;
+pub mod cst_to_ast;
 /// error handling utilities
 pub mod err;
 /// implementations for formatting, like `Display`

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -91,6 +91,7 @@ fn load_styles() -> ExtStyles<'static> {
                 }
             }
             CallStyle::MethodStyle => {
+                debug_assert!(func.name().is_unqualified());
                 methods.insert(func.name().basename());
             }
         };

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -95,7 +95,11 @@ fn load_styles() -> ExtStyles<'static> {
             }
         };
     }
-    ExtStyles { functions, unqualified_functions, methods }
+    ExtStyles {
+        functions,
+        unqualified_functions,
+        methods,
+    }
 }
 
 impl Node<Option<cst::Policies>> {


### PR DESCRIPTION
## Description of changes

Inspired by [this thread](https://github.com/cedar-policy/cedar/pull/1308#discussion_r1834981214) in #1308.  Avoids repeatedly calling `ast::Name::parse_unqualified_name()` during EST parsing.  On my machine (a different machine than the one I reported numbers on in #1308), the performance of our `deeply_nested_est` benchmark goes from 71.6 µs before this PR, to 63.3 µs after this PR, an 11% improvement.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
