### PR TITLE
implement `.isEmpty()` method

### DIFF
--- a/cedar-policy-cli/protobuf_schema/AST.proto
+++ b/cedar-policy-cli/protobuf_schema/AST.proto
@@ -236,6 +236,7 @@ message Expr {
         enum Op {
             Not = 0;
             Neg = 1;
+            IsEmpty = 2;
         }
     }
 

--- a/cedar-policy-core/protobuf_schema/AST.proto
+++ b/cedar-policy-core/protobuf_schema/AST.proto
@@ -236,6 +236,7 @@ message Expr {
         enum Op {
             Not = 0;
             Neg = 1;
+            IsEmpty = 2;
         }
     }
 

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -185,30 +185,6 @@ impl From<PartialValue> for Expr {
     }
 }
 
-impl<T> ExprKind<T> {
-    /// Describe this operator for error messages.
-    pub fn operator_description(self: &ExprKind<T>) -> String {
-        match self {
-            ExprKind::Lit(_) => "literal".to_string(),
-            ExprKind::Var(_) => "variable".to_string(),
-            ExprKind::Slot(_) => "slot".to_string(),
-            ExprKind::Unknown(_) => "unknown".to_string(),
-            ExprKind::If { .. } => "if".to_string(),
-            ExprKind::And { .. } => "&&".to_string(),
-            ExprKind::Or { .. } => "||".to_string(),
-            ExprKind::UnaryApp { op, .. } => op.to_string(),
-            ExprKind::BinaryApp { op, .. } => op.to_string(),
-            ExprKind::ExtensionFunctionApp { fn_name, .. } => fn_name.to_string(),
-            ExprKind::GetAttr { .. } => "get attribute".to_string(),
-            ExprKind::HasAttr { .. } => "has attribute".to_string(),
-            ExprKind::Like { .. } => "like".to_string(),
-            ExprKind::Is { .. } => "is".to_string(),
-            ExprKind::Set(_) => "set".to_string(),
-            ExprKind::Record(_) => "record".to_string(),
-        }
-    }
-}
-
 impl<T> Expr<T> {
     fn new(expr_kind: ExprKind<T>, source_loc: Option<Loc>, data: T) -> Self {
         Self {

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -355,6 +355,10 @@ impl<T> Expr<T> {
             ExprKind::UnaryApp {
                 op: UnaryOp::Not, ..
             } => Some(Type::Bool),
+            ExprKind::UnaryApp {
+                op: UnaryOp::IsEmpty,
+                ..
+            } => Some(Type::Bool),
             ExprKind::BinaryApp {
                 op: BinaryOp::Add | BinaryOp::Mul | BinaryOp::Sub,
                 ..
@@ -523,6 +527,11 @@ impl Expr {
     /// Create a `containsAny` expression. Arguments must evaluate to Set type
     pub fn contains_any(e1: Expr, e2: Expr) -> Self {
         ExprBuilder::new().contains_any(e1, e2)
+    }
+
+    /// Create a `isEmpty` expression. Argument must evaluate to Set type
+    pub fn is_empty(e: Expr) -> Self {
+        ExprBuilder::new().is_empty(e)
     }
 
     /// Create a `getTag` expression.
@@ -1396,6 +1405,14 @@ impl<T> ExprBuilder<T> {
         })
     }
 
+    /// Create an 'is_empty' expression. Argument must evaluate to Set type
+    pub fn is_empty(self, expr: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::UnaryApp {
+            op: UnaryOp::IsEmpty,
+            arg: Arc::new(expr),
+        })
+    }
+
     /// Create a 'getTag' expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
     pub fn get_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
@@ -2245,6 +2262,10 @@ mod test {
             (
                 ExprBuilder::with_data(1).contains_any(temp.clone(), temp.clone()),
                 Expr::contains_any(Expr::val(1), Expr::val(1)),
+            ),
+            (
+                ExprBuilder::with_data(1).is_empty(temp.clone()),
+                Expr::is_empty(Expr::val(1)),
             ),
             (
                 ExprBuilder::with_data(1).set([temp.clone()]),

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -32,6 +32,20 @@ pub enum UnaryOp {
     ///
     /// Argument must have Long type
     Neg,
+    /// isEmpty test for sets
+    ///
+    /// Argument must have Set type
+    IsEmpty,
+}
+
+impl std::fmt::Display for UnaryOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UnaryOp::Not => write!(f, "!_"),
+            UnaryOp::Neg => write!(f, "-_"),
+            UnaryOp::IsEmpty => write!(f, "isEmpty"),
+        }
+    }
 }
 
 #[cfg(feature = "protobufs")]
@@ -40,6 +54,7 @@ impl From<&proto::expr::unary_app::Op> for UnaryOp {
         match v {
             proto::expr::unary_app::Op::Not => UnaryOp::Not,
             proto::expr::unary_app::Op::Neg => UnaryOp::Neg,
+            proto::expr::unary_app::Op::IsEmpty => UnaryOp::IsEmpty,
         }
     }
 }
@@ -50,6 +65,7 @@ impl From<&UnaryOp> for proto::expr::unary_app::Op {
         match v {
             UnaryOp::Not => proto::expr::unary_app::Op::Not,
             UnaryOp::Neg => proto::expr::unary_app::Op::Neg,
+            UnaryOp::IsEmpty => proto::expr::unary_app::Op::IsEmpty,
         }
     }
 }
@@ -122,15 +138,6 @@ pub enum BinaryOp {
     ///
     /// First argument must have Entity type, second argument must have String type.
     HasTag,
-}
-
-impl std::fmt::Display for UnaryOp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            UnaryOp::Not => write!(f, "!_"),
-            UnaryOp::Neg => write!(f, "-_"),
-        }
-    }
 }
 
 impl std::fmt::Display for BinaryOp {

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-use crate::ast::CallStyle;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "protobufs")]
@@ -41,8 +40,8 @@ pub enum UnaryOp {
 impl std::fmt::Display for UnaryOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            UnaryOp::Not => write!(f, "!_"),
-            UnaryOp::Neg => write!(f, "-_"),
+            UnaryOp::Not => write!(f, "!"),
+            UnaryOp::Neg => write!(f, "-"),
             UnaryOp::IsEmpty => write!(f, "isEmpty"),
         }
     }
@@ -143,13 +142,13 @@ pub enum BinaryOp {
 impl std::fmt::Display for BinaryOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BinaryOp::Eq => write!(f, "_==_"),
-            BinaryOp::Less => write!(f, "_<_"),
-            BinaryOp::LessEq => write!(f, "_<=_"),
-            BinaryOp::Add => write!(f, "_+_"),
-            BinaryOp::Sub => write!(f, "_-_"),
-            BinaryOp::Mul => write!(f, "_*_"),
-            BinaryOp::In => write!(f, "_in_"),
+            BinaryOp::Eq => write!(f, "=="),
+            BinaryOp::Less => write!(f, "<"),
+            BinaryOp::LessEq => write!(f, "<="),
+            BinaryOp::Add => write!(f, "+"),
+            BinaryOp::Sub => write!(f, "-"),
+            BinaryOp::Mul => write!(f, "*"),
+            BinaryOp::In => write!(f, "in"),
             BinaryOp::Contains => write!(f, "contains"),
             BinaryOp::ContainsAll => write!(f, "containsAll"),
             BinaryOp::ContainsAny => write!(f, "containsAny"),
@@ -195,15 +194,6 @@ impl From<&BinaryOp> for proto::expr::binary_app::Op {
             BinaryOp::ContainsAny => proto::expr::binary_app::Op::ContainsAny,
             BinaryOp::GetTag => proto::expr::binary_app::Op::GetTag,
             BinaryOp::HasTag => proto::expr::binary_app::Op::HasTag,
-        }
-    }
-}
-
-impl std::fmt::Display for CallStyle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::FunctionStyle => write!(f, "function-style"),
-            Self::MethodStyle => write!(f, "method-style"),
         }
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -2220,6 +2220,7 @@ mod test {
                 principal.owners.contains("foo")
                 && principal.owners.containsAny([1, Linux::Group::"sudoers"])
                 && [2+3, "spam"].containsAll(resource.foos)
+                && context.violations.isEmpty()
             };
         "#;
         let cst = parser::text_to_cst::parse_policy(policy)
@@ -2247,66 +2248,82 @@ mod test {
                                 "left": {
                                     "&&": {
                                         "left": {
-                                            "contains": {
+                                            "&&": {
                                                 "left": {
-                                                    ".": {
+                                                    "contains": {
                                                         "left": {
-                                                            "Var": "principal"
+                                                            ".": {
+                                                                "left": {
+                                                                    "Var": "principal"
+                                                                },
+                                                                "attr": "owners"
+                                                            }
                                                         },
-                                                        "attr": "owners"
+                                                        "right": {
+                                                            "Value": "foo"
+                                                        }
                                                     }
                                                 },
                                                 "right": {
-                                                    "Value": "foo"
+                                                    "containsAny": {
+                                                        "left": {
+                                                            ".": {
+                                                                "left": {
+                                                                    "Var": "principal"
+                                                                },
+                                                                "attr": "owners"
+                                                            }
+                                                        },
+                                                        "right": {
+                                                            "Set": [
+                                                                { "Value": 1 },
+                                                                { "Value": {
+                                                                    "__entity": {
+                                                                        "type": "Linux::Group",
+                                                                        "id": "sudoers"
+                                                                    }
+                                                                } }
+                                                            ]
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
                                         "right": {
-                                            "containsAny": {
+                                            "containsAll": {
                                                 "left": {
-                                                    ".": {
-                                                        "left": {
-                                                            "Var": "principal"
-                                                        },
-                                                        "attr": "owners"
-                                                    }
+                                                    "Set": [
+                                                        { "+": {
+                                                            "left": {
+                                                                "Value": 2
+                                                            },
+                                                            "right": {
+                                                                "Value": 3
+                                                            }
+                                                        } },
+                                                        { "Value": "spam" },
+                                                    ]
                                                 },
                                                 "right": {
-                                                    "Set": [
-                                                        { "Value": 1 },
-                                                        { "Value": {
-                                                            "__entity": {
-                                                                "type": "Linux::Group",
-                                                                "id": "sudoers"
-                                                            }
-                                                        } }
-                                                    ]
+                                                    ".": {
+                                                        "left": {
+                                                            "Var": "resource"
+                                                        },
+                                                        "attr": "foos"
+                                                    }
                                                 }
                                             }
                                         }
                                     }
                                 },
                                 "right": {
-                                    "containsAll": {
-                                        "left": {
-                                            "Set": [
-                                                { "+": {
-                                                    "left": {
-                                                        "Value": 2
-                                                    },
-                                                    "right": {
-                                                        "Value": 3
-                                                    }
-                                                } },
-                                                { "Value": "spam" },
-                                            ]
-                                        },
-                                        "right": {
+                                    "isEmpty": {
+                                        "arg": {
                                             ".": {
                                                 "left": {
-                                                    "Var": "resource"
+                                                    "Var": "context"
                                                 },
-                                                "attr": "foos"
+                                                "attr": "violations"
                                             }
                                         }
                                     }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -614,12 +614,9 @@ mod tests {
     /// Tests parser+evaluator with builtin methods `containsAll()`, `hasTag()`, `getTag()`
     #[test]
     fn interpret_methods() {
-        // The below tests check not only that we get the expected `Value`, but
-        // that it has the expected source location.
-        // See note on this in the above test.
-
         let src = r#"
             [2, 3, "foo"].containsAll([3, "foo"])
+            && context.violations.isEmpty()
             && principal.hasTag(resource.getTag(context.cur_time))
         "#;
         let request = eval::test::basic_request();

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -492,7 +492,7 @@ impl ast::UnreservedId {
             "isEmpty" => {
                 require_zero_arguments(args.into_iter(), "isEmpty", loc)?;
                 Ok(construct_method_is_empty(e, loc.clone()))
-            },
+            }
             "getTag" => extract_single_argument(args.into_iter(), "getTag", loc)
                 .map(|arg| construct_method_get_tag(e, arg, loc.clone())),
             "hasTag" => extract_single_argument(args.into_iter(), "hasTag", loc)

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -4745,7 +4745,7 @@ mod tests {
         let src = "!!!!!!false";
         assert_matches!(parse_expr(src), Err(e) => {
             expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                "too many occurrences of `!_`",
+                "too many occurrences of `!`",
                 ).help(
                 "cannot chain more the 4 applications of a unary operator"
             ).exactly_one_underline("!!!!!!false").build());
@@ -4753,7 +4753,7 @@ mod tests {
         let src = "-------0";
         assert_matches!(parse_expr(src), Err(e) => {
             expect_err(src, &miette::Report::new(e), &ExpectedErrorMessageBuilder::error(
-                "too many occurrences of `-_`",
+                "too many occurrences of `-`",
                 ).help(
                 "cannot chain more the 4 applications of a unary operator"
             ).exactly_one_underline("-------0").build());

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -43,7 +43,7 @@ use crate::ast::{
     self, ActionConstraint, CallStyle, Integer, Pattern, PatternElem, PolicySetError,
     PrincipalConstraint, PrincipalOrResourceConstraint, ResourceConstraint, UnreservedId,
 };
-use crate::est::extract_single_argument;
+use crate::est::{extract_single_argument, require_zero_arguments};
 use crate::fuzzy_match::fuzzy_search_limited;
 use itertools::Either;
 use nonempty::nonempty;
@@ -489,6 +489,10 @@ impl ast::UnreservedId {
                 .map(|arg| construct_method_contains_all(e, arg, loc.clone())),
             "containsAny" => extract_single_argument(args.into_iter(), "containsAny", loc)
                 .map(|arg| construct_method_contains_any(e, arg, loc.clone())),
+            "isEmpty" => {
+                require_zero_arguments(args.into_iter(), "isEmpty", loc)?;
+                Ok(construct_method_is_empty(e, loc.clone()))
+            },
             "getTag" => extract_single_argument(args.into_iter(), "getTag", loc)
                 .map(|arg| construct_method_get_tag(e, arg, loc.clone())),
             "hasTag" => extract_single_argument(args.into_iter(), "hasTag", loc)
@@ -1671,7 +1675,7 @@ impl ast::Name {
             if EXTENSION_STYLES.methods.contains(&id)
                 || matches!(
                     id.as_ref(),
-                    "contains" | "containsAll" | "containsAny" | "getTag" | "hasTag"
+                    "contains" | "containsAll" | "containsAny" | "isEmpty" | "getTag" | "hasTag"
                 )
             {
                 return Err(ToASTError::new(
@@ -2010,6 +2014,9 @@ fn construct_method_contains_any(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast:
     ast::ExprBuilder::new()
         .with_source_loc(loc)
         .contains_any(e0, e1)
+}
+fn construct_method_is_empty(e: ast::Expr, loc: Loc) -> ast::Expr {
+    ast::ExprBuilder::new().with_source_loc(loc).is_empty(e)
 }
 fn construct_method_get_tag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
     ast::ExprBuilder::new().with_source_loc(loc).get_tag(e0, e1)
@@ -4221,6 +4228,14 @@ mod tests {
                     "call to `containsAny` requires exactly 1 argument, but got 2 arguments",
                 )
                 .exactly_one_underline("[].containsAny(1, 2)")
+                .build(),
+            ),
+            (
+                r#"[].isEmpty([])"#,
+                ExpectedErrorMessageBuilder::error(
+                    "call to `isEmpty` requires exactly 0 arguments, but got 1 argument",
+                )
+                .exactly_one_underline("[].isEmpty([])")
                 .build(),
             ),
             (

--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -96,8 +96,7 @@ impl<N: Display> Display for json_schema::RecordType<N> {
 
 /// Create a non-empty with borrowed contents from a slice
 fn non_empty_slice<T>(v: &[T]) -> Option<NonEmpty<&T>> {
-    let vs: Vec<&T> = v.iter().collect();
-    NonEmpty::from_vec(vs)
+    NonEmpty::collect(v.iter())
 }
 
 fn fmt_vec<T: Display>(f: &mut std::fmt::Formatter<'_>, ets: NonEmpty<T>) -> std::fmt::Result {

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -215,9 +215,6 @@ pub enum UnexpectedTypeHelp {
     /// Try using `== ""`
     #[error(r#"try using `== ""` to test if a string is empty"#)]
     TryUsingEqEmptyString,
-    /// Try using `== {}`
-    #[error("try using `== {{}}` to test if a record is empty")]
-    TryUsingEqEmptyRecord,
     /// Cedar doesn't support type tests
     #[error("Cedar only supports run time type tests for entities")]
     TypeTestNotSupported,

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -212,6 +212,12 @@ pub enum UnexpectedTypeHelp {
     /// Try using `in`
     #[error("try using `in` for entity hierarchy membership")]
     TryUsingIn,
+    /// Try using `== ""`
+    #[error("try using `== ""` to test if a string is empty")]
+    TryUsingEqEmptyString,
+    /// Try using `== {}`
+    #[error("try using `== {{}}` to test if a record is empty")]
+    TryUsingEqEmptyRecord,
     /// Cedar doesn't support type tests
     #[error("Cedar only supports run time type tests for entities")]
     TypeTestNotSupported,

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -213,7 +213,7 @@ pub enum UnexpectedTypeHelp {
     #[error("try using `in` for entity hierarchy membership")]
     TryUsingIn,
     /// Try using `== ""`
-    #[error("try using `== ""` to test if a string is empty")]
+    #[error(r#"try using `== ""` to test if a string is empty"#)]
     TryUsingEqEmptyString,
     /// Try using `== {}`
     #[error("try using `== {{}}` to test if a record is empty")]

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -2397,7 +2397,15 @@ impl<'a> Typechecker<'a> {
                     arg,
                     Type::any_set(),
                     type_errors,
-                    |_| None,
+                    |actual| match actual {
+                        Type::Primitive {
+                            primitive_type: Primitive::String,
+                        } => Some(UnexpectedTypeHelp::TryUsingEqEmptyString),
+                        Type::EntityOrRecord(EntityRecordKind::Record { .. }) => {
+                            Some(UnexpectedTypeHelp::TryUsingEqEmptyRecord)
+                        }
+                        _ => None,
+                    },
                 );
                 ans_arg.then_typecheck(|typ_expr_arg, _| {
                     TypecheckAnswer::success(

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -2401,9 +2401,6 @@ impl<'a> Typechecker<'a> {
                         Type::Primitive {
                             primitive_type: Primitive::String,
                         } => Some(UnexpectedTypeHelp::TryUsingEqEmptyString),
-                        Type::EntityOrRecord(EntityRecordKind::Record { .. }) => {
-                            Some(UnexpectedTypeHelp::TryUsingEqEmptyRecord)
-                        }
                         _ => None,
                     },
                 );

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -2390,6 +2390,23 @@ impl<'a> Typechecker<'a> {
                     )
                 })
             }
+            UnaryOp::IsEmpty => {
+                let ans_arg = self.expect_type(
+                    request_env,
+                    prior_capability,
+                    arg,
+                    Type::any_set(),
+                    type_errors,
+                    |_| None,
+                );
+                ans_arg.then_typecheck(|typ_expr_arg, _| {
+                    TypecheckAnswer::success(
+                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                            .with_same_source_loc(unary_expr)
+                            .is_empty(typ_expr_arg),
+                    )
+                })
+            }
         }
     }
 

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -982,6 +982,28 @@ fn contains_all_typecheck_literals_false() {
 }
 
 #[test]
+fn is_empty_typechecks() {
+    assert_typechecks_empty_schema(
+        Expr::is_empty(Expr::set([Expr::val(1)])),
+        Type::primitive_boolean(),
+    );
+}
+
+#[test]
+fn is_empty_typecheck_fails() {
+    let src = "\"crab\".isEmpty()";
+    let errors = assert_typecheck_fails_empty_schema(src.parse().unwrap(), Type::primitive_boolean());
+    let error = assert_exactly_one_diagnostic(errors);
+    assert_eq!(error, ValidationError::expected_type(
+        get_loc(src, "\"crab\""),
+        expr_id_placeholder(),
+        Type::any_set(),
+        Type::primitive_string(),
+        Some(UnexpectedTypeHelp::TryUsingEqEmptyString),
+    ))
+}
+
+#[test]
 fn like_typechecks() {
     assert_typechecks_empty_schema(
         Expr::like(

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -992,15 +992,19 @@ fn is_empty_typechecks() {
 #[test]
 fn is_empty_typecheck_fails() {
     let src = "\"crab\".isEmpty()";
-    let errors = assert_typecheck_fails_empty_schema(src.parse().unwrap(), Type::primitive_boolean());
+    let errors =
+        assert_typecheck_fails_empty_schema(src.parse().unwrap(), Type::primitive_boolean());
     let error = assert_exactly_one_diagnostic(errors);
-    assert_eq!(error, ValidationError::expected_type(
-        get_loc(src, "\"crab\""),
-        expr_id_placeholder(),
-        Type::any_set(),
-        Type::primitive_string(),
-        Some(UnexpectedTypeHelp::TryUsingEqEmptyString),
-    ))
+    assert_eq!(
+        error,
+        ValidationError::expected_type(
+            get_loc(src, "\"crab\""),
+            expr_id_placeholder(),
+            Type::any_set(),
+            Type::primitive_string(),
+            Some(UnexpectedTypeHelp::TryUsingEqEmptyString),
+        )
+    )
 }
 
 #[test]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,6 +15,7 @@ Cedar Language Version: TBD
 
 ### Added
 
+- New `.isEmpty()` operator on sets (#1358, resolving #1356)
 - Added protobuf schemas and (de)serialization code using on `prost` crate behind the experimental `protobufs` flag.
 - Added protobuf and JSON generation code to `cedar-policy-cli`.
 - Added a new get helper method to Context that allows easy extraction of generic values from the context by key. This method simplifies the common use case of retrieving values from Context objects.


### PR DESCRIPTION
## Description of changes

New builtin `.isEmpty()` method, which works on Sets.  Implemented similarly to `.contains()` which works on Sets.  This is our first builtin method that takes 0 arguments other than its receiver (although we have extension methods that take 0 arguments other than their receiver).

This PR contains the changes necessary in this repo (unless I've missed something); we'll also need changes in DRT, the Lean model, and the public docs.

## Issue #, if available

Fixes #1356 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
