### PR TITLE
bump crate version number to 4.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 name = "cedar-policy"
 version = "4.3.0"
 dependencies = [
- "cedar-policy-core 4.3.0",
+ "cedar-policy-core",
  "cedar-policy-formatter",
- "cedar-policy-validator 4.3.0",
+ "cedar-policy-validator",
  "cool_asserts",
  "criterion",
  "dhat",
@@ -331,9 +331,9 @@ version = "4.3.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
- "cedar-policy-core 4.1.0",
+ "cedar-policy-core",
  "cedar-policy-formatter",
- "cedar-policy-validator 4.1.0",
+ "cedar-policy-validator",
  "clap",
  "glob",
  "miette",
@@ -345,33 +345,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.3",
-]
-
-[[package]]
-name = "cedar-policy-core"
-version = "4.1.0"
-source = "git+https://github.com/cedar-policy/cedar.git?branch=main#2900ee4ce7d3c34ae644c31057920152e58c97eb"
-dependencies = [
- "chrono",
- "educe",
- "either",
- "itertools 0.13.0",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "miette",
- "nonempty",
- "prost",
- "prost-build",
- "ref-cast",
- "regex",
- "rustc_lexer",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
  "thiserror 2.0.3",
 ]
 
@@ -410,7 +383,7 @@ dependencies = [
 name = "cedar-policy-formatter"
 version = "4.3.0"
 dependencies = [
- "cedar-policy-core 4.3.0",
+ "cedar-policy-core",
  "insta",
  "itertools 0.13.0",
  "lazy_static",
@@ -423,34 +396,10 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-validator"
-version = "4.1.0"
-source = "git+https://github.com/cedar-policy/cedar.git?branch=main#2900ee4ce7d3c34ae644c31057920152e58c97eb"
-dependencies = [
- "cedar-policy-core 4.1.0",
- "itertools 0.13.0",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "miette",
- "nonempty",
- "prost",
- "prost-build",
- "ref-cast",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 2.0.3",
- "unicode-security",
-]
-
-[[package]]
-name = "cedar-policy-validator"
 version = "4.3.0"
 dependencies = [
  "arbitrary",
- "cedar-policy-core 4.3.0",
+ "cedar-policy-core",
  "cool_asserts",
  "itertools 0.13.0",
  "lalrpop",
@@ -480,8 +429,8 @@ version = "4.3.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
- "cedar-policy-core 4.3.0",
- "cedar-policy-validator 4.3.0",
+ "cedar-policy-core",
+ "cedar-policy-validator",
  "miette",
  "serde",
  "serde_json",
@@ -495,9 +444,9 @@ version = "4.3.0"
 dependencies = [
  "cargo-lock",
  "cedar-policy",
- "cedar-policy-core 4.3.0",
+ "cedar-policy-core",
  "cedar-policy-formatter",
- "cedar-policy-validator 4.3.0",
+ "cedar-policy-validator",
  "console_error_panic_hook",
  "cool_asserts",
  "itertools 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,11 +296,11 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.1.0"
+version = "4.3.0"
 dependencies = [
- "cedar-policy-core 4.1.0",
+ "cedar-policy-core 4.3.0",
  "cedar-policy-formatter",
- "cedar-policy-validator 4.1.0",
+ "cedar-policy-validator 4.3.0",
  "cool_asserts",
  "criterion",
  "dhat",
@@ -327,13 +327,13 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-cli"
-version = "4.1.0"
+version = "4.3.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
- "cedar-policy-core 4.1.0 (git+https://github.com/cedar-policy/cedar.git?branch=main)",
+ "cedar-policy-core 4.1.0",
  "cedar-policy-formatter",
- "cedar-policy-validator 4.1.0 (git+https://github.com/cedar-policy/cedar.git?branch=main)",
+ "cedar-policy-validator 4.1.0",
  "clap",
  "glob",
  "miette",
@@ -351,6 +351,33 @@ dependencies = [
 [[package]]
 name = "cedar-policy-core"
 version = "4.1.0"
+source = "git+https://github.com/cedar-policy/cedar.git?branch=main#2900ee4ce7d3c34ae644c31057920152e58c97eb"
+dependencies = [
+ "chrono",
+ "educe",
+ "either",
+ "itertools 0.13.0",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "prost",
+ "prost-build",
+ "ref-cast",
+ "regex",
+ "rustc_lexer",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 2.0.3",
+]
+
+[[package]]
+name = "cedar-policy-core"
+version = "4.3.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -380,36 +407,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cedar-policy-core"
-version = "4.1.0"
-source = "git+https://github.com/cedar-policy/cedar.git?branch=main#2e60d27a9536ad41824233c06e6fc7a701a404c4"
-dependencies = [
- "chrono",
- "either",
- "itertools 0.13.0",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "miette",
- "nonempty",
- "prost",
- "prost-build",
- "ref-cast",
- "regex",
- "rustc_lexer",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 2.0.3",
-]
-
-[[package]]
 name = "cedar-policy-formatter"
-version = "4.1.0"
+version = "4.3.0"
 dependencies = [
- "cedar-policy-core 4.1.0",
+ "cedar-policy-core 4.3.0",
  "insta",
  "itertools 0.13.0",
  "lazy_static",
@@ -423,9 +424,33 @@ dependencies = [
 [[package]]
 name = "cedar-policy-validator"
 version = "4.1.0"
+source = "git+https://github.com/cedar-policy/cedar.git?branch=main#2900ee4ce7d3c34ae644c31057920152e58c97eb"
+dependencies = [
+ "cedar-policy-core 4.1.0",
+ "itertools 0.13.0",
+ "lalrpop",
+ "lalrpop-util",
+ "lazy_static",
+ "miette",
+ "nonempty",
+ "prost",
+ "prost-build",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smol_str",
+ "stacker",
+ "thiserror 2.0.3",
+ "unicode-security",
+]
+
+[[package]]
+name = "cedar-policy-validator"
+version = "4.3.0"
 dependencies = [
  "arbitrary",
- "cedar-policy-core 4.1.0",
+ "cedar-policy-core 4.3.0",
  "cool_asserts",
  "itertools 0.13.0",
  "lalrpop",
@@ -450,37 +475,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "cedar-policy-validator"
-version = "4.1.0"
-source = "git+https://github.com/cedar-policy/cedar.git?branch=main#2e60d27a9536ad41824233c06e6fc7a701a404c4"
-dependencies = [
- "cedar-policy-core 4.1.0 (git+https://github.com/cedar-policy/cedar.git?branch=main)",
- "itertools 0.13.0",
- "lalrpop",
- "lalrpop-util",
- "lazy_static",
- "miette",
- "nonempty",
- "prost",
- "prost-build",
- "ref-cast",
- "serde",
- "serde_json",
- "serde_with",
- "smol_str",
- "stacker",
- "thiserror 2.0.3",
- "unicode-security",
-]
-
-[[package]]
 name = "cedar-testing"
-version = "4.1.0"
+version = "4.3.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
- "cedar-policy-core 4.1.0",
- "cedar-policy-validator 4.1.0",
+ "cedar-policy-core 4.3.0",
+ "cedar-policy-validator 4.3.0",
  "miette",
  "serde",
  "serde_json",
@@ -490,13 +491,13 @@ dependencies = [
 
 [[package]]
 name = "cedar-wasm"
-version = "4.1.0"
+version = "4.3.0"
 dependencies = [
  "cargo-lock",
  "cedar-policy",
- "cedar-policy-core 4.1.0",
+ "cedar-policy-core 4.3.0",
  "cedar-policy-formatter",
- "cedar-policy-validator 4.1.0",
+ "cedar-policy-validator 4.3.0",
  "console_error_panic_hook",
  "cool_asserts",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = "line-tables-only"  # this adds more debug symbols/info to the binary th
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)
 rust-version = "1.77"
-version = "4.1.0"
+version = "4.3.0"
 homepage = "https://cedarpolicy.com"
 keywords = ["cedar", "authorization", "policy", "security"]
 categories = ["compilers", "config"]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -13,8 +13,8 @@ repository.workspace = true
 [dependencies]
 cedar-policy = { version = "=4.3.0", path = "../cedar-policy" }
 cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
-cedar-policy-core = { package= "cedar-policy-core", git = "https://github.com/cedar-policy/cedar.git", branch = "main", version = "4.*"}
-cedar-policy-validator = { package= "cedar-policy-validator", git = "https://github.com/cedar-policy/cedar.git", branch = "main", version = "4.*"}
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator" }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -28,7 +28,7 @@ prost-build = {version = "0.13", optional = true}
 
 [features]
 default = []
-experimental = ["permissive-validate", "partial-validate", "partial-eval"]
+experimental = ["permissive-validate", "partial-validate", "partial-eval", "protobufs"]
 permissive-validate = ["cedar-policy/permissive-validate"]
 partial-validate = ["cedar-policy/partial-validate"]
 partial-eval = ["cedar-policy/partial-eval"]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -11,10 +11,10 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { version = "=4.1.0", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=4.1.0", path = "../cedar-policy-formatter" }
-cedar-policy-core = { package= "cedar-policy-core", git = "https://github.com/cedar-policy/cedar.git", branch = "main", version = "=4.1.0"}
-cedar-policy-validator = { package= "cedar-policy-validator", git = "https://github.com/cedar-policy/cedar.git", branch = "main", version = "=4.1.0"}
+cedar-policy = { version = "=4.3.0", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
+cedar-policy-core = { package= "cedar-policy-core", git = "https://github.com/cedar-policy/cedar.git", branch = "main", version = "4.*"}
+cedar-policy-validator = { package= "cedar-policy-validator", git = "https://github.com/cedar-policy/cedar.git", branch = "main", version = "4.*"}
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
 logos = "0.14.3"
 itertools = "0.13"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.0"
@@ -57,7 +57,7 @@ entity-manifest = []
 [dev-dependencies]
 similar-asserts = "1.5.0"
 cool_asserts = "2.0"
-cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core", features = ["test-util"] }
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core", features = ["test-util"] }
 miette = { version = "7.4.0", features = ["fancy"] }
 
 [build-dependencies]

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -48,7 +48,7 @@ corpus-timing = []
 
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
-experimental = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest"]
+experimental = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest", "protobufs"]
 entity-manifest = ["cedar-policy-validator/entity-manifest"]
 partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace = true
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.1.0", path = "../cedar-policy-validator" }
-cedar-policy-formatter = { version = "=4.1.0", path = "../cedar-policy-formatter" }
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator" }
+cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -66,7 +66,7 @@ miette = { version = "7.4.0", features = ["fancy"] }
 cool_asserts = "2.0"
 criterion = "0.5"
 globset = "0.4"
-cedar-policy-core = { version = "=4.1.0", features = [
+cedar-policy-core = { version = "=4.3.0", features = [
     "test-util",
 ], path = "../cedar-policy-core" }
 # NON-CRYPTOGRAPHIC random number generators

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6202,7 +6202,7 @@ mod version_tests {
 
     #[test]
     fn test_sdk_version() {
-        assert_eq!(get_sdk_version().to_string(), "4.1.0");
+        assert_eq!(get_sdk_version().to_string(), "4.3.0");
     }
 
     #[test]

--- a/cedar-testing/Cargo.toml
+++ b/cedar-testing/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cedar-policy = { version = "=4.1.0", path = "../cedar-policy" }
-cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.1.0", path = "../cedar-policy-validator" }
+cedar-policy = { version = "=4.3.0", path = "../cedar-policy" }
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 exclude = ['/build']
 
 [dependencies]
-cedar-policy = { version = "=4.1.0", path = "../cedar-policy", features = ["wasm"] }
-cedar-policy-core = { version = "=4.1.0", path = "../cedar-policy-core", features = ["wasm"] }
-cedar-policy-formatter = { version = "=4.1.0", path = "../cedar-policy-formatter" }
-cedar-policy-validator = { version = "=4.1.0", path = "../cedar-policy-validator", features = ["wasm"] }
+cedar-policy = { version = "=4.3.0", path = "../cedar-policy", features = ["wasm"] }
+cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core", features = ["wasm"] }
+cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
+cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator", features = ["wasm"] }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
## Description of changes

Bumps the version number to 4.3.0 (here on `main`).  The `main` branch already contains features that are targeted for 4.3.0, such as the `protobufs` experimental feature.