### PR TITLE
refactor schema arg structures in CLI

### DIFF
--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -19,11 +19,13 @@
 // PANIC SAFETY tests
 #![allow(clippy::unwrap_used)]
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use cedar_policy::EvalResult;
 use cedar_policy::SlotId;
 use cedar_policy_cli::check_parse;
+use cedar_policy_cli::OptionalSchemaArgs;
+use cedar_policy_cli::SchemaArgs;
 use cedar_policy_cli::SchemaFormat;
 use cedar_policy_cli::{
     authorize, evaluate, link, validate, Arguments, AuthorizeArgs, CedarExitCode, CheckParseArgs,
@@ -87,8 +89,10 @@ fn run_authorize_test_with_linked_policies(
             policy_format: PolicyFormat::Cedar,
             template_linked_file: links_file.map(Into::into),
         },
-        schema_file: None,
-        schema_format: SchemaFormat::default(),
+        schema: OptionalSchemaArgs {
+            schema_file: None,
+            schema_format: SchemaFormat::default(),
+        },
         entities_file: entities_file.into(),
         verbose: true,
         timing: false,
@@ -142,8 +146,10 @@ fn run_authorize_test_context(
             policy_format: PolicyFormat::Cedar,
             template_linked_file: None,
         },
-        schema_file: None,
-        schema_format: SchemaFormat::default(),
+        schema: OptionalSchemaArgs {
+            schema_file: None,
+            schema_format: SchemaFormat::default(),
+        },
         entities_file: entities_file.into(),
         verbose: true,
         timing: false,
@@ -172,8 +178,10 @@ fn run_authorize_test_json(
             policy_format: PolicyFormat::Cedar,
             template_linked_file: None,
         },
-        schema_file: None,
-        schema_format: SchemaFormat::default(),
+        schema: OptionalSchemaArgs {
+            schema_file: None,
+            schema_format: SchemaFormat::default(),
+        },
         entities_file: entities_file.into(),
         verbose: true,
         timing: false,
@@ -554,15 +562,18 @@ fn test_authorize_samples() {
 #[track_caller]
 fn test_validate_samples(
     #[case] policies_file: impl Into<String>,
-    #[case] schema_file: impl Into<String>,
+    #[case] schema_file: impl AsRef<Path>,
     #[case] exit_code: CedarExitCode,
 ) {
     let policies_file = policies_file.into();
-    let schema_file = schema_file.into();
+    let schema_file = schema_file.as_ref();
 
     // Run with JSON schema
     let cmd = ValidateArgs {
-        schema_file: schema_file.clone(),
+        schema: SchemaArgs {
+            schema_file: schema_file.into(),
+            schema_format: SchemaFormat::Json,
+        },
         policies: PoliciesArgs {
             policies_file: Some(policies_file.clone()),
             policy_format: PolicyFormat::Cedar,
@@ -570,17 +581,16 @@ fn test_validate_samples(
         },
         deny_warnings: false,
         validation_mode: cedar_policy_cli::ValidationMode::Strict,
-        schema_format: SchemaFormat::Json,
     };
     let output = validate(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd);
 
     // Run with Cedar schema
     let cmd = ValidateArgs {
-        schema_file: schema_file
-            .strip_suffix(".json")
-            .expect("`schema_file` should be the JSON schema")
-            .to_string(),
+        schema: SchemaArgs {
+            schema_file: schema_file.with_extension(""), // remove the `.json` extension to get the filename of the Cedar schema
+            schema_format: SchemaFormat::Cedar,
+        },
         policies: PoliciesArgs {
             policies_file: Some(policies_file),
             policy_format: PolicyFormat::Cedar,
@@ -588,7 +598,6 @@ fn test_validate_samples(
         },
         deny_warnings: false,
         validation_mode: cedar_policy_cli::ValidationMode::Strict,
-        schema_format: SchemaFormat::Cedar,
     };
     let output = validate(&cmd);
     assert_eq!(exit_code, output, "{:#?}", cmd)
@@ -690,8 +699,10 @@ fn test_evaluate_samples(
     #[case] expected: EvalResult,
 ) {
     let cmd = EvaluateArgs {
-        schema_file: None,
-        schema_format: SchemaFormat::default(),
+        schema: OptionalSchemaArgs {
+            schema_file: None,
+            schema_format: SchemaFormat::default(),
+        },
         entities_file: Some(entities_file.into()),
         request: RequestArgs {
             principal: None,


### PR DESCRIPTION
## Description of changes

Purely a refactor (no change to the actual CLI interface) of the structures for schema args in the CLI, to enable more reusability. (In particular, in a future PR, we'll hopefully use these structures in the protobufs commands as well.)

Technically a breaking change to public structures exported by the CLI library, although not a breaking change for users of the CLI as a binary.  Not sure if we care about that.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
