### PR TITLE
use educe in more places

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -563,7 +563,7 @@ pub type SlotEnv = HashMap<SlotId, EntityUID>;
 
 /// Represents either an static policy or a template linked policy
 /// This is the serializable version because it simply refers to the Template by its Id;
-#[derive(Debug, Clone, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LiteralPolicy {
     /// ID of the template this policy is an instance of
     template_id: PolicyID,
@@ -723,14 +723,6 @@ impl std::hash::Hash for LiteralPolicy {
             id.hash(state);
             euid.hash(state);
         }
-    }
-}
-
-impl std::cmp::PartialEq for LiteralPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.template_id() == other.template_id()
-            && self.link_id == other.link_id
-            && self.values == other.values
     }
 }
 
@@ -1006,11 +998,14 @@ impl From<StaticPolicy> for Arc<Template> {
 
 /// Policy datatype. This is used for both templates (in which case it contains
 /// slots) and static policies (in which case it contains zero slots).
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Educe, Serialize, Deserialize, Clone, Debug)]
+#[educe(PartialEq, Eq, Hash)]
 pub struct TemplateBody {
     /// ID of this policy
     id: PolicyID,
     /// Source location spanning the entire policy
+    #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     loc: Option<Loc>,
     /// Annotations available for external applications, as key-value store.
     /// Note that the keys are `AnyId`, so Cedar reserved words like `if` and `has`

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -15,8 +15,8 @@
  */
 
 use std::fmt::{self, Debug, Display};
-use std::hash::{Hash, Hasher};
 
+use educe::Educe;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 
@@ -24,12 +24,15 @@ use super::err::{ToASTError, ToASTErrorKind};
 use super::loc::Loc;
 
 /// Metadata for our syntax trees
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Educe, Debug, Clone, Deserialize, Serialize)]
+#[educe(PartialEq, Eq, Hash)]
 pub struct Node<T> {
     /// Main data represented
     pub node: T,
 
     /// Source location
+    #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     pub loc: Loc,
 }
 
@@ -136,21 +139,6 @@ impl<T: Diagnostic> Diagnostic for Node<T> {
 
     fn diagnostic_source(&self) -> Option<&dyn Diagnostic> {
         self.node.diagnostic_source()
-    }
-}
-
-// Ignore the metadata this node contains
-impl<T: PartialEq> PartialEq for Node<T> {
-    /// ignores metadata
-    fn eq(&self, other: &Self) -> bool {
-        self.node == other.node
-    }
-}
-impl<T: Eq> Eq for Node<T> {}
-impl<T: Hash> Hash for Node<T> {
-    /// ignores metadata
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.node.hash(state);
     }
 }
 


### PR DESCRIPTION
## Description of changes

* Uses `educe` to replace more manual impls of `PartialEq`, `PartialOrd`, and `Hash`.
* For `TemplateBody`, this is a functional change -- the `PartialEq` and `Hash` implementations now ignore the `loc` field.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
