### PR TITLE
Remove unreleased JSON serialization code from the CLI

### DIFF
--- a/cedar-policy-cli/src/main.rs
+++ b/cedar-policy-cli/src/main.rs
@@ -21,14 +21,12 @@ use miette::ErrorHook;
 
 use cedar_policy_cli::{
     authorize, check_parse, evaluate, format_policies, language_version, link, new,
-    partial_authorize, serialization::write_drt_json, translate_policy, translate_schema, validate,
-    visualize, CedarExitCode, Cli, Commands, ErrorFormat,
+    partial_authorize, translate_policy, translate_schema, validate, visualize, CedarExitCode, Cli,
+    Commands, ErrorFormat,
 };
 
 #[cfg(feature = "protobufs")]
-use cedar_policy_cli::{
-    serialization::protobuf::write_drt_proto, serialization::protobuf::write_drt_proto_from_json,
-};
+use cedar_policy_cli::{protobufs::write_drt_proto, protobufs::write_drt_proto_from_json};
 
 fn main() -> CedarExitCode {
     let cli = Cli::parse();
@@ -58,7 +56,6 @@ fn main() -> CedarExitCode {
         Commands::TranslateSchema(args) => translate_schema(&args),
         Commands::New(args) => new(&args),
         Commands::PartiallyAuthorize(args) => partial_authorize(&args),
-        Commands::WriteDRTJson(acmd) => write_drt_json(acmd),
         #[cfg(feature = "protobufs")]
         Commands::WriteDRTProto(acmd) => write_drt_proto(acmd),
         #[cfg(feature = "protobufs")]
@@ -69,29 +66,12 @@ fn main() -> CedarExitCode {
 
 #[cfg(test)]
 mod test {
-    use cedar_policy_cli::serialization::AnalysisCommands;
-    use cedar_policy_cli::serialization::EquivalenceArgs;
-    use std::path::Path;
-    use std::path::PathBuf;
-
-    #[test]
-    fn test_json_serialize() {
-        let test_data_root = PathBuf::from(r"../sample-data/sandbox_b");
-        let schema_file = Path::new(&test_data_root).join("schema.cedarschema");
-        let old_policies_file = Path::new(&test_data_root).join("policies_4.cedar");
-        let new_policies_file = old_policies_file.clone();
-
-        let acmd = AnalysisCommands::Equivalence(EquivalenceArgs {
-            schema_file,
-            old_policies_file,
-            new_policies_file,
-        });
-        super::write_drt_json(acmd);
-    }
-
     #[cfg(feature = "protobufs")]
     #[test]
     fn test_proto_serialize() {
+        use cedar_policy_cli::protobufs::{AnalysisCommands, EquivalenceArgs};
+        use std::path::PathBuf;
+
         let test_data_root = PathBuf::from(r"../sample-data/sandbox_b");
         let mut schema_file = test_data_root.clone();
         schema_file.push("schema.cedarschema");
@@ -110,7 +90,9 @@ mod test {
     #[cfg(feature = "protobufs")]
     #[test]
     fn test_proto_serialize_from_json() {
-        use cedar_policy_cli::serialization::AnalyzeCommandsFromJson;
+        use cedar_policy_cli::protobufs::{AnalyzeCommandsFromJson, AnalyzeCommandsFromJsonArgs};
+        use std::path::PathBuf;
+
         let data = r#"
         {
             "schema":"entity Team, UserGroup in [UserGroup];\r\nentity Issue  = {\r\n  \"repo\": Repository,\r\n  \"reporter\": User,\r\n};\r\nentity Org  = {\r\n  \"members\": UserGroup,\r\n  \"owners\": UserGroup,\r\n};\r\nentity Repository  = {\r\n  \"admins\": UserGroup,\r\n  \"maintainers\": UserGroup,\r\n  \"readers\": UserGroup,\r\n  \"triagers\": UserGroup,\r\n  \"writers\": UserGroup,\r\n};\r\nentity User in [UserGroup, Team] = {\r\n  \"is_intern\": Bool,\r\n};\r\nentity File  = {\r\n  \"filename\": String,\r\n  \"owner\": User,\r\n  \"private\": Bool,\r\n};\r\n\r\naction push, pull, fork appliesTo {\r\n  principal: [User],\r\n  resource: [Repository]\r\n};\r\naction assign_issue, delete_issue, edit_issue appliesTo {\r\n  principal: [User],\r\n  resource: [Issue]\r\n};\r\naction add_reader, add_writer, add_maintainer, add_admin, add_triager appliesTo {\r\n  principal: [User],\r\n  resource: [Repository]\r\n};\r\naction view, comment appliesTo {\r\n  principal: [User],\r\n  resource: [File]\r\n};",
@@ -121,9 +103,8 @@ mod test {
         "#.to_string();
         let output_path = PathBuf::from("/tmp/tmp.binpb");
 
-        let acmd = AnalyzeCommandsFromJson::Equivalence(
-            cedar_policy_cli::serialization::AnalyzeCommandsFromJsonArgs { data, output_path },
-        );
+        let acmd =
+            AnalyzeCommandsFromJson::Equivalence(AnalyzeCommandsFromJsonArgs { data, output_path });
         super::write_drt_proto_from_json(acmd);
     }
 }


### PR DESCRIPTION
## Description of changes

Following comment by @john-h-kastner-aws [here](https://github.com/cedar-policy/cedar/pull/1359#discussion_r1873592002).

#1326 added some JSON serialization commands to the CLI that were not guarded by the `protobufs` experimental feature.  These are due to be replaced by protobuf versions.  The code added by #1326 has not yet been released, so we're free to make changes before it is released without worrying about breaking things.  The immediate steps taken in this PR are to:
1. move all of the related code behind the `protobufs` experimental feature, and also to flatten the module while we're here.
2. Remove the JSON-serialization command, leaving just the protobuf-serialization commands.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
