### PR TITLE
ignore locs in Eq/Hash for Expr and Annotation

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -19,6 +19,7 @@ use crate::{
     extensions::Extensions,
     parser::{err::ParseErrors, Loc},
 };
+use educe::Educe;
 use miette::Diagnostic;
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
@@ -40,9 +41,12 @@ extern crate tsify;
 /// where the expression was written in policy source code, and some generic
 /// data which is stored on each node of the AST.
 /// Cloning is O(1).
-#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
+#[derive(Educe, Serialize, Deserialize, Debug, Clone)]
+#[educe(PartialEq, Eq, Hash)]
 pub struct Expr<T = ()> {
     expr_kind: ExprKind<T>,
+    #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
     source_loc: Option<Loc>,
     data: T,
 }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1358,12 +1358,16 @@ impl From<BTreeMap<AnyId, Annotation>> for Annotations {
 }
 
 /// Struct which holds the value of a particular annotation
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug, PartialOrd, Ord)]
+#[derive(Educe, Serialize, Deserialize, Clone, Debug)]
+#[educe(PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Annotation {
     /// Annotation value
     pub val: SmolStr,
     /// Source location. Note this is the location of _the entire key-value
     /// pair_ for the annotation, not just `val` above
+    #[educe(PartialEq(ignore))]
+    #[educe(Hash(ignore))]
+    #[educe(PartialOrd(ignore))]
     pub loc: Option<Loc>,
 }
 


### PR DESCRIPTION
## Description of changes

#1365 didn't go far enough.  It adjusted `TemplateBody`'s `Eq` and `Hash` impls to ignore source locs.  We need the same change for `Expr` and `Annotation`.  Based on local testing, I believe this should now be enough for cedar-policy/cedar-spec#488's CI to pass.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
