### PR TITLE
Update `logos` and related packages to v0.15.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,18 +1455,18 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "logos"
-version = "0.14.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c6b6e02facda28ca5fb8dbe4b152496ba3b1bd5a4b40bb2b1b2d8ad74e0f39b"
+checksum = "ab6f536c1af4c7cc81edf73da1f8029896e7e1e16a219ef09b184e76a296f3db"
 dependencies = [
  "logos-derive",
 ]
 
 [[package]]
 name = "logos-codegen"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f3303189202bb8a052bcd93d66b6c03e6fe70d9c7c47c0ea5e974955e54c876"
+checksum = "189bbfd0b61330abea797e5e9276408f2edbe4f822d7ad08685d67419aafb34e"
 dependencies = [
  "beef",
  "fnv",
@@ -1480,9 +1480,9 @@ dependencies = [
 
 [[package]]
 name = "logos-derive"
-version = "0.14.3"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774a1c225576486e4fdf40b74646f672c542ca3608160d348749693ae9d456e6"
+checksum = "ebfe8e1a19049ddbfccbd14ac834b215e11b85b90bab0c2dba7c7b92fb5d5cba"
 dependencies = [
  "logos-codegen",
 ]

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 [dependencies]
 cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
-logos = "0.14.2"
+logos = "0.15.0"
 itertools = "0.13"
 smol_str = { version = "0.3", features = ["serde"] }
 regex = { version= "1.9.1", features = ["unicode"] }


### PR DESCRIPTION
## Description of changes

For some reason, the CI in the dependabot update in #1364 does not pick up the most recent version of `cedar-spec`, which includes the protobuf installation step in the DRT workflow [here](https://github.com/cedar-policy/cedar-spec/blob/0859e58da86df1f2c5e4e4a70c0262e0a2d3fc6c/.github/workflows/build_and_test_drt_reusable.yml#L41-L42). This PR includes the same changes; we want to see if that resolves the CI issue.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
