### PR TITLE
Avoid building unnecessary maps on type error

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -34,6 +34,7 @@ mod names {
 
     lazy_static::lazy_static! {
         /// Extension type names that support operator overloading
+        // INVARIANT: this set must not be empty.
         pub static ref TYPES_WITH_OPERATOR_OVERLOADING : BTreeSet<Name> =
             BTreeSet::from_iter(
                 [Name::parse_unqualified_name("datetime").expect("valid identifier"),

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -99,11 +99,16 @@ impl Extensions<'static> {
         &EXTENSIONS_NONE
     }
 
-    /// Iterate over extension types that support operator overloading
+    /// Obtain the non-empty vector of types supporting operator overloading
     pub fn types_with_operator_overloading() -> NonEmpty<Name> {
         // PANIC SAFETY: There are more than one element in `TYPES_WITH_OPERATOR_OVERLOADING`
         #[allow(clippy::unwrap_used)]
         NonEmpty::collect(TYPES_WITH_OPERATOR_OVERLOADING.iter().cloned()).unwrap()
+    }
+
+    /// Iterate over extension types that support operator overloading
+    pub fn iter_type_with_operator_overloading() -> impl Iterator<Item = &'static Name> {
+        TYPES_WITH_OPERATOR_OVERLOADING.iter()
     }
 }
 

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -225,14 +225,14 @@ impl ValidationError {
     pub(crate) fn expected_one_of_types(
         source_loc: Option<Loc>,
         policy_id: PolicyID,
-        expected: impl IntoIterator<Item = Type>,
+        expected: Vec<Type>,
         actual: Type,
         help: Option<validation_errors::UnexpectedTypeHelp>,
     ) -> Self {
         validation_errors::UnexpectedType {
             source_loc,
             policy_id,
-            expected: expected.into_iter().collect::<BTreeSet<_>>(),
+            expected,
             actual,
             help,
         }

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -174,7 +174,7 @@ pub struct UnexpectedType {
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
     /// Type(s) which were expected
-    pub expected: BTreeSet<Type>,
+    pub expected: Vec<Type>,
     /// Type which was encountered
     pub actual: Type,
     /// Optional help for resolving the error

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1245,8 +1245,8 @@ impl<'a> Typechecker<'a> {
             }
 
             BinaryOp::Less | BinaryOp::LessEq => {
-                let expected_types = Extensions::types_with_operator_overloading()
-                    .into_iter()
+                let expected_types = Extensions::iter_type_with_operator_overloading()
+                    .cloned()
                     .map(Type::extension)
                     .chain(std::iter::once(Type::primitive_long()))
                     .collect_vec();

--- a/cedar-policy-validator/src/typecheck/test/expr.rs
+++ b/cedar-policy-validator/src/typecheck/test/expr.rs
@@ -653,7 +653,7 @@ fn has_typecheck_fails() {
         ValidationError::expected_one_of_types(
             get_loc(src, "true"),
             expr_id_placeholder(),
-            [Type::any_entity_reference(), Type::any_record()],
+            vec![Type::any_entity_reference(), Type::any_record()],
             Type::singleton_boolean(true),
             None,
         )
@@ -701,7 +701,7 @@ fn record_get_attr_typecheck_fails() {
         ValidationError::expected_one_of_types(
             get_loc(src, "2"),
             expr_id_placeholder(),
-            [Type::any_entity_reference(), Type::any_record()],
+            vec![Type::any_entity_reference(), Type::any_record()],
             Type::primitive_long(),
             None,
         )
@@ -821,7 +821,7 @@ fn in_typecheck_fails() {
             ValidationError::expected_one_of_types(
                 get_loc(src, "true"),
                 expr_id_placeholder(),
-                [
+                vec![
                     Type::set(Type::any_entity_reference()),
                     Type::any_entity_reference(),
                 ],
@@ -1115,12 +1115,10 @@ fn less_than_typechecks() {
 
 #[test]
 fn less_than_typecheck_fails() {
-    let expected_types = std::iter::once(Type::primitive_long())
-        .chain(
-            Extensions::types_with_operator_overloading()
-                .into_iter()
-                .map(Type::extension),
-        )
+    let expected_types = Extensions::types_with_operator_overloading()
+        .into_iter()
+        .map(Type::extension)
+        .chain(std::iter::once(Type::primitive_long()))
         .collect_vec();
     let src = "true < false";
     let errors =

--- a/cedar-policy-validator/src/typecheck/test/namespace.rs
+++ b/cedar-policy-validator/src/typecheck/test/namespace.rs
@@ -148,7 +148,7 @@ fn namespaced_entity_can_type_error() {
         ValidationError::expected_one_of_types(
             get_loc(src, r#"N::S::Foo::"alice""#),
             expr_id_placeholder(),
-            std::iter::once(Type::primitive_long()),
+            vec![Type::primitive_long()],
             Type::named_entity_reference_from_str("N::S::Foo"),
             None,
         )

--- a/cedar-policy-validator/src/typecheck/test/partial.rs
+++ b/cedar-policy-validator/src/typecheck/test/partial.rs
@@ -408,7 +408,8 @@ mod fails_empty_schema {
                 Extensions::types_with_operator_overloading()
                     .into_iter()
                     .map(Type::extension)
-                    .chain(std::iter::once(Type::primitive_long())),
+                    .chain(std::iter::once(Type::primitive_long()))
+                    .collect(),
                 Type::primitive_string(),
                 None,
             )],

--- a/cedar-policy-validator/src/typecheck/test/partial.rs
+++ b/cedar-policy-validator/src/typecheck/test/partial.rs
@@ -405,11 +405,10 @@ mod fails_empty_schema {
             [ValidationError::expected_one_of_types(
                 get_loc(src, r#""a""#),
                 PolicyID::from_string("policy0"),
-                std::iter::once(Type::primitive_long()).chain(
-                    Extensions::types_with_operator_overloading()
-                        .into_iter()
-                        .map(Type::extension),
-                ),
+                Extensions::types_with_operator_overloading()
+                    .into_iter()
+                    .map(Type::extension)
+                    .chain(std::iter::once(Type::primitive_long())),
                 Type::primitive_string(),
                 None,
             )],
@@ -653,11 +652,11 @@ mod fail_partial_schema {
             [ValidationError::expected_one_of_types(
                 get_loc(src, "principal.name"),
                 PolicyID::from_string("policy0"),
-                std::iter::once(Type::primitive_long()).chain(
-                    Extensions::types_with_operator_overloading()
-                        .into_iter()
-                        .map(Type::extension),
-                ),
+                Extensions::types_with_operator_overloading()
+                    .into_iter()
+                    .map(Type::extension)
+                    .chain(std::iter::once(Type::primitive_long()))
+                    .collect(),
                 Type::primitive_string(),
                 None,
             )],

--- a/cedar-policy-validator/src/typecheck/test/policy.rs
+++ b/cedar-policy-validator/src/typecheck/test/policy.rs
@@ -845,7 +845,7 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
         ValidationError::expected_one_of_types(
             get_loc(src, "true"),
             PolicyID::from_string("0"),
-            std::iter::once(Type::primitive_long()),
+            vec![Type::primitive_long()],
             Type::True,
             None,
         )

--- a/cedar-policy-validator/src/typecheck/test/test_utils.rs
+++ b/cedar-policy-validator/src/typecheck/test/test_utils.rs
@@ -124,7 +124,7 @@ pub(crate) fn assert_types_eq(schema: &ValidatorSchema, expected: &Type, actual:
 
 /// Assert that every `T` in `actual` appears in `expected`, and vice versa.
 #[track_caller]
-pub(crate) fn assert_sets_equal<T: Hash + Eq>(
+pub(crate) fn assert_sets_equal<T: Hash + Eq + std::fmt::Debug>(
     expected: impl IntoIterator<Item = T>,
     actual: impl IntoIterator<Item = T>,
 ) {

--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -675,7 +675,7 @@ impl Type {
     pub(crate) fn support_operator_overloading(&self) -> bool {
         match self {
             Self::ExtensionType { name } => {
-                Extensions::types_with_operator_overloading().contains(name)
+                Extensions::iter_type_with_operator_overloading().contains(name)
             }
             _ => false,
         }


### PR DESCRIPTION
## Description of changes

Minor optimization to validator to avoid constructing a BTreeMap of expected types on type error when a `Vec` is already available. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
