### PR TITLE
Improve substitution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 # Don't check in the Emacs temp files
 *~
 
+# Don't check in common editors configs
+.vscode
+.zed
+
 # Don't check in test framework files
 .attach_pid*
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -21,6 +21,7 @@ Cedar Language Version: TBD
 - Added protobuf and JSON generation code to `cedar-policy-cli`.
 - Added a new get helper method to Context that allows easy extraction of generic values from the context by key. This method simplifies the common use case of retrieving values from Context objects.
 - Implemented [RFC 62 (extended `has` operator)](https://github.com/cedar-policy/rfcs/blob/main/text/0062-extended-has.md)  (#1327, resolving #1329)
+- Added a helper method to `PartialResponse` to accept substitutions from an iterator.
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1057,20 +1057,20 @@ impl PartialResponse {
     }
 
     /// Attempt to re-authorize this response given a mapping from unknowns to values.
-    /// Consider ``reauthorize_with_iter`` if mappings are not naturally in a hashmap.
     #[allow(clippy::needless_pass_by_value)]
+    #[deprecated = "use reauthorize_with_bindings"]
     pub fn reauthorize(
         &self,
         mapping: HashMap<SmolStr, RestrictedExpression>,
         auth: &Authorizer,
         es: &Entities,
     ) -> Result<Self, ReauthorizationError> {
-        self.reauthorize_with_iter(mapping.iter().map(|(k, v)| (k.as_str(), v)), auth, es)
+        self.reauthorize_with_bindings(mapping.iter().map(|(k, v)| (k.as_str(), v)), auth, es)
     }
 
     /// Attempt to re-authorize this response given a mapping from unknowns to values, provided as an iterator.
     /// Exhausts the iterator, returning any evaluation errors in the restricted expressions, regardless whether there is a matching unknown.
-    pub fn reauthorize_with_iter<'m>(
+    pub fn reauthorize_with_bindings<'m>(
         &self,
         mapping: impl IntoIterator<Item = (&'m str, &'m RestrictedExpression)>,
         auth: &Authorizer,


### PR DESCRIPTION
## Description of changes

Adds a new function `reauthorize_with_iter` to `PartialResponse`, that takes an `IntoIterator` instead of the `HashMap<SmolString, RestrictedExpression>`. This has two advantages:
- The SmolStr, which is an implementation detail of the cedar-policy-core crate is not exposed to the callers, instead &str is used. This in in line with the apparent policy of the api in cedar-policy.
- `reauthorize` immediately consumes the hashmap, the new api removes the need to allocate it if the remappings are  already available in some other format.

I'm considering to add one that takes a Fn(&str) -> Option<Value> too, that one would remove the need to iterate them all.
In fact the whole substitution infrastructure in -core could be using such a function, but the current reauthorize API is not (easily) implementable in those terms, because of the fallibility of conversion from RestrictedExpression to Value.

However, I believe the most common case will be when the caller provides literal types in the substitutions: If we make a specialized method that takes only valid values, the need to evaluate the 'restricted expression' disappears.
But I suppose ast::Value shoudn't be exposed in the public API, instead EvalResult or a similar wrapper would be needed?

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
