### PR TITLE
Allow typed unknown resource and principal

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -120,6 +120,10 @@ impl EntityUIDEntry {
         }
     }
 
+    pub fn unknown_of_type(ty: EntityType, loc: Option<Loc>) -> Self {
+        Self::UnknownOfType { ty, loc }
+    }
+
     /// Get the UID of the entry, or `None` if it is unknown (partial evaluation)
     pub fn uid(&self) -> Option<&EntityUID> {
         match self {
@@ -128,6 +132,7 @@ impl EntityUIDEntry {
         }
     }
 
+    /// Get the type of the entry, or `None` if it is unknown (partial evaluation with no type annotation)
     pub fn get_type(&self) -> Option<&EntityType> {
         match self {
             Self::Known { euid, .. } => Some(euid.entity_type()),

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -170,7 +170,7 @@ impl From<&EntityUIDEntry> for proto::EntityUidEntry {
     #[allow(clippy::unimplemented)]
     fn from(v: &EntityUIDEntry) -> Self {
         match v {
-            EntityUIDEntry::Unknown { loc: _ } | EntityUID::UnknownOfType { .. } => {
+            EntityUIDEntry::Unknown { .. } => {
                 unimplemented!(
                     "Unknown EntityUID is not currently supported by the Protobuf interface"
                 );

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -124,7 +124,7 @@ impl EntityUIDEntry {
     pub fn uid(&self) -> Option<&EntityUID> {
         match self {
             Self::Known { euid, .. } => Some(euid),
-            Self::Unknown { .. } | Self::UnknownOfType { .. }=> None,
+            Self::Unknown { .. } | Self::UnknownOfType { .. } => None,
         }
     }
 
@@ -155,7 +155,7 @@ impl From<&EntityUIDEntry> for proto::EntityUidEntry {
     #[allow(clippy::unimplemented)]
     fn from(v: &EntityUIDEntry) -> Self {
         match v {
-            EntityUIDEntry::Unknown { loc: _ } | EntityUID::UnknownOfType { .. }=> {
+            EntityUIDEntry::Unknown { loc: _ } | EntityUID::UnknownOfType { .. } => {
                 unimplemented!(
                     "Unknown EntityUID is not currently supported by the Protobuf interface"
                 );

--- a/cedar-policy-core/src/authorizer/err.rs
+++ b/cedar-policy-core/src/authorizer/err.rs
@@ -57,6 +57,16 @@ pub enum ConcretizationError {
         /// The provided value
         given_value: Value,
     },
+    /// Errors that occur when binding variables with known values
+    #[error("concretizing existing but unknown entity value of type {existing_value} of {id} with value {given_value}")]
+    EntityTypeConfictError {
+        /// String representation of PARC
+        id: SmolStr,
+        /// Existing value of PARC
+        existing_value: EntityType,
+        /// The provided value
+        given_value: Value,
+    },
     /// Errors that occur when evaluating partial values
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -414,14 +414,19 @@ impl EntityUIDEntry {
                     existing_value: euid.as_ref().clone().into(),
                     given_value: val.clone(),
                 }),
-                EntityUIDEntry::Unknown { .. } => Ok(EntityUIDEntry::known(uid.clone(), None)),
-                EntityUIDEntry::UnknownOfType { ty, .. } => {
-                    if ty == uid.entity_type() {
+                EntityUIDEntry::Unknown { ty: None, .. } => {
+                    Ok(EntityUIDEntry::known(uid.clone(), None))
+                }
+                EntityUIDEntry::Unknown {
+                    ty: Some(type_of_unknown),
+                    ..
+                } => {
+                    if type_of_unknown == uid.entity_type() {
                         Ok(EntityUIDEntry::known(uid.clone(), None))
                     } else {
                         Err(ConcretizationError::EntityTypeConfictError {
                             id: key.to_owned(),
-                            existing_value: ty.clone(),
+                            existing_value: type_of_unknown.clone(),
                             given_value: val.to_owned(),
                         })
                     }
@@ -602,9 +607,9 @@ mod test {
             h,
             errs,
             Arc::new(Request::new_unchecked(
-                EntityUIDEntry::Unknown { loc: None },
-                EntityUIDEntry::Unknown { loc: None },
-                EntityUIDEntry::Unknown { loc: None },
+                EntityUIDEntry::unknown(),
+                EntityUIDEntry::unknown(),
+                EntityUIDEntry::unknown(),
                 Some(Context::empty()),
             )),
         );
@@ -785,8 +790,8 @@ mod test {
 
         let partial_request = Request {
             principal: EntityUIDEntry::known(r#"NS::"a""#.parse().unwrap(), None),
-            action: EntityUIDEntry::Unknown { loc: None },
-            resource: EntityUIDEntry::Unknown { loc: None },
+            action: EntityUIDEntry::unknown(),
+            resource: EntityUIDEntry::unknown(),
             context: Some(context_unknown),
         };
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -6399,10 +6399,7 @@ pub(crate) mod test {
         assert_eq!(r, Either::Left(Value::from(true)));
 
         // Two differently typed unknowns should not be equal
-        let e = Expr::is_eq(
-            Expr::var(Var::Principal),
-            Expr::var(Var::Resource),
-        );
+        let e = Expr::is_eq(Expr::var(Var::Principal), Expr::var(Var::Resource));
         let r = eval.partial_eval_expr(&e).unwrap();
         assert_eq!(r, Either::Left(Value::from(false)));
     }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -379,7 +379,8 @@ impl<'e> Evaluator<'e> {
             ExprKind::BinaryApp { op, arg1, arg2 } => {
                 // NOTE: There are more precise partial eval opportunities here, esp w/ typed unknowns
                 // Current limitations:
-                //   Operators are not partially evaluated.
+                //   Operators are not partially evaluated, except in a few 'simple' cases when comparing a concrete value with an unknown of known type
+                //   implemented in short_circuit_typed_residual
                 let (arg1, arg2) = match (
                     self.partial_interpret(arg1, slots)?,
                     self.partial_interpret(arg2, slots)?,

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -5029,9 +5029,9 @@ pub(crate) mod test {
             .get(&PolicyID::from_string("policy0"))
             .expect("No such policy");
         let q = Request::new_with_unknowns(
-            EntityUIDEntry::Unknown { loc: None },
-            EntityUIDEntry::Unknown { loc: None },
-            EntityUIDEntry::Unknown { loc: None },
+            EntityUIDEntry::unknown(),
+            EntityUIDEntry::unknown(),
+            EntityUIDEntry::unknown(),
             Some(Context::empty()),
             Some(&RequestSchemaAllPass),
             Extensions::none(),
@@ -6301,10 +6301,10 @@ pub(crate) mod test {
     fn typed_unknown_entity_id() {
         let mut q = basic_request();
         let entities = basic_entities();
-        q.principal = EntityUIDEntry::UnknownOfType {
-            ty: EntityType::from_str("different_test_type").expect("must parse"),
-            loc: None,
-        };
+        q.principal = EntityUIDEntry::unknown_with_type(
+            EntityType::from_str("different_test_type").expect("must parse"),
+            None,
+        );
         let eval = Evaluator::new(q, &entities, Extensions::none());
 
         let e = Expr::is_entity_type(Expr::var(Var::Principal), EntityUID::test_entity_type());

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -922,6 +922,9 @@ impl<'e> Evaluator<'e> {
         }
     }
 
+    /// Evaluate a binary operation between a value and a residual expression. If despite the unknown contained in the residual, concrete result
+    /// can be obtained (using the type annotation on the residual), it is returned.
+    /// Since it is not aware which of the inputs is on the left side, and which on the right, it needs to return None for all non-commutative operations.
     fn short_circuit_typed_residual(
         &self,
         v1: &Value,

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -214,7 +214,7 @@ impl ast::RequestSchema for ValidatorSchema {
                     }
                 }
             }
-            EntityUIDEntry::Unknown { .. } | EntityUIDEntry::UnknownOfType { .. } => {
+            EntityUIDEntry::Unknown { .. } => {
                 // We could hypothetically ensure that the concrete parts of the
                 // request are valid for _some_ action, but this is probably more
                 // expensive than we want for this validation step.
@@ -635,7 +635,7 @@ mod test {
     fn success_principal_unknown() {
         assert_matches!(
             ast::Request::new_with_unknowns(
-                ast::EntityUIDEntry::Unknown { loc: None },
+                ast::EntityUIDEntry::unknown(),
                 ast::EntityUIDEntry::known(
                     ast::EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
                     None,
@@ -661,7 +661,7 @@ mod test {
                     ast::EntityUID::with_eid_and_type("User", "abc123").unwrap(),
                     None,
                 ),
-                ast::EntityUIDEntry::Unknown { loc: None },
+                ast::EntityUIDEntry::unknown(),
                 ast::EntityUIDEntry::known(
                     ast::EntityUID::with_eid_and_type("Photo", "vacationphoto94.jpg").unwrap(),
                     None,
@@ -687,7 +687,7 @@ mod test {
                     ast::EntityUID::with_eid_and_type("Action", "view_photo").unwrap(),
                     None,
                 ),
-                ast::EntityUIDEntry::Unknown { loc: None },
+                ast::EntityUIDEntry::unknown(),
                 Some(ast::Context::empty()),
                 Some(&schema()),
                 Extensions::all_available(),
@@ -726,9 +726,9 @@ mod test {
     fn success_everything_unspecified() {
         assert_matches!(
             ast::Request::new_with_unknowns(
-                ast::EntityUIDEntry::Unknown { loc: None },
-                ast::EntityUIDEntry::Unknown { loc: None },
-                ast::EntityUIDEntry::Unknown { loc: None },
+                ast::EntityUIDEntry::unknown(),
+                ast::EntityUIDEntry::unknown(),
+                ast::EntityUIDEntry::unknown(),
                 None,
                 Some(&schema()),
                 Extensions::all_available(),
@@ -748,7 +748,7 @@ mod test {
                     ast::EntityUID::with_eid_and_type("Album", "abc123").unwrap(),
                     None,
                 ),
-                ast::EntityUIDEntry::Unknown { loc: None },
+                ast::EntityUIDEntry::unknown(),
                 ast::EntityUIDEntry::known(
                     ast::EntityUID::with_eid_and_type("User", "alice").unwrap(),
                     None,

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -23,7 +23,7 @@ Cedar Language Version: TBD
 - Added a new get helper method to Context that allows easy extraction of generic values from the context by key. This method simplifies the common use case of retrieving values from Context objects.
 - Implemented [RFC 62 (extended `has` operator)](https://github.com/cedar-policy/rfcs/blob/main/text/0062-extended-has.md)  (#1327, resolving #1329)
 - Added a helper method to `PartialResponse` to accept substitutions from an iterator.
-- Added `unknown_*_with_type` methods to the RequestBuilder in partial-eval, allowing an unknown pricipal or resource to be constrained to a certain entity type.
+- Added `unknown_*_with_type` methods to the RequestBuilder in partial-eval, allowing an unknown principal or resource to be constrained to a certain entity type.
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -23,6 +23,7 @@ Cedar Language Version: TBD
 - Added a new get helper method to Context that allows easy extraction of generic values from the context by key. This method simplifies the common use case of retrieving values from Context objects.
 - Implemented [RFC 62 (extended `has` operator)](https://github.com/cedar-policy/rfcs/blob/main/text/0062-extended-has.md)  (#1327, resolving #1329)
 - Added a helper method to `PartialResponse` to accept substitutions from an iterator.
+- Added `unknown_*_with_type` methods to the RequestBuilder in partial-eval, allowing an unknown pricipal or resource to be constrained to a certain entity type.
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3637,11 +3637,11 @@ impl<S> RequestBuilder<S> {
         }
     }
 
-    /// Set the principal to be unknown, which is known to belong a certain entity type.
+    /// Set the principal to be unknown, but known to belong to a certain entity type.
     ///
     /// Currently, this is used only to in 'is' expressions in the policy.
     #[must_use]
-    pub fn some_principal_of_type(self, principal_type: ast::EntityType) -> Self {
+    pub fn unknown_principal_with_type(self, principal_type: ast::EntityType) -> Self {
         Self {
             principal: ast::EntityUIDEntry::unknown_of_type(principal_type, None),
             ..self
@@ -3660,6 +3660,17 @@ impl<S> RequestBuilder<S> {
         }
     }
 
+    /// Set the action to be unknown, but known to belong to a certain entity type.
+    ///
+    /// Currently, this is used only to in 'is' expressions in the policy.
+    #[must_use]
+    pub fn unknown_action_with_type(self, action_type: ast::EntityType) -> Self {
+        Self {
+            action: ast::EntityUIDEntry::unknown_of_type(action_type, None),
+            ..self
+        }
+    }
+
     /// Set the resource.
     ///
     /// Note that you can create the `EntityUid` using `.parse()` on any
@@ -3672,11 +3683,11 @@ impl<S> RequestBuilder<S> {
         }
     }
 
-    /// Set the resource to be unknown, which is known to belong a certain entity type.
+    /// Set the resource to be unknown, but known to belong to a certain entity type.
     ///
     /// Currently, this is used only to in 'is' expressions in the policy.
     #[must_use]
-    pub fn some_resource_of_type(self, resource_type: ast::EntityType) -> Self {
+    pub fn unknown_resource_with_type(self, resource_type: ast::EntityType) -> Self {
         Self {
             resource: ast::EntityUIDEntry::unknown_of_type(resource_type, None),
             ..self

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3771,7 +3771,7 @@ impl Request {
     pub fn principal(&self) -> Option<&EntityUid> {
         match self.0.principal() {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
-            ast::EntityUIDEntry::Unknown { .. } => None,
+            ast::EntityUIDEntry::Unknown { .. } | ast::EntityUIDEntry::UnknownOfType { .. } => None,
         }
     }
 
@@ -3780,7 +3780,7 @@ impl Request {
     pub fn action(&self) -> Option<&EntityUid> {
         match self.0.action() {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
-            ast::EntityUIDEntry::Unknown { .. } => None,
+            ast::EntityUIDEntry::Unknown { .. } | ast::EntityUIDEntry::UnknownOfType { .. } => None,
         }
     }
 
@@ -3789,7 +3789,7 @@ impl Request {
     pub fn resource(&self) -> Option<&EntityUid> {
         match self.0.resource() {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
-            ast::EntityUIDEntry::Unknown { .. } => None,
+            ast::EntityUIDEntry::Unknown { .. } | ast::EntityUIDEntry::UnknownOfType { .. } => None,
         }
     }
 }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3637,6 +3637,17 @@ impl<S> RequestBuilder<S> {
         }
     }
 
+    /// Set the principal to be unknown, which is known to belong a certain entity type.
+    ///
+    /// Currently, this is used only to in 'is' expressions in the policy.
+    #[must_use]
+    pub fn some_principal_of_type(self, principal_type: ast::EntityType) -> Self {
+        Self {
+            principal: ast::EntityUIDEntry::unknown_of_type(principal_type, None),
+            ..self
+        }
+    }
+
     /// Set the action.
     ///
     /// Note that you can create the `EntityUid` using `.parse()` on any
@@ -3657,6 +3668,17 @@ impl<S> RequestBuilder<S> {
     pub fn resource(self, resource: EntityUid) -> Self {
         Self {
             resource: ast::EntityUIDEntry::known(resource.into(), None),
+            ..self
+        }
+    }
+
+    /// Set the resource to be unknown, which is known to belong a certain entity type.
+    ///
+    /// Currently, this is used only to in 'is' expressions in the policy.
+    #[must_use]
+    pub fn some_resource_of_type(self, resource_type: ast::EntityType) -> Self {
+        Self {
+            resource: ast::EntityUIDEntry::unknown_of_type(resource_type, None),
             ..self
         }
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3614,9 +3614,9 @@ pub struct UnsetSchema;
 impl Default for RequestBuilder<UnsetSchema> {
     fn default() -> Self {
         Self {
-            principal: ast::EntityUIDEntry::Unknown { loc: None },
-            action: ast::EntityUIDEntry::Unknown { loc: None },
-            resource: ast::EntityUIDEntry::Unknown { loc: None },
+            principal: ast::EntityUIDEntry::unknown(),
+            action: ast::EntityUIDEntry::unknown(),
+            resource: ast::EntityUIDEntry::unknown(),
             context: None,
             schema: UnsetSchema,
         }
@@ -3643,7 +3643,7 @@ impl<S> RequestBuilder<S> {
     #[must_use]
     pub fn unknown_principal_with_type(self, principal_type: ast::EntityType) -> Self {
         Self {
-            principal: ast::EntityUIDEntry::unknown_of_type(principal_type, None),
+            principal: ast::EntityUIDEntry::unknown_with_type(principal_type, None),
             ..self
         }
     }
@@ -3666,7 +3666,7 @@ impl<S> RequestBuilder<S> {
     #[must_use]
     pub fn unknown_action_with_type(self, action_type: ast::EntityType) -> Self {
         Self {
-            action: ast::EntityUIDEntry::unknown_of_type(action_type, None),
+            action: ast::EntityUIDEntry::unknown_with_type(action_type, None),
             ..self
         }
     }
@@ -3689,7 +3689,7 @@ impl<S> RequestBuilder<S> {
     #[must_use]
     pub fn unknown_resource_with_type(self, resource_type: ast::EntityType) -> Self {
         Self {
-            resource: ast::EntityUIDEntry::unknown_of_type(resource_type, None),
+            resource: ast::EntityUIDEntry::unknown_with_type(resource_type, None),
             ..self
         }
     }
@@ -3804,7 +3804,7 @@ impl Request {
     pub fn principal(&self) -> Option<&EntityUid> {
         match self.0.principal() {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
-            ast::EntityUIDEntry::Unknown { .. } | ast::EntityUIDEntry::UnknownOfType { .. } => None,
+            ast::EntityUIDEntry::Unknown { .. } => None,
         }
     }
 
@@ -3813,7 +3813,7 @@ impl Request {
     pub fn action(&self) -> Option<&EntityUid> {
         match self.0.action() {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
-            ast::EntityUIDEntry::Unknown { .. } | ast::EntityUIDEntry::UnknownOfType { .. } => None,
+            ast::EntityUIDEntry::Unknown { .. } => None,
         }
     }
 
@@ -3822,7 +3822,7 @@ impl Request {
     pub fn resource(&self) -> Option<&EntityUid> {
         match self.0.resource() {
             ast::EntityUIDEntry::Known { euid, .. } => Some(EntityUid::ref_cast(euid.as_ref())),
-            ast::EntityUIDEntry::Unknown { .. } | ast::EntityUIDEntry::UnknownOfType { .. } => None,
+            ast::EntityUIDEntry::Unknown { .. } => None,
         }
     }
 }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3639,7 +3639,7 @@ impl<S> RequestBuilder<S> {
 
     /// Set the principal to be unknown, but known to belong to a certain entity type.
     ///
-    /// Currently, this is used only to in 'is' expressions in the policy.
+    /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
     #[must_use]
     pub fn unknown_principal_with_type(self, principal_type: ast::EntityType) -> Self {
         Self {
@@ -3662,7 +3662,7 @@ impl<S> RequestBuilder<S> {
 
     /// Set the action to be unknown, but known to belong to a certain entity type.
     ///
-    /// Currently, this is used only to in 'is' expressions in the policy.
+    /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
     #[must_use]
     pub fn unknown_action_with_type(self, action_type: ast::EntityType) -> Self {
         Self {
@@ -3685,7 +3685,7 @@ impl<S> RequestBuilder<S> {
 
     /// Set the resource to be unknown, but known to belong to a certain entity type.
     ///
-    /// Currently, this is used only to in 'is' expressions in the policy.
+    /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
     #[must_use]
     pub fn unknown_resource_with_type(self, resource_type: ast::EntityType) -> Self {
         Self {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3660,17 +3660,6 @@ impl<S> RequestBuilder<S> {
         }
     }
 
-    /// Set the action to be unknown, but known to belong to a certain entity type.
-    ///
-    /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
-    #[must_use]
-    pub fn unknown_action_with_type(self, action_type: EntityTypeName) -> Self {
-        Self {
-            action: ast::EntityUIDEntry::unknown_with_type(action_type.0, None),
-            ..self
-        }
-    }
-
     /// Set the resource.
     ///
     /// Note that you can create the `EntityUid` using `.parse()` on any

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3641,9 +3641,9 @@ impl<S> RequestBuilder<S> {
     ///
     /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
     #[must_use]
-    pub fn unknown_principal_with_type(self, principal_type: ast::EntityType) -> Self {
+    pub fn unknown_principal_with_type(self, principal_type: EntityTypeName) -> Self {
         Self {
-            principal: ast::EntityUIDEntry::unknown_with_type(principal_type, None),
+            principal: ast::EntityUIDEntry::unknown_with_type(principal_type.0, None),
             ..self
         }
     }
@@ -3664,9 +3664,9 @@ impl<S> RequestBuilder<S> {
     ///
     /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
     #[must_use]
-    pub fn unknown_action_with_type(self, action_type: ast::EntityType) -> Self {
+    pub fn unknown_action_with_type(self, action_type: EntityTypeName) -> Self {
         Self {
-            action: ast::EntityUIDEntry::unknown_with_type(action_type, None),
+            action: ast::EntityUIDEntry::unknown_with_type(action_type.0, None),
             ..self
         }
     }
@@ -3687,9 +3687,9 @@ impl<S> RequestBuilder<S> {
     ///
     /// This information is taken into account when evaluating 'is', '==' and '!=' expressions.
     #[must_use]
-    pub fn unknown_resource_with_type(self, resource_type: ast::EntityType) -> Self {
+    pub fn unknown_resource_with_type(self, resource_type: EntityTypeName) -> Self {
         Self {
-            resource: ast::EntityUIDEntry::unknown_with_type(resource_type, None),
+            resource: ast::EntityUIDEntry::unknown_with_type(resource_type.0, None),
             ..self
         }
     }


### PR DESCRIPTION
## Description of changes

Allows the caller to create a request with an unknown principal or resource, that is still known to belong to a certain type.

I had to modify the evaluator a little bit, to take the type annotation into account for 'is' expressions. I know this is enroaching on the open rfc of https://github.com/cedar-policy/rfcs/pull/83/files
but I found it to be very useful for a 'query construction' usecase, similar to the one outlined here:
https://cedarland.blog/usage/partial-evaluation/content.html#what-can-alice-access

Without this, the only way to remove from the residual policies which are clearly excluded by the scope is to construct a full dummy entity ID of the right type, and then insert into the entity store an entry with that id.
But this requires all the fields of the entity to be explicitly set to 'unknown', and makes the evaluator assume the entity has no parents (since the parents of a concrete entity can't be unknown atm)

## Issue #, if available

https://github.com/cedar-policy/cedar/issues/1393

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)
(I guess partial-eval is not part of the formal spec, right)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.

