### PR TITLE
Add `cfg(test)` to entire schema test module

### DIFF
--- a/cedar-policy-validator/src/cedar_schema/test.rs
+++ b/cedar-policy-validator/src/cedar_schema/test.rs
@@ -13,11 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#![allow(clippy::cognitive_complexity)]
-
+#![cfg(test)]
 // PANIC SAFETY: unit tests
-#[allow(clippy::panic)]
-#[cfg(test)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::unreachable
+)]
+
 mod demo_tests {
     use std::{
         collections::BTreeMap,
@@ -928,7 +933,6 @@ namespace Baz {action "Foo" appliesTo {
     }
 }
 
-#[cfg(test)]
 mod parser_tests {
     use crate::cedar_schema::parser::parse_schema;
     use cool_asserts::assert_matches;
@@ -1155,11 +1159,6 @@ mod parser_tests {
     }
 }
 
-// PANIC SAFETY: tests
-#[allow(clippy::unreachable)]
-// PANIC SAFETY: tests
-#[allow(clippy::panic)]
-#[cfg(test)]
 mod translator_tests {
     use cedar_policy_core::ast as cedar_ast;
     use cedar_policy_core::extensions::Extensions;
@@ -1453,10 +1452,6 @@ mod translator_tests {
         });
     }
 
-    // PANIC SAFETY: testing
-    #[allow(clippy::unwrap_used)]
-    // PANIC SAFETY: testing
-    #[allow(clippy::indexing_slicing)]
     #[test]
     fn type_name_resolution_cross_namespace() {
         let (schema, _) = json_schema::Fragment::from_cedarschema_str(
@@ -2275,7 +2270,6 @@ mod translator_tests {
     }
 }
 
-#[cfg(test)]
 mod common_type_references {
     use cool_asserts::assert_matches;
 
@@ -2588,7 +2582,6 @@ mod common_type_references {
 }
 
 /// Tests involving entity tags (RFC 82)
-#[cfg(test)]
 mod entity_tags {
     use crate::json_schema;
     use crate::schema::test::utils::collect_warnings;
@@ -2658,7 +2651,6 @@ mod entity_tags {
     }
 }
 
-#[cfg(test)]
 pub(crate) const SPECIAL_IDS: [&str; 18] = [
     "principal",
     "action",
@@ -2681,7 +2673,6 @@ pub(crate) const SPECIAL_IDS: [&str; 18] = [
 ];
 
 // RFC 48 test cases
-#[cfg(test)]
 mod annotations {
     use cool_asserts::assert_matches;
 


### PR DESCRIPTION
## Description of changes

Small cleanup. Inner test modules were `cfg(test)`, but the outer module wasn't, so all new items in the test mod would need to be qualified individually. Also move `allow`s for clippy lints to the top level test module so they aren't duplicated.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
