### PR TITLE
Pass refs to extension functions

### DIFF
--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -124,9 +124,22 @@ pub enum CallStyle {
 
 // Note: we could use currying to make this a little nicer
 
-/// Trait object that implements the extension function call.
-pub type ExtensionFunctionObject =
-    Box<dyn Fn(&[Value]) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static>;
+macro_rules! extension_function_object {
+    ( $( $tys:ty ), * ) => {
+        Box<dyn Fn($($tys,)*) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static>
+    }
+}
+
+/// Trait object that implements the extension function call accepting any number of arguments.
+pub type ExtensionFunctionObject = extension_function_object!(&[Value]);
+/// Trait object that implements the extension function call accepting exactly 0 arguments
+pub type NullaryExtensionFunctionObject = extension_function_object!();
+/// Trait object that implements the extension function call accepting exactly 1 arguments
+pub type UnaryExtensionFunctionObject = extension_function_object!(&Value);
+/// Trait object that implements the extension function call accepting exactly 2 arguments
+pub type BinaryExtensionFunctionObject = extension_function_object!(&Value, &Value);
+/// Trait object that implements the extension function call accepting exactly 3 arguments
+pub type TernaryExtensionFunctionObject = extension_function_object!(&Value, &Value, &Value);
 
 /// Extension function. These can be called by the given `name` in Ceder
 /// expressions.
@@ -172,7 +185,7 @@ impl ExtensionFunction {
     pub fn nullary(
         name: Name,
         style: CallStyle,
-        func: Box<dyn Fn() -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static>,
+        func: NullaryExtensionFunctionObject,
         return_type: SchemaType,
     ) -> Self {
         Self::new(
@@ -200,14 +213,14 @@ impl ExtensionFunction {
     pub fn partial_eval_unknown(
         name: Name,
         style: CallStyle,
-        func: Box<dyn Fn(Value) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static>,
+        func: UnaryExtensionFunctionObject,
         arg_type: SchemaType,
     ) -> Self {
         Self::new(
             name.clone(),
             style,
             Box::new(move |args: &[Value]| match args.first() {
-                Some(arg) => func(arg.clone()),
+                Some(arg) => func(arg),
                 None => Err(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     1,
@@ -225,9 +238,7 @@ impl ExtensionFunction {
     pub fn unary(
         name: Name,
         style: CallStyle,
-        func: Box<
-            dyn Fn(&Value) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static,
-        >,
+        func: UnaryExtensionFunctionObject,
         return_type: SchemaType,
         arg_type: SchemaType,
     ) -> Self {
@@ -253,12 +264,7 @@ impl ExtensionFunction {
     pub fn binary(
         name: Name,
         style: CallStyle,
-        func: Box<
-            dyn Fn(&Value, &Value) -> evaluator::Result<ExtensionOutputValue>
-                + Sync
-                + Send
-                + 'static,
-        >,
+        func: BinaryExtensionFunctionObject,
         return_type: SchemaType,
         arg_types: (SchemaType, SchemaType),
     ) -> Self {
@@ -284,12 +290,7 @@ impl ExtensionFunction {
     pub fn ternary(
         name: Name,
         style: CallStyle,
-        func: Box<
-            dyn Fn(&Value, &Value, &Value) -> evaluator::Result<ExtensionOutputValue>
-                + Sync
-                + Send
-                + 'static,
-        >,
+        func: TernaryExtensionFunctionObject,
         return_type: SchemaType,
         arg_types: (SchemaType, SchemaType, SchemaType),
     ) -> Self {

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -221,10 +221,13 @@ impl ExtensionFunction {
     }
 
     /// Create a new `ExtensionFunction` taking one argument
+    #[allow(clippy::type_complexity)]
     pub fn unary(
         name: Name,
         style: CallStyle,
-        func: Box<dyn Fn(Value) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static>,
+        func: Box<
+            dyn Fn(&Value) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static,
+        >,
         return_type: SchemaType,
         arg_type: SchemaType,
     ) -> Self {
@@ -232,7 +235,7 @@ impl ExtensionFunction {
             name.clone(),
             style,
             Box::new(move |args: &[Value]| match &args {
-                &[arg] => func(arg.clone()),
+                &[arg] => func(arg),
                 _ => Err(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     1,
@@ -246,11 +249,15 @@ impl ExtensionFunction {
     }
 
     /// Create a new `ExtensionFunction` taking two arguments
+    #[allow(clippy::type_complexity)]
     pub fn binary(
         name: Name,
         style: CallStyle,
         func: Box<
-            dyn Fn(Value, Value) -> evaluator::Result<ExtensionOutputValue> + Sync + Send + 'static,
+            dyn Fn(&Value, &Value) -> evaluator::Result<ExtensionOutputValue>
+                + Sync
+                + Send
+                + 'static,
         >,
         return_type: SchemaType,
         arg_types: (SchemaType, SchemaType),
@@ -259,7 +266,7 @@ impl ExtensionFunction {
             name.clone(),
             style,
             Box::new(move |args: &[Value]| match &args {
-                &[first, second] => func(first.clone(), second.clone()),
+                &[first, second] => func(first, second),
                 _ => Err(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     2,
@@ -273,11 +280,12 @@ impl ExtensionFunction {
     }
 
     /// Create a new `ExtensionFunction` taking three arguments
+    #[allow(clippy::type_complexity)]
     pub fn ternary(
         name: Name,
         style: CallStyle,
         func: Box<
-            dyn Fn(Value, Value, Value) -> evaluator::Result<ExtensionOutputValue>
+            dyn Fn(&Value, &Value, &Value) -> evaluator::Result<ExtensionOutputValue>
                 + Sync
                 + Send
                 + 'static,
@@ -289,7 +297,7 @@ impl ExtensionFunction {
             name.clone(),
             style,
             Box::new(move |args: &[Value]| match &args {
-                &[first, second, third] => func(first.clone(), second.clone(), third.clone()),
+                &[first, second, third] => func(first, second, third),
                 _ => Err(evaluator::EvaluationError::wrong_num_arguments(
                     name.clone(),
                     3,

--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -71,7 +71,7 @@ mod constants {
 }
 
 // The `datetime` type, represented internally as an `i64`.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 struct DateTime {
     // The number of non-leap milliseconds from the Unix epoch
     epoch: i64,
@@ -161,13 +161,13 @@ where
 }
 
 /// Check that `v` is a datetime type and, if it is, return the wrapped value
-fn as_datetime(v: &Value) -> Result<&DateTime, evaluator::EvaluationError> {
-    as_ext(v, &DATETIME_CONSTRUCTOR_NAME)
+fn as_datetime(v: &Value) -> Result<DateTime, evaluator::EvaluationError> {
+    as_ext(v, &DATETIME_CONSTRUCTOR_NAME).copied()
 }
 
 /// Check that `v` is a duration type and, if it is, return the wrapped value
-fn as_duration(v: &Value) -> Result<&Duration, evaluator::EvaluationError> {
-    as_ext(v, &DURATION_CONSTRUCTOR_NAME)
+fn as_duration(v: &Value) -> Result<Duration, evaluator::EvaluationError> {
+    as_ext(v, &DURATION_CONSTRUCTOR_NAME).copied()
 }
 
 fn offset(datetime: &Value, duration: &Value) -> evaluator::Result<ExtensionOutputValue> {
@@ -177,7 +177,7 @@ fn offset(datetime: &Value, duration: &Value) -> evaluator::Result<ExtensionOutp
         extension_err(
             format!(
                 "overflows when adding an offset: {}+({})",
-                RestrictedExpr::from(datetime.clone()),
+                RestrictedExpr::from(datetime),
                 duration
             ),
             &OFFSET_METHOD_NAME,
@@ -198,8 +198,8 @@ fn duration_since(lhs: &Value, rhs: &Value) -> evaluator::Result<ExtensionOutput
         extension_err(
             format!(
                 "overflows when computing the duration between {} and {}",
-                RestrictedExpr::from(lhs.clone()),
-                RestrictedExpr::from(rhs.clone())
+                RestrictedExpr::from(lhs),
+                RestrictedExpr::from(rhs)
             ),
             &DURATION_SINCE_NAME,
             None,
@@ -218,7 +218,7 @@ fn to_date(value: &Value) -> evaluator::Result<ExtensionOutputValue> {
         extension_err(
             format!(
                 "overflows when computing the date of {}",
-                RestrictedExpr::from(d.clone()),
+                RestrictedExpr::from(d),
             ),
             &TO_DATE_NAME,
             None,
@@ -254,13 +254,13 @@ impl DateTime {
     const DAY_IN_MILLISECONDS: i64 = 1000 * 3600 * 24;
     const UNIX_EPOCH_STR: &'static str = "1970-01-01";
 
-    fn offset(&self, duration: &Duration) -> Option<Self> {
+    fn offset(self, duration: Duration) -> Option<Self> {
         self.epoch
             .checked_add(duration.ms)
             .map(|epoch| Self { epoch })
     }
 
-    fn duration_since(&self, other: &DateTime) -> Option<Duration> {
+    fn duration_since(self, other: DateTime) -> Option<Duration> {
         self.epoch
             .checked_sub(other.epoch)
             .map(|ms| Duration { ms })
@@ -268,7 +268,7 @@ impl DateTime {
 
     // essentially `self.epoch.div_floor(Self::DAY_IN_MILLISECONDS) * Self::DAY_IN_MILLISECONDS`
     // but `div_floor` is only available on nightly
-    fn to_date(&self) -> Option<Self> {
+    fn to_date(self) -> Option<Self> {
         if self.epoch.is_negative() {
             if self.epoch % Self::DAY_IN_MILLISECONDS == 0 {
                 Some(self.epoch)
@@ -281,7 +281,7 @@ impl DateTime {
         .map(|epoch| Self { epoch })
     }
 
-    fn to_time(&self) -> Duration {
+    fn to_time(self) -> Duration {
         Duration {
             ms: if self.epoch.is_negative() {
                 let rem = self.epoch % Self::DAY_IN_MILLISECONDS;
@@ -296,7 +296,7 @@ impl DateTime {
         }
     }
 
-    fn as_ext_func_call(&self) -> (Name, Vec<RestrictedExpr>) {
+    fn as_ext_func_call(self) -> (Name, Vec<RestrictedExpr>) {
         (
             OFFSET_METHOD_NAME.clone(),
             vec![
@@ -338,7 +338,7 @@ impl From<NaiveDateTime> for DateTime {
 }
 
 // The `duration` type
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 struct Duration {
     // The number of milliseconds
     ms: i64,
@@ -392,27 +392,27 @@ fn duration_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
 }
 
 impl Duration {
-    fn to_milliseconds(&self) -> i64 {
+    fn to_milliseconds(self) -> i64 {
         self.ms
     }
 
-    fn to_seconds(&self) -> i64 {
+    fn to_seconds(self) -> i64 {
         self.to_milliseconds() / 1000
     }
 
-    fn to_minutes(&self) -> i64 {
+    fn to_minutes(self) -> i64 {
         self.to_seconds() / 60
     }
 
-    fn to_hours(&self) -> i64 {
+    fn to_hours(self) -> i64 {
         self.to_minutes() / 60
     }
 
-    fn to_days(&self) -> i64 {
+    fn to_days(self) -> i64 {
         self.to_hours() / 24
     }
 
-    fn as_ext_func_call(&self) -> (Name, Vec<RestrictedExpr>) {
+    fn as_ext_func_call(self) -> (Name, Vec<RestrictedExpr>) {
         (
             DURATION_CONSTRUCTOR_NAME.clone(),
             vec![Value::from(self.to_string()).into()],
@@ -422,7 +422,7 @@ impl Duration {
 
 fn duration_method(
     value: &Value,
-    internal_func: impl Fn(&Duration) -> i64,
+    internal_func: impl Fn(Duration) -> i64,
 ) -> evaluator::Result<ExtensionOutputValue> {
     let d = as_duration(value)?;
     Ok(Value::from(internal_func(d)).into())
@@ -981,43 +981,43 @@ mod tests {
     fn test_offset() {
         let unix_epoch = DateTime { epoch: 0 };
         let date_time_max = unix_epoch
-            .offset(&parse_duration(&milliseconds_to_duration(i64::MAX.into())).unwrap())
+            .offset(parse_duration(&milliseconds_to_duration(i64::MAX.into())).unwrap())
             .expect("valid datetime");
         let date_time_min = unix_epoch
-            .offset(&parse_duration(&milliseconds_to_duration(i64::MIN.into())).unwrap())
+            .offset(parse_duration(&milliseconds_to_duration(i64::MIN.into())).unwrap())
             .expect("valid datetime");
         assert!(date_time_max
-            .offset(&parse_duration("1ms").unwrap())
+            .offset(parse_duration("1ms").unwrap())
             .is_none());
         assert_eq!(
-            date_time_max.offset(&parse_duration("-1ms").unwrap()),
+            date_time_max.offset(parse_duration("-1ms").unwrap()),
             Some(
                 unix_epoch
                     .offset(
-                        &parse_duration(&milliseconds_to_duration(i64::MAX as i128 - 1)).unwrap()
+                        parse_duration(&milliseconds_to_duration(i64::MAX as i128 - 1)).unwrap()
                     )
                     .expect("valid datetime")
             )
         );
         assert!(date_time_min
-            .offset(&parse_duration("-1ms").unwrap())
+            .offset(parse_duration("-1ms").unwrap())
             .is_none());
         assert_eq!(
-            date_time_min.offset(&parse_duration("1ms").unwrap()),
+            date_time_min.offset(parse_duration("1ms").unwrap()),
             Some(
                 unix_epoch
                     .offset(
-                        &parse_duration(&milliseconds_to_duration(i64::MIN as i128 + 1)).unwrap()
+                        parse_duration(&milliseconds_to_duration(i64::MIN as i128 + 1)).unwrap()
                     )
                     .expect("valid datetime")
             )
         );
         assert_eq!(
-            unix_epoch.offset(&parse_duration("1d").unwrap()),
+            unix_epoch.offset(parse_duration("1d").unwrap()),
             Some(parse_datetime("1970-01-02").unwrap().into())
         );
         assert_eq!(
-            unix_epoch.offset(&parse_duration("-1d").unwrap()),
+            unix_epoch.offset(parse_duration("-1d").unwrap()),
             Some(parse_datetime("1969-12-31").unwrap().into())
         );
     }
@@ -1027,23 +1027,23 @@ mod tests {
         let unix_epoch = DateTime { epoch: 0 };
         let today: DateTime = parse_datetime("2024-10-24").unwrap().into();
         assert_eq!(
-            today.duration_since(&unix_epoch),
+            today.duration_since(unix_epoch),
             Some(parse_duration("20020d").unwrap())
         );
         let yesterday: DateTime = parse_datetime("2024-10-23").unwrap().into();
         assert_eq!(
-            yesterday.duration_since(&today),
+            yesterday.duration_since(today),
             Some(parse_duration("-1d").unwrap())
         );
         assert_eq!(
-            today.duration_since(&yesterday),
+            today.duration_since(yesterday),
             Some(parse_duration("1d").unwrap())
         );
 
         let date_time_min = unix_epoch
-            .offset(&parse_duration(&milliseconds_to_duration(i64::MIN.into())).unwrap())
+            .offset(parse_duration(&milliseconds_to_duration(i64::MIN.into())).unwrap())
             .expect("valid datetime");
-        assert!(today.duration_since(&date_time_min).is_none());
+        assert!(today.duration_since(date_time_min).is_none());
     }
 
     #[test]
@@ -1051,12 +1051,12 @@ mod tests {
         let unix_epoch = DateTime { epoch: 0 };
         let today: DateTime = parse_datetime("2024-10-24").unwrap().into();
         assert_eq!(
-            today.duration_since(&unix_epoch),
+            today.duration_since(unix_epoch),
             Some(parse_duration("20020d").unwrap())
         );
         let yesterday: DateTime = parse_datetime("2024-10-23").unwrap().into();
         assert_eq!(
-            yesterday.duration_since(&today),
+            yesterday.duration_since(today),
             Some(parse_duration("-1d").unwrap())
         );
         let some_day_before_unix_epoch: DateTime = parse_datetime("1900-01-01").unwrap().into();
@@ -1064,31 +1064,26 @@ mod tests {
         let max_day_offset = parse_duration("23h59m59s999ms").unwrap();
         let min_day_offset = parse_duration("-23h59m59s999ms").unwrap();
 
-        for d in [
-            today,
-            yesterday,
-            unix_epoch.clone(),
-            some_day_before_unix_epoch,
-        ] {
+        for d in [today, yesterday, unix_epoch, some_day_before_unix_epoch] {
             assert_eq!(d.to_date().expect("should not overflow"), d);
             assert_eq!(
-                d.offset(&max_day_offset)
+                d.offset(max_day_offset)
                     .unwrap()
                     .to_date()
                     .expect("should not overflow"),
                 d
             );
             assert_eq!(
-                d.offset(&min_day_offset)
+                d.offset(min_day_offset)
                     .unwrap()
                     .to_date()
                     .expect("should not overflow"),
-                d.offset(&parse_duration("-1d").unwrap()).unwrap()
+                d.offset(parse_duration("-1d").unwrap()).unwrap()
             );
         }
 
         assert!(unix_epoch
-            .offset(&Duration { ms: i64::MIN })
+            .offset(Duration { ms: i64::MIN })
             .expect("should be able to construct")
             .to_date()
             .is_none());
@@ -1099,12 +1094,12 @@ mod tests {
         let unix_epoch = DateTime { epoch: 0 };
         let today: DateTime = parse_datetime("2024-10-24").unwrap().into();
         assert_eq!(
-            today.duration_since(&unix_epoch),
+            today.duration_since(unix_epoch),
             Some(parse_duration("20020d").unwrap())
         );
         let yesterday: DateTime = parse_datetime("2024-10-23").unwrap().into();
         assert_eq!(
-            yesterday.duration_since(&today),
+            yesterday.duration_since(today),
             Some(parse_duration("-1d").unwrap())
         );
         let some_day_before_unix_epoch: DateTime = parse_datetime("1900-01-01").unwrap().into();
@@ -1113,9 +1108,9 @@ mod tests {
         let min_day_offset = parse_duration("-23h59m59s999ms").unwrap();
 
         for d in [today, yesterday, unix_epoch, some_day_before_unix_epoch] {
-            assert_eq!(d.offset(&max_day_offset).unwrap().to_time(), max_day_offset);
+            assert_eq!(d.offset(max_day_offset).unwrap().to_time(), max_day_offset);
             assert_eq!(
-                d.offset(&min_day_offset).unwrap().to_time(),
+                d.offset(min_day_offset).unwrap().to_time(),
                 parse_duration("1ms").unwrap(),
             );
         }

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -184,7 +184,7 @@ fn extension_err(msg: impl Into<String>, advice: Option<String>) -> evaluator::E
 
 /// Cedar function that constructs a `decimal` Cedar type from a
 /// Cedar string
-fn decimal_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
+fn decimal_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
     let decimal =
         Decimal::from_str(str.as_str()).map_err(|e| extension_err(e.to_string(), None))?;
@@ -192,7 +192,7 @@ fn decimal_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
     let e = RepresentableExtensionValue::new(
         Arc::new(decimal),
         constants::DECIMAL_FROM_STR_NAME.clone(),
-        vec![arg.into()],
+        vec![arg.clone().into()],
     );
     Ok(Value {
         value: ValueKind::ExtensionValue(Arc::new(e)),
@@ -234,33 +234,33 @@ fn as_decimal(v: &Value) -> Result<&Decimal, evaluator::EvaluationError> {
 
 /// Cedar function that tests whether the first `decimal` Cedar type is
 /// less than the second `decimal` Cedar type, returning a Cedar bool
-fn decimal_lt(left: Value, right: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let left = as_decimal(&left)?;
-    let right = as_decimal(&right)?;
+fn decimal_lt(left: &Value, right: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let left = as_decimal(left)?;
+    let right = as_decimal(right)?;
     Ok(Value::from(left < right).into())
 }
 
 /// Cedar function that tests whether the first `decimal` Cedar type is
 /// less than or equal to the second `decimal` Cedar type, returning a Cedar bool
-fn decimal_le(left: Value, right: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let left = as_decimal(&left)?;
-    let right = as_decimal(&right)?;
+fn decimal_le(left: &Value, right: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let left = as_decimal(left)?;
+    let right = as_decimal(right)?;
     Ok(Value::from(left <= right).into())
 }
 
 /// Cedar function that tests whether the first `decimal` Cedar type is
 /// greater than the second `decimal` Cedar type, returning a Cedar bool
-fn decimal_gt(left: Value, right: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let left = as_decimal(&left)?;
-    let right = as_decimal(&right)?;
+fn decimal_gt(left: &Value, right: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let left = as_decimal(left)?;
+    let right = as_decimal(right)?;
     Ok(Value::from(left > right).into())
 }
 
 /// Cedar function that tests whether the first `decimal` Cedar type is
 /// greater than or equal to the second `decimal` Cedar type, returning a Cedar bool
-fn decimal_ge(left: Value, right: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let left = as_decimal(&left)?;
-    let right = as_decimal(&right)?;
+fn decimal_ge(left: &Value, right: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let left = as_decimal(left)?;
+    let right = as_decimal(right)?;
     Ok(Value::from(left >= right).into())
 }
 

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -305,13 +305,13 @@ fn str_contains_colons_and_dots(s: &str) -> Result<(), String> {
 
 /// Cedar function which constructs an `ipaddr` Cedar type from a
 /// Cedar string
-fn ip_from_str(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
+fn ip_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
     let arg_source_loc = arg.source_loc().cloned();
     let ipaddr = RepresentableExtensionValue::new(
         Arc::new(IPAddr::from_str(str.as_str()).map_err(extension_err)?),
         names::IP_FROM_STR_NAME.clone(),
-        vec![arg.into()],
+        vec![arg.clone().into()],
     );
     Ok(Value {
         value: ValueKind::ExtensionValue(Arc::new(ipaddr)),
@@ -352,38 +352,38 @@ fn as_ipaddr(v: &Value) -> Result<&IPAddr, evaluator::EvaluationError> {
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is an IPv4
 /// address, returning a Cedar bool
-fn is_ipv4(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr = as_ipaddr(&arg)?;
+fn is_ipv4(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let ipaddr = as_ipaddr(arg)?;
     Ok(ipaddr.is_ipv4().into())
 }
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is an IPv6
 /// address, returning a Cedar bool
-fn is_ipv6(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr = as_ipaddr(&arg)?;
+fn is_ipv6(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let ipaddr = as_ipaddr(arg)?;
     Ok(ipaddr.is_ipv6().into())
 }
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is a
 /// loopback address, returning a Cedar bool
-fn is_loopback(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr = as_ipaddr(&arg)?;
+fn is_loopback(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let ipaddr = as_ipaddr(arg)?;
     Ok(ipaddr.is_loopback().into())
 }
 
 /// Cedar function which tests whether an `ipaddr` Cedar type is a
 /// multicast address, returning a Cedar bool
-fn is_multicast(arg: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let ipaddr = as_ipaddr(&arg)?;
+fn is_multicast(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let ipaddr = as_ipaddr(arg)?;
     Ok(ipaddr.is_multicast().into())
 }
 
 /// Cedar function which tests whether the first `ipaddr` Cedar type is
 /// in the IP range represented by the second `ipaddr` Cedar type, returning
 /// a Cedar bool
-fn is_in_range(child: Value, parent: Value) -> evaluator::Result<ExtensionOutputValue> {
-    let child_ip = as_ipaddr(&child)?;
-    let parent_ip = as_ipaddr(&parent)?;
+fn is_in_range(child: &Value, parent: &Value) -> evaluator::Result<ExtensionOutputValue> {
+    let child_ip = as_ipaddr(child)?;
+    let parent_ip = as_ipaddr(parent)?;
     Ok(child_ip.is_in_range(parent_ip).into())
 }
 

--- a/cedar-policy-core/src/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/extensions/partial_evaluation.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 /// Create a new untyped `Unknown`
-fn create_new_unknown(v: Value) -> evaluator::Result<ExtensionOutputValue> {
+fn create_new_unknown(v: &Value) -> evaluator::Result<ExtensionOutputValue> {
     Ok(ExtensionOutputValue::Unknown(Unknown::new_untyped(
         v.get_as_string()?.clone(),
     )))


### PR DESCRIPTION
## Description of changes

A slightly more involved follow-up to #1398. Updates extension functions to take arguments by reference instead of by value. In the current code, extension function arguments start as a slice before the elements are unconditionally cloned and passed to the definition of the function. With this PR we now pass references to the extension function which may or may not clone the argument values.

I've also made the `Duration` and `DateTime` structs `Copy` since they are wrappers around `i64`s and updated function signatures using these types to take owned values rather than references based on clippy's recommendation. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
