### PR TITLE
Add `Entity::new_with_tags()` and `Entity::tag()`

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,6 +17,7 @@ Cedar Language Version: TBD
 
 - Implemented [RFC 48 (schema annotations)](https://github.com/cedar-policy/rfcs/blob/main/text/0048-schema-annotations.md)  (#1316)
 - New `.isEmpty()` operator on sets (#1358, resolving #1356)
+- New `Entity::new_with_tags()` and `Entity::tag()` functions (#1402, resolving #1374)
 - Added protobuf schemas and (de)serialization code using on `prost` crate behind the experimental `protobufs` flag.
 - Added protobuf and JSON generation code to `cedar-policy-cli`.
 - Added a new get helper method to Context that allows easy extraction of generic values from the context by key. This method simplifies the common use case of retrieving values from Context objects.

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -166,15 +166,7 @@ impl Entity {
         attrs: HashMap<String, RestrictedExpression>,
         parents: HashSet<EntityUid>,
     ) -> Result<Self, EntityAttrEvaluationError> {
-        // note that we take a "parents" parameter here; we will compute TC when
-        // the `Entities` object is created
-        Ok(Self(ast::Entity::new(
-            uid.into(),
-            attrs.into_iter().map(|(k, v)| (SmolStr::from(k), v.0)),
-            parents.into_iter().map(EntityUid::into).collect(),
-            [],
-            Extensions::all_available(),
-        )?))
+        Self::new_with_tags(uid, attrs, parents, [])
     }
 
     /// Create a new `Entity` with no attributes.
@@ -189,6 +181,27 @@ impl Entity {
             [],
             parents.into_iter().map(EntityUid::into).collect(),
         ))
+    }
+
+    /// Create a new `Entity` with this Uid, attributes, parents, and tags.
+    ///
+    /// Attribute and tag values are specified here as "restricted expressions".
+    /// See docs on [`RestrictedExpression`].
+    pub fn new_with_tags(
+        uid: EntityUid,
+        attrs: impl IntoIterator<Item = (String, RestrictedExpression)>,
+        parents: impl IntoIterator<Item = EntityUid>,
+        tags: impl IntoIterator<Item = (String, RestrictedExpression)>,
+    ) -> Result<Self, EntityAttrEvaluationError> {
+        // note that we take a "parents" parameter here, not "ancestors"; we
+        // will compute TC when the `Entities` object is created
+        Ok(Self(ast::Entity::new(
+            uid.into(),
+            attrs.into_iter().map(|(k, v)| (k.into(), v.0)),
+            parents.into_iter().map(EntityUid::into).collect(),
+            tags.into_iter().map(|(k, v)| (k.into(), v.0)),
+            Extensions::all_available(),
+        )?))
     }
 
     /// Create a new `Entity` with this Uid, no attributes, and no parents.
@@ -240,11 +253,21 @@ impl Entity {
     /// assert!(entity.attr("foo").is_none());
     /// ```
     pub fn attr(&self, attr: &str) -> Option<Result<EvalResult, PartialValueToValueError>> {
-        let v = match ast::Value::try_from(self.0.get(attr)?.clone()) {
-            Ok(v) => v,
-            Err(e) => return Some(Err(e)),
-        };
-        Some(Ok(EvalResult::from(v)))
+        match ast::Value::try_from(self.0.get(attr)?.clone()) {
+            Ok(v) => Some(Ok(EvalResult::from(v))),
+            Err(e) => Some(Err(e)),
+        }
+    }
+
+    /// Get the value for the given tag, or `None` if not present.
+    ///
+    /// This can also return Some(Err) if the tag is not a value (i.e., is
+    /// unknown due to partial evaluation).
+    pub fn tag(&self, tag: &str) -> Option<Result<EvalResult, PartialValueToValueError>> {
+        match ast::Value::try_from(self.0.get_tag(tag)?.clone()) {
+            Ok(v) => Some(Ok(EvalResult::from(v))),
+            Err(e) => Some(Err(e)),
+        }
     }
 
     /// Consume the entity and return the entity's owned Uid, attributes and parents.


### PR DESCRIPTION
## Description of changes

Adds public methods `Entity::new_with_tags()` and `Entity::tag()` as discussed in #1374.

Discussion points:
- I made `new_with_tags()` more generic than the existing `Entity::new()`; we can take any `IntoIterator` for the `attrs` and `parents` parameters, there's no reason we need to force callers to have `HashMap` and `HashSet` specifically.  Theoretically I believe we could adjust the `Entity::new()` signature in the same way without breaking semver if we wanted to keep these aligned.
- There's also no real reason we need owned `String` for attribute and tag names; the implementation immediately converts to `SmolStr` anyway, so we could take any `ToSmolStr` for instance.  I haven't made that change in the current version of this PR because I'm not sure how much we want to keep `SmolStr` and related types/functions as an implementation detail.

## Issue #, if available

Fixes #1374

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
