### PR TITLE
Use generic expression builder for AST and EST

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -16,6 +16,7 @@
 
 use crate::{
     ast::*,
+    expr_builder::{self, ExprBuilder as _},
     extensions::Extensions,
     parser::{err::ParseErrors, Loc},
 };
@@ -1135,105 +1136,57 @@ pub struct ExprBuilder<T> {
     data: T,
 }
 
-impl<T> ExprBuilder<T>
-where
-    T: Default,
-{
-    /// Construct a new `ExprBuilder` where the data used for an expression
-    /// takes a default value.
-    pub fn new() -> Self {
-        Self {
-            source_loc: None,
-            data: T::default(),
-        }
+impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
+    type Expr = Expr<T>;
+
+    type Data = T;
+
+    fn loc(&self) -> Option<&Loc> {
+        self.source_loc.as_ref()
     }
 
-    /// Create a '!=' expression.
-    /// Defined only for `T: Default` because the caller would otherwise need to
-    /// provide a `data` for the intermediate `not` Expr node.
-    pub fn noteq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
-        match &self.source_loc {
-            Some(source_loc) => ExprBuilder::new().with_source_loc(source_loc.clone()),
-            None => ExprBuilder::new(),
-        }
-        .not(self.with_expr_kind(ExprKind::BinaryApp {
-            op: BinaryOp::Eq,
-            arg1: Arc::new(e1),
-            arg2: Arc::new(e2),
-        }))
+    fn data(&self) -> &Self::Data {
+        &self.data
     }
-}
 
-impl<T: Default> Default for ExprBuilder<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<T> ExprBuilder<T> {
-    /// Construct a new `ExprBuild` where the specified data will be stored on
-    /// the `Expr`. This constructor does not populate the `source_loc` field,
-    /// so `with_source_loc` should be called if constructing an `Expr` where
-    /// the source location is known.
-    pub fn with_data(data: T) -> Self {
+    fn with_data(data: T) -> Self {
         Self {
             source_loc: None,
             data,
         }
     }
 
-    /// Update the `ExprBuilder` to build an expression with some known location
-    /// in policy source code.
-    pub fn with_source_loc(self, source_loc: Loc) -> Self {
-        self.with_maybe_source_loc(Some(source_loc))
-    }
-
-    /// Utility used the validator to get an expression with the same source
-    /// location as an existing expression. This is done when reconstructing the
-    /// `Expr` with type information.
-    pub fn with_same_source_loc<U>(self, expr: &Expr<U>) -> Self {
-        self.with_maybe_source_loc(expr.source_loc.clone())
-    }
-
-    /// internally used to update `.source_loc` to the given `Some` or `None`
-    fn with_maybe_source_loc(mut self, maybe_source_loc: Option<Loc>) -> Self {
-        self.source_loc = maybe_source_loc;
+    fn with_maybe_source_loc(mut self, maybe_source_loc: Option<&Loc>) -> Self {
+        self.source_loc = maybe_source_loc.cloned();
         self
-    }
-
-    /// Internally used by the following methods to construct an `Expr`
-    /// containing the `data` and `source_loc` in this `ExprBuilder` with some
-    /// inner `ExprKind`.
-    fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
-        Expr::new(expr_kind, self.source_loc, self.data)
     }
 
     /// Create an `Expr` that's just a single `Literal`.
     ///
     /// Note that you can pass this a `Literal`, an `Integer`, a `String`, etc.
-    pub fn val(self, v: impl Into<Literal>) -> Expr<T> {
+    fn val(self, v: impl Into<Literal>) -> Expr<T> {
         self.with_expr_kind(ExprKind::Lit(v.into()))
     }
 
     /// Create an `Unknown` `Expr`
-    pub fn unknown(self, u: Unknown) -> Expr<T> {
+    fn unknown(self, u: Unknown) -> Expr<T> {
         self.with_expr_kind(ExprKind::Unknown(u))
     }
 
     /// Create an `Expr` that's just this literal `Var`
-    pub fn var(self, v: Var) -> Expr<T> {
+    fn var(self, v: Var) -> Expr<T> {
         self.with_expr_kind(ExprKind::Var(v))
     }
 
     /// Create an `Expr` that's just this `SlotId`
-    pub fn slot(self, s: SlotId) -> Expr<T> {
+    fn slot(self, s: SlotId) -> Expr<T> {
         self.with_expr_kind(ExprKind::Slot(s))
     }
 
     /// Create a ternary (if-then-else) `Expr`.
     ///
     /// `test_expr` must evaluate to a Bool type
-    pub fn ite(self, test_expr: Expr<T>, then_expr: Expr<T>, else_expr: Expr<T>) -> Expr<T> {
+    fn ite(self, test_expr: Expr<T>, then_expr: Expr<T>, else_expr: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::If {
             test_expr: Arc::new(test_expr),
             then_expr: Arc::new(then_expr),
@@ -1241,24 +1194,8 @@ impl<T> ExprBuilder<T> {
         })
     }
 
-    /// Create a ternary (if-then-else) `Expr`.
-    /// Takes `Arc`s instead of owned `Expr`s.
-    /// `test_expr` must evaluate to a Bool type
-    pub fn ite_arc(
-        self,
-        test_expr: Arc<Expr<T>>,
-        then_expr: Arc<Expr<T>>,
-        else_expr: Arc<Expr<T>>,
-    ) -> Expr<T> {
-        self.with_expr_kind(ExprKind::If {
-            test_expr,
-            then_expr,
-            else_expr,
-        })
-    }
-
     /// Create a 'not' expression. `e` must evaluate to Bool type
-    pub fn not(self, e: Expr<T>) -> Expr<T> {
+    fn not(self, e: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::UnaryApp {
             op: UnaryOp::Not,
             arg: Arc::new(e),
@@ -1266,7 +1203,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a '==' expression
-    pub fn is_eq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn is_eq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::Eq,
             arg1: Arc::new(e1),
@@ -1275,7 +1212,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'and' expression. Arguments must evaluate to Bool type
-    pub fn and(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn and(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(match (&e1.expr_kind, &e2.expr_kind) {
             (ExprKind::Lit(Literal::Bool(b1)), ExprKind::Lit(Literal::Bool(b2))) => {
                 ExprKind::Lit(Literal::Bool(*b1 && *b2))
@@ -1288,7 +1225,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'or' expression. Arguments must evaluate to Bool type
-    pub fn or(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn or(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(match (&e1.expr_kind, &e2.expr_kind) {
             (ExprKind::Lit(Literal::Bool(b1)), ExprKind::Lit(Literal::Bool(b2))) => {
                 ExprKind::Lit(Literal::Bool(*b1 || *b2))
@@ -1302,7 +1239,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a '<' expression. Arguments must evaluate to Long type
-    pub fn less(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn less(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::Less,
             arg1: Arc::new(e1),
@@ -1311,7 +1248,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a '<=' expression. Arguments must evaluate to Long type
-    pub fn lesseq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn lesseq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::LessEq,
             arg1: Arc::new(e1),
@@ -1320,7 +1257,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'add' expression. Arguments must evaluate to Long type
-    pub fn add(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn add(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::Add,
             arg1: Arc::new(e1),
@@ -1329,7 +1266,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a 'sub' expression. Arguments must evaluate to Long type
-    pub fn sub(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn sub(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::Sub,
             arg1: Arc::new(e1),
@@ -1338,7 +1275,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a 'mul' expression. Arguments must evaluate to Long type
-    pub fn mul(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn mul(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::Mul,
             arg1: Arc::new(e1),
@@ -1347,7 +1284,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a 'neg' expression. `e` must evaluate to Long type.
-    pub fn neg(self, e: Expr<T>) -> Expr<T> {
+    fn neg(self, e: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::UnaryApp {
             op: UnaryOp::Neg,
             arg: Arc::new(e),
@@ -1357,7 +1294,7 @@ impl<T> ExprBuilder<T> {
     /// Create an 'in' expression. First argument must evaluate to Entity type.
     /// Second argument must evaluate to either Entity type or Set type where
     /// all set elements have Entity type.
-    pub fn is_in(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn is_in(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::In,
             arg1: Arc::new(e1),
@@ -1367,7 +1304,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create a 'contains' expression.
     /// First argument must have Set type.
-    pub fn contains(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn contains(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::Contains,
             arg1: Arc::new(e1),
@@ -1376,7 +1313,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create a 'contains_all' expression. Arguments must evaluate to Set type
-    pub fn contains_all(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn contains_all(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::ContainsAll,
             arg1: Arc::new(e1),
@@ -1385,7 +1322,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'contains_any' expression. Arguments must evaluate to Set type
-    pub fn contains_any(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn contains_any(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::ContainsAny,
             arg1: Arc::new(e1),
@@ -1394,7 +1331,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'is_empty' expression. Argument must evaluate to Set type
-    pub fn is_empty(self, expr: Expr<T>) -> Expr<T> {
+    fn is_empty(self, expr: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::UnaryApp {
             op: UnaryOp::IsEmpty,
             arg: Arc::new(expr),
@@ -1403,7 +1340,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create a 'getTag' expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
-    pub fn get_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
+    fn get_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::GetTag,
             arg1: Arc::new(expr),
@@ -1413,7 +1350,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create a 'hasTag' expression.
     /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
-    pub fn has_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
+    fn has_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::HasTag,
             arg1: Arc::new(expr),
@@ -1422,12 +1359,12 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an `Expr` which evaluates to a Set of the given `Expr`s
-    pub fn set(self, exprs: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
+    fn set(self, exprs: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
         self.with_expr_kind(ExprKind::Set(Arc::new(exprs.into_iter().collect())))
     }
 
     /// Create an `Expr` which evaluates to a Record with the given (key, value) pairs.
-    pub fn record(
+    fn record(
         self,
         pairs: impl IntoIterator<Item = (SmolStr, Expr<T>)>,
     ) -> Result<Expr<T>, ExpressionConstructionError> {
@@ -1449,23 +1386,9 @@ impl<T> ExprBuilder<T> {
         Ok(self.with_expr_kind(ExprKind::Record(Arc::new(map))))
     }
 
-    /// Create an `Expr` which evalutes to a Record with the given key-value mapping.
-    ///
-    /// If you have an iterator of pairs, generally prefer calling `.record()`
-    /// instead of `.collect()`-ing yourself and calling this, potentially for
-    /// efficiency reasons but also because `.record()` will properly handle
-    /// duplicate keys but your own `.collect()` will not (by default).
-    pub fn record_arc(self, map: Arc<BTreeMap<SmolStr, Expr<T>>>) -> Expr<T> {
-        self.with_expr_kind(ExprKind::Record(map))
-    }
-
     /// Create an `Expr` which calls the extension function with the given
     /// `Name` on `args`
-    pub fn call_extension_fn(
-        self,
-        fn_name: Name,
-        args: impl IntoIterator<Item = Expr<T>>,
-    ) -> Expr<T> {
+    fn call_extension_fn(self, fn_name: Name, args: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
         self.with_expr_kind(ExprKind::ExtensionFunctionApp {
             fn_name,
             args: Arc::new(args.into_iter().collect()),
@@ -1474,7 +1397,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create an application `Expr` which applies the given built-in unary
     /// operator to the given `arg`
-    pub fn unary_app(self, op: impl Into<UnaryOp>, arg: Expr<T>) -> Expr<T> {
+    fn unary_app(self, op: impl Into<UnaryOp>, arg: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::UnaryApp {
             op: op.into(),
             arg: Arc::new(arg),
@@ -1483,7 +1406,7 @@ impl<T> ExprBuilder<T> {
 
     /// Create an application `Expr` which applies the given built-in binary
     /// operator to `arg1` and `arg2`
-    pub fn binary_app(self, op: impl Into<BinaryOp>, arg1: Expr<T>, arg2: Expr<T>) -> Expr<T> {
+    fn binary_app(self, op: impl Into<BinaryOp>, arg1: Expr<T>, arg2: Expr<T>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: op.into(),
             arg1: Arc::new(arg1),
@@ -1494,7 +1417,7 @@ impl<T> ExprBuilder<T> {
     /// Create an `Expr` which gets a given attribute of a given `Entity` or record.
     ///
     /// `expr` must evaluate to either Entity or Record type
-    pub fn get_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
+    fn get_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
         self.with_expr_kind(ExprKind::GetAttr {
             expr: Arc::new(expr),
             attr,
@@ -1505,7 +1428,7 @@ impl<T> ExprBuilder<T> {
     /// attribute on a given `Entity` or record.
     ///
     /// `expr` must evaluate to either Entity or Record type
-    pub fn has_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
+    fn has_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
         self.with_expr_kind(ExprKind::HasAttr {
             expr: Arc::new(expr),
             attr,
@@ -1515,7 +1438,7 @@ impl<T> ExprBuilder<T> {
     /// Create a 'like' expression.
     ///
     /// `expr` must evaluate to a String type
-    pub fn like(self, expr: Expr<T>, pattern: Pattern) -> Expr<T> {
+    fn like(self, expr: Expr<T>, pattern: Pattern) -> Expr<T> {
         self.with_expr_kind(ExprKind::Like {
             expr: Arc::new(expr),
             pattern,
@@ -1523,7 +1446,7 @@ impl<T> ExprBuilder<T> {
     }
 
     /// Create an 'is' expression.
-    pub fn is_entity_type(self, expr: Expr<T>, entity_type: EntityType) -> Expr<T> {
+    fn is_entity_type(self, expr: Expr<T>, entity_type: EntityType) -> Expr<T> {
         self.with_expr_kind(ExprKind::Is {
             expr: Arc::new(expr),
             entity_type,
@@ -1531,53 +1454,48 @@ impl<T> ExprBuilder<T> {
     }
 }
 
-impl<T: Clone> ExprBuilder<T> {
-    /// Create an `and` expression that may have more than two subexpressions (A && B && C)
-    /// or may have only one subexpression, in which case no `&&` is performed at all.
-    /// Arguments must evaluate to Bool type.
-    ///
-    /// This may create multiple AST `&&` nodes. If it does, all the nodes will have the same
-    /// source location and the same `T` data (taken from this builder) unless overridden, e.g.,
-    /// with another call to `with_source_loc()`.
-    pub fn and_nary(self, first: Expr<T>, others: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
-        others.into_iter().fold(first, |acc, next| {
-            Self::with_data(self.data.clone())
-                .with_maybe_source_loc(self.source_loc.clone())
-                .and(acc, next)
+impl<T> ExprBuilder<T> {
+    /// Internally used by the following methods to construct an `Expr`
+    /// containing the `data` and `source_loc` in this `ExprBuilder` with some
+    /// inner `ExprKind`.
+    fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
+        Expr::new(expr_kind, self.source_loc, self.data)
+    }
+
+    /// Create a ternary (if-then-else) `Expr`.
+    /// Takes `Arc`s instead of owned `Expr`s.
+    /// `test_expr` must evaluate to a Bool type
+    pub fn ite_arc(
+        self,
+        test_expr: Arc<Expr<T>>,
+        then_expr: Arc<Expr<T>>,
+        else_expr: Arc<Expr<T>>,
+    ) -> Expr<T> {
+        self.with_expr_kind(ExprKind::If {
+            test_expr,
+            then_expr,
+            else_expr,
         })
     }
 
-    /// Create an `or` expression that may have more than two subexpressions (A || B || C)
-    /// or may have only one subexpression, in which case no `||` is performed at all.
-    /// Arguments must evaluate to Bool type.
+    /// Create an `Expr` which evaluates to a Record with the given key-value mapping.
     ///
-    /// This may create multiple AST `||` nodes. If it does, all the nodes will have the same
-    /// source location and the same `T` data (taken from this builder) unless overridden, e.g.,
-    /// with another call to `with_source_loc()`.
-    pub fn or_nary(self, first: Expr<T>, others: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
-        others.into_iter().fold(first, |acc, next| {
-            Self::with_data(self.data.clone())
-                .with_maybe_source_loc(self.source_loc.clone())
-                .or(acc, next)
-        })
+    /// If you have an iterator of pairs, generally prefer calling `.record()`
+    /// instead of `.collect()`-ing yourself and calling this, potentially for
+    /// efficiency reasons but also because `.record()` will properly handle
+    /// duplicate keys but your own `.collect()` will not (by default).
+    pub fn record_arc(self, map: Arc<BTreeMap<SmolStr, Expr<T>>>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Record(map))
     }
+}
 
-    /// Create a '>' expression. Arguments must evaluate to Long type
-    pub fn greater(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
-        // e1 > e2 is defined as !(e1 <= e2)
-        let leq = Self::with_data(self.data.clone())
-            .with_maybe_source_loc(self.source_loc.clone())
-            .lesseq(e1, e2);
-        self.not(leq)
-    }
-
-    /// Create a '>=' expression. Arguments must evaluate to Long type
-    pub fn greatereq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
-        // e1 >= e2 is defined as !(e1 < e2)
-        let leq = Self::with_data(self.data.clone())
-            .with_maybe_source_loc(self.source_loc.clone())
-            .less(e1, e2);
-        self.not(leq)
+impl<T: Clone + Default> ExprBuilder<T> {
+    /// Utility used the validator to get an expression with the same source
+    /// location as an existing expression. This is done when reconstructing the
+    /// `Expr` with type information.
+    pub fn with_same_source_loc<U>(self, expr: &Expr<U>) -> Self {
+        use expr_builder::ExprBuilder;
+        self.with_maybe_source_loc(expr.source_loc.as_ref())
     }
 }
 
@@ -1852,14 +1770,6 @@ impl<T> Expr<T> {
             }
         }
     }
-
-    pub(crate) fn is_true(&self) -> bool {
-        matches!(self.expr_kind(), ExprKind::Lit(Literal::Bool(true)))
-    }
-
-    pub(crate) fn is_false(&self) -> bool {
-        matches!(self.expr_kind(), ExprKind::Lit(Literal::Bool(false)))
-    }
 }
 
 /// AST variables
@@ -1962,6 +1872,8 @@ mod test {
     use cool_asserts::assert_matches;
     use itertools::Itertools;
     use std::collections::{hash_map::DefaultHasher, HashSet};
+
+    use crate::expr_builder::ExprBuilder as _;
 
     use super::{var_generator::all_vars, *};
 

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1494,7 +1494,6 @@ impl<T: Clone + Default> ExprBuilder<T> {
     /// location as an existing expression. This is done when reconstructing the
     /// `Expr` with type information.
     pub fn with_same_source_loc<U>(self, expr: &Expr<U>) -> Self {
-        use expr_builder::ExprBuilder;
         self.with_maybe_source_loc(expr.source_loc.as_ref())
     }
 }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1130,7 +1130,7 @@ impl From<&Expr> for proto::Expr {
 
 /// Builder for constructing `Expr` objects annotated with some `data`
 /// (possibly taking default value) and optionally a `source_loc`.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ExprBuilder<T> {
     source_loc: Option<Loc>,
     data: T,

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -30,6 +30,7 @@ pub use annotation::*;
 use crate::ast::EntityUID;
 use crate::ast::{self, Annotation};
 use crate::entities::json::{err::JsonDeserializationError, EntityUidJson};
+use crate::expr_builder::ExprBuilder;
 use crate::parser::cst;
 use crate::parser::err::{parse_errors, ParseErrors, ToASTError, ToASTErrorKind};
 use crate::parser::util::{flatten_tuple_2, flatten_tuple_4};

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -406,7 +406,7 @@ pub struct ExtFuncCall {
 }
 
 /// Construct an [`Expr`].
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Builder;
 
 impl ExprBuilder for Builder {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -15,26 +15,23 @@
  */
 
 use super::FromJsonError;
-use crate::ast::{self, BoundedDisplay, EntityUID, InputInteger};
+use crate::ast::{self, BoundedDisplay, EntityUID};
 use crate::entities::json::{
     err::EscapeKind, err::JsonDeserializationError, err::JsonDeserializationErrorContext,
-    CedarValueJson, FnAndArg, TypeAndId,
+    CedarValueJson, FnAndArg,
 };
+use crate::expr_builder::ExprBuilder;
 use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
-use crate::parser::cst::{self, Ident};
 use crate::parser::cst_to_ast;
-use crate::parser::err::{ParseErrors, ToASTError, ToASTErrorKind};
-use crate::parser::unescape::to_unescaped_string;
-use crate::parser::util::flatten_tuple_2;
-use crate::parser::{Loc, Node};
-use either::Either;
+use crate::parser::err::ParseErrors;
+use crate::parser::Node;
+use crate::parser::{cst, Loc};
 use itertools::Itertools;
-use nonempty::nonempty;
 use serde::{de::Visitor, Deserialize, Serialize};
 use serde_with::serde_as;
 use smol_str::{SmolStr, ToSmolStr};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{btree_map, BTreeMap, HashMap};
 use std::sync::Arc;
 
 /// Serde JSON structure for a Cedar expression in the EST format
@@ -408,43 +405,65 @@ pub struct ExtFuncCall {
     call: HashMap<SmolStr, Vec<Expr>>,
 }
 
-#[allow(clippy::should_implement_trait)] // the names of arithmetic constructors alias with those of certain trait methods such as `add` of `std::ops::Add`
-impl Expr {
+/// Construct an [`Expr`].
+#[derive(Debug)]
+pub struct Builder;
+
+impl ExprBuilder for Builder {
+    type Expr = Expr;
+
+    type Data = ();
+
+    fn with_data(_data: Self::Data) -> Self {
+        Self
+    }
+
+    fn with_maybe_source_loc(self, _: Option<&Loc>) -> Self {
+        self
+    }
+
+    fn loc(&self) -> Option<&Loc> {
+        None
+    }
+
+    fn data(&self) -> &Self::Data {
+        &()
+    }
+
     /// literal
-    pub fn lit(lit: CedarValueJson) -> Self {
-        Expr::ExprNoExt(ExprNoExt::Value(lit))
+    fn val(self, lit: impl Into<ast::Literal>) -> Expr {
+        Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::from_lit(lit.into())))
     }
 
     /// principal, action, resource, context
-    pub fn var(var: ast::Var) -> Self {
+    fn var(self, var: ast::Var) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Var(var))
     }
 
     /// Template slots
-    pub fn slot(slot: ast::SlotId) -> Self {
+    fn slot(self, slot: ast::SlotId) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Slot(slot))
     }
 
     /// An extension call with one arg, which is the name of the unknown
-    pub fn unknown(name: impl Into<SmolStr>) -> Self {
-        Expr::ext_call(
-            "unknown".into(),
-            vec![Expr::lit(CedarValueJson::String(name.into()))],
-        )
+    fn unknown(self, u: ast::Unknown) -> Expr {
+        Expr::ExtFuncCall(ExtFuncCall {
+            call: HashMap::from([("unknown".to_smolstr(), vec![Builder::new().val(u.name)])]),
+        })
     }
 
     /// `!`
-    pub fn not(e: Expr) -> Self {
+    fn not(self, e: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Not { arg: Arc::new(e) })
     }
 
     /// `-`
-    pub fn neg(e: Expr) -> Self {
+    fn neg(self, e: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Neg { arg: Arc::new(e) })
     }
 
     /// `==`
-    pub fn eq(left: Expr, right: Expr) -> Self {
+    fn is_eq(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Eq {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -452,7 +471,7 @@ impl Expr {
     }
 
     /// `!=`
-    pub fn noteq(left: Expr, right: Expr) -> Self {
+    fn noteq(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::NotEq {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -460,7 +479,7 @@ impl Expr {
     }
 
     /// `in`
-    pub fn _in(left: Expr, right: Expr) -> Self {
+    fn is_in(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::In {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -468,7 +487,7 @@ impl Expr {
     }
 
     /// `<`
-    pub fn less(left: Expr, right: Expr) -> Self {
+    fn less(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Less {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -476,7 +495,7 @@ impl Expr {
     }
 
     /// `<=`
-    pub fn lesseq(left: Expr, right: Expr) -> Self {
+    fn lesseq(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::LessEq {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -484,7 +503,7 @@ impl Expr {
     }
 
     /// `>`
-    pub fn greater(left: Expr, right: Expr) -> Self {
+    fn greater(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Greater {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -492,7 +511,7 @@ impl Expr {
     }
 
     /// `>=`
-    pub fn greatereq(left: Expr, right: Expr) -> Self {
+    fn greatereq(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::GreaterEq {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -500,7 +519,7 @@ impl Expr {
     }
 
     /// `&&`
-    pub fn and(left: Expr, right: Expr) -> Self {
+    fn and(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::And {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -508,7 +527,7 @@ impl Expr {
     }
 
     /// `||`
-    pub fn or(left: Expr, right: Expr) -> Self {
+    fn or(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Or {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -516,7 +535,7 @@ impl Expr {
     }
 
     /// `+`
-    pub fn add(left: Expr, right: Expr) -> Self {
+    fn add(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Add {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -524,7 +543,7 @@ impl Expr {
     }
 
     /// `-`
-    pub fn sub(left: Expr, right: Expr) -> Self {
+    fn sub(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Sub {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -532,7 +551,7 @@ impl Expr {
     }
 
     /// `*`
-    pub fn mul(left: Expr, right: Expr) -> Self {
+    fn mul(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Mul {
             left: Arc::new(left),
             right: Arc::new(right),
@@ -540,94 +559,96 @@ impl Expr {
     }
 
     /// `left.contains(right)`
-    pub fn contains(left: Arc<Expr>, right: Expr) -> Self {
+    fn contains(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Contains {
-            left,
+            left: Arc::new(left),
             right: Arc::new(right),
         })
     }
 
     /// `left.containsAll(right)`
-    pub fn contains_all(left: Arc<Expr>, right: Expr) -> Self {
+    fn contains_all(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::ContainsAll {
-            left,
+            left: Arc::new(left),
             right: Arc::new(right),
         })
     }
 
     /// `left.containsAny(right)`
-    pub fn contains_any(left: Arc<Expr>, right: Expr) -> Self {
+    fn contains_any(self, left: Expr, right: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::ContainsAny {
-            left,
+            left: Arc::new(left),
             right: Arc::new(right),
         })
     }
 
     /// `arg.isEmpty()`
-    pub fn is_empty(arg: Arc<Expr>) -> Self {
-        Expr::ExprNoExt(ExprNoExt::IsEmpty { arg })
+    fn is_empty(self, expr: Expr) -> Expr {
+        Expr::ExprNoExt(ExprNoExt::IsEmpty {
+            arg: Arc::new(expr),
+        })
     }
 
     /// `left.getTag(right)`
-    pub fn get_tag(left: Arc<Expr>, right: Expr) -> Self {
+    fn get_tag(self, expr: Expr, tag: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::GetTag {
-            left,
-            right: Arc::new(right),
+            left: Arc::new(expr),
+            right: Arc::new(tag),
         })
     }
 
     /// `left.hasTag(right)`
-    pub fn has_tag(left: Arc<Expr>, right: Expr) -> Self {
+    fn has_tag(self, expr: Expr, tag: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::HasTag {
-            left,
-            right: Arc::new(right),
+            left: Arc::new(expr),
+            right: Arc::new(tag),
         })
     }
 
     /// `left.attr`
-    pub fn get_attr(left: Expr, attr: SmolStr) -> Self {
+    fn get_attr(self, expr: Expr, attr: SmolStr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::GetAttr {
-            left: Arc::new(left),
+            left: Arc::new(expr),
             attr,
         })
     }
 
     /// `left has attr`
-    pub fn has_attr(left: Expr, attr: SmolStr) -> Self {
+    fn has_attr(self, expr: Expr, attr: SmolStr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::HasAttr {
-            left: Arc::new(left),
+            left: Arc::new(expr),
             attr,
         })
     }
 
     /// `left like pattern`
-    pub fn like(left: Expr, pattern: impl IntoIterator<Item = PatternElem>) -> Self {
+    fn like(self, expr: Expr, pattern: ast::Pattern) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Like {
-            left: Arc::new(left),
-            pattern: pattern.into_iter().collect(),
+            left: Arc::new(expr),
+            pattern: pattern.into(),
         })
     }
 
     /// `left is entity_type`
-    pub fn is_entity_type(left: Expr, entity_type: SmolStr) -> Self {
+    fn is_entity_type(self, left: Expr, entity_type: ast::EntityType) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Is {
             left: Arc::new(left),
-            entity_type,
+            entity_type: entity_type.to_smolstr(),
             in_expr: None,
         })
     }
 
     /// `left is entity_type in entity`
-    pub fn is_entity_type_in(left: Expr, entity_type: SmolStr, entity: Expr) -> Self {
+    fn is_in_entity_type(self, left: Expr, entity_type: ast::EntityType, entity: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Is {
             left: Arc::new(left),
-            entity_type,
+            entity_type: entity_type.to_smolstr(),
             in_expr: Some(Arc::new(entity)),
         })
     }
 
     /// `if cond_expr then then_expr else else_expr`
-    pub fn ite(cond_expr: Expr, then_expr: Expr, else_expr: Expr) -> Self {
+    fn ite(self, cond_expr: Expr, then_expr: Expr, else_expr: Expr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::If {
             cond_expr: Arc::new(cond_expr),
             then_expr: Arc::new(then_expr),
@@ -636,22 +657,42 @@ impl Expr {
     }
 
     /// e.g. [1+2, !(context has department)]
-    pub fn set(elements: Vec<Expr>) -> Self {
-        Expr::ExprNoExt(ExprNoExt::Set(elements))
+    fn set(self, elements: impl IntoIterator<Item = Expr>) -> Expr {
+        Expr::ExprNoExt(ExprNoExt::Set(elements.into_iter().collect()))
     }
 
     /// e.g. {foo: 1+2, bar: !(context has department)}
-    pub fn record(map: BTreeMap<SmolStr, Expr>) -> Self {
-        Expr::ExprNoExt(ExprNoExt::Record(map))
+    fn record(
+        self,
+        map: impl IntoIterator<Item = (SmolStr, Expr)>,
+    ) -> Result<Expr, ast::ExpressionConstructionError> {
+        let mut dedup_map = BTreeMap::new();
+        for (k, v) in map {
+            match dedup_map.entry(k) {
+                btree_map::Entry::Occupied(oentry) => {
+                    return Err(ast::expression_construction_errors::DuplicateKeyError {
+                        key: oentry.key().clone(),
+                        context: "in record literal",
+                    }
+                    .into());
+                }
+                btree_map::Entry::Vacant(ventry) => {
+                    ventry.insert(v);
+                }
+            }
+        }
+        Ok(Expr::ExprNoExt(ExprNoExt::Record(dedup_map)))
     }
 
     /// extension function call, including method calls
-    pub fn ext_call(fn_name: SmolStr, args: Vec<Expr>) -> Self {
+    fn call_extension_fn(self, fn_name: ast::Name, args: impl IntoIterator<Item = Expr>) -> Expr {
         Expr::ExtFuncCall(ExtFuncCall {
-            call: HashMap::from([(fn_name, args)]),
+            call: HashMap::from([(fn_name.to_smolstr(), args.into_iter().collect())]),
         })
     }
+}
 
+impl Expr {
     /// Consume the `Expr`, producing a string literal if it was a string literal, otherwise returns the literal in the `Err` variant.
     pub fn into_string_literal(self) -> Result<SmolStr, Self> {
         match self {
@@ -1015,666 +1056,88 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
             ast::ExprKind::Lit(lit) => lit.into(),
             ast::ExprKind::Var(var) => var.into(),
             ast::ExprKind::Slot(slot) => slot.into(),
-            ast::ExprKind::Unknown(ast::Unknown { name, .. }) => Expr::unknown(name),
+            ast::ExprKind::Unknown(u) => Builder::new().unknown(u),
             ast::ExprKind::If {
                 test_expr,
                 then_expr,
                 else_expr,
-            } => Expr::ite(
+            } => Builder::new().ite(
                 Arc::unwrap_or_clone(test_expr).into(),
                 Arc::unwrap_or_clone(then_expr).into(),
                 Arc::unwrap_or_clone(else_expr).into(),
             ),
-            ast::ExprKind::And { left, right } => Expr::and(
+            ast::ExprKind::And { left, right } => Builder::new().and(
                 Arc::unwrap_or_clone(left).into(),
                 Arc::unwrap_or_clone(right).into(),
             ),
-            ast::ExprKind::Or { left, right } => Expr::or(
+            ast::ExprKind::Or { left, right } => Builder::new().or(
                 Arc::unwrap_or_clone(left).into(),
                 Arc::unwrap_or_clone(right).into(),
             ),
             ast::ExprKind::UnaryApp { op, arg } => {
                 let arg = Arc::unwrap_or_clone(arg).into();
-                match op {
-                    ast::UnaryOp::Not => Expr::not(arg),
-                    ast::UnaryOp::Neg => Expr::neg(arg),
-                    ast::UnaryOp::IsEmpty => Expr::is_empty(Arc::new(arg)),
-                }
+                Builder::new().unary_app(op, arg)
             }
             ast::ExprKind::BinaryApp { op, arg1, arg2 } => {
                 let arg1 = Arc::unwrap_or_clone(arg1).into();
                 let arg2 = Arc::unwrap_or_clone(arg2).into();
-                match op {
-                    ast::BinaryOp::Eq => Expr::eq(arg1, arg2),
-                    ast::BinaryOp::In => Expr::_in(arg1, arg2),
-                    ast::BinaryOp::Less => Expr::less(arg1, arg2),
-                    ast::BinaryOp::LessEq => Expr::lesseq(arg1, arg2),
-                    ast::BinaryOp::Add => Expr::add(arg1, arg2),
-                    ast::BinaryOp::Sub => Expr::sub(arg1, arg2),
-                    ast::BinaryOp::Mul => Expr::mul(arg1, arg2),
-                    ast::BinaryOp::Contains => Expr::contains(Arc::new(arg1), arg2),
-                    ast::BinaryOp::ContainsAll => Expr::contains_all(Arc::new(arg1), arg2),
-                    ast::BinaryOp::ContainsAny => Expr::contains_any(Arc::new(arg1), arg2),
-                    ast::BinaryOp::GetTag => Expr::get_tag(Arc::new(arg1), arg2),
-                    ast::BinaryOp::HasTag => Expr::has_tag(Arc::new(arg1), arg2),
-                }
+                Builder::new().binary_app(op, arg1, arg2)
             }
             ast::ExprKind::ExtensionFunctionApp { fn_name, args } => {
-                let args = Arc::unwrap_or_clone(args)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect();
-                Expr::ext_call(fn_name.to_string().into(), args)
+                let args = Arc::unwrap_or_clone(args).into_iter().map(Into::into);
+                Builder::new().call_extension_fn(fn_name, args)
             }
             ast::ExprKind::GetAttr { expr, attr } => {
-                Expr::get_attr(Arc::unwrap_or_clone(expr).into(), attr)
+                Builder::new().get_attr(Arc::unwrap_or_clone(expr).into(), attr)
             }
             ast::ExprKind::HasAttr { expr, attr } => {
-                Expr::has_attr(Arc::unwrap_or_clone(expr).into(), attr)
+                Builder::new().has_attr(Arc::unwrap_or_clone(expr).into(), attr)
             }
-            ast::ExprKind::Like { expr, pattern } => Expr::like(
-                Arc::unwrap_or_clone(expr).into(),
-                Vec::<PatternElem>::from(pattern),
-            ),
-            ast::ExprKind::Is { expr, entity_type } => Expr::is_entity_type(
-                Arc::unwrap_or_clone(expr).into(),
-                entity_type.to_string().into(),
-            ),
-            ast::ExprKind::Set(set) => Expr::set(
-                Arc::unwrap_or_clone(set)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
-            ),
-            ast::ExprKind::Record(map) => Expr::record(
-                Arc::unwrap_or_clone(map)
-                    .into_iter()
-                    .map(|(k, v)| (k, v.into()))
-                    .collect(),
-            ),
+            ast::ExprKind::Like { expr, pattern } => {
+                Builder::new().like(Arc::unwrap_or_clone(expr).into(), pattern)
+            }
+            ast::ExprKind::Is { expr, entity_type } => {
+                Builder::new().is_entity_type(Arc::unwrap_or_clone(expr).into(), entity_type)
+            }
+            ast::ExprKind::Set(set) => {
+                Builder::new().set(Arc::unwrap_or_clone(set).into_iter().map(Into::into))
+            }
+            // PANIC SAFETY: `map` is a map, so it will not have duplicates
+            // keys, so the `record` constructor cannot error.
+            #[allow(clippy::unwrap_used)]
+            ast::ExprKind::Record(map) => Builder::new()
+                .record(
+                    Arc::unwrap_or_clone(map)
+                        .into_iter()
+                        .map(|(k, v)| (k, v.into())),
+                )
+                .unwrap(),
         }
     }
 }
 
 impl From<ast::Literal> for Expr {
     fn from(lit: ast::Literal) -> Expr {
-        Expr::lit(CedarValueJson::from_lit(lit))
+        Builder::new().val(lit)
     }
 }
 
 impl From<ast::Var> for Expr {
     fn from(var: ast::Var) -> Expr {
-        Expr::var(var)
+        Builder::new().var(var)
     }
 }
 
 impl From<ast::SlotId> for Expr {
     fn from(slot: ast::SlotId) -> Expr {
-        Expr::slot(slot)
+        Builder::new().slot(slot)
     }
 }
 
 impl TryFrom<&Node<Option<cst::Expr>>> for Expr {
     type Error = ParseErrors;
     fn try_from(e: &Node<Option<cst::Expr>>) -> Result<Expr, ParseErrors> {
-        match &*e.try_as_inner()?.expr {
-            cst::ExprData::Or(node) => node.try_into(),
-            cst::ExprData::If(if_node, then_node, else_node) => {
-                let cond_expr = if_node.try_into()?;
-                let then_expr = then_node.try_into()?;
-                let else_expr = else_node.try_into()?;
-                Ok(Expr::ite(cond_expr, then_expr, else_expr))
-            }
-        }
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Or>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(o: &Node<Option<cst::Or>>) -> Result<Expr, ParseErrors> {
-        let o_node = o.try_as_inner()?;
-        let mut expr = (&o_node.initial).try_into()?;
-        for node in &o_node.extended {
-            let rhs = node.try_into()?;
-            expr = Expr::or(expr, rhs);
-        }
-        Ok(expr)
-    }
-}
-
-impl TryFrom<&Node<Option<cst::And>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(a: &Node<Option<cst::And>>) -> Result<Expr, ParseErrors> {
-        let a_node = a.try_as_inner()?;
-        let mut expr = (&a_node.initial).try_into()?;
-        for node in &a_node.extended {
-            let rhs = node.try_into()?;
-            expr = Expr::and(expr, rhs);
-        }
-        Ok(expr)
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Relation>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(r: &Node<Option<cst::Relation>>) -> Result<Expr, ParseErrors> {
-        match r.try_as_inner()? {
-            cst::Relation::Common { initial, extended } => {
-                let mut expr = initial.try_into()?;
-                for (op, node) in extended {
-                    let rhs = node.try_into()?;
-                    match op {
-                        cst::RelOp::Eq => {
-                            expr = Expr::eq(expr, rhs);
-                        }
-                        cst::RelOp::NotEq => {
-                            expr = Expr::noteq(expr, rhs);
-                        }
-                        cst::RelOp::In => {
-                            expr = Expr::_in(expr, rhs);
-                        }
-                        cst::RelOp::Less => {
-                            expr = Expr::less(expr, rhs);
-                        }
-                        cst::RelOp::LessEq => {
-                            expr = Expr::lesseq(expr, rhs);
-                        }
-                        cst::RelOp::Greater => {
-                            expr = Expr::greater(expr, rhs);
-                        }
-                        cst::RelOp::GreaterEq => {
-                            expr = Expr::greatereq(expr, rhs);
-                        }
-                        cst::RelOp::InvalidSingleEq => {
-                            return Err(ToASTError::new(
-                                ToASTErrorKind::InvalidSingleEq,
-                                r.loc.clone(),
-                            )
-                            .into());
-                        }
-                    }
-                }
-                Ok(expr)
-            }
-            cst::Relation::Has { target, field } => {
-                let target_expr: Expr = target.try_into()?;
-                let attrs = match field.to_has_rhs()? {
-                    Either::Left(attr) => nonempty![attr],
-                    Either::Right(ids) => ids.map(|id| id.to_smolstr()),
-                };
-                let (first, rest) = attrs.split_first();
-                let has_expr = Expr::has_attr(target_expr.clone(), first.clone());
-                let get_expr = Expr::get_attr(target_expr, first.clone());
-                Ok(rest
-                    .iter()
-                    .fold((has_expr, get_expr), |(has_expr, get_expr), attr| {
-                        (
-                            Expr::and(has_expr, Expr::has_attr(get_expr.clone(), attr.to_owned())),
-                            Expr::get_attr(get_expr, attr.to_owned()),
-                        )
-                    })
-                    .0)
-            }
-            cst::Relation::Like { target, pattern } => {
-                let target_expr = target.try_into()?;
-                pattern
-                    .to_expr_or_special()?
-                    .into_pattern()
-                    .map(|pat| Expr::like(target_expr, pat.into_iter().map(PatternElem::from)))
-            }
-            cst::Relation::IsIn {
-                target,
-                entity_type,
-                in_entity,
-            } => {
-                let target = target.try_into()?;
-                let type_str = entity_type.try_as_inner()?.to_string().into();
-                match in_entity {
-                    Some(in_entity) => Ok(Expr::is_entity_type_in(
-                        target,
-                        type_str,
-                        in_entity.try_into()?,
-                    )),
-                    None => Ok(Expr::is_entity_type(target, type_str)),
-                }
-            }
-        }
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Add>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(a: &Node<Option<cst::Add>>) -> Result<Expr, ParseErrors> {
-        let a_node = a.try_as_inner()?;
-        let mut expr = (&a_node.initial).try_into()?;
-        for (op, node) in &a_node.extended {
-            let rhs = node.try_into()?;
-            match op {
-                cst::AddOp::Plus => {
-                    expr = Expr::add(expr, rhs);
-                }
-                cst::AddOp::Minus => {
-                    expr = Expr::sub(expr, rhs);
-                }
-            }
-        }
-        Ok(expr)
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Mult>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(m: &Node<Option<cst::Mult>>) -> Result<Expr, ParseErrors> {
-        let m_node = m.try_as_inner()?;
-        let mut expr = (&m_node.initial).try_into()?;
-        for (op, node) in &m_node.extended {
-            let rhs = node.try_into()?;
-            match op {
-                cst::MultOp::Times => {
-                    expr = Expr::mul(expr, rhs);
-                }
-                cst::MultOp::Divide => {
-                    return Err(node.to_ast_err(ToASTErrorKind::UnsupportedDivision).into())
-                }
-                cst::MultOp::Mod => {
-                    return Err(node.to_ast_err(ToASTErrorKind::UnsupportedModulo).into())
-                }
-            }
-        }
-        Ok(expr)
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Unary>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(u: &Node<Option<cst::Unary>>) -> Result<Expr, ParseErrors> {
-        let u_node = u.try_as_inner()?;
-
-        match u_node.op {
-            Some(cst::NegOp::Bang(num_bangs)) => {
-                let inner = (&u_node.item).try_into()?;
-                match num_bangs {
-                    0 => Ok(inner),
-                    1 => Ok(Expr::not(inner)),
-                    2 => Ok(Expr::not(Expr::not(inner))),
-                    3 => Ok(Expr::not(Expr::not(Expr::not(inner)))),
-                    4 => Ok(Expr::not(Expr::not(Expr::not(Expr::not(inner))))),
-                    _ => Err(u
-                        .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Not))
-                        .into()),
-                }
-            }
-            Some(cst::NegOp::Dash(0)) => Ok((&u_node.item).try_into()?),
-            Some(cst::NegOp::Dash(mut num_dashes)) => {
-                let inner = match &u_node.item.to_lit() {
-                    Some(cst::Literal::Num(num)) => {
-                        match num.cmp(&(InputInteger::MAX as u64 + 1)) {
-                            std::cmp::Ordering::Less => {
-                                num_dashes -= 1;
-                                Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(
-                                    -(*num as InputInteger),
-                                )))
-                            }
-                            std::cmp::Ordering::Equal => {
-                                num_dashes -= 1;
-                                Expr::ExprNoExt(ExprNoExt::Value(CedarValueJson::Long(
-                                    InputInteger::MIN,
-                                )))
-                            }
-                            std::cmp::Ordering::Greater => {
-                                return Err(u_node
-                                    .item
-                                    .to_ast_err(ToASTErrorKind::IntegerLiteralTooLarge(*num))
-                                    .into());
-                            }
-                        }
-                    }
-                    _ => (&u_node.item).try_into()?,
-                };
-                match num_dashes {
-                    0 => Ok(inner),
-                    1 => Ok(Expr::neg(inner)),
-                    2 => {
-                        // not safe to collapse `--` to nothing
-                        Ok(Expr::neg(Expr::neg(inner)))
-                    }
-                    3 => Ok(Expr::neg(Expr::neg(Expr::neg(inner)))),
-                    4 => Ok(Expr::neg(Expr::neg(Expr::neg(Expr::neg(inner))))),
-                    _ => Err(u
-                        .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Neg))
-                        .into()),
-                }
-            }
-            Some(cst::NegOp::OverBang) => Err(u
-                .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Not))
-                .into()),
-            Some(cst::NegOp::OverDash) => Err(u
-                .to_ast_err(ToASTErrorKind::UnaryOpLimit(ast::UnaryOp::Neg))
-                .into()),
-            None => Ok((&u_node.item).try_into()?),
-        }
-    }
-}
-
-/// Convert the given `cst::Primary` into either a (possibly namespaced)
-/// function name, or an `Expr`.
-///
-/// (Upstream, the case where the `Primary` is a function name needs special
-/// handling, because in that case it is not a valid expression. In all other
-/// cases a `Primary` can be converted into an `Expr`.)
-fn interpret_primary(
-    p: &Node<Option<cst::Primary>>,
-) -> Result<Either<ast::Name, Expr>, ParseErrors> {
-    match p.try_as_inner()? {
-        cst::Primary::Literal(lit) => Ok(Either::Right(lit.try_into()?)),
-        cst::Primary::Ref(node) => match node.try_as_inner()? {
-            cst::Ref::Uid {
-                path,
-                eid: eid_node,
-            } => {
-                let maybe_name = path.to_name().map(ast::EntityType::from);
-                let maybe_eid = eid_node.as_valid_string();
-
-                let (name, eid) = flatten_tuple_2(maybe_name, maybe_eid)?;
-                match to_unescaped_string(eid) {
-                    Ok(eid) => Ok(Either::Right(Expr::lit(CedarValueJson::EntityEscape {
-                        __entity: TypeAndId::from(ast::EntityUID::from_components(
-                            name,
-                            ast::Eid::new(eid),
-                            None,
-                        )),
-                    }))),
-                    Err(unescape_errs) => {
-                        Err(ParseErrors::new_from_nonempty(unescape_errs.map(|err| {
-                            {
-                                crate::parser::err::ParseError::from(
-                                    eid_node.to_ast_err(ToASTErrorKind::Unescape(err)),
-                                )
-                            }
-                        })))
-                    }
-                }
-            }
-            r @ cst::Ref::Ref { .. } => Err(node
-                .to_ast_err(ToASTErrorKind::InvalidEntityLiteral(r.to_string()))
-                .into()),
-        },
-        cst::Primary::Name(node) => {
-            let name = node.try_as_inner()?;
-            let base_name = name.name.try_as_inner()?;
-            match (&name.path[..], base_name) {
-                (&[], cst::Ident::Principal) => Ok(Either::Right(Expr::var(ast::Var::Principal))),
-                (&[], cst::Ident::Action) => Ok(Either::Right(Expr::var(ast::Var::Action))),
-                (&[], cst::Ident::Resource) => Ok(Either::Right(Expr::var(ast::Var::Resource))),
-                (&[], cst::Ident::Context) => Ok(Either::Right(Expr::var(ast::Var::Context))),
-                (path, cst::Ident::Ident(id)) => Ok(Either::Left(
-                    ast::InternalName::new(
-                        id.parse()?,
-                        path.iter()
-                            .map(|node| {
-                                node.try_as_inner()
-                                    .map_err(Into::into)
-                                    .and_then(|id| id.to_string().parse().map_err(Into::into))
-                            })
-                            .collect::<Result<Vec<ast::Id>, ParseErrors>>()?,
-                        Some(node.loc.clone()),
-                    )
-                    .try_into()?,
-                )),
-                (path, id) => {
-                    let (l, r, src) = match (path.first(), path.last()) {
-                        (Some(l), Some(r)) => (
-                            l.loc.start(),
-                            r.loc.end() + ident_to_str_len(id),
-                            Arc::clone(&l.loc.src),
-                        ),
-                        (_, _) => (0, 0, Arc::from("")),
-                    };
-                    Err(ToASTError::new(
-                        ToASTErrorKind::ArbitraryVariable(name.to_string().into()),
-                        Loc::new(l..r, src),
-                    )
-                    .into())
-                }
-            }
-        }
-        cst::Primary::Slot(node) => Ok(Either::Right(Expr::slot(
-            node.try_as_inner()?
-                .try_into()
-                .map_err(|e| node.to_ast_err(e))?,
-        ))),
-        cst::Primary::Expr(e) => Ok(Either::Right(e.try_into()?)),
-        cst::Primary::EList(nodes) => nodes
-            .iter()
-            .map(|node| node.try_into())
-            .collect::<Result<Vec<Expr>, _>>()
-            .map(Expr::set)
-            .map(Either::Right),
-        cst::Primary::RInits(nodes) => nodes
-            .iter()
-            .map(|node| {
-                let cst::RecInit(k, v) = node.try_as_inner()?;
-                let s = k.to_expr_or_special().and_then(|es| es.into_valid_attr())?;
-                Ok((s, v.try_into()?))
-            })
-            .collect::<Result<BTreeMap<SmolStr, Expr>, ParseErrors>>()
-            .map(Expr::record)
-            .map(Either::Right),
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Member>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(m: &Node<Option<cst::Member>>) -> Result<Expr, ParseErrors> {
-        let m_node = m.try_as_inner()?;
-        let mut item: Either<ast::Name, Expr> = interpret_primary(&m_node.item)?;
-        for access in &m_node.access {
-            match access.try_as_inner()? {
-                cst::MemAccess::Field(node) => {
-                    let id = node.to_valid_ident()?;
-                    item = match item {
-                        Either::Left(name) => {
-                            return Err(node
-                                .to_ast_err(ToASTErrorKind::InvalidAccess {
-                                    lhs: name,
-                                    field: id.to_smolstr(),
-                                })
-                                .into())
-                        }
-                        Either::Right(expr) => Either::Right(Expr::get_attr(expr, id.to_smolstr())),
-                    };
-                }
-                cst::MemAccess::Call(args) => {
-                    // we have item(args).  We hope item is either:
-                    //   - an `ast::Name`, in which case we have a standard function call
-                    //   - or an expr of the form `x.y`, in which case y is the method
-                    //      name and not a field name. In the previous iteration of the
-                    //      `for` loop we would have made `item` equal to
-                    //      `Expr::GetAttr(x, y)`. Now we have to undo that to make a
-                    //      method call instead.
-                    //   - any other expression: it's an illegal call as the target is a higher order expression
-                    item = match item {
-                        Either::Left(name) => Either::Right(Expr::ext_call(
-                            name.to_string().into(),
-                            args.iter()
-                                .map(|node| node.try_into())
-                                .collect::<Result<Vec<_>, _>>()?,
-                        )),
-                        Either::Right(Expr::ExprNoExt(ExprNoExt::GetAttr { left, attr })) => {
-                            let args = args.iter().map(|node| node.try_into()).collect::<Result<
-                                Vec<Expr>,
-                                ParseErrors,
-                            >>(
-                            )?;
-                            let args = args.into_iter();
-                            match attr.as_str() {
-                                "contains" => Either::Right(Expr::contains(
-                                    left,
-                                    extract_single_argument(args, "contains()", &access.loc)?,
-                                )),
-                                "containsAll" => Either::Right(Expr::contains_all(
-                                    left,
-                                    extract_single_argument(args, "containsAll()", &access.loc)?,
-                                )),
-                                "containsAny" => Either::Right(Expr::contains_any(
-                                    left,
-                                    extract_single_argument(args, "containsAny()", &access.loc)?,
-                                )),
-                                "isEmpty" => {
-                                    require_zero_arguments(&args, "isEmpty()", &access.loc)?;
-                                    Either::Right(Expr::is_empty(left))
-                                }
-                                "getTag" => Either::Right(Expr::get_tag(
-                                    left,
-                                    extract_single_argument(args, "getTag()", &access.loc)?,
-                                )),
-                                "hasTag" => Either::Right(Expr::has_tag(
-                                    left,
-                                    extract_single_argument(args, "hasTag()", &access.loc)?,
-                                )),
-                                _ => {
-                                    // have to add the "receiver" argument as
-                                    // first in the list for the method call
-                                    let mut args = args.collect::<Vec<_>>();
-                                    args.insert(0, Arc::unwrap_or_clone(left));
-                                    Either::Right(Expr::ext_call(attr, args))
-                                }
-                            }
-                        }
-                        _ => return Err(access.to_ast_err(ToASTErrorKind::ExpressionCall).into()),
-                    };
-                }
-                cst::MemAccess::Index(node) => {
-                    let s = Expr::try_from(node)?
-                        .into_string_literal()
-                        .map_err(|_| node.to_ast_err(ToASTErrorKind::NonStringIndex))?;
-                    item = match item {
-                        Either::Left(name) => {
-                            return Err(node
-                                .to_ast_err(ToASTErrorKind::InvalidIndex {
-                                    lhs: name,
-                                    field: s,
-                                })
-                                .into())
-                        }
-                        Either::Right(expr) => Either::Right(Expr::get_attr(expr, s)),
-                    };
-                }
-            }
-        }
-        match item {
-            Either::Left(_) => Err(m.to_ast_err(ToASTErrorKind::MembershipInvariantViolation))?,
-            Either::Right(expr) => Ok(expr),
-        }
-    }
-}
-
-/// Return the single argument in `args` iterator, or return a wrong arity error
-/// if the iterator has 0 elements or more than 1 element.
-pub fn extract_single_argument<T>(
-    args: impl ExactSizeIterator<Item = T>,
-    fn_name: &'static str,
-    loc: &Loc,
-) -> Result<T, ParseErrors> {
-    let mut iter = args.fuse().peekable();
-    let first = iter.next();
-    let second = iter.peek();
-    match (first, second) {
-        (None, _) => Err(ParseErrors::singleton(ToASTError::new(
-            ToASTErrorKind::wrong_arity(fn_name, 1, 0),
-            loc.clone(),
-        ))),
-        (Some(_), Some(_)) => Err(ParseErrors::singleton(ToASTError::new(
-            ToASTErrorKind::wrong_arity(fn_name, 1, iter.len() + 1),
-            loc.clone(),
-        ))),
-        (Some(first), None) => Ok(first),
-    }
-}
-
-/// Return a wrong arity error if the iterator has any elements.
-pub fn require_zero_arguments<T>(
-    args: &impl ExactSizeIterator<Item = T>,
-    fn_name: &'static str,
-    loc: &Loc,
-) -> Result<(), ParseErrors> {
-    match args.len() {
-        0 => Ok(()),
-        n => Err(ParseErrors::singleton(ToASTError::new(
-            ToASTErrorKind::wrong_arity(fn_name, 0, n),
-            loc.clone(),
-        ))),
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Literal>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(lit: &Node<Option<cst::Literal>>) -> Result<Expr, ParseErrors> {
-        match lit.try_as_inner()? {
-            cst::Literal::True => Ok(Expr::lit(CedarValueJson::Bool(true))),
-            cst::Literal::False => Ok(Expr::lit(CedarValueJson::Bool(false))),
-            cst::Literal::Num(n) => Ok(Expr::lit(CedarValueJson::Long(
-                (*n).try_into()
-                    .map_err(|_| lit.to_ast_err(ToASTErrorKind::IntegerLiteralTooLarge(*n)))?,
-            ))),
-            cst::Literal::Str(node) => match node.try_as_inner()? {
-                cst::Str::String(s) => match to_unescaped_string(s) {
-                    Ok(s) => Ok(Expr::lit(CedarValueJson::String(s))),
-                    Err(errs) => {
-                        Err(ParseErrors::new_from_nonempty(errs.map(|err| {
-                            node.to_ast_err(ToASTErrorKind::Unescape(err)).into()
-                        })))
-                    }
-                },
-                cst::Str::Invalid(invalid_str) => Err(node
-                    .to_ast_err(ToASTErrorKind::InvalidString(invalid_str.to_string()))
-                    .into()),
-            },
-        }
-    }
-}
-
-impl TryFrom<&Node<Option<cst::Name>>> for Expr {
-    type Error = ParseErrors;
-    fn try_from(name: &Node<Option<cst::Name>>) -> Result<Expr, ParseErrors> {
-        let name_node = name.try_as_inner()?;
-        let base_name = name_node.name.try_as_inner()?;
-        match (&name_node.path[..], base_name) {
-            (&[], cst::Ident::Principal) => Ok(Expr::var(ast::Var::Principal)),
-            (&[], cst::Ident::Action) => Ok(Expr::var(ast::Var::Action)),
-            (&[], cst::Ident::Resource) => Ok(Expr::var(ast::Var::Resource)),
-            (&[], cst::Ident::Context) => Ok(Expr::var(ast::Var::Context)),
-            (_, _) => Err(name
-                .to_ast_err(ToASTErrorKind::ArbitraryVariable(
-                    name_node.to_string().into(),
-                ))
-                .into()),
-        }
-    }
-}
-
-/// Get the string length of an `Ident`. Used to print the source location for error messages
-fn ident_to_str_len(i: &Ident) -> usize {
-    match i {
-        Ident::Principal => 9,
-        Ident::Action => 6,
-        Ident::Resource => 8,
-        Ident::Context => 7,
-        Ident::True => 4,
-        Ident::False => 5,
-        Ident::Permit => 6,
-        Ident::Forbid => 6,
-        Ident::When => 4,
-        Ident::Unless => 6,
-        Ident::In => 2,
-        Ident::Has => 3,
-        Ident::Like => 4,
-        Ident::If => 2,
-        Ident::Then => 4,
-        Ident::Else => 4,
-        Ident::Ident(s) => s.len(),
-        Ident::Invalid(s) => s.len(),
-        Ident::Is => 2,
+        e.to_expr::<Builder>()
     }
 }
 
@@ -2104,7 +1567,10 @@ fn maybe_with_parens(
 // PANIC SAFETY: Unit Test Code
 #[allow(clippy::panic)]
 mod test {
-    use crate::parser::{err::ParseError, parse_expr};
+    use crate::parser::{
+        err::{ParseError, ToASTErrorKind},
+        parse_expr,
+    };
 
     use super::*;
     use ast::BoundedToString;
@@ -2112,23 +1578,13 @@ mod test {
 
     #[test]
     fn test_invalid_expr_from_cst_name() {
-        let src = "some_long_str";
-        let path = vec![Node::with_source_loc(
-            Some(cst::Ident::Ident(src.into())),
-            Loc::new(0..12, Arc::from(src)),
-        )];
-        let name = Node::with_source_loc(Some(cst::Ident::Else), Loc::new(13..16, Arc::from(src)));
-        let cst_name = Node::with_source_loc(
-            Some(cst::Name { path, name }),
-            Loc::new(0..16, Arc::from(src)),
-        );
-
-        assert_matches!(Expr::try_from(&cst_name), Err(e) => {
+        let e = crate::parser::text_to_cst::parse_expr("some_long_str::else").unwrap();
+        assert_matches!(Expr::try_from(&e), Err(e) => {
             assert!(e.len() == 1);
             assert_matches!(&e[0],
                 ParseError::ToAST(to_ast_error) => {
-                    assert_matches!(to_ast_error.kind(), ToASTErrorKind::ArbitraryVariable(s) => {
-                        assert_eq!(s, "some_long_str::else");
+                    assert_matches!(to_ast_error.kind(), ToASTErrorKind::ReservedIdentifier(s) => {
+                        assert_eq!(s.to_string(), "else");
                     });
                 }
             );

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1050,6 +1050,8 @@ impl Expr {
     }
 }
 
+// PANIC SAFETY: See comment on `unwrap`
+#[allow(clippy::fallible_impl_from)]
 impl<T: Clone> From<ast::Expr<T>> for Expr {
     fn from(expr: ast::Expr<T>) -> Expr {
         match expr.into_expr_kind() {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1104,8 +1104,7 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
             ast::ExprKind::Set(set) => {
                 Builder::new().set(Arc::unwrap_or_clone(set).into_iter().map(Into::into))
             }
-            // PANIC SAFETY: `map` is a map, so it will not have duplicates
-            // keys, so the `record` constructor cannot error.
+            // PANIC SAFETY: `map` is a map, so it will not have duplicates keys, so the `record` constructor cannot error.
             #[allow(clippy::unwrap_used)]
             ast::ExprKind::Record(map) => Builder::new()
                 .record(

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -297,8 +297,8 @@ pub trait ExprBuilder: Clone {
         })
     }
 
-    /// Create expression containing addition and subtraction that may have more
-    /// than two subexpressions (A + B - C) or may have only one subexpression,
+    /// Create expression containing multiplication that may have more than two
+    /// subexpressions (A * B * C) or may have only one subexpression,
     /// in which case no operations are performed at all.
     fn mul_nary(self, first: Self::Expr, other: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
     where

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -1,0 +1,292 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Contains the trait [`ExprBuilder`], defining a generic interface for
+//! building different expression data structures (e.g., AST and EST).
+
+use smol_str::SmolStr;
+
+use crate::{
+    ast::{
+        BinaryOp, EntityType, ExpressionConstructionError, Literal, Name, Pattern, SlotId, UnaryOp,
+        Unknown, Var,
+    },
+    parser::Loc,
+};
+
+/// Defines a generic interface for building different expression data
+/// structures.
+pub trait ExprBuilder {
+    /// The type of expression constructed by this instance of `ExprBuilder``.
+    type Expr: Clone + std::fmt::Display;
+
+    /// Type for extra information stored on nodes of the expression AST. This
+    /// can be `()` if no data is stored.
+    type Data: Clone + Default;
+
+    /// Construct a new expression builder for an expression that will not carry any data.
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Self::with_data(Self::Data::default())
+    }
+
+    /// Build an expression storing this information
+    fn with_data(data: Self::Data) -> Self;
+
+    /// Build an expression located at `l`, if `l` is Some. An implementation
+    /// may ignore this if it cannot store source information.
+    fn with_maybe_source_loc(self, l: Option<&Loc>) -> Self;
+
+    /// Build an expression located at `l`. An implementation may ignore this if
+    /// it cannot store source information.
+    fn with_source_loc(self, l: &Loc) -> Self
+    where
+        Self: Sized,
+    {
+        self.with_maybe_source_loc(Some(l))
+    }
+
+    /// Extract the location for this builder, if set. Used internally to
+    /// provide utilities that construct multiple nodes which should all be
+    /// reported as having the same source location.
+    fn loc(&self) -> Option<&Loc>;
+
+    /// Extract the the data that will be stored on the constructed expression.
+    /// Used internally to provide utilities that construct multiple nodes which
+    /// will all have the same data.
+    fn data(&self) -> &Self::Data;
+
+    /// Create an expression that's just a single `Literal`.
+    ///
+    /// Note that you can pass this a `Literal`, an `Integer`, a `String`, etc.
+    fn val(self, v: impl Into<Literal>) -> Self::Expr;
+
+    /// Create an `Expr` that's just this literal `Var`
+    fn var(self, v: Var) -> Self::Expr;
+
+    /// Create an `Unknown` `Expr`
+    fn unknown(self, u: Unknown) -> Self::Expr;
+
+    /// Create an `Expr` that's just this `SlotId`
+    fn slot(self, s: SlotId) -> Self::Expr;
+
+    /// Create a ternary (if-then-else) `Expr`.
+    fn ite(self, test_expr: Self::Expr, then_expr: Self::Expr, else_expr: Self::Expr)
+        -> Self::Expr;
+
+    /// Create a 'not' expression.
+    fn not(self, e: Self::Expr) -> Self::Expr;
+
+    /// Create a '==' expression
+    fn is_eq(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create an 'and' expression.
+    fn and(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create an 'or' expression.
+    fn or(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a '<' expression.
+    fn less(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a '<=' expression.
+    fn lesseq(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create an 'add' expression.
+    fn add(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a 'sub' expression.
+    fn sub(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a 'mul' expression.
+    fn mul(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a 'neg' expression.
+    fn neg(self, e: Self::Expr) -> Self::Expr;
+
+    /// Create an 'in' expression. First argument must evaluate to Entity type.
+    fn is_in(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a 'contains' expression.
+    fn contains(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create a 'contains_all' expression. Arguments must evaluate to Set type
+    fn contains_all(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create an 'contains_any' expression. Arguments must evaluate to Set type
+    fn contains_any(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+
+    /// Create an 'is_empty' expression. Argument must evaluate to Set type
+    fn is_empty(self, expr: Self::Expr) -> Self::Expr;
+
+    /// Create a 'getTag' expression.
+    fn get_tag(self, expr: Self::Expr, tag: Self::Expr) -> Self::Expr;
+
+    /// Create a 'hasTag' expression.
+    fn has_tag(self, expr: Self::Expr, tag: Self::Expr) -> Self::Expr;
+
+    /// Create an `Expr` which evaluates to a Set of the given `Expr`s
+    fn set(self, exprs: impl IntoIterator<Item = Self::Expr>) -> Self::Expr;
+
+    /// Create an `Expr` which evaluates to a Record with the given (key, value) pairs.
+    fn record(
+        self,
+        pairs: impl IntoIterator<Item = (SmolStr, Self::Expr)>,
+    ) -> Result<Self::Expr, ExpressionConstructionError>;
+
+    /// Create an `Expr` which calls the extension function with the given
+    /// `Name` on `args`
+    fn call_extension_fn(
+        self,
+        fn_name: Name,
+        args: impl IntoIterator<Item = Self::Expr>,
+    ) -> Self::Expr;
+
+    /// Create an `Expr` which gets a given attribute of a given `Entity` or record.
+    fn get_attr(self, expr: Self::Expr, attr: SmolStr) -> Self::Expr;
+
+    /// Create an `Expr` which tests for the existence of a given
+    /// attribute on a given `Entity` or record.
+    fn has_attr(self, expr: Self::Expr, attr: SmolStr) -> Self::Expr;
+
+    /// Create a 'like' expression.
+    fn like(self, expr: Self::Expr, pattern: Pattern) -> Self::Expr;
+
+    /// Create an 'is' expression.
+    fn is_entity_type(self, expr: Self::Expr, entity_type: EntityType) -> Self::Expr;
+
+    /// Create an `_ is _ in _`  expression
+    fn is_in_entity_type(
+        self,
+        e1: Self::Expr,
+        entity_type: EntityType,
+        e2: Self::Expr,
+    ) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        Self::with_data(self.data().clone()).and(
+            Self::with_data(self.data().clone()).is_entity_type(e1.clone(), entity_type),
+            Self::with_data(self.data().clone()).is_in(e1, e2),
+        )
+    }
+
+    /// Create an application `Expr` which applies the given built-in unary
+    /// operator to the given `arg`
+    fn unary_app(self, op: impl Into<UnaryOp>, arg: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        match op.into() {
+            UnaryOp::Not => self.not(arg),
+            UnaryOp::Neg => self.neg(arg),
+            UnaryOp::IsEmpty => self.is_empty(arg),
+        }
+    }
+
+    /// Create an application `Expr` which applies the given built-in binary
+    /// operator to `arg1` and `arg2`
+    fn binary_app(self, op: impl Into<BinaryOp>, arg1: Self::Expr, arg2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        match op.into() {
+            BinaryOp::Eq => self.is_eq(arg1, arg2),
+            BinaryOp::Less => self.less(arg1, arg2),
+            BinaryOp::LessEq => self.lesseq(arg1, arg2),
+            BinaryOp::Add => self.add(arg1, arg2),
+            BinaryOp::Sub => self.sub(arg1, arg2),
+            BinaryOp::Mul => self.mul(arg1, arg2),
+            BinaryOp::In => self.is_in(arg1, arg2),
+            BinaryOp::Contains => self.contains(arg1, arg2),
+            BinaryOp::ContainsAll => self.contains_all(arg1, arg2),
+            BinaryOp::ContainsAny => self.contains_any(arg1, arg2),
+            BinaryOp::GetTag => self.get_tag(arg1, arg2),
+            BinaryOp::HasTag => self.has_tag(arg1, arg2),
+        }
+    }
+
+    /// Create a '!=' expression.
+    fn noteq(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        Self::with_data(self.data().clone())
+            .with_maybe_source_loc(self.loc())
+            .not(self.is_eq(e1, e2))
+    }
+
+    /// Create a '>' expression.
+    fn greater(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        // e1 > e2 is defined as !(e1 <= e2)
+        Self::with_data(self.data().clone())
+            .with_maybe_source_loc(self.loc())
+            .not(self.lesseq(e1, e2))
+    }
+
+    /// Create a '>=' expression.
+    fn greatereq(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        // e1 >= e2 is defined as !(e1 < e2)
+        // TODO preserve source loc
+        Self::with_data(self.data().clone())
+            .with_maybe_source_loc(self.loc())
+            .not(self.less(e1, e2))
+    }
+
+    /// Create an `and` expression that may have more than two subexpressions (A && B && C)
+    /// or may have only one subexpression, in which case no `&&` is performed at all.
+    /// Arguments must evaluate to Bool type.
+    ///
+    /// This may create multiple AST `&&` nodes. If it does, all the nodes will have the same
+    /// source location and the same `T` data (taken from this builder) unless overridden, e.g.,
+    /// with another call to `with_source_loc()`.
+    fn and_nary(self, first: Self::Expr, others: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        others.into_iter().fold(first, |acc, next| {
+            Self::with_data(self.data().clone())
+                .with_maybe_source_loc(self.loc())
+                .and(acc, next)
+        })
+    }
+
+    /// Create an `or` expression that may have more than two subexpressions (A || B || C)
+    /// or may have only one subexpression, in which case no `||` is performed at all.
+    /// Arguments must evaluate to Bool type.
+    ///
+    /// This may create multiple AST `||` nodes. If it does, all the nodes will have the same
+    /// source location and the same `T` data (taken from this builder) unless overridden, e.g.,
+    /// with another call to `with_source_loc()`.
+    fn or_nary(self, first: Self::Expr, others: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        others.into_iter().fold(first, |acc, next| {
+            Self::with_data(self.data().clone())
+                .with_maybe_source_loc(self.loc())
+                .or(acc, next)
+        })
+    }
+}

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -29,6 +29,7 @@ use crate::{
 
 /// Defines a generic interface for building different expression data
 /// structures.
+#[allow(clippy::wrong_self_convention)]
 pub trait ExprBuilder {
     /// The type of expression constructed by this instance of `ExprBuilder``.
     type Expr: Clone + std::fmt::Display;

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -31,7 +31,7 @@ use crate::{
 /// structures.
 #[allow(clippy::wrong_self_convention)]
 pub trait ExprBuilder {
-    /// The type of expression constructed by this instance of `ExprBuilder``.
+    /// The type of expression constructed by this instance of `ExprBuilder`.
     type Expr: Clone + std::fmt::Display;
 
     /// Type for extra information stored on nodes of the expression AST. This
@@ -67,7 +67,7 @@ pub trait ExprBuilder {
     /// reported as having the same source location.
     fn loc(&self) -> Option<&Loc>;
 
-    /// Extract the the data that will be stored on the constructed expression.
+    /// Extract the data that will be stored on the constructed expression.
     /// Used internally to provide utilities that construct multiple nodes which
     /// will all have the same data.
     fn data(&self) -> &Self::Data;
@@ -249,7 +249,6 @@ pub trait ExprBuilder {
         Self: Sized,
     {
         // e1 >= e2 is defined as !(e1 < e2)
-        // TODO preserve source loc
         Self::with_data(self.data().clone())
             .with_maybe_source_loc(self.loc())
             .not(self.less(e1, e2))

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -30,13 +30,13 @@ use crate::{
 /// Defines a generic interface for building different expression data
 /// structures.
 #[allow(clippy::wrong_self_convention)]
-pub trait ExprBuilder {
+pub trait ExprBuilder: Clone {
     /// The type of expression constructed by this instance of `ExprBuilder`.
     type Expr: Clone + std::fmt::Display;
 
     /// Type for extra information stored on nodes of the expression AST. This
     /// can be `()` if no data is stored.
-    type Data: Clone + Default;
+    type Data: Default;
 
     /// Construct a new expression builder for an expression that will not carry any data.
     fn new() -> Self
@@ -181,9 +181,9 @@ pub trait ExprBuilder {
     where
         Self: Sized,
     {
-        Self::with_data(self.data().clone()).and(
-            Self::with_data(self.data().clone()).is_entity_type(e1.clone(), entity_type),
-            Self::with_data(self.data().clone()).is_in(e1, e2),
+        self.clone().and(
+            self.clone().is_entity_type(e1.clone(), entity_type),
+            self.clone().is_in(e1, e2),
         )
     }
 
@@ -227,9 +227,7 @@ pub trait ExprBuilder {
     where
         Self: Sized,
     {
-        Self::with_data(self.data().clone())
-            .with_maybe_source_loc(self.loc())
-            .not(self.is_eq(e1, e2))
+        self.clone().not(self.is_eq(e1, e2))
     }
 
     /// Create a '>' expression.
@@ -238,9 +236,7 @@ pub trait ExprBuilder {
         Self: Sized,
     {
         // e1 > e2 is defined as !(e1 <= e2)
-        Self::with_data(self.data().clone())
-            .with_maybe_source_loc(self.loc())
-            .not(self.lesseq(e1, e2))
+        self.clone().not(self.lesseq(e1, e2))
     }
 
     /// Create a '>=' expression.
@@ -249,9 +245,7 @@ pub trait ExprBuilder {
         Self: Sized,
     {
         // e1 >= e2 is defined as !(e1 < e2)
-        Self::with_data(self.data().clone())
-            .with_maybe_source_loc(self.loc())
-            .not(self.less(e1, e2))
+        self.clone().not(self.less(e1, e2))
     }
 
     /// Create an `and` expression that may have more than two subexpressions (A && B && C)
@@ -265,11 +259,9 @@ pub trait ExprBuilder {
     where
         Self: Sized,
     {
-        others.into_iter().fold(first, |acc, next| {
-            Self::with_data(self.data().clone())
-                .with_maybe_source_loc(self.loc())
-                .and(acc, next)
-        })
+        others
+            .into_iter()
+            .fold(first, |acc, next| self.clone().and(acc, next))
     }
 
     /// Create an `or` expression that may have more than two subexpressions (A || B || C)
@@ -283,10 +275,8 @@ pub trait ExprBuilder {
     where
         Self: Sized,
     {
-        others.into_iter().fold(first, |acc, next| {
-            Self::with_data(self.data().clone())
-                .with_maybe_source_loc(self.loc())
-                .or(acc, next)
-        })
+        others
+            .into_iter()
+            .fold(first, |acc, next| self.clone().or(acc, next))
     }
 }

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -183,7 +183,7 @@ pub trait ExprBuilder: Clone {
     {
         self.clone().and(
             self.clone().is_entity_type(e1.clone(), entity_type),
-            self.clone().is_in(e1, e2),
+            self.is_in(e1, e2),
         )
     }
 

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -30,6 +30,7 @@ pub mod entities;
 mod error_macros;
 pub mod est;
 pub mod evaluator;
+pub mod expr_builder;
 pub mod extensions;
 pub mod fuzzy_match;
 pub mod jsonvalue;

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -187,7 +187,7 @@ pub fn parse_policy_or_template_to_est(text: &str) -> Result<est::Policy, err::P
 /// or its constructors
 pub(crate) fn parse_expr(ptext: &str) -> Result<ast::Expr, err::ParseErrors> {
     let cst = text_to_cst::parse_expr(ptext)?;
-    cst.to_expr()
+    cst.to_expr::<ast::ExprBuilder<()>>()
 }
 
 /// parse a RestrictedExpr
@@ -225,7 +225,7 @@ pub(crate) fn parse_internal_name(name: &str) -> Result<ast::InternalName, err::
 /// or its constructors
 pub(crate) fn parse_literal(val: &str) -> Result<ast::Literal, err::LiteralParseError> {
     let cst = text_to_cst::parse_primary(val)?;
-    match cst.to_expr() {
+    match cst.to_expr::<ast::ExprBuilder<()>>() {
         Ok(ast) => match ast.expr_kind() {
             ast::ExprKind::Lit(v) => Ok(v.clone()),
             _ => Err(err::LiteralParseError::InvalidLiteral(ast)),
@@ -247,7 +247,7 @@ pub(crate) fn parse_literal(val: &str) -> Result<ast::Literal, err::LiteralParse
 pub fn parse_internal_string(val: &str) -> Result<SmolStr, err::ParseErrors> {
     // we need to add quotes for this to be a valid string literal
     let cst = text_to_cst::parse_primary(&format!(r#""{val}""#))?;
-    cst.to_string_literal()
+    cst.to_string_literal::<ast::ExprBuilder<()>>()
 }
 
 /// parse an identifier

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1109,9 +1109,7 @@ impl Node<Option<cst::Relation>> {
                         })
                     }
                     None => Ok(ExprOrSpecial::Expr {
-                        expr: Build::new()
-                            .with_source_loc(&self.loc)
-                            .is_entity_type(t, n),
+                        expr: Build::new().with_source_loc(&self.loc).is_entity_type(t, n),
                         loc: self.loc.clone(),
                     }),
                 }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1111,7 +1111,7 @@ impl Node<Option<cst::Relation>> {
                     None => Ok(ExprOrSpecial::Expr {
                         expr: Build::new()
                             .with_source_loc(&self.loc)
-                            .is_entity_type(t.clone(), n),
+                            .is_entity_type(t, n),
                         loc: self.loc.clone(),
                     }),
                 }
@@ -1395,6 +1395,7 @@ impl Node<Option<cst::Member>> {
     /// `next` access applied to `head`, and the second element is the new tail of
     /// acessors. In most cases, `tail` is returned unmodified, but in the method
     /// call case we need to pull off the `Call` element containing the arguments.
+    #[allow(clippy::type_complexity)]
     fn build_expr_accessor<'a, Build: ExprBuilder>(
         &self,
         head: Build::Expr,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -40,10 +40,10 @@ use super::node::Node;
 use super::unescape::{to_pattern, to_unescaped_string};
 use super::util::{flatten_tuple_2, flatten_tuple_3, flatten_tuple_4};
 use crate::ast::{
-    self, ActionConstraint, CallStyle, Integer, Pattern, PatternElem, PolicySetError,
-    PrincipalConstraint, PrincipalOrResourceConstraint, ResourceConstraint, UnreservedId,
+    self, ActionConstraint, CallStyle, Integer, PatternElem, PolicySetError, PrincipalConstraint,
+    PrincipalOrResourceConstraint, ResourceConstraint, UnreservedId,
 };
-use crate::est::{extract_single_argument, require_zero_arguments};
+use crate::expr_builder::ExprBuilder;
 use crate::fuzzy_match::fuzzy_search_limited;
 use itertools::Either;
 use nonempty::nonempty;
@@ -230,7 +230,7 @@ impl Node<Option<cst::Policy>> {
 
         // convert conditions
         let maybe_conds = ParseErrors::transpose(policy.conds.iter().map(|c| {
-            let (e, is_when) = c.to_expr()?;
+            let (e, is_when) = c.to_expr::<ast::ExprBuilder<()>>()?;
             let slot_errs = e.slots().map(|slot| {
                 ToASTError::new(
                     ToASTErrorKind::slots_in_condition_clause(
@@ -481,29 +481,35 @@ impl Node<Option<cst::Ident>> {
 }
 
 impl ast::UnreservedId {
-    fn to_meth(&self, e: ast::Expr, args: Vec<ast::Expr>, loc: &Loc) -> Result<ast::Expr> {
+    fn to_meth<Build: ExprBuilder>(
+        &self,
+        e: Build::Expr,
+        args: Vec<Build::Expr>,
+        loc: &Loc,
+    ) -> Result<Build::Expr> {
+        let builder = Build::new().with_source_loc(loc);
         match self.as_ref() {
             "contains" => extract_single_argument(args.into_iter(), "contains", loc)
-                .map(|arg| construct_method_contains(e, arg, loc.clone())),
+                .map(|arg| builder.contains(e, arg)),
             "containsAll" => extract_single_argument(args.into_iter(), "containsAll", loc)
-                .map(|arg| construct_method_contains_all(e, arg, loc.clone())),
+                .map(|arg| builder.contains_all(e, arg)),
             "containsAny" => extract_single_argument(args.into_iter(), "containsAny", loc)
-                .map(|arg| construct_method_contains_any(e, arg, loc.clone())),
+                .map(|arg| builder.contains_any(e, arg)),
             "isEmpty" => {
                 require_zero_arguments(&args.into_iter(), "isEmpty", loc)?;
-                Ok(construct_method_is_empty(e, loc.clone()))
+                Ok(builder.is_empty(e))
             }
             "getTag" => extract_single_argument(args.into_iter(), "getTag", loc)
-                .map(|arg| construct_method_get_tag(e, arg, loc.clone())),
+                .map(|arg| builder.get_tag(e, arg)),
             "hasTag" => extract_single_argument(args.into_iter(), "hasTag", loc)
-                .map(|arg| construct_method_has_tag(e, arg, loc.clone())),
+                .map(|arg| builder.has_tag(e, arg)),
             _ => {
                 if EXTENSION_STYLES.methods.contains(self) {
                     let args = NonEmpty {
                         head: e,
                         tail: args,
                     };
-                    Ok(construct_ext_meth(self.clone(), args, loc.clone()))
+                    Ok(builder.call_extension_fn(ast::Name::unqualified_name(self.clone()), args))
                 } else {
                     let unqual_name = ast::Name::unqualified_name(self.clone());
                     if EXTENSION_STYLES.functions.contains(&unqual_name) {
@@ -540,6 +546,44 @@ impl ast::UnreservedId {
                 }
             }
         }
+    }
+}
+
+/// Return the single argument in `args` iterator, or return a wrong arity error
+/// if the iterator has 0 elements or more than 1 element.
+fn extract_single_argument<T>(
+    args: impl ExactSizeIterator<Item = T>,
+    fn_name: &'static str,
+    loc: &Loc,
+) -> Result<T> {
+    let mut iter = args.fuse().peekable();
+    let first = iter.next();
+    let second = iter.peek();
+    match (first, second) {
+        (None, _) => Err(ParseErrors::singleton(ToASTError::new(
+            ToASTErrorKind::wrong_arity(fn_name, 1, 0),
+            loc.clone(),
+        ))),
+        (Some(_), Some(_)) => Err(ParseErrors::singleton(ToASTError::new(
+            ToASTErrorKind::wrong_arity(fn_name, 1, iter.len() + 1),
+            loc.clone(),
+        ))),
+        (Some(first), None) => Ok(first),
+    }
+}
+
+/// Return a wrong arity error if the iterator has any elements.
+fn require_zero_arguments<T>(
+    args: &impl ExactSizeIterator<Item = T>,
+    fn_name: &'static str,
+    loc: &Loc,
+) -> Result<()> {
+    match args.len() {
+        0 => Ok(()),
+        n => Err(ParseErrors::singleton(ToASTError::new(
+            ToASTErrorKind::wrong_arity(fn_name, 0, n),
+            loc.clone(),
+        ))),
     }
 }
 
@@ -583,13 +627,13 @@ impl Node<Option<cst::VariableDef>> {
         let var = vardef.variable.to_var()?;
 
         if let Some(unused_typename) = vardef.unused_type_name.as_ref() {
-            unused_typename.to_type_constraint()?;
+            unused_typename.to_type_constraint::<ast::ExprBuilder<()>>()?;
         }
 
         let c = if let Some((op, rel_expr)) = &vardef.ineq {
             // special check for the syntax `_ in _ is _`
             if op == &cst::RelOp::In {
-                if let Ok(expr) = rel_expr.to_expr() {
+                if let Ok(expr) = rel_expr.to_expr::<ast::ExprBuilder<()>>() {
                     if matches!(expr.expr_kind(), ast::ExprKind::Is { .. }) {
                         return Err(self.to_ast_err(ToASTErrorKind::InvertedIsIn).into());
                     }
@@ -601,7 +645,10 @@ impl Node<Option<cst::VariableDef>> {
                 (cst::RelOp::Eq, Some(_)) => Err(self.to_ast_err(ToASTErrorKind::IsWithEq)),
                 (cst::RelOp::In, None) => Ok(PrincipalOrResourceConstraint::In(eref)),
                 (cst::RelOp::In, Some(entity_type)) => {
-                    match entity_type.to_expr_or_special()?.into_entity_type() {
+                    match entity_type
+                        .to_expr_or_special::<ast::ExprBuilder<()>>()?
+                        .into_entity_type()
+                    {
                         Ok(et) => Ok(PrincipalOrResourceConstraint::IsIn(Arc::new(et), eref)),
                         Err(eos) => Err(eos.to_ast_err(ToASTErrorKind::InvalidIsType {
                             lhs: var.to_string(),
@@ -615,7 +662,10 @@ impl Node<Option<cst::VariableDef>> {
                 (op, _) => Err(self.to_ast_err(ToASTErrorKind::InvalidScopeOperator(*op))),
             }
         } else if let Some(entity_type) = &vardef.entity_type {
-            match entity_type.to_expr_or_special()?.into_entity_type() {
+            match entity_type
+                .to_expr_or_special::<ast::ExprBuilder<()>>()?
+                .into_entity_type()
+            {
                 Ok(et) => Ok(PrincipalOrResourceConstraint::Is(Arc::new(et))),
                 Err(eos) => Err(eos.to_ast_err(ToASTErrorKind::InvalidIsType {
                     lhs: var.to_string(),
@@ -649,7 +699,7 @@ impl Node<Option<cst::VariableDef>> {
         }?;
 
         if let Some(typename) = vardef.unused_type_name.as_ref() {
-            typename.to_type_constraint()?;
+            typename.to_type_constraint::<ast::ExprBuilder<()>>()?;
         }
 
         if vardef.entity_type.is_some() {
@@ -660,7 +710,7 @@ impl Node<Option<cst::VariableDef>> {
             let action_constraint = match op {
                 cst::RelOp::In => {
                     // special check for the syntax `_ in _ is _`
-                    if let Ok(expr) = rel_expr.to_expr() {
+                    if let Ok(expr) = rel_expr.to_expr::<ast::ExprBuilder<()>>() {
                         if matches!(expr.expr_kind(), ast::ExprKind::Is { .. }) {
                             return Err(self.to_ast_err(ToASTErrorKind::IsInActionScope).into());
                         }
@@ -701,13 +751,13 @@ impl Node<Option<cst::Cond>> {
     /// `true` if the cond is a `when` clause, `false` if it is an `unless`
     /// clause. (The returned `expr` is already adjusted for this, the `bool` is
     /// for information only.)
-    fn to_expr(&self) -> Result<(ast::Expr, bool)> {
+    fn to_expr<Build: ExprBuilder>(&self) -> Result<(Build::Expr, bool)> {
         let cond = self.try_as_inner()?;
 
         let is_when = cond.cond.to_cond_is_when()?;
 
         let maybe_expr = match &cond.expr {
-            Some(expr) => expr.to_expr(),
+            Some(expr) => expr.to_expr::<Build>(),
             None => {
                 let ident = match cond.cond.as_inner() {
                     Some(ident) => ident.clone(),
@@ -732,7 +782,7 @@ impl Node<Option<cst::Cond>> {
             if is_when {
                 (e, true)
             } else {
-                (construct_expr_not(e, self.loc.clone()), false)
+                (Build::new().with_source_loc(&self.loc).not(e), false)
             }
         })
     }
@@ -758,9 +808,9 @@ impl Node<Option<cst::Str>> {
 /// as function names, record names, or record attributes. This prevents parsing these
 /// terms to a general Expr expression and then immediately unwrapping them.
 #[derive(Debug)]
-pub(crate) enum ExprOrSpecial<'a> {
-    /// Any expression except a variable, name, or string literal
-    Expr { expr: ast::Expr, loc: Loc },
+pub(crate) enum ExprOrSpecial<'a, Expr> {
+    /// Any expression except a variable, name, string literal, or boolean literal
+    Expr { expr: Expr, loc: Loc },
     /// Variables, which act as expressions or names
     Var { var: ast::Var, loc: Loc },
     /// Name that isn't an expr and couldn't be converted to var
@@ -768,15 +818,21 @@ pub(crate) enum ExprOrSpecial<'a> {
     /// String literal, not yet unescaped
     /// Must be processed with to_unescaped_string or to_pattern before inclusion in the AST
     StrLit { lit: &'a SmolStr, loc: Loc },
+    /// A boolean literal
+    BoolLit { val: bool, loc: Loc },
 }
 
-impl ExprOrSpecial<'_> {
+impl<Expr> ExprOrSpecial<'_, Expr>
+where
+    Expr: std::fmt::Display,
+{
     fn loc(&self) -> &Loc {
         match self {
             Self::Expr { loc, .. } => loc,
             Self::Var { loc, .. } => loc,
             Self::Name { loc, .. } => loc,
             Self::StrLit { loc, .. } => loc,
+            Self::BoolLit { loc, .. } => loc,
         }
     }
 
@@ -784,10 +840,10 @@ impl ExprOrSpecial<'_> {
         ToASTError::new(kind.into(), self.loc().clone())
     }
 
-    fn into_expr(self) -> Result<ast::Expr> {
+    fn into_expr<Build: ExprBuilder<Expr = Expr>>(self) -> Result<Expr> {
         match self {
             Self::Expr { expr, .. } => Ok(expr),
-            Self::Var { var, loc } => Ok(construct_expr_var(var, loc)),
+            Self::Var { var, loc } => Ok(Build::new().with_source_loc(&loc).var(var)),
             Self::Name { name, loc } => Err(ToASTError::new(
                 ToASTErrorKind::ArbitraryVariable(name.to_string().into()),
                 loc,
@@ -795,12 +851,13 @@ impl ExprOrSpecial<'_> {
             .into()),
             Self::StrLit { lit, loc } => {
                 match to_unescaped_string(lit) {
-                    Ok(s) => Ok(construct_expr_string(s, loc)),
+                    Ok(s) => Ok(Build::new().with_source_loc(&loc).val(s)),
                     Err(escape_errs) => Err(ParseErrors::new_from_nonempty(escape_errs.map(|e| {
                         ToASTError::new(ToASTErrorKind::Unescape(e), loc.clone()).into()
                     }))),
                 }
             }
+            Self::BoolLit { val, loc } => Ok(Build::new().with_source_loc(&loc).val(val)),
         }
     }
 
@@ -817,6 +874,15 @@ impl ExprOrSpecial<'_> {
             }),
             Self::Expr { expr, loc } => Err(ToASTError::new(
                 ToASTErrorKind::InvalidAttribute(expr.to_string().into()),
+                loc,
+            )
+            .into()),
+            Self::BoolLit { val, loc } => Err(ToASTError::new(
+                ToASTErrorKind::ReservedIdentifier(if val {
+                    cst::Ident::True
+                } else {
+                    cst::Ident::False
+                }),
                 loc,
             )
             .into()),
@@ -839,6 +905,9 @@ impl ExprOrSpecial<'_> {
             Self::Expr { expr, .. } => Err(self
                 .to_ast_err(ToASTErrorKind::InvalidPattern(expr.to_string()))
                 .into()),
+            Self::BoolLit { val, .. } => Err(self
+                .to_ast_err(ToASTErrorKind::InvalidPattern(val.to_string()))
+                .into()),
         }
     }
     /// to string literal
@@ -858,6 +927,9 @@ impl ExprOrSpecial<'_> {
             Self::Expr { expr, .. } => Err(self
                 .to_ast_err(ToASTErrorKind::InvalidString(expr.to_string()))
                 .into()),
+            Self::BoolLit { val, .. } => Err(self
+                .to_ast_err(ToASTErrorKind::InvalidString(val.to_string()))
+                .into()),
         }
     }
 
@@ -869,32 +941,33 @@ impl ExprOrSpecial<'_> {
     /// Returns `Err` if `self` is not an `ast::Name`. The `Err` will give you the `self` reference back
     fn into_name(self) -> std::result::Result<ast::Name, Self> {
         match self {
-            Self::StrLit { .. } => Err(self),
             Self::Var { var, .. } => Ok(ast::Name::unqualified_name(var.into())),
             Self::Name { name, .. } => Ok(name),
-            Self::Expr { .. } => Err(self),
+            _ => Err(self),
         }
     }
 }
 
 impl Node<Option<cst::Expr>> {
     /// convert `cst::Expr` to `ast::Expr`
-    pub fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    pub fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
-    pub(crate) fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    pub(crate) fn to_expr_or_special<Build: ExprBuilder>(
+        &self,
+    ) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let expr = self.try_as_inner()?;
 
         match &*expr.expr {
-            cst::ExprData::Or(or) => or.to_expr_or_special(),
+            cst::ExprData::Or(or) => or.to_expr_or_special::<Build>(),
             cst::ExprData::If(i, t, e) => {
-                let maybe_guard = i.to_expr();
-                let maybe_then = t.to_expr();
-                let maybe_else = e.to_expr();
+                let maybe_guard = i.to_expr::<Build>();
+                let maybe_then = t.to_expr::<Build>();
+                let maybe_else = e.to_expr::<Build>();
 
                 let (i, t, e) = flatten_tuple_3(maybe_guard, maybe_then, maybe_else)?;
                 Ok(ExprOrSpecial::Expr {
-                    expr: construct_expr_if(i, t, e, self.loc.clone()),
+                    expr: Build::new().with_source_loc(&self.loc).ite(i, t, e),
                     loc: self.loc.clone(),
                 })
             }
@@ -903,60 +976,66 @@ impl Node<Option<cst::Expr>> {
 }
 
 impl Node<Option<cst::Or>> {
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let or = self.try_as_inner()?;
 
-        let maybe_first = or.initial.to_expr_or_special();
-        let maybe_rest = ParseErrors::transpose(or.extended.iter().map(|i| i.to_expr()));
+        let maybe_first = or.initial.to_expr_or_special::<Build>();
+        let maybe_rest = ParseErrors::transpose(or.extended.iter().map(|i| i.to_expr::<Build>()));
 
         let (first, rest) = flatten_tuple_2(maybe_first, maybe_rest)?;
-        let mut rest = rest.into_iter();
-        let second = rest.next();
-        match second {
-            None => Ok(first),
-            Some(second) => first.into_expr().map(|first| ExprOrSpecial::Expr {
-                expr: construct_expr_or(first, second, rest, &self.loc),
+        if rest.is_empty() {
+            // This case is required so the "special" expression variants are
+            // not converted into a plain `ExprOrSpecial::Expr`.
+            Ok(first)
+        } else {
+            first.into_expr::<Build>().map(|first| ExprOrSpecial::Expr {
+                expr: Build::new().with_source_loc(&self.loc).or_nary(first, rest),
                 loc: self.loc.clone(),
-            }),
+            })
         }
     }
 }
 
 impl Node<Option<cst::And>> {
-    fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    pub(crate) fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let and = self.try_as_inner()?;
 
-        let maybe_first = and.initial.to_expr_or_special();
-        let maybe_rest = ParseErrors::transpose(and.extended.iter().map(|i| i.to_expr()));
+        let maybe_first = and.initial.to_expr_or_special::<Build>();
+        let maybe_rest = ParseErrors::transpose(and.extended.iter().map(|i| i.to_expr::<Build>()));
 
         let (first, rest) = flatten_tuple_2(maybe_first, maybe_rest)?;
-        let mut rest = rest.into_iter();
-        let second = rest.next();
-        match second {
-            None => Ok(first),
-            Some(second) => first.into_expr().map(|first| ExprOrSpecial::Expr {
-                expr: construct_expr_and(first, second, rest, &self.loc),
+        if rest.is_empty() {
+            // This case is required so the "special" expression variants are
+            // not converted into a plain `ExprOrSpecial::Expr`.
+            Ok(first)
+        } else {
+            first.into_expr::<Build>().map(|first| ExprOrSpecial::Expr {
+                expr: Build::new()
+                    .with_source_loc(&self.loc)
+                    .and_nary(first, rest),
                 loc: self.loc.clone(),
-            }),
+            })
         }
     }
 }
 
 impl Node<Option<cst::Relation>> {
-    fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let rel = self.try_as_inner()?;
 
         match rel {
             cst::Relation::Common { initial, extended } => {
-                let maybe_first = initial.to_expr_or_special();
+                let maybe_first = initial.to_expr_or_special::<Build>();
                 let maybe_rest = ParseErrors::transpose(
-                    extended.iter().map(|(op, i)| i.to_expr().map(|e| (op, e))),
+                    extended
+                        .iter()
+                        .map(|(op, i)| i.to_expr::<Build>().map(|e| (op, e))),
                 );
                 let maybe_extra_elmts = if extended.len() > 1 {
                     Err(self.to_ast_err(ToASTErrorKind::AmbiguousOperators).into())
@@ -968,32 +1047,34 @@ impl Node<Option<cst::Relation>> {
                 let second = rest.next();
                 match second {
                     None => Ok(first),
-                    Some((&op, second)) => first.into_expr().and_then(|first| {
+                    Some((&op, second)) => first.into_expr::<Build>().and_then(|first| {
                         Ok(ExprOrSpecial::Expr {
-                            expr: construct_expr_rel(first, op, second, self.loc.clone())?,
+                            expr: construct_expr_rel::<Build>(first, op, second, self.loc.clone())?,
                             loc: self.loc.clone(),
                         })
                     }),
                 }
             }
             cst::Relation::Has { target, field } => {
-                let maybe_target = target.to_expr();
-                let maybe_field = Ok(match field.to_has_rhs()? {
+                let maybe_target = target.to_expr::<Build>();
+                let maybe_field = Ok(match field.to_has_rhs::<Build>()? {
                     Either::Left(s) => nonempty![s],
                     Either::Right(ids) => ids.map(|id| id.to_smolstr()),
                 });
                 let (target, field) = flatten_tuple_2(maybe_target, maybe_field)?;
                 Ok(ExprOrSpecial::Expr {
-                    expr: construct_exprs_extended_has(target, &field, &self.loc),
+                    expr: construct_exprs_extended_has::<Build>(target, &field, &self.loc),
                     loc: self.loc.clone(),
                 })
             }
             cst::Relation::Like { target, pattern } => {
-                let maybe_target = target.to_expr();
-                let maybe_pattern = pattern.to_expr_or_special()?.into_pattern();
+                let maybe_target = target.to_expr::<Build>();
+                let maybe_pattern = pattern.to_expr_or_special::<Build>()?.into_pattern();
                 let (target, pattern) = flatten_tuple_2(maybe_target, maybe_pattern)?;
                 Ok(ExprOrSpecial::Expr {
-                    expr: construct_expr_like(target, pattern, self.loc.clone()),
+                    expr: Build::new()
+                        .with_source_loc(&self.loc)
+                        .like(target, pattern.into()),
                     loc: self.loc.clone(),
                 })
             }
@@ -1002,9 +1083,9 @@ impl Node<Option<cst::Relation>> {
                 entity_type,
                 in_entity,
             } => {
-                let maybe_target = target.to_expr();
+                let maybe_target = target.to_expr::<Build>();
                 let maybe_entity_type = entity_type
-                    .to_expr_or_special()?
+                    .to_expr_or_special::<Build>()?
                     .into_entity_type()
                     .map_err(|eos| {
                         eos.to_ast_err(ToASTErrorKind::InvalidIsType {
@@ -1019,19 +1100,18 @@ impl Node<Option<cst::Relation>> {
                 let (t, n) = flatten_tuple_2(maybe_target, maybe_entity_type)?;
                 match in_entity {
                     Some(in_entity) => {
-                        let in_expr = in_entity.to_expr()?;
+                        let in_expr = in_entity.to_expr::<Build>()?;
                         Ok(ExprOrSpecial::Expr {
-                            expr: construct_expr_and(
-                                construct_expr_is(t.clone(), n, self.loc.clone()),
-                                construct_expr_rel(t, cst::RelOp::In, in_expr, self.loc.clone())?,
-                                std::iter::empty(),
-                                &self.loc,
-                            ),
+                            expr: Build::new()
+                                .with_source_loc(&self.loc)
+                                .is_in_entity_type(t, n, in_expr),
                             loc: self.loc.clone(),
                         })
                     }
                     None => Ok(ExprOrSpecial::Expr {
-                        expr: construct_expr_is(t, n, self.loc.clone()),
+                        expr: Build::new()
+                            .with_source_loc(&self.loc)
+                            .is_entity_type(t.clone(), n),
                         loc: self.loc.clone(),
                     }),
                 }
@@ -1041,8 +1121,8 @@ impl Node<Option<cst::Relation>> {
 }
 
 impl Node<Option<cst::Add>> {
-    fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
 
     // Peel the grammar onion until we see valid RHS
@@ -1054,7 +1134,9 @@ impl Node<Option<cst::Add>> {
     // added to directly tackle the CST to AST conversion for the has operator,
     // This design choice should be noninvasive to existing CST to AST logic,
     // despite producing deadcode.
-    pub(crate) fn to_has_rhs(&self) -> Result<Either<SmolStr, NonEmpty<UnreservedId>>> {
+    pub(crate) fn to_has_rhs<Build: ExprBuilder>(
+        &self,
+    ) -> Result<Either<SmolStr, NonEmpty<UnreservedId>>> {
         let inner @ cst::Add { initial, extended } = self.try_as_inner()?;
         let err = |loc| {
             ToASTError::new(ToASTErrorKind::InvalidHasRHS(inner.to_string().into()), loc).into()
@@ -1098,7 +1180,7 @@ impl Node<Option<cst::Add>> {
                 | cst::Primary::Ref(_)
                 | cst::Primary::Slot(_) => Err(err(item.loc.clone())),
                 cst::Primary::Literal(_) | cst::Primary::Name(_) => {
-                    let item = item.to_expr_or_special()?;
+                    let item = item.to_expr_or_special::<Build>()?;
                     match (item, access.as_slice()) {
                         (ExprOrSpecial::StrLit { lit, loc }, []) => Ok(Either::Left(
                             to_unescaped_string(lit).map_err(|escape_errs| {
@@ -1126,22 +1208,16 @@ impl Node<Option<cst::Add>> {
                                 .into())
                             }
                         }
-                        // Attempt to return a precise error message for RHS like `true.<...>`
-                        (ExprOrSpecial::Expr { loc, expr }, _) if expr.is_true() => {
-                            Err(ToASTError::new(
-                                ToASTErrorKind::ReservedIdentifier(cst::Ident::True),
-                                loc,
-                            )
-                            .into())
-                        }
-                        // Attempt to return a precise error message for RHS like `false.<...>`
-                        (ExprOrSpecial::Expr { loc, expr }, _) if expr.is_false() => {
-                            Err(ToASTError::new(
-                                ToASTErrorKind::ReservedIdentifier(cst::Ident::False),
-                                loc,
-                            )
-                            .into())
-                        }
+                        // Attempt to return a precise error message for RHS like `true.<...>` and `false.<...>`
+                        (ExprOrSpecial::BoolLit { val, loc }, _) => Err(ToASTError::new(
+                            ToASTErrorKind::ReservedIdentifier(if val {
+                                cst::Ident::True
+                            } else {
+                                cst::Ident::False
+                            }),
+                            loc,
+                        )
+                        .into()),
                         (ExprOrSpecial::Expr { loc, .. }, _) => Err(err(loc)),
                         _ => Err(err(self.loc.clone())),
                     }
@@ -1152,21 +1228,23 @@ impl Node<Option<cst::Add>> {
         }
     }
 
-    pub(crate) fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    pub(crate) fn to_expr_or_special<Build: ExprBuilder>(
+        &self,
+    ) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let add = self.try_as_inner()?;
 
-        let maybe_first = add.initial.to_expr_or_special();
+        let maybe_first = add.initial.to_expr_or_special::<Build>();
         let maybe_rest = ParseErrors::transpose(
             add.extended
                 .iter()
-                .map(|&(op, ref i)| i.to_expr().map(|e| (op, e))),
+                .map(|&(op, ref i)| i.to_expr::<Build>().map(|e| (op, e))),
         );
         let (first, rest) = flatten_tuple_2(maybe_first, maybe_rest)?;
         if !rest.is_empty() {
             // in this case, `first` must be an expr, we should check for errors there as well
-            let first = first.into_expr()?;
+            let first = first.into_expr::<Build>()?;
             Ok(ExprOrSpecial::Expr {
-                expr: construct_expr_add(first, rest, &self.loc),
+                expr: construct_chained_add::<Build>(first, rest, &self.loc),
                 loc: self.loc.clone(),
             })
         } else {
@@ -1176,15 +1254,15 @@ impl Node<Option<cst::Add>> {
 }
 
 impl Node<Option<cst::Mult>> {
-    fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let mult = self.try_as_inner()?;
 
-        let maybe_first = mult.initial.to_expr_or_special();
+        let maybe_first = mult.initial.to_expr_or_special::<Build>();
         let maybe_rest = ParseErrors::transpose(mult.extended.iter().map(|&(op, ref i)| {
-            i.to_expr().and_then(|e| match op {
+            i.to_expr::<Build>().and_then(|e| match op {
                 cst::MultOp::Times => Ok(e),
                 cst::MultOp::Divide => {
                     Err(self.to_ast_err(ToASTErrorKind::UnsupportedDivision).into())
@@ -1196,9 +1274,9 @@ impl Node<Option<cst::Mult>> {
         let (first, rest) = flatten_tuple_2(maybe_first, maybe_rest)?;
         if !rest.is_empty() {
             // in this case, `first` must be an expr, we should check for errors there as well
-            let first = first.into_expr()?;
+            let first = first.into_expr::<Build>()?;
             Ok(ExprOrSpecial::Expr {
-                expr: construct_expr_mul(first, rest, &self.loc),
+                expr: construct_chained_mul::<Build>(first, rest, &self.loc),
                 loc: self.loc.clone(),
             })
         } else {
@@ -1208,25 +1286,25 @@ impl Node<Option<cst::Mult>> {
 }
 
 impl Node<Option<cst::Unary>> {
-    fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let unary = self.try_as_inner()?;
 
         match unary.op {
-            None => unary.item.to_expr_or_special(),
+            None => unary.item.to_expr_or_special::<Build>(),
             Some(cst::NegOp::Bang(n)) => {
-                (0..n).fold(unary.item.to_expr_or_special(), |inner, _| {
+                (0..n).fold(unary.item.to_expr_or_special::<Build>(), |inner, _| {
                     inner
-                        .and_then(|e| e.into_expr())
+                        .and_then(|e| e.into_expr::<Build>())
                         .map(|expr| ExprOrSpecial::Expr {
-                            expr: construct_expr_not(expr, self.loc.clone()),
+                            expr: Build::new().with_source_loc(&self.loc).not(expr),
                             loc: self.loc.clone(),
                         })
                 })
             }
-            Some(cst::NegOp::Dash(0)) => unary.item.to_expr_or_special(),
+            Some(cst::NegOp::Dash(0)) => unary.item.to_expr_or_special::<Build>(),
             Some(cst::NegOp::Dash(c)) => {
                 // Test if there is a negative numeric literal.
                 // A negative numeric literal should match regex pattern
@@ -1236,11 +1314,13 @@ impl Node<Option<cst::Unary>> {
                 let (last, rc) = if let Some(cst::Literal::Num(n)) = unary.item.to_lit() {
                     match n.cmp(&(i64::MAX as u64 + 1)) {
                         Ordering::Equal => (
-                            Ok(construct_expr_num(i64::MIN, unary.item.loc.clone())),
+                            Ok(Build::new().with_source_loc(&unary.item.loc).val(i64::MIN)),
                             c - 1,
                         ),
                         Ordering::Less => (
-                            Ok(construct_expr_num(-(*n as i64), unary.item.loc.clone())),
+                            Ok(Build::new()
+                                .with_source_loc(&unary.item.loc)
+                                .val(-(*n as i64))),
                             c - 1,
                         ),
                         Ordering::Greater => (
@@ -1254,14 +1334,17 @@ impl Node<Option<cst::Unary>> {
                     // If the operand is not a CST literal, convert it into
                     // an expression.
                     (
-                        unary.item.to_expr_or_special().and_then(|i| i.into_expr()),
+                        unary
+                            .item
+                            .to_expr_or_special::<Build>()
+                            .and_then(|i| i.into_expr::<Build>()),
                         c,
                     )
                 };
                 // Fold the expression into a series of negation operations.
                 (0..rc)
                     .fold(last, |r, _| {
-                        r.map(|e| (construct_expr_neg(e, self.loc.clone())))
+                        r.map(|e| Build::new().with_source_loc(&self.loc).neg(e))
                     })
                     .map(|expr| ExprOrSpecial::Expr {
                         expr,
@@ -1279,9 +1362,9 @@ impl Node<Option<cst::Unary>> {
 }
 
 /// Temporary converted data, mirroring `cst::MemAccess`
-enum AstAccessor {
+enum AstAccessor<Expr> {
     Field(ast::UnreservedId),
-    Call(Vec<ast::Expr>),
+    Call(Vec<Expr>),
     Index(SmolStr),
 }
 
@@ -1312,12 +1395,12 @@ impl Node<Option<cst::Member>> {
     /// `next` access applied to `head`, and the second element is the new tail of
     /// acessors. In most cases, `tail` is returned unmodified, but in the method
     /// call case we need to pull off the `Call` element containing the arguments.
-    fn build_expr_accessor<'a>(
+    fn build_expr_accessor<'a, Build: ExprBuilder>(
         &self,
-        head: ast::Expr,
-        next: &mut AstAccessor,
-        tail: &'a mut [AstAccessor],
-    ) -> Result<(ast::Expr, &'a mut [AstAccessor])> {
+        head: Build::Expr,
+        next: &mut AstAccessor<Build::Expr>,
+        tail: &'a mut [AstAccessor<Build::Expr>],
+    ) -> Result<(Build::Expr, &'a mut [AstAccessor<Build::Expr>])> {
         use AstAccessor::*;
         match (next, tail) {
             // trying to "call" an expression as a function like `(1 + 1)("foo")`. Always an error.
@@ -1329,14 +1412,16 @@ impl Node<Option<cst::Member>> {
                 let args = std::mem::take(args);
                 // move the id out of the slice as well, to avoid cloning the internal string
                 let id = mem::replace(id, ast::UnreservedId::empty());
-                Ok((id.to_meth(head, args, &self.loc)?, rest))
+                Ok((id.to_meth::<Build>(head, args, &self.loc)?, rest))
             }
 
             // field of arbitrary expr like `(principal.foo).bar`
             (Field(id), rest) => {
                 let id = mem::replace(id, ast::UnreservedId::empty());
                 Ok((
-                    construct_expr_attr(head, id.to_smolstr(), self.loc.clone()),
+                    Build::new()
+                        .with_source_loc(&self.loc)
+                        .get_attr(head, id.to_smolstr()),
                     rest,
                 ))
             }
@@ -1344,16 +1429,20 @@ impl Node<Option<cst::Member>> {
             // index into arbitrary expr like `(principal.foo)["bar"]`
             (Index(i), rest) => {
                 let i = mem::take(i);
-                Ok((construct_expr_attr(head, i, self.loc.clone()), rest))
+                Ok((
+                    Build::new().with_source_loc(&self.loc).get_attr(head, i),
+                    rest,
+                ))
             }
         }
     }
 
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let mem = self.try_as_inner()?;
 
-        let maybe_prim = mem.item.to_expr_or_special();
-        let maybe_accessors = ParseErrors::transpose(mem.access.iter().map(|a| a.to_access()));
+        let maybe_prim = mem.item.to_expr_or_special::<Build>();
+        let maybe_accessors =
+            ParseErrors::transpose(mem.access.iter().map(|a| a.to_access::<Build>()));
 
         // Return errors in case parsing failed for any element
         let (prim, mut accessors) = flatten_tuple_2(maybe_prim, maybe_accessors)?;
@@ -1365,31 +1454,19 @@ impl Node<Option<cst::Member>> {
                 // no accessors, return head immediately.
                 (prim, []) => return Ok(prim),
 
-                // Any access on an arbitrary expression. We will handle the
-                // possibility of multiple chained accesses on this expression
-                // in the loop at the end of this function.
-                (Expr { expr, .. }, [next, rest @ ..]) => {
-                    self.build_expr_accessor(expr, next, rest)?
-                }
-                // String literals are handled the same ways as expressions
-                (StrLit { lit, loc }, [next, rest @ ..]) => {
-                    let str_lit_expr = match to_unescaped_string(lit) {
-                        Ok(s) => construct_expr_string(s, loc),
-                        Err(escape_errs) => {
-                            return Err(ParseErrors::new_from_nonempty(
-                                escape_errs
-                                    .map(|e| self.to_ast_err(ToASTErrorKind::Unescape(e)).into()),
-                            ))
-                        }
-                    };
-                    self.build_expr_accessor(str_lit_expr, next, rest)?
+                // Any access on an arbitrary expression (or string or boolean
+                // literal). We will handle the possibility of multiple chained
+                // accesses on this expression in the loop at the end of this
+                // function.
+                (prim @ (Expr { .. } | StrLit { .. } | BoolLit { .. }), [next, rest @ ..]) => {
+                    self.build_expr_accessor::<Build>(prim.into_expr::<Build>()?, next, rest)?
                 }
 
                 // function call
                 (Name { name, .. }, [Call(args), rest @ ..]) => {
                     // move the vec out of the slice, we won't use the slice after
                     let args = std::mem::take(args);
-                    (name.into_func(args, self.loc.clone())?, rest)
+                    (name.into_func::<Build>(args, self.loc.clone())?, rest)
                 }
                 // variable function call - error
                 (Var { var, .. }, [Call(_), ..]) => {
@@ -1408,7 +1485,11 @@ impl Node<Option<cst::Member>> {
                     // move the id out of the slice as well, to avoid cloning the internal string
                     let id = mem::replace(id, ast::UnreservedId::empty());
                     (
-                        id.to_meth(construct_expr_var(var, var_loc), args, &self.loc)?,
+                        id.to_meth::<Build>(
+                            Build::new().with_source_loc(&var_loc).var(var),
+                            args,
+                            &self.loc,
+                        )?,
                         rest,
                     )
                 }
@@ -1417,10 +1498,9 @@ impl Node<Option<cst::Member>> {
                 (Var { var, loc: var_loc }, [Field(i), rest @ ..]) => {
                     let id = mem::replace(i, ast::UnreservedId::empty());
                     (
-                        construct_expr_attr(
-                            construct_expr_var(var, var_loc),
+                        Build::new().with_source_loc(&self.loc).get_attr(
+                            Build::new().with_source_loc(&var_loc).var(var),
                             id.to_smolstr(),
-                            self.loc.clone(),
                         ),
                         rest,
                     )
@@ -1448,7 +1528,9 @@ impl Node<Option<cst::Member>> {
                 (Var { var, loc: var_loc }, [Index(i), rest @ ..]) => {
                     let i = mem::take(i);
                     (
-                        construct_expr_attr(construct_expr_var(var, var_loc), i, self.loc.clone()),
+                        Build::new()
+                            .with_source_loc(&self.loc)
+                            .get_attr(Build::new().with_source_loc(&var_loc).var(var), i),
                         rest,
                     )
                 }
@@ -1460,7 +1542,7 @@ impl Node<Option<cst::Member>> {
         // without need to consider the other cases until we've consumed the
         // list of accesses.
         while let [next, rest @ ..] = tail {
-            (head, tail) = self.build_expr_accessor(head, next, rest)?;
+            (head, tail) = self.build_expr_accessor::<Build>(head, next, rest)?;
         }
         Ok(ExprOrSpecial::Expr {
             expr: head,
@@ -1470,7 +1552,7 @@ impl Node<Option<cst::Member>> {
 }
 
 impl Node<Option<cst::MemAccess>> {
-    fn to_access(&self) -> Result<AstAccessor> {
+    fn to_access<Build: ExprBuilder>(&self) -> Result<AstAccessor<Build::Expr>> {
         let acc = self.try_as_inner()?;
 
         match acc {
@@ -1479,11 +1561,11 @@ impl Node<Option<cst::MemAccess>> {
                 maybe_ident.map(AstAccessor::Field)
             }
             cst::MemAccess::Call(args) => {
-                let maybe_args = ParseErrors::transpose(args.iter().map(|e| e.to_expr()));
+                let maybe_args = ParseErrors::transpose(args.iter().map(|e| e.to_expr::<Build>()));
                 maybe_args.map(AstAccessor::Call)
             }
             cst::MemAccess::Index(index) => {
-                let maybe_index = index.to_expr_or_special()?.into_string_literal();
+                let maybe_index = index.to_expr_or_special::<Build>()?.into_string_literal();
                 maybe_index.map(AstAccessor::Index)
             }
         }
@@ -1491,22 +1573,26 @@ impl Node<Option<cst::MemAccess>> {
 }
 
 impl Node<Option<cst::Primary>> {
-    pub(crate) fn to_expr(&self) -> Result<ast::Expr> {
-        self.to_expr_or_special()?.into_expr()
+    pub(crate) fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
+        self.to_expr_or_special::<Build>()?.into_expr::<Build>()
     }
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let prim = self.try_as_inner()?;
 
         match prim {
-            cst::Primary::Literal(lit) => lit.to_expr_or_special(),
-            cst::Primary::Ref(r) => r.to_expr().map(|expr| ExprOrSpecial::Expr {
+            cst::Primary::Literal(lit) => lit.to_expr_or_special::<Build>(),
+            cst::Primary::Ref(r) => r.to_expr::<Build>().map(|expr| ExprOrSpecial::Expr {
                 expr,
                 loc: r.loc.clone(),
             }),
-            cst::Primary::Slot(s) => s.clone().into_expr().map(|expr| ExprOrSpecial::Expr {
-                expr,
-                loc: s.loc.clone(),
-            }),
+            cst::Primary::Slot(s) => {
+                s.clone()
+                    .into_expr::<Build>()
+                    .map(|expr| ExprOrSpecial::Expr {
+                        expr,
+                        loc: s.loc.clone(),
+                    })
+            }
             #[allow(clippy::manual_map)]
             cst::Primary::Name(n) => {
                 // ignore errors in the case where `n` isn't a var - we'll get them elsewhere
@@ -1525,20 +1611,25 @@ impl Node<Option<cst::Primary>> {
                     })
                 }
             }
-            cst::Primary::Expr(e) => e.to_expr().map(|expr| ExprOrSpecial::Expr {
+            cst::Primary::Expr(e) => e.to_expr::<Build>().map(|expr| ExprOrSpecial::Expr {
                 expr,
                 loc: e.loc.clone(),
             }),
             cst::Primary::EList(es) => {
-                let maybe_list = ParseErrors::transpose(es.iter().map(|e| e.to_expr()));
+                let maybe_list = ParseErrors::transpose(es.iter().map(|e| e.to_expr::<Build>()));
                 maybe_list.map(|list| ExprOrSpecial::Expr {
-                    expr: construct_expr_set(list, self.loc.clone()),
+                    expr: Build::new().with_source_loc(&self.loc).set(list),
                     loc: self.loc.clone(),
                 })
             }
             cst::Primary::RInits(is) => {
-                let rec = ParseErrors::transpose(is.iter().map(|i| i.to_init()))?;
-                let expr = construct_expr_record(rec, self.loc.clone())?;
+                let rec = ParseErrors::transpose(is.iter().map(|i| i.to_init::<Build>()))?;
+                let expr = Build::new()
+                    .with_source_loc(&self.loc)
+                    .record(rec)
+                    .map_err(|e| {
+                        Into::<ParseErrors>::into(ToASTError::new(e.into(), self.loc.clone()))
+                    })?;
                 Ok(ExprOrSpecial::Expr {
                     expr,
                     loc: self.loc.clone(),
@@ -1548,11 +1639,11 @@ impl Node<Option<cst::Primary>> {
     }
 
     /// convert `cst::Primary` representing a string literal to a `SmolStr`.
-    pub fn to_string_literal(&self) -> Result<SmolStr> {
+    pub fn to_string_literal<Build: ExprBuilder>(&self) -> Result<SmolStr> {
         let prim = self.try_as_inner()?;
 
         match prim {
-            cst::Primary::Literal(lit) => lit.to_expr_or_special()?.into_string_literal(),
+            cst::Primary::Literal(lit) => lit.to_expr_or_special::<Build>()?.into_string_literal(),
             _ => Err(self
                 .to_ast_err(ToASTErrorKind::InvalidString(prim.to_string()))
                 .into()),
@@ -1561,11 +1652,9 @@ impl Node<Option<cst::Primary>> {
 }
 
 impl Node<Option<cst::Slot>> {
-    fn into_expr(self) -> Result<ast::Expr> {
+    fn into_expr<Build: ExprBuilder>(self) -> Result<Build::Expr> {
         match self.try_as_inner()?.try_into() {
-            Ok(slot_id) => Ok(ast::ExprBuilder::new()
-                .with_source_loc(self.loc)
-                .slot(slot_id)),
+            Ok(slot_id) => Ok(Build::new().with_source_loc(&self.loc).slot(slot_id)),
             Err(e) => Err(self.to_ast_err(e).into()),
         }
     }
@@ -1594,10 +1683,10 @@ impl From<ast::SlotId> for cst::Slot {
 
 impl Node<Option<cst::Name>> {
     /// Build type constraints
-    fn to_type_constraint(&self) -> Result<ast::Expr> {
+    fn to_type_constraint<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
         match self.as_inner() {
             Some(_) => Err(self.to_ast_err(ToASTErrorKind::TypeConstraints).into()),
-            None => Ok(construct_expr_bool(true, self.loc.clone())),
+            None => Ok(Build::new().with_source_loc(&self.loc).val(true)),
         }
     }
 
@@ -1668,7 +1757,11 @@ impl ast::Name {
         }
     }
 
-    fn into_func(self, args: Vec<ast::Expr>, loc: Loc) -> Result<ast::Expr> {
+    fn into_func<Build: ExprBuilder>(
+        self,
+        args: Vec<Build::Expr>,
+        loc: Loc,
+    ) -> Result<Build::Expr> {
         // error on standard methods
         if self.0.path.is_empty() {
             let id = self.basename();
@@ -1686,7 +1779,9 @@ impl ast::Name {
             }
         }
         if EXTENSION_STYLES.functions.contains(&self) {
-            Ok(construct_ext_func(self, args, loc))
+            Ok(Build::new()
+                .with_source_loc(&loc)
+                .call_extension_fn(self, args))
         } else {
             fn suggest_function(name: &ast::Name, funs: &HashSet<&ast::Name>) -> Option<String> {
                 const SUGGEST_FUNCTION_MAX_DISTANCE: usize = 3;
@@ -1722,35 +1817,38 @@ impl Node<Option<cst::Ref>> {
                 });
 
                 let (p, e) = flatten_tuple_2(maybe_path, maybe_eid)?;
-                Ok(construct_refr(p, e, self.loc.clone()))
+                Ok({
+                    let loc = self.loc.clone();
+                    ast::EntityUID::from_components(p, ast::Eid::new(e), Some(loc))
+                })
             }
             r @ cst::Ref::Ref { .. } => Err(self
                 .to_ast_err(ToASTErrorKind::InvalidEntityLiteral(r.to_string()))
                 .into()),
         }
     }
-    fn to_expr(&self) -> Result<ast::Expr> {
+    fn to_expr<Build: ExprBuilder>(&self) -> Result<Build::Expr> {
         self.to_ref()
-            .map(|euid| construct_expr_ref(euid, self.loc.clone()))
+            .map(|euid| Build::new().with_source_loc(&self.loc).val(euid))
     }
 }
 
 impl Node<Option<cst::Literal>> {
-    fn to_expr_or_special(&self) -> Result<ExprOrSpecial<'_>> {
+    fn to_expr_or_special<Build: ExprBuilder>(&self) -> Result<ExprOrSpecial<'_, Build::Expr>> {
         let lit = self.try_as_inner()?;
 
         match lit {
-            cst::Literal::True => Ok(ExprOrSpecial::Expr {
-                expr: construct_expr_bool(true, self.loc.clone()),
+            cst::Literal::True => Ok(ExprOrSpecial::BoolLit {
+                val: true,
                 loc: self.loc.clone(),
             }),
-            cst::Literal::False => Ok(ExprOrSpecial::Expr {
-                expr: construct_expr_bool(false, self.loc.clone()),
+            cst::Literal::False => Ok(ExprOrSpecial::BoolLit {
+                val: false,
                 loc: self.loc.clone(),
             }),
             cst::Literal::Num(n) => match Integer::try_from(*n) {
                 Ok(i) => Ok(ExprOrSpecial::Expr {
-                    expr: construct_expr_num(i, self.loc.clone()),
+                    expr: Build::new().with_source_loc(&self.loc).val(i),
                     loc: self.loc.clone(),
                 }),
                 Err(_) => Err(self
@@ -1769,11 +1867,11 @@ impl Node<Option<cst::Literal>> {
 }
 
 impl Node<Option<cst::RecInit>> {
-    fn to_init(&self) -> Result<(SmolStr, ast::Expr)> {
+    fn to_init<Build: ExprBuilder>(&self) -> Result<(SmolStr, Build::Expr)> {
         let lit = self.try_as_inner()?;
 
-        let maybe_attr = lit.0.to_expr_or_special()?.into_valid_attr();
-        let maybe_value = lit.1.to_expr();
+        let maybe_attr = lit.0.to_expr_or_special::<Build>()?.into_valid_attr();
+        let maybe_value = lit.1.to_expr::<Build>();
 
         flatten_tuple_2(maybe_attr, maybe_value)
     }
@@ -1808,13 +1906,14 @@ fn construct_template_policy(
     if let Some(first_expr) = conds_iter.next() {
         // a left fold of conditions
         // e.g., [c1, c2, c3,] --> ((c1 && c2) && c3)
-        construct_template(match conds_iter.next() {
-            Some(e) => construct_expr_and(first_expr, e, conds_iter, loc),
-            None => first_expr,
-        })
+        construct_template(
+            ast::ExprBuilder::new()
+                .with_source_loc(loc)
+                .and_nary(first_expr, conds_iter),
+        )
     } else {
         // use `true` to mark the absence of non-scope constraints
-        construct_template(construct_expr_bool(true, loc.clone()))
+        construct_template(ast::ExprBuilder::new().with_source_loc(loc).val(true))
     }
 }
 fn construct_string_from_var(v: ast::Var) -> SmolStr {
@@ -1832,65 +1931,14 @@ fn construct_name(path: Vec<ast::Id>, id: ast::Id, loc: Loc) -> ast::InternalNam
         loc: Some(loc),
     }
 }
-fn construct_refr(p: ast::EntityType, n: SmolStr, loc: Loc) -> ast::EntityUID {
-    ast::EntityUID::from_components(p, ast::Eid::new(n), Some(loc))
-}
-fn construct_expr_ref(r: ast::EntityUID, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).val(r)
-}
-fn construct_expr_num(n: Integer, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).val(n)
-}
-fn construct_expr_string(s: SmolStr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).val(s)
-}
-fn construct_expr_bool(b: bool, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).val(b)
-}
-fn construct_expr_neg(e: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).neg(e)
-}
-fn construct_expr_not(e: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).not(e)
-}
-fn construct_expr_var(v: ast::Var, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).var(v)
-}
-fn construct_expr_if(i: ast::Expr, t: ast::Expr, e: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).ite(i, t, e)
-}
-fn construct_expr_or(
-    f: ast::Expr,
-    s: ast::Expr,
-    chained: impl IntoIterator<Item = ast::Expr>,
-    loc: &Loc,
-) -> ast::Expr {
-    let first = ast::ExprBuilder::new()
-        .with_source_loc(loc.clone())
-        .or(f, s);
-    chained.into_iter().fold(first, |a, n| {
-        ast::ExprBuilder::new()
-            .with_source_loc(loc.clone())
-            .or(a, n)
-    })
-}
-fn construct_expr_and(
-    f: ast::Expr,
-    s: ast::Expr,
-    chained: impl IntoIterator<Item = ast::Expr>,
-    loc: &Loc,
-) -> ast::Expr {
-    let first = ast::ExprBuilder::new()
-        .with_source_loc(loc.clone())
-        .and(f, s);
-    chained.into_iter().fold(first, |a, n| {
-        ast::ExprBuilder::new()
-            .with_source_loc(loc.clone())
-            .and(a, n)
-    })
-}
-fn construct_expr_rel(f: ast::Expr, rel: cst::RelOp, s: ast::Expr, loc: Loc) -> Result<ast::Expr> {
-    let builder = ast::ExprBuilder::new().with_source_loc(loc.clone());
+
+fn construct_expr_rel<Build: ExprBuilder>(
+    f: Build::Expr,
+    rel: cst::RelOp,
+    s: Build::Expr,
+    loc: Loc,
+) -> Result<Build::Expr> {
+    let builder = Build::new().with_source_loc(&loc);
     match rel {
         cst::RelOp::Less => Ok(builder.less(f, s)),
         cst::RelOp::LessEq => Ok(builder.lesseq(f, s)),
@@ -1905,14 +1953,14 @@ fn construct_expr_rel(f: ast::Expr, rel: cst::RelOp, s: ast::Expr, loc: Loc) -> 
     }
 }
 /// used for a chain of addition and/or subtraction
-fn construct_expr_add(
-    f: ast::Expr,
-    chained: impl IntoIterator<Item = (cst::AddOp, ast::Expr)>,
+fn construct_chained_add<Build: ExprBuilder>(
+    f: Build::Expr,
+    chained: impl IntoIterator<Item = (cst::AddOp, Build::Expr)>,
     loc: &Loc,
-) -> ast::Expr {
+) -> Build::Expr {
     let mut expr = f;
     for (op, next_expr) in chained {
-        let builder = ast::ExprBuilder::new().with_source_loc(loc.clone());
+        let builder = Build::new().with_source_loc(loc);
         expr = match op {
             cst::AddOp::Plus => builder.add(expr, next_expr),
             cst::AddOp::Minus => builder.sub(expr, next_expr),
@@ -1921,30 +1969,30 @@ fn construct_expr_add(
     expr
 }
 /// used for a chain of multiplication only (no division or mod)
-fn construct_expr_mul(
-    f: ast::Expr,
-    chained: impl IntoIterator<Item = ast::Expr>,
+fn construct_chained_mul<Build: ExprBuilder>(
+    f: Build::Expr,
+    chained: impl IntoIterator<Item = Build::Expr>,
     loc: &Loc,
-) -> ast::Expr {
+) -> Build::Expr {
     let mut expr = f;
     for next_expr in chained {
-        expr = ast::ExprBuilder::new()
-            .with_source_loc(loc.clone())
-            .mul(expr, next_expr);
+        expr = Build::new().with_source_loc(loc).mul(expr, next_expr);
     }
     expr
 }
 
-fn construct_expr_has_attr(t: ast::Expr, s: SmolStr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).has_attr(t, s)
-}
-fn construct_expr_get_attr(t: ast::Expr, s: SmolStr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).get_attr(t, s)
-}
-fn construct_exprs_extended_has(t: ast::Expr, attrs: &NonEmpty<SmolStr>, loc: &Loc) -> ast::Expr {
+fn construct_exprs_extended_has<Build: ExprBuilder>(
+    t: Build::Expr,
+    attrs: &NonEmpty<SmolStr>,
+    loc: &Loc,
+) -> Build::Expr {
     let (first, rest) = attrs.split_first();
-    let has_expr = construct_expr_has_attr(t.clone(), first.to_owned(), loc.clone());
-    let get_expr = construct_expr_get_attr(t, first.to_owned(), loc.clone());
+    let has_expr = Build::new()
+        .with_source_loc(loc)
+        .has_attr(t.clone(), first.to_owned());
+    let get_expr = Build::new()
+        .with_source_loc(loc)
+        .get_attr(t, first.to_owned());
     // Foldl on the attribute list
     // It produces the following for `principal has contactInfo.address.zip`
     //     Expr.and
@@ -1969,77 +2017,18 @@ fn construct_exprs_extended_has(t: ast::Expr, attrs: &NonEmpty<SmolStr>, loc: &L
     rest.iter()
         .fold((has_expr, get_expr), |(has_expr, get_expr), attr| {
             (
-                construct_expr_and(
+                Build::new().with_source_loc(loc).and(
                     has_expr,
-                    construct_expr_has_attr(get_expr.clone(), attr.to_owned(), loc.clone()),
-                    std::iter::empty(),
-                    loc,
+                    Build::new()
+                        .with_source_loc(loc)
+                        .has_attr(get_expr.clone(), attr.to_owned()),
                 ),
-                construct_expr_get_attr(get_expr, attr.to_owned(), loc.clone()),
+                Build::new()
+                    .with_source_loc(loc)
+                    .get_attr(get_expr, attr.to_owned()),
             )
         })
         .0
-}
-fn construct_expr_attr(e: ast::Expr, s: SmolStr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).get_attr(e, s)
-}
-fn construct_expr_like(e: ast::Expr, s: Vec<PatternElem>, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .like(e, Pattern::from(s))
-}
-fn construct_expr_is(e: ast::Expr, n: ast::EntityType, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .is_entity_type(e, n)
-}
-fn construct_ext_func(name: ast::Name, args: Vec<ast::Expr>, loc: Loc) -> ast::Expr {
-    // INVARIANT (MethodStyleArgs): CallStyle is not MethodStyle, so any args vector is fine
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .call_extension_fn(name, args)
-}
-
-fn construct_method_contains(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .contains(e0, e1)
-}
-fn construct_method_contains_all(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .contains_all(e0, e1)
-}
-fn construct_method_contains_any(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .contains_any(e0, e1)
-}
-fn construct_method_is_empty(e: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).is_empty(e)
-}
-fn construct_method_get_tag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).get_tag(e0, e1)
-}
-fn construct_method_has_tag(e0: ast::Expr, e1: ast::Expr, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).has_tag(e0, e1)
-}
-
-fn construct_ext_meth(n: UnreservedId, args: NonEmpty<ast::Expr>, loc: Loc) -> ast::Expr {
-    let name = ast::Name::unqualified_name(n);
-    // Satisfies INVARIANT (MethodStyleArgs), because `args` is a `NonEmpty`, so it's not empty.
-    ast::ExprBuilder::new()
-        .with_source_loc(loc)
-        .call_extension_fn(name, args)
-}
-fn construct_expr_set(s: Vec<ast::Expr>, loc: Loc) -> ast::Expr {
-    ast::ExprBuilder::new().with_source_loc(loc).set(s)
-}
-fn construct_expr_record(kvs: Vec<(SmolStr, ast::Expr)>, loc: Loc) -> Result<ast::Expr> {
-    ast::ExprBuilder::new()
-        .with_source_loc(loc.clone())
-        .record(kvs)
-        .map_err(|e| ToASTError::new(e.into(), loc).into())
 }
 
 // PANIC SAFETY: Unit Test Code
@@ -2062,7 +2051,7 @@ mod tests {
     fn assert_parse_expr_succeeds(text: &str) -> Expr {
         text_to_cst::parse_expr(text)
             .expect("failed parser")
-            .to_expr()
+            .to_expr::<ast::ExprBuilder<()>>()
             .unwrap_or_else(|errs| {
                 panic!("failed conversion to AST:\n{:?}", miette::Report::new(errs))
             })
@@ -2072,7 +2061,7 @@ mod tests {
     fn assert_parse_expr_fails(text: &str) -> ParseErrors {
         let result = text_to_cst::parse_expr(text)
             .expect("failed parser")
-            .to_expr();
+            .to_expr::<ast::ExprBuilder<()>>();
         match result {
             Ok(expr) => {
                 panic!("conversion to AST should have failed, but succeeded with:\n{expr}")
@@ -3043,7 +3032,7 @@ mod tests {
 
     #[test]
     fn pattern_roundtrip() {
-        let test_pattern = Pattern::from(vec![
+        let test_pattern = ast::Pattern::from(vec![
             PatternElem::Char('h'),
             PatternElem::Char('e'),
             PatternElem::Char('l'),
@@ -3289,15 +3278,15 @@ mod tests {
         );
         assert_invalid_escape(
             r#"permit(principal, action, resource) when { "\q".contains(0) };"#,
-            r#""\q".contains(0)"#,
+            r#""\q""#,
         );
         assert_invalid_escape(
             r#"permit(principal, action, resource) when { "\q".bar };"#,
-            r#""\q".bar"#,
+            r#""\q""#,
         );
         assert_invalid_escape(
             r#"permit(principal, action, resource) when { "\q"["a"] };"#,
-            r#""\q"["a"]"#,
+            r#""\q""#,
         );
         assert_invalid_escape(
             r#"permit(principal, action, resource) when { "" like "\q" };"#,

--- a/cedar-policy-core/src/parser/unescape.rs
+++ b/cedar-policy-core/src/parser/unescape.rs
@@ -186,7 +186,7 @@ mod test {
         assert!(
             matches!(text_to_cst::parse_expr(r#""aa" like "\t\r\n\\\0\x42\*""#)
             .expect("failed parsing")
-            .to_expr()
+            .to_expr::<ast::ExprBuilder<()>>()
             .expect("failed conversion").expr_kind(),
             ast::ExprKind::Like {
                 expr: _,
@@ -200,7 +200,7 @@ mod test {
         // invalid ASCII escapes
         let errs = text_to_cst::parse_expr(r#""abc" like "abc\xFF\xFEdef""#)
             .expect("failed parsing")
-            .to_expr()
+            .to_expr::<ast::ExprBuilder<()>>()
             .unwrap_err();
         assert_eq!(errs.len(), 2);
         assert_matches!(&errs[0], ParseError::ToAST(e) => assert_matches!(e.kind(), ToASTErrorKind::Unescape(_)));
@@ -210,7 +210,7 @@ mod test {
         assert!(
             matches!(text_to_cst::parse_expr(r#""aaa" like "👀👀\*🤞🤞\*🤝""#)
             .expect("failed parsing")
-            .to_expr()
+            .to_expr::<ast::ExprBuilder<()>>()
             .expect("failed conversion").expr_kind(),
             ast::ExprKind::Like { expr: _, pattern} if pattern.to_string() == *r"👀👀\*🤞🤞\*🤝")
         );
@@ -218,7 +218,7 @@ mod test {
         // invalid escapes
         let errs = text_to_cst::parse_expr(r#""aaa" like "abc\d\bdef""#)
             .expect("failed parsing")
-            .to_expr()
+            .to_expr::<ast::ExprBuilder<()>>()
             .unwrap_err();
         assert_eq!(errs.len(), 2);
         assert_matches!(&errs[0], ParseError::ToAST(e) => assert_matches!(e.kind(), ToASTErrorKind::Unescape(_)));

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -723,7 +723,10 @@ impl Display for AttributeAccess {
 // optional attribute without a guard, then the help message is also printed.
 #[cfg(test)]
 mod test_attr_access {
-    use cedar_policy_core::ast::{EntityUID, Expr, ExprBuilder, ExprKind, Var};
+    use cedar_policy_core::{
+        ast::{EntityUID, Expr, ExprBuilder, ExprKind, Var},
+        expr_builder::ExprBuilder as _,
+    };
 
     use super::AttributeAccess;
     use crate::types::{OpenTag, RequestEnv, Type};

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -44,6 +44,7 @@ use cedar_policy_core::{
         BinaryOp, EntityType, EntityUID, Expr, ExprBuilder, ExprKind, Literal, Name, PolicyID,
         PrincipalOrResourceConstraint, SlotId, Template, UnaryOp, Var,
     },
+    expr_builder::ExprBuilder as _,
     extensions::Extensions,
 };
 

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -18,7 +18,10 @@ use cool_asserts::assert_matches;
 use serde_json::json;
 use std::collections::HashSet;
 
-use cedar_policy_core::ast::{EntityUID, Expr, ExprBuilder, PolicyID};
+use cedar_policy_core::{
+    ast::{EntityUID, Expr, ExprBuilder, PolicyID},
+    expr_builder::ExprBuilder as _,
+};
 
 use super::test_utils::{empty_schema_file, expr_id_placeholder};
 use crate::{json_schema, typecheck::Typechecker, types::Type, ValidationMode};

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6338,6 +6338,7 @@ mod reserved_keywords_in_policies {
     }
 
     #[track_caller]
+    #[allow(unused)]
     fn assert_invalid_expression_with_help(src: &str, error: &str, underline: &str, help: &str) {
         let expected_err = ExpectedErrorMessageBuilder::error(error)
             .exactly_one_underline(underline)
@@ -6381,11 +6382,15 @@ mod reserved_keywords_in_policies {
             // slightly different errors depending on `id`; related to #407
             match id {
                 "true" | "false" => {
-                    assert_invalid_expression_with_help(
+                    assert_invalid_expression(
                         &format!("{{ {id}: 1 }}"),
-                        &format!("invalid attribute name: {id}"),
+                        &RESERVED_IDENT_MSG(id),
                         id,
-                        "attribute names can either be identifiers or string literals",
+                    );
+                    assert_invalid_expression(
+                        &format!("principal has {id}"),
+                        &RESERVED_IDENT_MSG(id),
+                        id,
                     );
                     assert_invalid_expression(
                         &format!("principal has {id}"),


### PR DESCRIPTION
## Description of changes

Fix #1341. Fully removes the CST->EST code, instead reusing the CST->AST code for both conversion by introducing a generic expression builder. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
