### PR TITLE
add source locations to a bunch more errors

### DIFF
--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -626,7 +626,7 @@ impl ContextCreationError {
 /// Error subtypes for [`ContextCreationError`]
 pub mod context_creation_errors {
     use super::Expr;
-    use crate::impl_diagnostic_from_expr_field;
+    use crate::impl_diagnostic_from_method_on_field;
     use miette::Diagnostic;
     use thiserror::Error;
 
@@ -642,9 +642,9 @@ pub mod context_creation_errors {
         pub(super) expr: Box<Expr>,
     }
 
-    // custom impl of `Diagnostic`: take source location from the `expr` field
+    // custom impl of `Diagnostic`: take source location from the `expr` field's `.source_loc()` method
     impl Diagnostic for NotARecord {
-        impl_diagnostic_from_expr_field!(expr);
+        impl_diagnostic_from_method_on_field!(expr, source_loc);
     }
 }
 

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -639,7 +639,7 @@ pub enum RestrictedExpressionError {
 /// Error subtypes for [`RestrictedExpressionError`]
 pub mod restricted_expr_errors {
     use super::Expr;
-    use crate::impl_diagnostic_from_expr_field;
+    use crate::impl_diagnostic_from_method_on_field;
     use miette::Diagnostic;
     use smol_str::SmolStr;
     use thiserror::Error;
@@ -660,9 +660,9 @@ pub mod restricted_expr_errors {
         pub(crate) expr: Expr,
     }
 
-    // custom impl of `Diagnostic`: take source location from the `expr` field
+    // custom impl of `Diagnostic`: take source location from the `expr` field's `.source_loc()` method
     impl Diagnostic for InvalidRestrictedExpressionError {
-        impl_diagnostic_from_expr_field!(expr);
+        impl_diagnostic_from_method_on_field!(expr, source_loc);
     }
 }
 

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -277,10 +277,6 @@ impl<'a> ExpectedErrorMessage<'a> {
     }
 
     /// Internal helper: whether the underlines match
-    ///
-    /// `src` is the full source text (which the miette labels index into).
-    /// It can be omitted only in the case where we expect no underlines.
-    /// Panics if this invariant is violated.
     fn matches_underlines(&self, err: &impl miette::Diagnostic) -> bool {
         let expected_num_labels = self.underlines.len();
         let actual_num_labels = err.labels().map(|iter| iter.count()).unwrap_or(0);
@@ -315,18 +311,15 @@ impl<'a> ExpectedErrorMessage<'a> {
     }
 
     /// Internal helper: assert the underlines match
-    ///
-    /// `src` is the full source text (which the miette labels index into).
-    /// It can be omitted only in the case where we expect no underlines.
-    /// Panics if this invariant is violated.
     #[track_caller]
-    fn expect_underlines_match(&self, src: Option<&'a str>, err: &miette::Report) {
+    fn expect_underlines_match(&self, err: &miette::Report) {
         let expected_num_labels = self.underlines.len();
         let actual_num_labels = err.labels().map(|iter| iter.count()).unwrap_or(0);
         assert_eq!(expected_num_labels, actual_num_labels, "in the following error:\n{err:?}\n\nexpected {expected_num_labels} underlines but found {actual_num_labels}"); // the Debug representation of miette::Report is the pretty one
         if expected_num_labels != 0 {
-            let src =
-                src.expect("src can be `None` only in the case where we expect no underlines");
+            let src = err
+                .source_code()
+                .expect("err.source_code() should be `Some` if we are expecting underlines");
             for (expected, actual) in self
                 .underlines
                 .iter()
@@ -335,11 +328,8 @@ impl<'a> ExpectedErrorMessage<'a> {
                 let (expected_snippet, expected_label) = expected;
                 let actual_snippet = {
                     let span = actual.inner();
-                    if span.offset() < src.len() {
-                        &src[span.offset()..span.offset() + span.len()]
-                    } else {
-                        ""
-                    }
+                    std::str::from_utf8(src.read_span(span, 0, 0).expect("should read span").data())
+                        .expect("should be utf8 encoded")
                 };
                 let actual_label = actual.label();
                 assert_eq!(
@@ -433,18 +423,5 @@ pub fn expect_err<'a>(
     msg.expect_error_matches(src, err);
     msg.expect_help_matches(src, err);
     msg.expect_source_matches(src, err);
-    if msg.underlines.is_empty() {
-        msg.expect_underlines_match(None, err);
-    } else {
-        match src.into() {
-            OriginalInput::String(s) => {
-                msg.expect_underlines_match(Some(s), err);
-            }
-            OriginalInput::Json(val) => {
-                // need to convert to string so we can compute the underlines
-                let src = serde_json::to_string_pretty(val).unwrap();
-                msg.expect_underlines_match(Some(&src), err);
-            }
-        }
-    }
+    msg.expect_underlines_match(err);
 }

--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -22,10 +22,10 @@ use std::{collections::HashSet, fmt::Display};
 use itertools::Itertools;
 use miette::Diagnostic;
 use nonempty::NonEmpty;
-use smol_str::{SmolStr, ToSmolStr};
 use thiserror::Error;
 
 use crate::{json_schema, RawName};
+use cedar_policy_core::{ast::InternalName, impl_diagnostic_from_method_on_nonempty_field};
 
 impl<N: Display> Display for json_schema::Fragment<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -171,17 +171,23 @@ pub enum ToCedarSchemaSyntaxError {
 }
 
 /// Duplicate names were found in the schema
-#[derive(Debug, Error, Diagnostic)]
+//
+// This is NOT a publicly exported error type.
+#[derive(Debug, Error)]
 #[error("There are name collisions: [{}]", .names.iter().join(", "))]
 pub struct NameCollisionsError {
     /// Names that had collisions
-    names: NonEmpty<SmolStr>,
+    names: NonEmpty<InternalName>,
+}
+
+impl Diagnostic for NameCollisionsError {
+    impl_diagnostic_from_method_on_nonempty_field!(names, loc);
 }
 
 impl NameCollisionsError {
     /// Get the names that had collisions
-    pub fn names(&self) -> impl Iterator<Item = &str> {
-        self.names.iter().map(smol_str::SmolStr::as_str)
+    pub fn names(&self) -> impl Iterator<Item = &InternalName> {
+        self.names.iter()
     }
 }
 
@@ -203,24 +209,21 @@ impl NameCollisionsError {
 pub fn json_schema_to_cedar_schema_str<N: Display>(
     json_schema: &json_schema::Fragment<N>,
 ) -> Result<String, ToCedarSchemaSyntaxError> {
-    let mut name_collisions: Vec<SmolStr> = Vec::new();
+    let mut name_collisions: Vec<InternalName> = Vec::new();
     for (name, ns) in json_schema.0.iter().filter(|(name, _)| !name.is_none()) {
-        let entity_types: HashSet<SmolStr> = ns
+        let entity_types: HashSet<InternalName> = ns
             .entity_types
             .keys()
             .map(|ty_name| {
-                RawName::new_from_unreserved(ty_name.clone())
-                    .qualify_with_name(name.as_ref())
-                    .to_smolstr()
+                RawName::new_from_unreserved(ty_name.clone()).qualify_with_name(name.as_ref())
             })
             .collect();
-        let common_types: HashSet<SmolStr> = ns
+        let common_types: HashSet<InternalName> = ns
             .common_types
             .keys()
             .map(|ty_name| {
                 RawName::new_from_unreserved(ty_name.clone().into())
                     .qualify_with_name(name.as_ref())
-                    .to_smolstr()
             })
             .collect();
         name_collisions.extend(entity_types.intersection(&common_types).cloned());

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -304,17 +304,22 @@ pub enum RequestValidationError {
 /// Errors related to validation
 pub mod request_validation_errors {
     use cedar_policy_core::ast;
+    use cedar_policy_core::impl_diagnostic_from_method_on_field;
     use itertools::Itertools;
     use miette::Diagnostic;
     use std::sync::Arc;
     use thiserror::Error;
 
     /// Request action is not declared in the schema
-    #[derive(Debug, Error, Diagnostic)]
+    #[derive(Debug, Error)]
     #[error("request's action `{action}` is not declared in the schema")]
     pub struct UndeclaredActionError {
         /// Action which was not declared in the schema
         pub(super) action: Arc<ast::EntityUID>,
+    }
+
+    impl Diagnostic for UndeclaredActionError {
+        impl_diagnostic_from_method_on_field!(action, loc);
     }
 
     impl UndeclaredActionError {
@@ -325,11 +330,15 @@ pub mod request_validation_errors {
     }
 
     /// Request principal is of a type not declared in the schema
-    #[derive(Debug, Error, Diagnostic)]
+    #[derive(Debug, Error)]
     #[error("principal type `{principal_ty}` is not declared in the schema")]
     pub struct UndeclaredPrincipalTypeError {
         /// Principal type which was not declared in the schema
         pub(super) principal_ty: ast::EntityType,
+    }
+
+    impl Diagnostic for UndeclaredPrincipalTypeError {
+        impl_diagnostic_from_method_on_field!(principal_ty, loc);
     }
 
     impl UndeclaredPrincipalTypeError {
@@ -340,11 +349,15 @@ pub mod request_validation_errors {
     }
 
     /// Request resource is of a type not declared in the schema
-    #[derive(Debug, Error, Diagnostic)]
+    #[derive(Debug, Error)]
     #[error("resource type `{resource_ty}` is not declared in the schema")]
     pub struct UndeclaredResourceTypeError {
         /// Resource type which was not declared in the schema
         pub(super) resource_ty: ast::EntityType,
+    }
+
+    impl Diagnostic for UndeclaredResourceTypeError {
+        impl_diagnostic_from_method_on_field!(resource_ty, loc);
     }
 
     impl UndeclaredResourceTypeError {
@@ -356,9 +369,8 @@ pub mod request_validation_errors {
 
     /// Request principal is of a type that is declared in the schema, but is
     /// not valid for the request action
-    #[derive(Debug, Error, Diagnostic)]
+    #[derive(Debug, Error)]
     #[error("principal type `{principal_ty}` is not valid for `{action}`")]
-    #[diagnostic(help("{}", invalid_principal_type_help(valid_principal_tys, .action.as_ref())))]
     pub struct InvalidPrincipalTypeError {
         /// Principal type which is not valid
         pub(super) principal_ty: ast::EntityType,
@@ -366,6 +378,19 @@ pub mod request_validation_errors {
         pub(super) action: Arc<ast::EntityUID>,
         /// Principal types which actually are valid for that `action`
         pub(super) valid_principal_tys: Vec<ast::EntityType>,
+    }
+
+    impl Diagnostic for InvalidPrincipalTypeError {
+        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+            Some(Box::new(invalid_principal_type_help(
+                &self.valid_principal_tys,
+                &self.action,
+            )))
+        }
+
+        // possible future improvement: provide two labels, one for the source
+        // loc on `principal_ty` and the other for the source loc on `action`
+        impl_diagnostic_from_method_on_field!(principal_ty, loc);
     }
 
     fn invalid_principal_type_help(
@@ -405,9 +430,8 @@ pub mod request_validation_errors {
 
     /// Request resource is of a type that is declared in the schema, but is
     /// not valid for the request action
-    #[derive(Debug, Error, Diagnostic)]
+    #[derive(Debug, Error)]
     #[error("resource type `{resource_ty}` is not valid for `{action}`")]
-    #[diagnostic(help("{}", invalid_resource_type_help(valid_resource_tys, .action.as_ref())))]
     pub struct InvalidResourceTypeError {
         /// Resource type which is not valid
         pub(super) resource_ty: ast::EntityType,
@@ -415,6 +439,19 @@ pub mod request_validation_errors {
         pub(super) action: Arc<ast::EntityUID>,
         /// Resource types which actually are valid for that `action`
         pub(super) valid_resource_tys: Vec<ast::EntityType>,
+    }
+
+    impl Diagnostic for InvalidResourceTypeError {
+        fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
+            Some(Box::new(invalid_resource_type_help(
+                &self.valid_resource_tys,
+                &self.action,
+            )))
+        }
+
+        // possible future improvement: provide two labels, one for the source
+        // loc on `resource_ty` and the other for the source loc on `action`
+        impl_diagnostic_from_method_on_field!(resource_ty, loc);
     }
 
     fn invalid_resource_type_help(

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -456,7 +456,10 @@ impl ValidatorSchema {
                 match common_types.entry(name) {
                     Entry::Vacant(v) => v.insert(ty),
                     Entry::Occupied(o) => {
-                        return Err(DuplicateCommonTypeError(o.key().clone()).into());
+                        return Err(DuplicateCommonTypeError {
+                            ty: o.key().clone(),
+                        }
+                        .into());
                     }
                 };
             }
@@ -465,7 +468,10 @@ impl ValidatorSchema {
                 match entity_type_fragments.entry(name) {
                     Entry::Vacant(v) => v.insert(entity_type),
                     Entry::Occupied(o) => {
-                        return Err(DuplicateEntityTypeError(o.key().clone()).into())
+                        return Err(DuplicateEntityTypeError {
+                            ty: o.key().clone(),
+                        }
+                        .into())
                     }
                 };
             }
@@ -516,8 +522,8 @@ impl ValidatorSchema {
                     Self::record_attributes_or_none(
                         unresolved.resolve_common_type_refs(&common_types)?,
                     )
-                    .ok_or_else(|| {
-                        ContextOrShapeNotRecordError(ContextOrShape::EntityTypeShape(name.clone()))
+                    .ok_or_else(|| ContextOrShapeNotRecordError {
+                        ctx_or_shape: ContextOrShape::EntityTypeShape(name.clone()),
                     })?
                 };
                 let tags = entity_type
@@ -558,8 +564,8 @@ impl ValidatorSchema {
                     Self::record_attributes_or_none(
                         unresolved.resolve_common_type_refs(&common_types)?,
                     )
-                    .ok_or_else(|| {
-                        ContextOrShapeNotRecordError(ContextOrShape::ActionContext(name.clone()))
+                    .ok_or_else(|| ContextOrShapeNotRecordError {
+                        ctx_or_shape: ContextOrShape::ActionContext(name.clone()),
                     })?
                 };
                 Ok((
@@ -670,8 +676,8 @@ impl ValidatorSchema {
                 }
             }
         }
-        if !undeclared_e.is_empty() {
-            return Err(UndeclaredEntityTypesError(undeclared_e).into());
+        if let Some(types) = NonEmpty::collect(undeclared_e) {
+            return Err(UndeclaredEntityTypesError { types }.into());
         }
         if let Some(euids) = NonEmpty::collect(undeclared_a) {
             // This should not happen, because undeclared actions should be caught
@@ -1408,7 +1414,7 @@ impl<'a> CommonTypeResolver<'a> {
     // [`InternalName`] of a common type to its [`Type`] definition
     fn resolve(&self, extensions: &Extensions<'_>) -> Result<HashMap<&'a InternalName, Type>> {
         let sorted_names = self.topo_sort().map_err(|n| {
-            SchemaError::CycleInCommonTypeReferences(CycleInCommonTypeReferencesError(n))
+            SchemaError::CycleInCommonTypeReferences(CycleInCommonTypeReferencesError { ty: n })
         })?;
 
         let mut resolve_table: HashMap<&InternalName, json_schema::Type<InternalName>> =
@@ -1657,6 +1663,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve types: Grop, Usr, Phoot"#)
                     .help("`Grop` has not been declared as an entity type")
+                    .exactly_one_underline("Grop")
                     .build());
         });
     }
@@ -1681,6 +1688,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve type: Bar::Group"#)
                     .help("`Bar::Group` has not been declared as an entity type")
+                    .exactly_one_underline("Bar::Group")
                     .build());
         });
     }
@@ -1707,6 +1715,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve types: Bar::User, Bar::Photo"#)
                     .help("`Bar::User` has not been declared as an entity type")
+                    .exactly_one_underline("Bar::User")
                     .build());
         });
     }
@@ -1768,7 +1777,7 @@ pub(crate) mod test {
         let schema: Result<ValidatorSchema> = schema_file.try_into();
         assert_matches!(
             schema,
-            Err(SchemaError::CycleInActionHierarchy(CycleInActionHierarchyError(euid))) => {
+            Err(SchemaError::CycleInActionHierarchy(CycleInActionHierarchyError { uid: euid })) => {
                 assert_eq!(euid, r#"Action::"view_photo""#.parse().unwrap());
             }
         )
@@ -1907,6 +1916,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve type: C::D::Foo"#)
                     .help("`C::D::Foo` has not been declared as an entity type")
+                    .exactly_one_underline("C::D::Foo")
                     .build());
         });
     }
@@ -2487,8 +2497,8 @@ pub(crate) mod test {
         );
 
         // should error because schema fragments have duplicate types
-        assert_matches!(schema, Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError(s))) => {
-            assert_eq!(s, "A::MyLong".parse().unwrap());
+        assert_matches!(schema, Err(SchemaError::DuplicateCommonType(DuplicateCommonTypeError { ty })) => {
+            assert_eq!(ty, "A::MyLong".parse().unwrap());
         });
     }
 
@@ -2872,6 +2882,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve type: Demo::id"#)
                     .help("`Demo::id` has not been declared as a common type")
+                    .exactly_one_underline("Demo::id")
                     .build());
         });
     }
@@ -2899,6 +2910,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve type: undeclared"#)
                     .help("`undeclared` has not been declared as an entity type")
+                    .exactly_one_underline("undeclared")
                     .build());
         });
     }
@@ -2931,6 +2943,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve type: undeclared"#)
                     .help("`undeclared` has not been declared as an entity type")
+                    .exactly_one_underline("undeclared")
                     .build());
         });
     }
@@ -2961,6 +2974,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error(r#"failed to resolve type: undeclared"#)
                     .help("`undeclared` has not been declared as an entity type")
+                    .exactly_one_underline("undeclared")
                     .build());
         });
     }
@@ -3609,6 +3623,7 @@ pub(crate) mod test {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error("failed to resolve type: __cedar")
                     .help("`__cedar` has not been declared as a common type")
+                    .exactly_one_underline("__cedar")
                     .build(),
             );
         });
@@ -4756,6 +4771,7 @@ mod entity_tags {
                 &miette::Report::new(e),
                 &ExpectedErrorMessageBuilder::error("failed to resolve type: Undef")
                     .help("`Undef` has not been declared as a common or entity type")
+                    .exactly_one_underline("Undef")
                     .build(),
             );
         });

--- a/cedar-policy-validator/src/schema/err.rs
+++ b/cedar-policy-validator/src/schema/err.rs
@@ -382,7 +382,9 @@ pub mod schema_errors {
             } else {
                 write!(f, "undeclared entity types: ")?;
             }
-            join_with_conjunction(f, "and", self.types.iter(), |f, s| s.fmt(f))
+            join_with_conjunction(f, "and", self.types.iter().sorted_unstable(), |f, s| {
+                s.fmt(f)
+            })
         }
     }
 

--- a/cedar-policy-validator/src/schema/raw_name.rs
+++ b/cedar-policy-validator/src/schema/raw_name.rs
@@ -243,6 +243,11 @@ impl ConditionalName {
         self.possibilities.iter()
     }
 
+    /// Get the source location of this [`ConditionalName`]
+    pub fn loc(&self) -> Option<&Loc> {
+        self.raw.loc()
+    }
+
     /// Resolve the [`ConditionalName`] into a fully-qualified [`InternalName`],
     /// given that `all_defs` includes all fully-qualified [`InternalName`]s
     /// defined in all schema fragments.
@@ -282,7 +287,9 @@ impl ConditionalName {
                 return Ok(possibility.clone());
             }
         }
-        Err(TypeNotDefinedError(nonempty![self]))
+        Err(TypeNotDefinedError {
+            undefined_types: nonempty![self],
+        })
     }
 
     /// Provide a help message for the case where this [`ConditionalName`] failed to resolve

--- a/cedar-policy-validator/src/schema/test_579.rs
+++ b/cedar-policy-validator/src/schema/test_579.rs
@@ -1145,14 +1145,12 @@ fn A1c() {
     let expected_cedar =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as a common or entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
     let expected_json =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
+            .exactly_one_underline("MyType")
             .build();
     assert_parse_error_cedar(&c_cedar(A1_cedar()), &expected_cedar);
     assert_parse_error_json(A1X1_json(c_json()), &expected_json);
@@ -1171,13 +1169,11 @@ fn A2a2() {
 fn A2b1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&b1_cedar(A2_cedar()), &expected_cedar);
     assert_parse_error_json(A2X1_json(b1_json()), &expected_json);
@@ -1186,13 +1182,11 @@ fn A2b1() {
 fn A2b2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&b2_cedar(A2_cedar()), &expected_cedar);
     assert_parse_error_json(A2X2_json(b2_json()), &expected_json);
@@ -1201,13 +1195,11 @@ fn A2b2() {
 fn A2c() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&c_cedar(A2_cedar()), &expected_cedar);
     assert_parse_error_json(A2X1_json(c_json()), &expected_json);
@@ -1216,13 +1208,11 @@ fn A2c() {
 fn A3a1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&a1_cedar(A3_cedar()), &expected_cedar);
     assert_parse_error_json(A3X1_json(a1_json()), &expected_json);
@@ -1231,13 +1221,11 @@ fn A3a1() {
 fn A3a2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&a2_cedar(A3_cedar()), &expected_cedar);
     assert_parse_error_json(A3X2_json(a2_json()), &expected_json);
@@ -1246,13 +1234,11 @@ fn A3a2() {
 fn A3b1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&b1_cedar(A3_cedar()), &expected_cedar);
     assert_parse_error_json(A3X1_json(b1_json()), &expected_json);
@@ -1261,13 +1247,11 @@ fn A3b1() {
 fn A3b2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&b2_cedar(A3_cedar()), &expected_cedar);
     assert_parse_error_json(A3X2_json(b2_json()), &expected_json);
@@ -1276,13 +1260,11 @@ fn A3b2() {
 fn A3c() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&c_cedar(A3_cedar()), &expected_cedar);
     assert_parse_error_json(A3X1_json(c_json()), &expected_json);
@@ -1322,14 +1304,12 @@ fn B1c() {
     let expected_cedar =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as a common or entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
     let expected_json =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
+            .exactly_one_underline("MyType")
             .build();
     assert_parse_error_cedar(&c_cedar(B1_cedar()), &expected_cedar);
     assert_parse_error_json(B1X1_json(c_json()), &expected_json);
@@ -1348,13 +1328,11 @@ fn B2a2() {
 fn B2b1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&b1_cedar(B2_cedar()), &expected_cedar);
     assert_parse_error_json(B2X1_json(b1_json()), &expected_json);
@@ -1363,13 +1341,11 @@ fn B2b1() {
 fn B2b2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&b2_cedar(B2_cedar()), &expected_cedar);
     assert_parse_error_json(B2X2_json(b2_json()), &expected_json);
@@ -1378,13 +1354,11 @@ fn B2b2() {
 fn B2c() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&c_cedar(B2_cedar()), &expected_cedar);
     assert_parse_error_json(B2X1_json(c_json()), &expected_json);
@@ -1393,13 +1367,11 @@ fn B2c() {
 fn B3a1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&a1_cedar(B3_cedar()), &expected_cedar);
     assert_parse_error_json(B3X1_json(a1_json()), &expected_json);
@@ -1408,13 +1380,11 @@ fn B3a1() {
 fn B3a2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&a2_cedar(B3_cedar()), &expected_cedar);
     assert_parse_error_json(B3X2_json(a2_json()), &expected_json);
@@ -1423,13 +1393,11 @@ fn B3a2() {
 fn B3b1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&b1_cedar(B3_cedar()), &expected_cedar);
     assert_parse_error_json(B3X1_json(b1_json()), &expected_json);
@@ -1438,13 +1406,11 @@ fn B3b1() {
 fn B3b2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&b2_cedar(B3_cedar()), &expected_cedar);
     assert_parse_error_json(B3X2_json(b2_json()), &expected_json);
@@ -1453,13 +1419,11 @@ fn B3b2() {
 fn B3c() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&c_cedar(B3_cedar()), &expected_cedar);
     assert_parse_error_json(B3X1_json(c_json()), &expected_json);
@@ -1499,14 +1463,12 @@ fn C1c() {
     let expected_cedar =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as a common or entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
     let expected_json =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
+            .exactly_one_underline("MyType")
             .build();
     assert_parse_error_cedar(&c_cedar(C1_cedar()), &expected_cedar);
     assert_parse_error_json(C1X1_json(c_json()), &expected_json);
@@ -1525,13 +1487,11 @@ fn C2a2() {
 fn C2b1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&b1_cedar(C2_cedar()), &expected_cedar);
     assert_parse_error_json(C2X1_json(b1_json()), &expected_json);
@@ -1540,13 +1500,11 @@ fn C2b1() {
 fn C2b2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&b2_cedar(C2_cedar()), &expected_cedar);
     assert_parse_error_json(C2X2_json(b2_json()), &expected_json);
@@ -1555,13 +1513,11 @@ fn C2b2() {
 fn C2c() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS1::MyType")
         .build();
     assert_parse_error_cedar(&c_cedar(C2_cedar()), &expected_cedar);
     assert_parse_error_json(C2X1_json(c_json()), &expected_json);
@@ -1570,13 +1526,11 @@ fn C2c() {
 fn C3a1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&a1_cedar(C3_cedar()), &expected_cedar);
     assert_parse_error_json(C3X1_json(a1_json()), &expected_json);
@@ -1585,13 +1539,11 @@ fn C3a1() {
 fn C3a2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&a2_cedar(C3_cedar()), &expected_cedar);
     assert_parse_error_json(C3X2_json(a2_json()), &expected_json);
@@ -1600,13 +1552,11 @@ fn C3a2() {
 fn C3b1() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&b1_cedar(C3_cedar()), &expected_cedar);
     assert_parse_error_json(C3X1_json(b1_json()), &expected_json);
@@ -1615,13 +1565,11 @@ fn C3b1() {
 fn C3b2() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&b2_cedar(C3_cedar()), &expected_cedar);
     assert_parse_error_json(C3X2_json(b2_json()), &expected_json);
@@ -1630,13 +1578,11 @@ fn C3b2() {
 fn C3c() {
     let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as a common or entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
     let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
     assert_parse_error_cedar(&c_cedar(C3_cedar()), &expected_cedar);
     assert_parse_error_json(C3X1_json(c_json()), &expected_json);
@@ -1662,20 +1608,13 @@ fn D1a2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
-            .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            .build();
-    assert_parse_error_cedar(&a2_cedar(D1_cedar()), &expected_cedar);
-    assert_parse_error_json(D1_json(a2_json()), &expected_json);
+    assert_parse_error_cedar(&a2_cedar(D1_cedar()), &expected);
+    assert_parse_error_json(D1_json(a2_json()), &expected);
 }
 #[test]
 fn D1b1() {
@@ -1688,37 +1627,23 @@ fn D1b2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
-            .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            .build();
-    assert_parse_error_cedar(&b2_cedar(D1_cedar()), &expected_cedar);
-    assert_parse_error_json(D1_json(b2_json()), &expected_json);
+    assert_parse_error_cedar(&b2_cedar(D1_cedar()), &expected);
+    assert_parse_error_json(D1_json(b2_json()), &expected);
 }
 #[test]
 fn D1c() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
-            .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            .build();
-    assert_parse_error_cedar(&c_cedar(D1_cedar()), &expected_cedar);
-    assert_parse_error_json(D1_json(c_json()), &expected_json);
+    assert_parse_error_cedar(&c_cedar(D1_cedar()), &expected);
+    assert_parse_error_json(D1_json(c_json()), &expected);
 }
 #[test]
 fn D2a1() {
@@ -1731,138 +1656,84 @@ fn D2a2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&a2_cedar(D2_cedar()), &expected_cedar);
-    assert_parse_error_json(D2_json(a2_json()), &expected_json);
+    assert_parse_error_cedar(&a2_cedar(D2_cedar()), &expected);
+    assert_parse_error_json(D2_json(a2_json()), &expected);
 }
 #[test]
 fn D2b1() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b1_cedar(D2_cedar()), &expected_cedar);
-    assert_parse_error_json(D2_json(b1_json()), &expected_json);
+    assert_parse_error_cedar(&b1_cedar(D2_cedar()), &expected);
+    assert_parse_error_json(D2_json(b1_json()), &expected);
 }
 #[test]
 fn D2b2() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b2_cedar(D2_cedar()), &expected_cedar);
-    assert_parse_error_json(D2_json(b2_json()), &expected_json);
+    assert_parse_error_cedar(&b2_cedar(D2_cedar()), &expected);
+    assert_parse_error_json(D2_json(b2_json()), &expected);
 }
 #[test]
 fn D2c() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&c_cedar(D2_cedar()), &expected_cedar);
-    assert_parse_error_json(D2_json(c_json()), &expected_json);
+    assert_parse_error_cedar(&c_cedar(D2_cedar()), &expected);
+    assert_parse_error_json(D2_json(c_json()), &expected);
 }
 #[test]
 fn D3a1() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&a1_cedar(D3_cedar()), &expected_cedar);
-    assert_parse_error_json(D3_json(a1_json()), &expected_json);
+    assert_parse_error_cedar(&a1_cedar(D3_cedar()), &expected);
+    assert_parse_error_json(D3_json(a1_json()), &expected);
 }
 #[test]
 fn D3a2() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&a2_cedar(D3_cedar()), &expected_cedar);
-    assert_parse_error_json(D3_json(a2_json()), &expected_json);
+    assert_parse_error_cedar(&a2_cedar(D3_cedar()), &expected);
+    assert_parse_error_json(D3_json(a2_json()), &expected);
 }
 #[test]
 fn D3b1() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b1_cedar(D3_cedar()), &expected_cedar);
-    assert_parse_error_json(D3_json(b1_json()), &expected_json);
+    assert_parse_error_cedar(&b1_cedar(D3_cedar()), &expected);
+    assert_parse_error_json(D3_json(b1_json()), &expected);
 }
 #[test]
 fn D3b2() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b2_cedar(D3_cedar()), &expected_cedar);
-    assert_parse_error_json(D3_json(b2_json()), &expected_json);
+    assert_parse_error_cedar(&b2_cedar(D3_cedar()), &expected);
+    assert_parse_error_json(D3_json(b2_json()), &expected);
 }
 #[test]
 fn D3c() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&c_cedar(D3_cedar()), &expected_cedar);
-    assert_parse_error_json(D3_json(c_json()), &expected_json);
+    assert_parse_error_cedar(&c_cedar(D3_cedar()), &expected);
+    assert_parse_error_json(D3_json(c_json()), &expected);
 }
 #[test]
 fn D3d1() {
@@ -1875,14 +1746,12 @@ fn D3d2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&d2_cedar(D3_cedar()), &expected_cedar);
-    assert_parse_error_json(D3_json(d2_json()), &expected_json);
+    assert_parse_error_cedar(&d2_cedar(D3_cedar()), &expected);
+    assert_parse_error_json(D3_json(d2_json()), &expected);
 }
 #[test]
 fn E1a1() {
@@ -1895,20 +1764,13 @@ fn E1a2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
-            .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            .build();
-    assert_parse_error_cedar(&a2_cedar(E1_cedar()), &expected_cedar);
-    assert_parse_error_json(E1_json(a2_json()), &expected_json);
+    assert_parse_error_cedar(&a2_cedar(E1_cedar()), &expected);
+    assert_parse_error_json(E1_json(a2_json()), &expected);
 }
 #[test]
 fn E1b1() {
@@ -1921,37 +1783,23 @@ fn E1b2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
-            .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            .build();
-    assert_parse_error_cedar(&b2_cedar(E1_cedar()), &expected_cedar);
-    assert_parse_error_json(E1_json(b2_json()), &expected_json);
+    assert_parse_error_cedar(&b2_cedar(E1_cedar()), &expected);
+    assert_parse_error_json(E1_json(b2_json()), &expected);
 }
 #[test]
 fn E1c() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
             .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            // No source location on this error because the JSON structures don't carry source locations,
-            // and since the cedar-syntax processing works by first converting to the JSON structures,
-            // we lose the source locations at that point.
-            // See #1084.
+            .exactly_one_underline("MyType")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("failed to resolve type: MyType")
-            .help("neither `NS1::MyType` nor `MyType` refers to anything that has been declared as an entity type")
-            .build();
-    assert_parse_error_cedar(&c_cedar(E1_cedar()), &expected_cedar);
-    assert_parse_error_json(E1_json(c_json()), &expected_json);
+    assert_parse_error_cedar(&c_cedar(E1_cedar()), &expected);
+    assert_parse_error_json(E1_json(c_json()), &expected);
 }
 #[test]
 fn E2a1() {
@@ -1964,138 +1812,84 @@ fn E2a2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&a2_cedar(E2_cedar()), &expected_cedar);
-    assert_parse_error_json(E2_json(a2_json()), &expected_json);
+    assert_parse_error_cedar(&a2_cedar(E2_cedar()), &expected);
+    assert_parse_error_json(E2_json(a2_json()), &expected);
 }
 #[test]
 fn E2b1() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b1_cedar(E2_cedar()), &expected_cedar);
-    assert_parse_error_json(E2_json(b1_json()), &expected_json);
+    assert_parse_error_cedar(&b1_cedar(E2_cedar()), &expected);
+    assert_parse_error_json(E2_json(b1_json()), &expected);
 }
 #[test]
 fn E2b2() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b2_cedar(E2_cedar()), &expected_cedar);
-    assert_parse_error_json(E2_json(b2_json()), &expected_json);
+    assert_parse_error_cedar(&b2_cedar(E2_cedar()), &expected);
+    assert_parse_error_json(E2_json(b2_json()), &expected);
 }
 #[test]
 fn E2c() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
         .help("`NS1::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS1::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS1::MyType")
-        .help("`NS1::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&c_cedar(E2_cedar()), &expected_cedar);
-    assert_parse_error_json(E2_json(c_json()), &expected_json);
+    assert_parse_error_cedar(&c_cedar(E2_cedar()), &expected);
+    assert_parse_error_json(E2_json(c_json()), &expected);
 }
 #[test]
 fn E3a1() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&a1_cedar(E3_cedar()), &expected_cedar);
-    assert_parse_error_json(E3_json(a1_json()), &expected_json);
+    assert_parse_error_cedar(&a1_cedar(E3_cedar()), &expected);
+    assert_parse_error_json(E3_json(a1_json()), &expected);
 }
 #[test]
 fn E3a2() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&a2_cedar(E3_cedar()), &expected_cedar);
-    assert_parse_error_json(E3_json(a2_json()), &expected_json);
+    assert_parse_error_cedar(&a2_cedar(E3_cedar()), &expected);
+    assert_parse_error_json(E3_json(a2_json()), &expected);
 }
 #[test]
 fn E3b1() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b1_cedar(E3_cedar()), &expected_cedar);
-    assert_parse_error_json(E3_json(b1_json()), &expected_json);
+    assert_parse_error_cedar(&b1_cedar(E3_cedar()), &expected);
+    assert_parse_error_json(E3_json(b1_json()), &expected);
 }
 #[test]
 fn E3b2() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&b2_cedar(E3_cedar()), &expected_cedar);
-    assert_parse_error_json(E3_json(b2_json()), &expected_json);
+    assert_parse_error_cedar(&b2_cedar(E3_cedar()), &expected);
+    assert_parse_error_json(E3_json(b2_json()), &expected);
 }
 #[test]
 fn E3c() {
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
-        // No source location on this error because the JSON structures don't carry source locations,
-        // and since the cedar-syntax processing works by first converting to the JSON structures,
-        // we lose the source locations at that point.
-        // See #1084.
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&c_cedar(E3_cedar()), &expected_cedar);
-    assert_parse_error_json(E3_json(c_json()), &expected_json);
+    assert_parse_error_cedar(&c_cedar(E3_cedar()), &expected);
+    assert_parse_error_json(E3_json(c_json()), &expected);
 }
 #[test]
 fn E3d1() {
@@ -2108,14 +1902,12 @@ fn E3d2() {
     // The error message could be more clear, e.g., specialized to check whether
     // the type that failed to resolve would have resolved to a common type if
     // it were allowed to.
-    let expected_cedar = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
+    let expected = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
         .help("`NS2::MyType` has not been declared as an entity type")
+        .exactly_one_underline("NS2::MyType")
         .build();
-    let expected_json = ExpectedErrorMessageBuilder::error("failed to resolve type: NS2::MyType")
-        .help("`NS2::MyType` has not been declared as an entity type")
-        .build();
-    assert_parse_error_cedar(&d2_cedar(E3_cedar()), &expected_cedar);
-    assert_parse_error_json(E3_json(d2_json()), &expected_json);
+    assert_parse_error_cedar(&d2_cedar(E3_cedar()), &expected);
+    assert_parse_error_json(E3_json(d2_json()), &expected);
 }
 #[test]
 fn F1a() {
@@ -2129,16 +1921,11 @@ fn F1b() {
 }
 #[test]
 fn F1c() {
-    let expected_cedar =
-        ExpectedErrorMessageBuilder::error("undeclared action: Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("undeclared action: Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    assert_parse_error_cedar(F1c_cedar(), &expected_cedar);
-    assert_parse_error_json(F1c_json(), &expected_json);
+    let expected = ExpectedErrorMessageBuilder::error("undeclared action: Action::\"ActionGroup\"")
+        .help("any actions appearing as parents need to be declared as actions")
+        .build();
+    assert_parse_error_cedar(F1c_cedar(), &expected);
+    assert_parse_error_json(F1c_json(), &expected);
 }
 #[test]
 fn F2a() {
@@ -2147,68 +1934,48 @@ fn F2a() {
 }
 #[test]
 fn F2b() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("undeclared action: NS1::Action::\"ActionGroup\"")
             .help("any actions appearing as parents need to be declared as actions")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("undeclared action: NS1::Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    assert_parse_error_cedar(F2b_cedar(), &expected_cedar);
-    assert_parse_error_json(F2b_json(), &expected_json);
+    assert_parse_error_cedar(F2b_cedar(), &expected);
+    assert_parse_error_json(F2b_json(), &expected);
 }
 #[test]
 fn F2c() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("undeclared action: NS1::Action::\"ActionGroup\"")
             .help("any actions appearing as parents need to be declared as actions")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("undeclared action: NS1::Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    assert_parse_error_cedar(F2c_cedar(), &expected_cedar);
-    assert_parse_error_json(F2c_json(), &expected_json);
+    assert_parse_error_cedar(F2c_cedar(), &expected);
+    assert_parse_error_json(F2c_json(), &expected);
 }
 #[test]
 fn F3a() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("undeclared action: NS2::Action::\"ActionGroup\"")
             .help("any actions appearing as parents need to be declared as actions")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("undeclared action: NS2::Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    assert_parse_error_cedar(F3a_cedar(), &expected_cedar);
-    assert_parse_error_json(F3a_json(), &expected_json);
+    assert_parse_error_cedar(F3a_cedar(), &expected);
+    assert_parse_error_json(F3a_json(), &expected);
 }
 #[test]
 fn F3b() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("undeclared action: NS2::Action::\"ActionGroup\"")
             .help("any actions appearing as parents need to be declared as actions")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("undeclared action: NS2::Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    assert_parse_error_cedar(F3b_cedar(), &expected_cedar);
-    assert_parse_error_json(F3b_json(), &expected_json);
+    assert_parse_error_cedar(F3b_cedar(), &expected);
+    assert_parse_error_json(F3b_json(), &expected);
 }
 #[test]
 fn F3c() {
-    let expected_cedar =
+    let expected =
         ExpectedErrorMessageBuilder::error("undeclared action: NS2::Action::\"ActionGroup\"")
             .help("any actions appearing as parents need to be declared as actions")
             .build();
-    let expected_json =
-        ExpectedErrorMessageBuilder::error("undeclared action: NS2::Action::\"ActionGroup\"")
-            .help("any actions appearing as parents need to be declared as actions")
-            .build();
-    assert_parse_error_cedar(F3c_cedar(), &expected_cedar);
-    assert_parse_error_json(F3c_json(), &expected_json);
+    assert_parse_error_cedar(F3c_cedar(), &expected);
+    assert_parse_error_json(F3c_json(), &expected);
 }
 #[test]
 fn F3d() {

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -5670,6 +5670,7 @@ mod request_validation_tests {
             &ExpectedErrorMessageBuilder::error(
                 "principal type `Undeclared` is not declared in the schema",
             )
+            .exactly_one_underline("Undeclared")
             .build(),
         );
     }
@@ -5691,6 +5692,7 @@ mod request_validation_tests {
             &ExpectedErrorMessageBuilder::error(
                 "resource type `Undeclared` is not declared in the schema",
             )
+            .exactly_one_underline("Undeclared")
             .build(),
         );
     }
@@ -5713,6 +5715,7 @@ mod request_validation_tests {
                 r#"principal type `Resource` is not valid for `Action::"action"`"#,
             )
             .help(r#"valid principal types for `Action::"action"`: `Principal`"#)
+            .exactly_one_underline("Resource")
             .build(),
         );
 
@@ -5731,6 +5734,7 @@ mod request_validation_tests {
                 r#"principal type `Resource` is not valid for `Action::"manipulate"`"#,
             )
             .help(r#"valid principal types for `Action::"manipulate"`: `Cat`, `Duck`, `Principal`"#)
+            .exactly_one_underline("Resource")
             .build(),
         );
 
@@ -5749,6 +5753,7 @@ mod request_validation_tests {
                 r#"principal type `Resource` is not valid for `Action::"group"`"#,
             )
             .help(r#"no principal types are valid for `Action::"group"`"#)
+            .exactly_one_underline("Resource")
             .build(),
         );
     }
@@ -5771,6 +5776,7 @@ mod request_validation_tests {
                 r#"resource type `Principal` is not valid for `Action::"action"`"#,
             )
             .help(r#"valid resource types for `Action::"action"`: `Resource`"#)
+            .exactly_one_underline("Principal")
             .build(),
         );
 
@@ -5789,6 +5795,7 @@ mod request_validation_tests {
                 r#"resource type `Principal` is not valid for `Action::"manipulate"`"#,
             )
             .help(r#"valid resource types for `Action::"manipulate"`: `Folder`, `Resource`, `Widget`"#)
+            .exactly_one_underline("Principal")
             .build(),
         );
     }


### PR DESCRIPTION
## Description of changes

Finishes #1084 by actually adapting the `Diagnostic` implementations of a bunch of errors to take advantage of the now-propagated source locs.

As a side effect of this PR, a number of JSON schema errors now have source locations, although fairly unhelpful, as it's just based on parsing a single string in the JSON.  For instance, an undefined-entity-type-name error for `Foo` now has a source location where the source is just `Foo` and the span is the entire thing.  I view this as neither helpful nor harmful; this PR is still a step towards actual JSON source locations (#174), we just need to populate the source-locs in the types differently.

## Issue #, if available

Resolves #1084

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
