### PR TITLE
Enable `ref_option` pedantic lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,9 @@ rust-2018-idioms = "deny"
 # means we'll see it in local runs.
 [workspace.lints.clippy]
 nursery = { level = "warn", priority = -1 }
+# Enabling some pedantic lints incrementally
 needless_pass_by_value = "warn"
+ref_option = "warn"
 
 # These lints may be worth enforcing, but cause a lot of noise at the moment.
 use_self = "allow"

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1216,9 +1216,9 @@ impl<'a> Typechecker<'a> {
                         let type_of_eq = self.type_of_equality(
                             request_env,
                             arg1,
-                            lhs_ty.data(),
+                            lhs_ty.data().as_ref(),
                             arg2,
-                            rhs_ty.data(),
+                            rhs_ty.data().as_ref(),
                         );
 
                         if self.mode.is_strict() {
@@ -1228,8 +1228,8 @@ impl<'a> Typechecker<'a> {
                             self.enforce_strict_equality(
                                 bin_expr,
                                 annotated_eq,
-                                lhs_ty.data(),
-                                rhs_ty.data(),
+                                lhs_ty.data().as_ref(),
+                                rhs_ty.data().as_ref(),
                                 type_errors,
                                 LubContext::Equality,
                             )
@@ -1451,13 +1451,13 @@ impl<'a> Typechecker<'a> {
                                 self.enforce_strict_equality(
                                     bin_expr,
                                     annotated_expr,
-                                    &match expr_ty_arg1.data() {
+                                    match expr_ty_arg1.data() {
                                         Some(Type::Set {
                                             element_type: Some(ty),
-                                        }) => Some(*ty.clone()),
+                                        }) => Some(ty.as_ref()),
                                         _ => None,
                                     },
-                                    expr_ty_arg2.data(),
+                                    expr_ty_arg2.data().as_ref(),
                                     type_errors,
                                     LubContext::Contains,
                                 )
@@ -1513,8 +1513,8 @@ impl<'a> Typechecker<'a> {
                             self.enforce_strict_equality(
                                 bin_expr,
                                 annotated_expr,
-                                expr_ty_arg1.data(),
-                                expr_ty_arg2.data(),
+                                expr_ty_arg1.data().as_ref(),
+                                expr_ty_arg2.data().as_ref(),
                                 type_errors,
                                 LubContext::ContainsAnyAll,
                             )
@@ -1746,8 +1746,8 @@ impl<'a> Typechecker<'a> {
         &self,
         unannotated_expr: &'b Expr,
         annotated_expr: Expr<Option<Type>>,
-        lhs_ty: &Option<Type>,
-        rhs_ty: &Option<Type>,
+        lhs_ty: Option<&Type>,
+        rhs_ty: Option<&Type>,
         type_errors: &mut Vec<ValidationError>,
         context: LubContext,
     ) -> TypecheckAnswer<'b> {
@@ -1789,9 +1789,9 @@ impl<'a> Typechecker<'a> {
         &self,
         request_env: &RequestEnv<'_>,
         lhs_expr: &'b Expr,
-        lhs_ty: &Option<Type>,
+        lhs_ty: Option<&Type>,
         rhs_expr: &'b Expr,
-        rhs_ty: &Option<Type>,
+        rhs_ty: Option<&Type>,
     ) -> Type {
         // If we know the types are disjoint, then we can return give the
         // expression type False. See `are_types_disjoint` definition for


### PR DESCRIPTION
## Description of changes

Turning on another useful pedantic lint

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
