### PR TITLE
Schema options for `partially-authorize` command

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -5,6 +5,9 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ## Unreleased
 
+- Add schema options `schema` and `schema-format` for the `partially-authorize`
+  command (#1416, resolving #1332)
+
 ## 4.2.2
 
 ## 4.2.1

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -452,7 +452,7 @@ impl PartialRequestArgs {
 
         if let Some(schema) = schema {
             let builder_schema = builder.schema(schema);
-            builder_schema.build().wrap_err_with(|| format!("failed to build request with validation:"))
+            builder_schema.build().wrap_err_with(|| format!("failed to build request with validation"))
         } else {
             Ok(builder.build())
         }

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1332,6 +1332,7 @@ pub fn partial_authorize(args: &PartiallyAuthorizeArgs) -> CedarExitCode {
         &args.request,
         &args.policies,
         &args.entities_file,
+        &args.schema,
         args.timing,
     );
     match ans {

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -442,8 +442,11 @@ impl PartialRequestArgs {
         if let Some(context) = qjson
             .context
             .map(|json| {
-                Context::from_json_value(json.clone(), schema.and_then(|s| Some((s, action.as_ref()?))))
-                    .wrap_err_with(|| format!("fail to convert context json {json} to Context"))
+                Context::from_json_value(
+                    json.clone(),
+                    schema.and_then(|s| Some((s, action.as_ref()?))),
+                )
+                .wrap_err_with(|| format!("fail to convert context json {json} to Context"))
             })
             .transpose()?
         {
@@ -452,7 +455,9 @@ impl PartialRequestArgs {
 
         if let Some(schema) = schema {
             let builder_schema = builder.schema(schema);
-            builder_schema.build().wrap_err_with(|| format!("failed to build request with validation"))
+            builder_schema
+                .build()
+                .wrap_err_with(|| format!("failed to build request with validation"))
         } else {
             Ok(builder.build())
         }

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -454,7 +454,8 @@ impl PartialRequestArgs {
         }
 
         if let Some(schema) = schema {
-            builder.schema(schema)
+            builder
+                .schema(schema)
                 .build()
                 .wrap_err_with(|| format!("failed to build request with validation"))
         } else {

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -454,8 +454,7 @@ impl PartialRequestArgs {
         }
 
         if let Some(schema) = schema {
-            let builder_schema = builder.schema(schema);
-            builder_schema
+            builder.schema(schema)
                 .build()
                 .wrap_err_with(|| format!("failed to build request with validation"))
         } else {

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -442,8 +442,7 @@ impl PartialRequestArgs {
         if let Some(context) = qjson
             .context
             .map(|json| {
-                let action_ref = action.as_ref();
-                Context::from_json_value(json.clone(), schema.and_then(|s| action_ref.map(|a| (s, a))))
+                Context::from_json_value(json.clone(), schema.and_then(|s| Some((s, action.as_ref()?))))
                     .wrap_err_with(|| format!("fail to convert context json {json} to Context"))
             })
             .transpose()?

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3707,7 +3707,7 @@ impl RequestBuilder<&Schema> {
             self.context,
             Some(&self.schema.0),
             Extensions::all_available(),
-        )?)) // This looks like the request we should be building
+        )?))
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3707,7 +3707,7 @@ impl RequestBuilder<&Schema> {
             self.context,
             Some(&self.schema.0),
             Extensions::all_available(),
-        )?))
+        )?)) // This looks like the request we should be building
     }
 }
 


### PR DESCRIPTION
## Description of changes

Adds the schema options `schema` and `schema-format` to the `partially-authorize` command, which were not included in #1082. Basically, we add the schema options to `PartiallyAuthorizeArgs`, extend `get_request` with an optional schmea argument and rely on the existing builder from #393 to build requests with partial evaluation.

## Issue #, if available

Resolves #1332 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
