### PR TITLE
bump language version to 4.2

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -71,7 +71,7 @@ pub(crate) mod version {
         static ref SDK_VERSION: Version = env!("CARGO_PKG_VERSION").parse().unwrap();
         // Cedar language version
         // The patch version field may be unnecessary
-        static ref LANG_VERSION: Version = Version::new(4, 0, 0);
+        static ref LANG_VERSION: Version = Version::new(4, 2, 0);
     }
     /// Get the Cedar SDK Semantic Versioning version
     #[allow(clippy::module_name_repetitions)]

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6292,7 +6292,7 @@ mod version_tests {
 
     #[test]
     fn test_lang_version() {
-        assert_eq!(get_lang_version().to_string(), "4.0.0");
+        assert_eq!(get_lang_version().to_string(), "4.2.0");
     }
 }
 


### PR DESCRIPTION
## Description of changes

Bumps the language version to 4.2.  This will be the new language version as of SDK 4.3.0.  Differences from language 4.1 (SDK 4.2.0) include the `isEmpty` operator, which warrants a minor bump.

Previously, the `main` branch was incorrectly reporting 4.0 as the language version, even though the released SDK 4.2.x correctly reports 4.1 as the language version for 4.2.x.