### PR TITLE
new method on core Expr

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -222,6 +222,12 @@ impl<T> Expr<T> {
         self.data
     }
 
+    /// Consume the `Expr`, returning the `ExprKind`, `source_loc`, and stored
+    /// data.
+    pub fn into_parts(self) -> (ExprKind<T>, Option<Loc>, T) {
+        (self.expr_kind, self.source_loc, self.data)
+    }
+
     /// Access the `Loc` stored on the `Expr`.
     pub fn source_loc(&self) -> Option<&Loc> {
         self.source_loc.as_ref()

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1461,10 +1461,9 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
 }
 
 impl<T> ExprBuilder<T> {
-    /// Internally used by the following methods to construct an `Expr`
-    /// containing the `data` and `source_loc` in this `ExprBuilder` with some
-    /// inner `ExprKind`.
-    fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
+    /// Construct an `Expr` containing the `data` and `source_loc` in this
+    /// `ExprBuilder` and the given `ExprKind`.
+    pub fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
         Expr::new(expr_kind, self.source_loc, self.data)
     }
 


### PR DESCRIPTION
## Description of changes

We have `into_expr_kind()` and `into_data()`, but no way for other Core consumers to consume the `Expr` and get back both the kind and the data.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
