### PR TITLE
Adds JSON serialized PolicySet from bindings to cedar_policy::PolicySet conversion

### DIFF
--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -225,7 +225,7 @@ pub enum SchemaToJsonAnswer {
     },
 }
 
-/// Convert cedar_policy::ffi::PolicySet JSON to cedar_policy::PolicySet Object
+/// Convert `cedar_policy::ffi::PolicySet` JSON to `cedar_policy::PolicySet` Object
 pub fn json_to_policyset(
     json_string: &str,
 ) -> Result<crate::PolicySet, Box<dyn std::error::Error>> {

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -18,7 +18,7 @@
 //! Cedar Wasm conversion functions are generated from the functions in this
 //! file.
 
-use super::utils::JsonValueWithNoDuplicateKeys;
+use super::utils::{JsonValueWithNoDuplicateKeys, PolicySet};
 use super::{DetailedError, Policy, Schema, Template};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "wasm")]
@@ -223,6 +223,23 @@ pub enum SchemaToJsonAnswer {
         /// Errors
         errors: Vec<DetailedError>,
     },
+}
+
+/// Convert cedar_policy::ffi::PolicySet JSON to cedar_policy::PolicySet Object
+pub fn json_to_policyset(
+    json_string: &str,
+) -> Result<crate::PolicySet, Box<dyn std::error::Error>> {
+    let policy_set_ffi: PolicySet =
+        serde_json::from_str(json_string).map_err(|e| format!("Failed to parse JSON: {}", e))?;
+    let policy_set = policy_set_ffi.parse().map_err(|errs| {
+        let err_msg = errs
+            .iter()
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("Failed to parse policy set: {}", err_msg)
+    })?;
+    Ok(policy_set)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description of changes
- Adds function to convert JSON serialized `PolicySet` object from bindings (E.g., CedarJava) to a `cedar_policy::PolicySet` instance
- The resulting instance can be used to expose `cedar_policy::PolicySet`'s methods (E.g., to_json) in bindings

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
