### PR TITLE
Assume sufficient stack space when it cannot be determined

### DIFF
--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -34,7 +34,6 @@ use itertools::{Either, Itertools};
 use nonempty::nonempty;
 use smol_str::SmolStr;
 
-#[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
 // PANIC SAFETY `Name`s in here are valid `Name`s
@@ -1108,11 +1107,9 @@ impl Value {
 
 #[inline(always)]
 fn stack_size_check() -> Result<()> {
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        if stacker::remaining_stack().unwrap_or(0) < REQUIRED_STACK_SPACE {
-            return Err(EvaluationError::recursion_limit(None));
-        }
+    // We assume there's enough space if we cannot determine it with `remaining_stack`
+    if stacker::remaining_stack().unwrap_or(REQUIRED_STACK_SPACE) < REQUIRED_STACK_SPACE {
+        return Err(EvaluationError::recursion_limit(None));
     }
     Ok(())
 }

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -321,7 +321,6 @@ impl EvaluationError {
     }
 
     /// Construct a [`RecursionLimit`] error
-    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn recursion_limit(source_loc: Option<Loc>) -> Self {
         evaluation_errors::RecursionLimitError { source_loc }.into()
     }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -47,7 +47,6 @@ use cedar_policy_core::{
     expr_builder::ExprBuilder as _,
 };
 
-#[cfg(not(target_arch = "wasm32"))]
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
 /// Basic result for typechecking
@@ -352,8 +351,8 @@ impl<'a> SingleEnvTypechecker<'a> {
         e: &'b Expr,
         type_errors: &mut Vec<ValidationError>,
     ) -> TypecheckAnswer<'b> {
-        #[cfg(not(target_arch = "wasm32"))]
-        if stacker::remaining_stack().unwrap_or(0) < REQUIRED_STACK_SPACE {
+        // We assume there's enough space if we cannot determine it with `remaining_stack`
+        if stacker::remaining_stack().unwrap_or(REQUIRED_STACK_SPACE) < REQUIRED_STACK_SPACE {
             return TypecheckAnswer::RecursionLimit;
         }
 


### PR DESCRIPTION
## Description of changes

This PR changes the two checks we do based on `stacker::remaining_stack` to assume there's enough stack space when the function would return `None`. This should prevent the application from returning an error in platforms where the remaining stack space cannot be determined with `stacker`, as it happens with Android in #1443.

Resolves #1443 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
