### PR TITLE
Datetime extension: Allow timezone offsets with a duration of less than 24 hours

### DIFF
--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -520,7 +520,6 @@ impl UTCOffset {
         }
     }
 
-    // Reference: https://en.wikipedia.org/wiki/List_of_UTC_offsets
     fn is_valid(&self) -> bool {
         self.hh < Self::MAX_HH && self.mm < Self::MAX_MM
     }

--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -496,7 +496,7 @@ enum DateTimeParseError {
     #[help("A valid datetime should end with Z|.SSSZ|(+|-)hhmm|.SSS(+|-)hhmm")]
     InvalidMSOffsetPattern,
     #[error("invalid offset range: {}{}", ._0.0, ._0.1)]
-    #[help("A valid offset hour range should be [0,12) and minute range should be [0, 60)")]
+    #[help("A valid offset hour range should be [0,24) and minute range should be [0, 60)")]
     InvalidOffset((u32, u32)),
 }
 
@@ -508,16 +508,9 @@ struct UTCOffset {
 }
 
 impl UTCOffset {
-    const MIN: Self = Self {
-        positive: false,
-        hh: 12,
-        mm: 0,
-    };
-    const MAX: Self = Self {
-        positive: true,
-        hh: 14,
-        mm: 0,
-    };
+    const MAX_HH: u32 = 24;
+    const MAX_MM: u32 = 60;
+
     fn to_seconds(&self) -> i64 {
         let offset_in_seconds_unsigned = (self.hh * 3600 + self.mm * 60) as i64;
         if self.positive {
@@ -529,7 +522,7 @@ impl UTCOffset {
 
     // Reference: https://en.wikipedia.org/wiki/List_of_UTC_offsets
     fn is_valid(&self) -> bool {
-        self.mm < 60 && self >= &Self::MIN && self <= &Self::MAX
+        self.hh < Self::MAX_HH && self.mm < Self::MAX_MM
     }
 }
 
@@ -790,6 +783,16 @@ mod tests {
             parse_datetime(s).unwrap(),
             NaiveDateTime::from_str("2024-10-15T23:12:02").unwrap()
         );
+        let s = "2024-10-15T23:59:00+2359";
+        assert_eq!(
+            parse_datetime(s).unwrap(),
+            NaiveDateTime::from_str("2024-10-15T00:00:00").unwrap()
+        );
+        let s = "2024-10-15T00:00:00-2359";
+        assert_eq!(
+            parse_datetime(s).unwrap(),
+            NaiveDateTime::from_str("2024-10-15T23:59:00").unwrap()
+        );
     }
 
     #[test]
@@ -923,6 +926,10 @@ mod tests {
         assert_matches!(
             parse_datetime("2016-12-31T00:00:00+1199"),
             Err(DateTimeParseError::InvalidOffset((11, 99)))
+        );
+        assert_matches!(
+            parse_datetime("2016-12-31T00:00:00+2400"),
+            Err(DateTimeParseError::InvalidOffset((24, 0)))
         );
     }
 


### PR DESCRIPTION
## Description of changes

Changes the definition of the `is_valid` method for timezone offsets according to the updated specification in https://github.com/cedar-policy/rfcs/pull/94

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
