### PR TITLE
fix cedar_schema/fmt.rs for enumerated entities

### DIFF
--- a/cedar-policy-validator/src/cedar_schema/fmt.rs
+++ b/cedar-policy-validator/src/cedar_schema/fmt.rs
@@ -112,7 +112,7 @@ impl<N: Display> Display for json_schema::EntityType<N> {
             json_schema::EntityTypeKind::Standard(ty) => ty.fmt(f),
             json_schema::EntityTypeKind::Enum { choices } => write!(
                 f,
-                "[{}]",
+                " enum [{}]",
                 choices
                     .iter()
                     .map(|e| format!("\"{}\"", e.escape_debug()))


### PR DESCRIPTION
## Description of changes

Fixes cedar_schema/fmt.rs (conversion of internal JSON schema structures to Cedar-format string) for enumerated entities.  Declarations of enumerated entities were not being printed in the valid [RFC 53](https://cedar-policy.github.io/rfcs/0053-enum-entities.html) format.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
