### PR TITLE
Fix protobuf deserialization of `ValidatorEntityType`

### DIFF
--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -197,7 +197,7 @@ impl From<&proto::ValidatorEntityType> for ValidatorEntityType {
             name,
             descendants,
             // We use emptiness of the `enums` field as an indictor to tell if `v` represents an enumerated entity type or not
-            // In other words, we essentially ignore other fields like `attributes` when `enums` is empty
+            // In other words, we essentially ignore other fields like `attributes` when `enums` is not empty
             kind: match &v.enums[..] {
                 [] => {
                     let tags = match &v.tags {

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -174,13 +174,7 @@ impl From<&ValidatorEntityType> for proto::ValidatorEntityType {
                 .iter()
                 .map(ast::proto::EntityType::from)
                 .collect(),
-            attributes: Some(proto::Attributes::from(
-                &Attributes::with_required_attributes(
-                    v.attributes()
-                        .into_iter()
-                        .map(|(attr, ty)| (attr, ty.attr_type)),
-                ),
-            )),
+            attributes: Some(proto::Attributes::from(&v.attributes())),
             open_attributes: proto::OpenTag::from(&v.open_attributes()).into(),
             tags,
             enums,


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
