### PR TITLE
Allow reauthorization with also initially undiscovered unknowns in the Expr

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -630,6 +630,10 @@ impl Expr {
     ///
     /// Ignores unmapped unknowns.
     /// Ignores type annotations on unknowns.
+    /// Note that there might be "undiscovered unknowns" in the Expr, which
+    /// this function does not notice if evaluation of this Expr did not
+    /// traverse all entities and attributes during evaluation, leading to
+    /// this function only substituting one unknown at a time.
     pub fn substitute(&self, definitions: &HashMap<SmolStr, Value>) -> Expr {
         match self.substitute_general::<UntypedSubstitution>(definitions) {
             Ok(e) => e,
@@ -641,6 +645,10 @@ impl Expr {
     ///
     /// Ignores unmapped unknowns.
     /// Errors if the substituted value does not match the type annotation on the unknown.
+    /// Note that there might be "undiscovered unknowns" in the Expr, which
+    /// this function does not notice if evaluation of this Expr did not
+    /// traverse all entities and attributes during evaluation, leading to
+    /// this function only substituting one unknown at a time.
     pub fn substitute_typed(
         &self,
         definitions: &HashMap<SmolStr, Value>,

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -92,6 +92,17 @@ impl Authorizer {
         entities: &Entities,
     ) -> PartialResponse {
         let eval = Evaluator::new(q.clone(), entities, self.extensions);
+        self.is_authorized_core_internal(eval, q, pset)
+    }
+
+    /// The same as is_authorized_core, but for any Evaluator.
+    /// A PartialResponse caller constructs its own evaluator, with an unknown mapper function.
+    pub(crate) fn is_authorized_core_internal(
+        &self,
+        eval: Evaluator<'_>,
+        q: Request,
+        pset: &PolicySet,
+    ) -> PartialResponse {
         let mut true_permits = vec![];
         let mut true_forbids = vec![];
         let mut false_permits = vec![];

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -20,8 +20,8 @@ use either::Either;
 use std::sync::Arc;
 
 use super::{
-    Annotations, AuthorizationError, Decision, Effect, EntityUIDEntry, Expr,
-    Policy, Request, Response, 
+    Annotations, AuthorizationError, Decision, Effect, EntityUIDEntry, Expr, Policy, Request,
+    Response,
 };
 use crate::{ast::PolicyID, evaluator::EvaluationError};
 
@@ -29,12 +29,12 @@ use crate::{ast::PolicyID, evaluator::EvaluationError};
 use smol_str::SmolStr;
 
 #[cfg(feature = "partial-eval")]
-use crate::{evaluator::Evaluator, entities::Entities};
+use crate::{entities::Entities, evaluator::Evaluator};
 
 #[cfg(feature = "partial-eval")]
 use super::{
     err::{ConcretizationError, ReauthorizationError},
-    Context, PolicySet, PolicySetError, Authorizer, Value,
+    Authorizer, Context, PolicySet, PolicySetError, Value,
 };
 
 type PolicyComponents<'a> = (Effect, &'a PolicyID, &'a Arc<Expr>, &'a Arc<Annotations>);
@@ -333,12 +333,11 @@ impl PartialResponse {
         let policyset = self.all_residual_policies()?;
         let new_request = self.concretize_request(mapping)?;
         // Although this function takes a HashMap, keep the internal mapping function generic
-        let unknowns_mapper = |unknown_name: &str| -> Option<Value> {
-            mapping.get(unknown_name).cloned()
-        };
+        let unknowns_mapper =
+            |unknown_name: &str| -> Option<Value> { mapping.get(unknown_name).cloned() };
         // Construct an evaluator resolving these specific unknown mappings
-        let eval = Evaluator::new(new_request.clone(), es, auth.extensions).
-            with_unknowns_mapper(Box::new(unknowns_mapper));
+        let eval = Evaluator::new(new_request.clone(), es, auth.extensions)
+            .with_unknowns_mapper(Box::new(unknowns_mapper));
         Ok(auth.is_authorized_core_internal(eval, new_request, &policyset))
     }
 
@@ -561,9 +560,7 @@ mod test {
         }
     }
 
-    use crate::authorizer::{
-        ActionConstraint, PrincipalConstraint, ResourceConstraint, Context,
-    };
+    use crate::authorizer::{ActionConstraint, Context, PrincipalConstraint, ResourceConstraint};
 
     #[cfg(feature = "partial-eval")]
     use crate::{
@@ -794,14 +791,16 @@ mod test {
         .unwrap();
 
         let context_unknown = Context::from_pairs(
-            [(
-                "c".into(),
-                RestrictedExpr::unknown(Unknown::new_untyped("c")),
-            ),
-            (
-                "d".into(),
-                RestrictedExpr::unknown(Unknown::new_untyped("d")),
-            )],
+            [
+                (
+                    "c".into(),
+                    RestrictedExpr::unknown(Unknown::new_untyped("c")),
+                ),
+                (
+                    "d".into(),
+                    RestrictedExpr::unknown(Unknown::new_untyped("d")),
+                ),
+            ],
             Extensions::all_available(),
         )
         .unwrap();
@@ -830,7 +829,9 @@ mod test {
             .unwrap();
 
         assert_eq!(
-            response_with_concrete_resource.get(&PolicyID::from_string("policy0")).map(|p| p.effect()),
+            response_with_concrete_resource
+                .get(&PolicyID::from_string("policy0"))
+                .map(|p| p.effect()),
             Some(Effect::Permit)
         );
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -20,6 +20,7 @@ use crate::ast::*;
 use crate::entities::{Dereference, Entities};
 use crate::extensions::Extensions;
 use crate::parser::Loc;
+#[cfg(feature = "partial-eval")]
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -68,6 +69,7 @@ pub struct Evaluator<'e> {
     /// Extensions which are active for this evaluation
     extensions: &'e Extensions<'e>,
     /// Mapper of unknown values into concrete ones, if recognized
+    #[cfg(feature = "partial-eval")]
     unknowns_mapper: Box<dyn Fn(&str) -> Option<Value> + 'e>,
 }
 
@@ -210,11 +212,13 @@ impl<'e> Evaluator<'e> {
             },
             entities,
             extensions,
+            #[cfg(feature = "partial-eval")]
             unknowns_mapper: Box::new(|_: &str| -> Option<Value> {None}),
         }
     }
 
     // Constructs an Evaluator for a given unknowns mapper function.
+    #[cfg(feature = "partial-eval")]
     pub(crate) fn with_unknowns_mapper(self, unknowns_mapper: Box<dyn Fn(&str) -> Option<Value> + 'e>) -> Self {
         Self {
             principal: self.principal,
@@ -1131,6 +1135,7 @@ impl Value {
     }
 
     /// Convert the `Value` to a Record, or throw a type error if it's not a Record.
+    #[cfg(feature = "partial-eval")]
     pub(crate) fn get_as_record(&self) -> Result<&Arc<BTreeMap<SmolStr, Value>>> {
         match &self.value {
             ValueKind::Record(rec) => Ok(rec),

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -213,13 +213,16 @@ impl<'e> Evaluator<'e> {
             entities,
             extensions,
             #[cfg(feature = "partial-eval")]
-            unknowns_mapper: Box::new(|_: &str| -> Option<Value> {None}),
+            unknowns_mapper: Box::new(|_: &str| -> Option<Value> { None }),
         }
     }
 
     // Constructs an Evaluator for a given unknowns mapper function.
     #[cfg(feature = "partial-eval")]
-    pub(crate) fn with_unknowns_mapper(self, unknowns_mapper: Box<dyn Fn(&str) -> Option<Value> + 'e>) -> Self {
+    pub(crate) fn with_unknowns_mapper(
+        self,
+        unknowns_mapper: Box<dyn Fn(&str) -> Option<Value> + 'e>,
+    ) -> Self {
         Self {
             principal: self.principal,
             action: self.action,
@@ -808,7 +811,7 @@ impl<'e> Evaluator<'e> {
             }
         }
     }
-    
+
     fn eval_in(
         &self,
         uid1: &EntityUID,
@@ -948,14 +951,12 @@ impl<'e> Evaluator<'e> {
                 }
                 Dereference::Data(entity) => entity
                     .get(attr)
-                    .map(|pv| {
-                        match pv {
-                            PartialValue::Value(_) => Ok(pv.clone()),
-                            PartialValue::Residual(e) => match e.expr_kind() {
-                                ExprKind::Unknown(u) => self.unknown_to_partialvalue(u),
-                                _ => Ok(pv.clone()),
-                            }
-                        }
+                    .map(|pv| match pv {
+                        PartialValue::Value(_) => Ok(pv.clone()),
+                        PartialValue::Residual(e) => match e.expr_kind() {
+                            ExprKind::Unknown(u) => self.unknown_to_partialvalue(u),
+                            _ => Ok(pv.clone()),
+                        },
                     })
                     .ok_or_else(|| {
                         EvaluationError::entity_attr_does_not_exist(


### PR DESCRIPTION
## Description of changes

Fixes: #1465 
Please read the issue description first for context.

There might be "undiscovered" unknowns in a partially evaluated `Expr` residual. In my example in #1465, that would be `resource.newlabels` that is during the first partial evaluation call omitted and thus unknown, but not yet evaluated by Cedar into a `unknown("resource.newlabels")`, as the LHS of the `&&` didn't proceed to evaluate the RHS (#1445).

In the issue I described three quick potential solutions, of which this one probably is the most realistic to actually implement.

This PR solves the described issue by moving the reauthorization substitution logic from `expr.substitute` to `partial_interpret`, where unknowns can be looked up any number of times needed, also while proceeding to the RHS of an `&&` (of course, given the LHS evaluated to true). The code isn't super neat, having to pass the `mappings` around everywhere, I'm definitely open to discuss neater solutions.

Note: `Expr.substitute` is now almost unused; the only place I saw it used is in `Context.substitute`, which indeed is used.

Longer-term, indeed [RFC 95](https://github.com/cedar-policy/rfcs/pull/95) is the better solution, addressing this bug and probably a whole class of others in one go. However, I wanted to open this PR to show the approach, as at the end of the day, the fix wasn't very complicated (and hopefully I didn't break anything else).

If this becomes an accepted approach to go forward in the short term, I'll make tests, etc. so this PR becomes ready to merge.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change/bug fix "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.). Also this only touches experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure. (AFAIK there is no formal model yet for partial evaluation)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
