### PR TITLE
add conversions between api types and proto types

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3336,7 +3336,7 @@ impl FromStr for Policy {
 ///
 /// This structure can be used for static policies, linked policies, and templates.
 #[derive(Debug, Clone)]
-enum LosslessPolicy {
+pub(crate) enum LosslessPolicy {
     /// EST representation
     Est(est::Policy),
     /// Text representation

--- a/cedar-policy/src/proto.rs
+++ b/cedar-policy/src/proto.rs
@@ -47,3 +47,9 @@ mod entities;
 
 /// Conversions between proto types and `cedar_policy_validator` types
 mod validator;
+
+/// Conversions between proto types and `cedar_policy::api` types
+mod api;
+
+/// `Protobuf` trait and associated utilities
+pub mod traits;

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -139,9 +139,7 @@ impl traits::Protobuf for api::Policy {
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
-        Ok(
-            traits::try_decode::<models::LiteralPolicy, _, Self>(buf)?
-                .expect("protobuf-encoded policy should be a valid policy"),
-        )
+        Ok(traits::try_decode::<models::LiteralPolicy, _, Self>(buf)?
+            .expect("protobuf-encoded policy should be a valid policy"))
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -1,0 +1,145 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use super::super::api;
+use super::{models, traits};
+
+/// Macro that implements From<> both ways for cases where the `A` type is a
+/// simple wrapper around a different type `C` which already has From<>
+/// conversions both ways with `B`
+macro_rules! standard_conversions {
+    ( $A:ty, $A_expr:expr, $B:ty ) => {
+        impl From<&$A> for $B {
+            fn from(v: &$A) -> $B {
+                Self::from(&v.0)
+            }
+        }
+
+        impl From<&$B> for $A {
+            fn from(v: &$B) -> $A {
+                $A_expr(v.into())
+            }
+        }
+    };
+}
+
+// standard conversions
+
+standard_conversions!(api::Entity, api::Entity, models::Entity);
+standard_conversions!(api::Entities, api::Entities, models::Entities);
+standard_conversions!(api::Schema, api::Schema, models::ValidatorSchema);
+standard_conversions!(api::EntityNamespace, api::EntityNamespace, models::Name);
+standard_conversions!(api::Expression, api::Expression, models::Expr);
+standard_conversions!(api::Request, api::Request, models::Request);
+
+// nonstandard conversions
+
+impl From<&api::Template> for models::TemplateBody {
+    fn from(v: &api::Template) -> Self {
+        Self::from(&v.ast)
+    }
+}
+
+impl From<&models::TemplateBody> for api::Template {
+    fn from(v: &models::TemplateBody) -> Self {
+        api::Template::from_ast(v.into())
+    }
+}
+
+impl From<&api::Policy> for models::LiteralPolicy {
+    fn from(v: &api::Policy) -> Self {
+        Self::from(&v.ast)
+    }
+}
+
+impl TryFrom<&models::LiteralPolicy> for api::Policy {
+    type Error = cedar_policy_core::ast::ReificationError;
+    fn try_from(v: &models::LiteralPolicy) -> Result<Self, Self::Error> {
+        let p = cedar_policy_core::ast::Policy::try_from(v)?;
+        Ok(api::Policy::from_ast(p))
+    }
+}
+
+impl From<&api::PolicySet> for models::LiteralPolicySet {
+    fn from(v: &api::PolicySet) -> Self {
+        Self::from(&v.ast)
+    }
+}
+
+impl TryFrom<&models::LiteralPolicySet> for api::PolicySet {
+    type Error = api::PolicySetError;
+    fn try_from(v: &models::LiteralPolicySet) -> Result<Self, Self::Error> {
+        api::PolicySet::from_ast(
+            v.try_into()
+                .expect("proto-encoded policy set should be a valid policy set"),
+        )
+    }
+}
+
+/// Macro that implements `traits::Protobuf` for cases where From<> conversions
+/// exist both ways between the api type `$api` and the protobuf model type `$model`
+macro_rules! standard_protobuf_impl {
+    ( $api:ty, $model:ty ) => {
+        impl traits::Protobuf for $api {
+            fn encode(&self) -> Vec<u8> {
+                traits::encode_to_vec::<$model>(self)
+            }
+            fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+                traits::decode::<$model, _>(buf)
+            }
+        }
+    };
+}
+
+// standard implementations of `traits::Protobuf`
+
+standard_protobuf_impl!(api::Entity, models::Entity);
+standard_protobuf_impl!(api::Entities, models::Entities);
+standard_protobuf_impl!(api::Schema, models::ValidatorSchema);
+standard_protobuf_impl!(api::EntityNamespace, models::Name);
+standard_protobuf_impl!(api::Template, models::TemplateBody);
+standard_protobuf_impl!(api::Expression, models::Expr);
+standard_protobuf_impl!(api::Request, models::Request);
+
+// nonstandard implementations of `traits::Protobuf`
+
+impl traits::Protobuf for api::PolicySet {
+    fn encode(&self) -> Vec<u8> {
+        traits::encode_to_vec::<models::LiteralPolicySet>(self)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        // PANIC SAFETY: experimental feature
+        #[allow(clippy::expect_used)]
+        Ok(
+            traits::try_decode::<models::LiteralPolicySet, _, api::PolicySet>(buf)?
+                .expect("protobuf-encoded policy set should be a valid policy set"),
+        )
+    }
+}
+
+impl traits::Protobuf for api::Policy {
+    fn encode(&self) -> Vec<u8> {
+        traits::encode_to_vec::<models::LiteralPolicy>(self)
+    }
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
+        // PANIC SAFETY: experimental feature
+        #[allow(clippy::expect_used)]
+        Ok(
+            traits::try_decode::<models::LiteralPolicy, _, api::Policy>(buf)?
+                .expect("protobuf-encoded policy should be a valid policy"),
+        )
+    }
+}

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -55,7 +55,7 @@ impl From<&api::Template> for models::TemplateBody {
 
 impl From<&models::TemplateBody> for api::Template {
     fn from(v: &models::TemplateBody) -> Self {
-        api::Template::from_ast(v.into())
+        Self::from_ast(v.into())
     }
 }
 
@@ -69,7 +69,7 @@ impl TryFrom<&models::LiteralPolicy> for api::Policy {
     type Error = cedar_policy_core::ast::ReificationError;
     fn try_from(v: &models::LiteralPolicy) -> Result<Self, Self::Error> {
         let p = cedar_policy_core::ast::Policy::try_from(v)?;
-        Ok(api::Policy::from_ast(p))
+        Ok(Self::from_ast(p))
     }
 }
 
@@ -82,7 +82,9 @@ impl From<&api::PolicySet> for models::LiteralPolicySet {
 impl TryFrom<&models::LiteralPolicySet> for api::PolicySet {
     type Error = api::PolicySetError;
     fn try_from(v: &models::LiteralPolicySet) -> Result<Self, Self::Error> {
-        api::PolicySet::from_ast(
+        // PANIC SAFETY: experimental feature
+        #[allow(clippy::expect_used)]
+        Self::from_ast(
             v.try_into()
                 .expect("proto-encoded policy set should be a valid policy set"),
         )
@@ -124,7 +126,7 @@ impl traits::Protobuf for api::PolicySet {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
         Ok(
-            traits::try_decode::<models::LiteralPolicySet, _, api::PolicySet>(buf)?
+            traits::try_decode::<models::LiteralPolicySet, _, Self>(buf)?
                 .expect("protobuf-encoded policy set should be a valid policy set"),
         )
     }
@@ -138,7 +140,7 @@ impl traits::Protobuf for api::Policy {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
         Ok(
-            traits::try_decode::<models::LiteralPolicy, _, api::Policy>(buf)?
+            traits::try_decode::<models::LiteralPolicy, _, Self>(buf)?
                 .expect("protobuf-encoded policy should be a valid policy"),
         )
     }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -1,0 +1,55 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/// Trait allowing serializing and deserializing in protobuf format
+pub trait Protobuf: Sized {
+    /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
+    fn encode(&self) -> Vec<u8>;
+    /// Decode the binary data in `buf`, producing something of type `Self`
+    fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError>;
+}
+
+/// Encode `thing` into `buf` using the protobuf format `M`
+///
+/// `Err` is only returned if `buf` has insufficient space.
+#[allow(dead_code)] // experimental feature, we might have use for this one in the future
+pub(crate) fn encode<M: prost::Message>(
+    thing: impl Into<M>,
+    buf: &mut impl prost::bytes::BufMut,
+) -> Result<(), prost::EncodeError> {
+    thing.into().encode(buf)
+}
+
+/// Encode `thing` into a freshly-allocated buffer using the protobuf format `M`
+pub(crate) fn encode_to_vec<M: prost::Message>(thing: impl Into<M>) -> Vec<u8> {
+    thing.into().encode_to_vec()
+}
+
+use std::default::Default;
+
+/// Decode something of type `T` from `buf` using the protobuf format `M`
+pub(crate) fn decode<M: prost::Message + Default, T: for<'a> From<&'a M>>(
+    buf: impl prost::bytes::Buf,
+) -> Result<T, prost::DecodeError> {
+    M::decode(buf).map(|m| T::from(&m))
+}
+
+/// Decode something of type `T` from `buf` using the protobuf format `M`
+pub(crate) fn try_decode<M: prost::Message + Default, E, T: for<'a> TryFrom<&'a M, Error = E>>(
+    buf: impl prost::bytes::Buf,
+) -> Result<Result<T, E>, prost::DecodeError> {
+    M::decode(buf).map(|m| T::try_from(&m))
+}


### PR DESCRIPTION
## Description of changes

* Adds conversions between `api` types and the newly public types in `proto`.  This is in addition to the public `Protobuf` trait that allows directly serializing/deserializing to/from binary data.  These new conversions are potentially useful for consumers that want to not just ser/de a single struct, but define their own protobuf formats that include these types.
* Moves more existing protobuf code into the new public `proto` module that was created in #1452.  This is a breaking change for experimental code -- in particular, the public `Protobuf` trait is now `proto::traits::Protobuf` instead of available at the crate root.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
