### PR TITLE
 Allow error expressions in AST and handle empty When error

### DIFF
--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -56,7 +56,7 @@ test-util = []
 
 # Experimental features.
 partial-eval = []
-error-ast = []
+tolerant-ast = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [build-dependencies]

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -56,6 +56,7 @@ test-util = []
 
 # Experimental features.
 partial-eval = []
+error-ast = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [build-dependencies]

--- a/cedar-policy-core/src/ast.rs
+++ b/cedar-policy-core/src/ast.rs
@@ -17,6 +17,7 @@
 //! This module contains the AST datatypes.
 
 mod expr;
+pub(crate) mod expr_allows_errors;
 pub use expr::*;
 mod entity;
 pub use entity::*;

--- a/cedar-policy-core/src/ast.rs
+++ b/cedar-policy-core/src/ast.rs
@@ -17,7 +17,7 @@
 //! This module contains the AST datatypes.
 
 mod expr;
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 pub(crate) mod expr_allows_errors;
 pub use expr::*;
 mod entity;

--- a/cedar-policy-core/src/ast.rs
+++ b/cedar-policy-core/src/ast.rs
@@ -17,6 +17,7 @@
 //! This module contains the AST datatypes.
 
 mod expr;
+#[cfg(feature = "error-ast")]
 pub(crate) mod expr_allows_errors;
 pub use expr::*;
 mod entity;

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#[cfg(feature = "error-ast")]
+use super::expr_allows_errors::AstExprErrorKind;
 use crate::{
     ast::*,
     expr_builder::{self, ExprBuilder as _},
@@ -32,8 +34,6 @@ use std::{
     sync::Arc,
 };
 use thiserror::Error;
-
-use super::expr_allows_errors::AstExprErrorKind;
 
 #[cfg(feature = "wasm")]
 extern crate tsify;

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -162,7 +162,7 @@ pub enum ExprKind<T = ()> {
     Error {
         /// Type of error that led to the failure
         error_kind: AstExprErrorKind,
-        /// Any subexpressions that were successfully parsed - useful for nested errors 
+        /// Any subexpressions that were successfully parsed - useful for nested errors
         sub_expression: Option<Arc<Expr<T>>>,
     },
 }
@@ -1505,10 +1505,7 @@ impl<T> Expr<T> {
                 expr.hash_shape(state);
                 entity_type.hash(state);
             }
-            ExprKind::Error {
-                error_kind,
-                ..
-            } => error_kind.hash(state),
+            ExprKind::Error { error_kind, .. } => error_kind.hash(state),
         }
     }
 }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1184,6 +1184,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     }
 
     /// Don't support AST Error nodes - return the error right back
+    #[cfg(feature = "error-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType> {
         Err(parse_errors)
     }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -157,7 +157,7 @@ pub enum ExprKind<T = ()> {
     Set(Arc<Vec<Expr<T>>>),
     /// Anonymous record (whose elements may be arbitrary expressions)
     Record(Arc<BTreeMap<SmolStr, Expr<T>>>),
-
+    #[cfg(feature = "error-ast")]
     /// Error expression - allows us to continue parsing even when we have errors
     Error {
         /// Type of error that led to the failure
@@ -393,6 +393,7 @@ impl<T> Expr<T> {
             ExprKind::Is { .. } => Some(Type::Bool),
             ExprKind::Set(_) => Some(Type::Set),
             ExprKind::Record(_) => Some(Type::Record),
+            #[cfg(feature = "error-ast")]
             ExprKind::Error { .. } => None,
         }
     }
@@ -726,6 +727,7 @@ impl Expr {
                 expr.substitute_general::<T>(definitions)?,
                 entity_type.clone(),
             )),
+            #[cfg(feature = "error-ast")]
             ExprKind::Error { .. } => Ok(self.clone()),
         }
     }
@@ -1499,6 +1501,7 @@ impl<T> Expr<T> {
                 expr.hash_shape(state);
                 entity_type.hash(state);
             }
+            #[cfg(feature = "error-ast")]
             ExprKind::Error { error_kind, .. } => error_kind.hash(state),
         }
     }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -162,8 +162,6 @@ pub enum ExprKind<T = ()> {
     Error {
         /// Type of error that led to the failure
         error_kind: AstExprErrorKind,
-        /// Any subexpressions that were successfully parsed - useful for nested errors
-        sub_expression: Option<Arc<Expr<T>>>,
     },
 }
 
@@ -1184,11 +1182,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     }
 
     /// Don't support AST Error nodes - return the error right back
-    fn error(
-        self,
-        parse_errors: ParseErrors,
-        _sub_expression: Option<Arc<Self::Expr>>,
-    ) -> Result<Self::Expr, Self::ErrorType> {
+    fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType> {
         Err(parse_errors)
     }
 }

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 use super::expr_allows_errors::AstExprErrorKind;
 use crate::{
     ast::*,
@@ -157,7 +157,7 @@ pub enum ExprKind<T = ()> {
     Set(Arc<Vec<Expr<T>>>),
     /// Anonymous record (whose elements may be arbitrary expressions)
     Record(Arc<BTreeMap<SmolStr, Expr<T>>>),
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     /// Error expression - allows us to continue parsing even when we have errors
     Error {
         /// Type of error that led to the failure
@@ -393,7 +393,7 @@ impl<T> Expr<T> {
             ExprKind::Is { .. } => Some(Type::Bool),
             ExprKind::Set(_) => Some(Type::Set),
             ExprKind::Record(_) => Some(Type::Record),
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => None,
         }
     }
@@ -727,7 +727,7 @@ impl Expr {
                 expr.substitute_general::<T>(definitions)?,
                 entity_type.clone(),
             )),
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => Ok(self.clone()),
         }
     }
@@ -869,6 +869,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
 
     type Data = T;
 
+    #[cfg(feature = "tolerant-ast")]
     type ErrorType = ParseErrors;
 
     fn loc(&self) -> Option<&Loc> {
@@ -1184,7 +1185,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     }
 
     /// Don't support AST Error nodes - return the error right back
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType> {
         Err(parse_errors)
     }
@@ -1502,7 +1503,7 @@ impl<T> Expr<T> {
                 expr.hash_shape(state);
                 entity_type.hash(state);
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { error_kind, .. } => error_kind.hash(state),
         }
     }

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -26,14 +26,12 @@ impl From<ToASTErrorKind> for AstExprErrorKind {
     }
 }
 
-#[cfg(feature = "error-ast")]
 #[derive(Clone, Debug)]
 pub struct ExprWithErrsBuilder<T = ()> {
     source_loc: Option<Loc>,
     data: T,
 }
 
-#[cfg(feature = "error-ast")]
 impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     type Expr = Expr<T>;
 
@@ -454,7 +452,6 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     }
 }
 
-#[cfg(feature = "error-ast")]
 impl<T> ExprWithErrsBuilder<T> {
     /// Construct an `Expr` containing the `data` and `source_loc` in this
     /// `ExprBuilder` and the given `ExprKind`.

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -1,0 +1,502 @@
+
+use crate::{
+    ast::*,
+    expr_builder::{self, ExprBuilder as _},
+    extensions::Extensions,
+    parser::{err::{ParseErrors, ToASTErrorKind}, Loc},
+};
+use educe::Educe;
+use miette::Diagnostic;
+use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+use std::{
+    borrow::Cow,
+    collections::{btree_map, BTreeMap, HashMap},
+    hash::{Hash, Hasher},
+    mem,
+    sync::Arc,
+};
+use thiserror::Error;
+
+
+
+#[derive(Error, Debug, Serialize, Deserialize, Hash, Clone, PartialEq, Eq)]
+pub enum  AstExprErrorKind {
+    #[error("Invalid expression node: {0}")]
+    InvalidExpr(String),
+}
+ 
+impl From<ToASTErrorKind> for AstExprErrorKind {
+    fn from(value: ToASTErrorKind) -> Self {
+        AstExprErrorKind::InvalidExpr(value.to_string())
+    }
+}
+#[derive(Clone, Debug)]
+
+pub struct ExprWithErrsBuilder<T = ()> {
+    source_loc: Option<Loc>,
+    data: T,
+}
+
+impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
+    type Expr = Expr<T>;
+
+    type Data = T;
+
+    type ErrorType = Infallible;
+
+    fn loc(&self) -> Option<&Loc> {
+        self.source_loc.as_ref()
+    }
+
+    fn data(&self) -> &Self::Data {
+        &self.data
+    }
+
+    fn with_data(data: T) -> Self {
+        Self {
+            source_loc: None,
+            data,
+        }
+    }
+
+    fn with_maybe_source_loc(mut self, maybe_source_loc: Option<&Loc>) -> Self {
+        self.source_loc = maybe_source_loc.cloned();
+        self
+    }
+
+    /// Create an `Expr` that's just a single `Literal`.
+    ///
+    /// Note that you can pass this a `Literal`, an `Integer`, a `String`, etc.
+    fn val(self, v: impl Into<Literal>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Lit(v.into()))
+    }
+
+    /// Create an `Unknown` `Expr`
+    fn unknown(self, u: Unknown) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Unknown(u))
+    }
+
+    /// Create an `Expr` that's just this literal `Var`
+    fn var(self, v: Var) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Var(v))
+    }
+
+    fn error(self, parse_errors: ParseErrors, sub_expression: Option<Arc<Expr<T>>>) -> Result<Expr<T>, Self::ErrorType> {
+        Ok(self.with_expr_kind(ExprKind::Error {
+            error_kind: AstExprErrorKind::InvalidExpr(parse_errors.to_string()),
+            sub_expression,
+        }))
+    }
+
+    /// Create an `Expr` that's just this `SlotId`
+    fn slot(self, s: SlotId) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Slot(s))
+    }
+
+    /// Create a ternary (if-then-else) `Expr`.
+    ///
+    /// `test_expr` must evaluate to a Bool type
+    fn ite(self, test_expr: Expr<T>, then_expr: Expr<T>, else_expr: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::If {
+            test_expr: Arc::new(test_expr),
+            then_expr: Arc::new(then_expr),
+            else_expr: Arc::new(else_expr),
+        })
+    }
+
+    /// Create a 'not' expression. `e` must evaluate to Bool type
+    fn not(self, e: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::UnaryApp {
+            op: UnaryOp::Not,
+            arg: Arc::new(e),
+        })
+    }
+
+    /// Create a '==' expression
+    fn is_eq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::Eq,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create an 'and' expression. Arguments must evaluate to Bool type
+    fn and(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(match (&e1.expr_kind(), &e2.expr_kind()) {
+            (ExprKind::Lit(Literal::Bool(b1)), ExprKind::Lit(Literal::Bool(b2))) => {
+                ExprKind::Lit(Literal::Bool(*b1 && *b2))
+            }
+            _ => ExprKind::And {
+                left: Arc::new(e1),
+                right: Arc::new(e2),
+            },
+        })
+    }
+
+    /// Create an 'or' expression. Arguments must evaluate to Bool type
+    fn or(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(match (&e1.expr_kind(), &e2.expr_kind()) {
+            (ExprKind::Lit(Literal::Bool(b1)), ExprKind::Lit(Literal::Bool(b2))) => {
+                ExprKind::Lit(Literal::Bool(*b1 || *b2))
+            }
+
+            _ => ExprKind::Or {
+                left: Arc::new(e1),
+                right: Arc::new(e2),
+            },
+        })
+    }
+
+    /// Create a '<' expression. Arguments must evaluate to Long type
+    fn less(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::Less,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create a '<=' expression. Arguments must evaluate to Long type
+    fn lesseq(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::LessEq,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create an 'add' expression. Arguments must evaluate to Long type
+    fn add(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::Add,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create a 'sub' expression. Arguments must evaluate to Long type
+    fn sub(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::Sub,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create a 'mul' expression. Arguments must evaluate to Long type
+    fn mul(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::Mul,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create a 'neg' expression. `e` must evaluate to Long type.
+    fn neg(self, e: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::UnaryApp {
+            op: UnaryOp::Neg,
+            arg: Arc::new(e),
+        })
+    }
+
+    /// Create an 'in' expression. First argument must evaluate to Entity type.
+    /// Second argument must evaluate to either Entity type or Set type where
+    /// all set elements have Entity type.
+    fn is_in(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::In,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create a 'contains' expression.
+    /// First argument must have Set type.
+    fn contains(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::Contains,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create a 'contains_all' expression. Arguments must evaluate to Set type
+    fn contains_all(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::ContainsAll,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create an 'contains_any' expression. Arguments must evaluate to Set type
+    fn contains_any(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::ContainsAny,
+            arg1: Arc::new(e1),
+            arg2: Arc::new(e2),
+        })
+    }
+
+    /// Create an 'is_empty' expression. Argument must evaluate to Set type
+    fn is_empty(self, expr: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::UnaryApp {
+            op: UnaryOp::IsEmpty,
+            arg: Arc::new(expr),
+        })
+    }
+
+    /// Create a 'getTag' expression.
+    /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
+    fn get_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::GetTag,
+            arg1: Arc::new(expr),
+            arg2: Arc::new(tag),
+        })
+    }
+
+    /// Create a 'hasTag' expression.
+    /// `expr` must evaluate to Entity type, `tag` must evaluate to String type.
+    fn has_tag(self, expr: Expr<T>, tag: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: BinaryOp::HasTag,
+            arg1: Arc::new(expr),
+            arg2: Arc::new(tag),
+        })
+    }
+
+    /// Create an `Expr` which evaluates to a Set of the given `Expr`s
+    fn set(self, exprs: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Set(Arc::new(exprs.into_iter().collect())))
+    }
+
+    /// Create an `Expr` which evaluates to a Record with the given (key, value) pairs.
+    fn record(
+        self,
+        pairs: impl IntoIterator<Item = (SmolStr, Expr<T>)>,
+    ) -> Result<Expr<T>, ExpressionConstructionError> {
+        let mut map = BTreeMap::new();
+        for (k, v) in pairs {
+            match map.entry(k) {
+                btree_map::Entry::Occupied(oentry) => {
+                    return Err(expression_construction_errors::DuplicateKeyError {
+                        key: oentry.key().clone(),
+                        context: "in record literal",
+                    }
+                    .into());
+                }
+                btree_map::Entry::Vacant(ventry) => {
+                    ventry.insert(v);
+                }
+            }
+        }
+        Ok(self.with_expr_kind(ExprKind::Record(Arc::new(map))))
+    }
+
+    /// Create an `Expr` which calls the extension function with the given
+    /// `Name` on `args`
+    fn call_extension_fn(self, fn_name: Name, args: impl IntoIterator<Item = Expr<T>>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::ExtensionFunctionApp {
+            fn_name,
+            args: Arc::new(args.into_iter().collect()),
+        })
+    }
+
+    /// Create an application `Expr` which applies the given built-in unary
+    /// operator to the given `arg`
+    fn unary_app(self, op: impl Into<UnaryOp>, arg: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::UnaryApp {
+            op: op.into(),
+            arg: Arc::new(arg),
+        })
+    }
+
+    /// Create an application `Expr` which applies the given built-in binary
+    /// operator to `arg1` and `arg2`
+    fn binary_app(self, op: impl Into<BinaryOp>, arg1: Expr<T>, arg2: Expr<T>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::BinaryApp {
+            op: op.into(),
+            arg1: Arc::new(arg1),
+            arg2: Arc::new(arg2),
+        })
+    }
+
+    /// Create an `Expr` which gets a given attribute of a given `Entity` or record.
+    ///
+    /// `expr` must evaluate to either Entity or Record type
+    fn get_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
+        self.with_expr_kind(ExprKind::GetAttr {
+            expr: Arc::new(expr),
+            attr,
+        })
+    }
+
+    /// Create an `Expr` which tests for the existence of a given
+    /// attribute on a given `Entity` or record.
+    ///
+    /// `expr` must evaluate to either Entity or Record type
+    fn has_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
+        self.with_expr_kind(ExprKind::HasAttr {
+            expr: Arc::new(expr),
+            attr,
+        })
+    }
+
+    /// Create a 'like' expression.
+    ///
+    /// `expr` must evaluate to a String type
+    fn like(self, expr: Expr<T>, pattern: Pattern) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Like {
+            expr: Arc::new(expr),
+            pattern,
+        })
+    }
+
+    /// Create an 'is' expression.
+    fn is_entity_type(self, expr: Expr<T>, entity_type: EntityType) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Is {
+            expr: Arc::new(expr),
+            entity_type,
+        })
+    }
+    
+    fn new() -> Self
+    where
+        Self: Sized,
+    {
+        Self::with_data(Self::Data::default())
+    }
+    
+    fn with_source_loc(self, l: &Loc) -> Self
+    where
+        Self: Sized,
+    {
+        self.with_maybe_source_loc(Some(l))
+    }
+    
+    fn is_in_entity_type(
+        self,
+        e1: Self::Expr,
+        entity_type: EntityType,
+        e2: Self::Expr,
+    ) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        self.clone().and(
+            self.clone().is_entity_type(e1.clone(), entity_type),
+            self.is_in(e1, e2),
+        )
+    }
+    
+    fn noteq(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        self.clone().not(self.is_eq(e1, e2))
+    }
+    
+    fn greater(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        // e1 > e2 is defined as !(e1 <= e2)
+        self.clone().not(self.lesseq(e1, e2))
+    }
+    
+    fn greatereq(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        // e1 >= e2 is defined as !(e1 < e2)
+        self.clone().not(self.less(e1, e2))
+    }
+    
+    fn and_nary(self, first: Self::Expr, others: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        others
+            .into_iter()
+            .fold(first, |acc, next| self.clone().and(acc, next))
+    }
+    
+    fn or_nary(self, first: Self::Expr, others: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        others
+            .into_iter()
+            .fold(first, |acc, next| self.clone().or(acc, next))
+    }
+    
+    fn add_nary(
+        self,
+        first: Self::Expr,
+        other: impl IntoIterator<Item = (crate::parser::cst::AddOp, Self::Expr)>,
+    ) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        other.into_iter().fold(first, |acc, (op, next)| match op {
+            crate::parser::cst::AddOp::Plus => self.clone().add(acc, next),
+            crate::parser::cst::AddOp::Minus => self.clone().sub(acc, next),
+        })
+    }
+    
+    fn mul_nary(self, first: Self::Expr, other: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    where
+        Self: Sized,
+    {
+        other
+            .into_iter()
+            .fold(first, |acc, next| self.clone().mul(acc, next))
+    }
+}
+
+impl<T> ExprWithErrsBuilder<T> {
+    /// Construct an `Expr` containing the `data` and `source_loc` in this
+    /// `ExprBuilder` and the given `ExprKind`.
+    pub fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
+        Expr::new(expr_kind, self.source_loc, self.data)
+    }
+
+    /// Create a ternary (if-then-else) `Expr`.
+    /// Takes `Arc`s instead of owned `Expr`s.
+    /// `test_expr` must evaluate to a Bool type
+    pub fn ite_arc(
+        self,
+        test_expr: Arc<Expr<T>>,
+        then_expr: Arc<Expr<T>>,
+        else_expr: Arc<Expr<T>>,
+    ) -> Expr<T> {
+        self.with_expr_kind(ExprKind::If {
+            test_expr,
+            then_expr,
+            else_expr,
+        })
+    }
+
+    /// Create an `Expr` which evaluates to a Record with the given key-value mapping.
+    ///
+    /// If you have an iterator of pairs, generally prefer calling `.record()`
+    /// instead of `.collect()`-ing yourself and calling this, potentially for
+    /// efficiency reasons but also because `.record()` will properly handle
+    /// duplicate keys but your own `.collect()` will not (by default).
+    pub fn record_arc(self, map: Arc<BTreeMap<SmolStr, Expr<T>>>) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Record(map))
+    }
+}
+
+impl<T: Clone + Default> ExprWithErrsBuilder<T> {
+    /// Utility used the validator to get an expression with the same source
+    /// location as an existing expression. This is done when reconstructing the
+    /// `Expr` with type information.
+    pub fn with_same_source_loc<U>(self, expr: &Expr<U>) -> Self {
+        self.with_maybe_source_loc(expr.source_loc())
+    }
+}

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -37,6 +37,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
 
     type Data = T;
 
+    #[cfg(feature = "tolerant-ast")]
     type ErrorType = Infallible;
 
     fn loc(&self) -> Option<&Loc> {

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -25,13 +25,15 @@ impl From<ToASTErrorKind> for AstExprErrorKind {
         AstExprErrorKind::InvalidExpr(value.to_string())
     }
 }
-#[derive(Clone, Debug)]
 
+#[cfg(feature = "error-ast")]
+#[derive(Clone, Debug)]
 pub struct ExprWithErrsBuilder<T = ()> {
     source_loc: Option<Loc>,
     data: T,
 }
 
+#[cfg(feature = "error-ast")]
 impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     type Expr = Expr<T>;
 
@@ -76,6 +78,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
         self.with_expr_kind(ExprKind::Var(v))
     }
 
+    #[cfg(feature = "error-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Expr<T>, Self::ErrorType> {
         Ok(self.with_expr_kind(ExprKind::Error {
             error_kind: AstExprErrorKind::InvalidExpr(parse_errors.to_string()),
@@ -451,6 +454,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     }
 }
 
+#[cfg(feature = "error-ast")]
 impl<T> ExprWithErrsBuilder<T> {
     /// Construct an `Expr` containing the `data` and `source_loc` in this
     /// `ExprBuilder` and the given `ExprKind`.

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -1,11 +1,17 @@
 use crate::{
     ast::*,
     expr_builder::{self, ExprBuilder as _},
-    parser::{Loc, err::{ToASTErrorKind, ParseErrors}},
+    parser::{
+        err::{ParseErrors, ToASTErrorKind},
+        Loc,
+    },
 };
 use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
-use std::{collections::{btree_map, BTreeMap}, sync::Arc};
+use std::{
+    collections::{btree_map, BTreeMap},
+    sync::Arc,
+};
 use thiserror::Error;
 
 #[derive(Error, Debug, Serialize, Deserialize, Hash, Clone, PartialEq, Eq)]

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -1,6 +1,6 @@
 use crate::{
     ast::*,
-    expr_builder::{self, ExprBuilder as _},
+    expr_builder::{self},
     parser::{
         err::{ParseErrors, ToASTErrorKind},
         Loc,
@@ -461,40 +461,5 @@ impl<T> ExprWithErrsBuilder<T> {
     /// `ExprBuilder` and the given `ExprKind`.
     pub fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
         Expr::new(expr_kind, self.source_loc, self.data)
-    }
-
-    /// Create a ternary (if-then-else) `Expr`.
-    /// Takes `Arc`s instead of owned `Expr`s.
-    /// `test_expr` must evaluate to a Bool type
-    pub fn ite_arc(
-        self,
-        test_expr: Arc<Expr<T>>,
-        then_expr: Arc<Expr<T>>,
-        else_expr: Arc<Expr<T>>,
-    ) -> Expr<T> {
-        self.with_expr_kind(ExprKind::If {
-            test_expr,
-            then_expr,
-            else_expr,
-        })
-    }
-
-    /// Create an `Expr` which evaluates to a Record with the given key-value mapping.
-    ///
-    /// If you have an iterator of pairs, generally prefer calling `.record()`
-    /// instead of `.collect()`-ing yourself and calling this, potentially for
-    /// efficiency reasons but also because `.record()` will properly handle
-    /// duplicate keys but your own `.collect()` will not (by default).
-    pub fn record_arc(self, map: Arc<BTreeMap<SmolStr, Expr<T>>>) -> Expr<T> {
-        self.with_expr_kind(ExprKind::Record(map))
-    }
-}
-
-impl<T: Clone + Default> ExprWithErrsBuilder<T> {
-    /// Utility used the validator to get an expression with the same source
-    /// location as an existing expression. This is done when reconstructing the
-    /// `Expr` with type information.
-    pub fn with_same_source_loc<U>(self, expr: &Expr<U>) -> Self {
-        self.with_maybe_source_loc(expr.source_loc())
     }
 }

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -76,14 +76,9 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
         self.with_expr_kind(ExprKind::Var(v))
     }
 
-    fn error(
-        self,
-        parse_errors: ParseErrors,
-        sub_expression: Option<Arc<Expr<T>>>,
-    ) -> Result<Expr<T>, Self::ErrorType> {
+    fn error(self, parse_errors: ParseErrors) -> Result<Expr<T>, Self::ErrorType> {
         Ok(self.with_expr_kind(ExprKind::Error {
             error_kind: AstExprErrorKind::InvalidExpr(parse_errors.to_string()),
-            sub_expression,
         }))
     }
 

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -76,7 +76,7 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
         self.with_expr_kind(ExprKind::Var(v))
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Expr<T>, Self::ErrorType> {
         Ok(self.with_expr_kind(ExprKind::Error {
             error_kind: AstExprErrorKind::InvalidExpr(parse_errors.to_string()),

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -82,6 +82,7 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
             ExprKind::Record(map) => {
                 self.expression_stack.extend(map.values());
             }
+            ExprKind::Error { error_kind, sub_expression } => (),
         }
         Some(next_expr)
     }

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -82,7 +82,7 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
             ExprKind::Record(map) => {
                 self.expression_stack.extend(map.values());
             }
-            ExprKind::Error { error_kind, sub_expression } => (),
+            ExprKind::Error { .. } => (),
         }
         Some(next_expr)
     }

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -82,6 +82,7 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
             ExprKind::Record(map) => {
                 self.expression_stack.extend(map.values());
             }
+            #[cfg(feature = "error-ast")]
             ExprKind::Error { .. } => (),
         }
         Some(next_expr)

--- a/cedar-policy-core/src/ast/expr_iterator.rs
+++ b/cedar-policy-core/src/ast/expr_iterator.rs
@@ -82,7 +82,7 @@ impl<'a, T> Iterator for ExprIterator<'a, T> {
             ExprKind::Record(map) => {
                 self.expression_stack.extend(map.values());
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => (),
         }
         Some(next_expr)

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -529,6 +529,7 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExpressionError> {
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
         ExprKind::Record(map) => map.values().try_for_each(is_restricted),
+        #[cfg(feature = "error-ast")]
         ExprKind::Error { .. } => Ok(()),
     }
 }

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -529,7 +529,7 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExpressionError> {
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
         ExprKind::Record(map) => map.values().try_for_each(is_restricted),
-        #[cfg(feature = "error-ast")]
+        #[cfg(feature = "tolerant-ast")]
         ExprKind::Error { .. } => Ok(()),
     }
 }

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -529,6 +529,7 @@ fn is_restricted(expr: &Expr) -> Result<(), RestrictedExpressionError> {
         ExprKind::ExtensionFunctionApp { args, .. } => args.iter().try_for_each(is_restricted),
         ExprKind::Set(exprs) => exprs.iter().try_for_each(is_restricted),
         ExprKind::Record(map) => map.values().try_for_each(is_restricted),
+        ExprKind::Error { .. } => Ok(()),
     }
 }
 

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -359,6 +359,7 @@ impl TryFrom<Expr> for ValueKind {
                 .map(|(k, v)| Value::try_from(v.clone()).map(|v| (k.clone(), v)))
                 .collect::<Result<BTreeMap<SmolStr, Value>, _>>()
                 .map(|m| Self::Record(Arc::new(m))),
+            ExprKind::Error { .. } => Err(NotValue::NotValue { loc }),
         }
     }
 }

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -359,6 +359,7 @@ impl TryFrom<Expr> for ValueKind {
                 .map(|(k, v)| Value::try_from(v.clone()).map(|v| (k.clone(), v)))
                 .collect::<Result<BTreeMap<SmolStr, Value>, _>>()
                 .map(|m| Self::Record(Arc::new(m))),
+            #[cfg(feature = "error-ast")]
             ExprKind::Error { .. } => Err(NotValue::NotValue { loc }),
         }
     }

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -359,7 +359,7 @@ impl TryFrom<Expr> for ValueKind {
                 .map(|(k, v)| Value::try_from(v.clone()).map(|v| (k.clone(), v)))
                 .collect::<Result<BTreeMap<SmolStr, Value>, _>>()
                 .map(|m| Self::Record(Arc::new(m))),
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => Err(NotValue::NotValue { loc }),
         }
     }

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -123,6 +123,7 @@ pub enum JsonDeserializationError {
     /// When trying to deserialize an AST with an error in it - this should fail
     #[cfg(feature = "error-ast")]
     #[error("Unable to deserialize an AST Error node")]
+    #[diagnostic(help("AST error node indicates that the expression has failed to parse"))]
     ASTErrorNode,
     /// Raised when a JsonValue contains the no longer supported `__expr` escape
     #[error("{0}, the `__expr` escape is no longer supported")]

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -121,7 +121,7 @@ pub enum JsonDeserializationError {
     #[diagnostic(transparent)]
     TypeMismatch(TypeMismatch),
     /// When trying to deserialize an AST with an error in it - this should fail
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[error("Unable to deserialize an AST Error node")]
     #[diagnostic(help("AST error node indicates that the expression has failed to parse"))]
     ASTErrorNode,
@@ -258,6 +258,7 @@ pub struct MissingRequiredRecordAttr {
     record_attr: SmolStr,
 }
 
+#[cfg(feature = "tolerant-ast")]
 #[derive(Debug, Error, Diagnostic)]
 #[error("AST Error node")]
 /// Error type for a record missing a required attr

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -258,15 +258,6 @@ pub struct MissingRequiredRecordAttr {
     record_attr: SmolStr,
 }
 
-#[cfg(feature = "tolerant-ast")]
-#[derive(Debug, Error, Diagnostic)]
-#[error("AST Error node")]
-/// Error type for a record missing a required attr
-pub struct ErrorNode {
-    /// Context of this error
-    ctx: Box<JsonDeserializationErrorContext>,
-}
-
 #[derive(Debug, Diagnostic, Error)]
 #[error("{}, record attribute `{}` should not exist according to the schema", .ctx, .record_attr)]
 /// Error type for record attributes that should not exist

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -123,7 +123,7 @@ pub enum JsonDeserializationError {
     /// When trying to deserialize an AST with an error in it - this should fail
     #[cfg(feature = "error-ast")]
     #[error("Unable to deserialize an AST Error node")]
-    ErrorNode,
+    ASTErrorNode,
     /// Raised when a JsonValue contains the no longer supported `__expr` escape
     #[error("{0}, the `__expr` escape is no longer supported")]
     #[diagnostic(help("to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"))]

--- a/cedar-policy-core/src/entities/json/err.rs
+++ b/cedar-policy-core/src/entities/json/err.rs
@@ -120,6 +120,10 @@ pub enum JsonDeserializationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     TypeMismatch(TypeMismatch),
+    /// When trying to deserialize an AST with an error in it - this should fail
+    #[cfg(feature = "error-ast")]
+    #[error("Unable to deserialize an AST Error node")]
+    ErrorNode,
     /// Raised when a JsonValue contains the no longer supported `__expr` escape
     #[error("{0}, the `__expr` escape is no longer supported")]
     #[diagnostic(help("to create an entity reference, use `__entity`; to create an extension value, use `__extn`; and for all other values, use JSON directly"))]
@@ -251,6 +255,14 @@ pub struct MissingRequiredRecordAttr {
     ctx: Box<JsonDeserializationErrorContext>,
     /// Name of the (Record) attribute which was expected
     record_attr: SmolStr,
+}
+
+#[derive(Debug, Error, Diagnostic)]
+#[error("AST Error node")]
+/// Error type for a record missing a required attr
+pub struct ErrorNode {
+    /// Context of this error
+    ctx: Box<JsonDeserializationErrorContext>,
 }
 
 #[derive(Debug, Diagnostic, Error)]

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -80,6 +80,8 @@ pub enum FromJsonError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionType(#[from] parse_errors::InvalidActionType),
+    #[error("AST error node")]
+    ErrorNode,
 }
 
 /// Errors arising while converting a policy set from its JSON representation (aka EST) into an AST

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -81,6 +81,7 @@ pub enum FromJsonError {
     #[diagnostic(transparent)]
     InvalidActionType(#[from] parse_errors::InvalidActionType),
     /// Returned when we have an error node in an AST - this is not supported
+    #[cfg(feature = "error-ast")]
     #[error("AST error node")]
     ASTErrorNode,
 }

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -81,7 +81,7 @@ pub enum FromJsonError {
     #[diagnostic(transparent)]
     InvalidActionType(#[from] parse_errors::InvalidActionType),
     /// Returned when we have an error node in an AST - this is not supported
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[error("AST error node")]
     ASTErrorNode,
 }

--- a/cedar-policy-core/src/est/err.rs
+++ b/cedar-policy-core/src/est/err.rs
@@ -80,8 +80,9 @@ pub enum FromJsonError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidActionType(#[from] parse_errors::InvalidActionType),
+    /// Returned when we have an error node in an AST - this is not supported
     #[error("AST error node")]
-    ErrorNode,
+    ASTErrorNode,
 }
 
 /// Errors arising while converting a policy set from its JSON representation (aka EST) into an AST

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -413,6 +413,7 @@ impl ExprBuilder for Builder {
     type Expr = Expr;
 
     type Data = ();
+    type ErrorType = ParseErrors;
 
     fn with_data(_data: Self::Data) -> Self {
         Self
@@ -689,6 +690,10 @@ impl ExprBuilder for Builder {
         Expr::ExtFuncCall(ExtFuncCall {
             call: HashMap::from([(fn_name.to_smolstr(), args.into_iter().collect())]),
         })
+    }
+    
+    fn error(self, parse_errors: ParseErrors, _sub_expression: Option<Arc<Self::Expr>>) -> Result<Self::Expr, Self::ErrorType> {
+        Err(parse_errors)
     }
 }
 
@@ -1113,6 +1118,9 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
                         .map(|(k, v)| (k, v.into())),
                 )
                 .unwrap(),
+            ast::ExprKind::Error { .. } => {
+                panic!("We do not support converting an AST Error node into an EST");
+            }
         }
     }
 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -15,6 +15,7 @@
  */
 
 use super::FromJsonError;
+#[cfg(feature = "error-ast")]
 use crate::ast::expr_allows_errors::AstExprErrorKind;
 use crate::ast::{self, BoundedDisplay, EntityUID, Infallible};
 use crate::entities::json::{
@@ -25,7 +26,9 @@ use crate::expr_builder::ExprBuilder;
 use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use crate::parser::cst_to_ast;
-use crate::parser::err::{ParseErrors, ToASTError, ToASTErrorKind};
+use crate::parser::err::ParseErrors;
+#[cfg(feature = "error-ast")]
+use crate::parser::err::{ToASTError, ToASTErrorKind};
 use crate::parser::Node;
 use crate::parser::{cst, Loc};
 use itertools::Itertools;

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -692,11 +692,7 @@ impl ExprBuilder for Builder {
         })
     }
 
-    fn error(
-        self,
-        parse_errors: ParseErrors,
-        _sub_expression: Option<Arc<Self::Expr>>,
-    ) -> Result<Self::Expr, Self::ErrorType> {
+    fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType> {
         Err(parse_errors)
     }
 }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -17,7 +17,9 @@
 use super::FromJsonError;
 #[cfg(feature = "tolerant-ast")]
 use crate::ast::expr_allows_errors::AstExprErrorKind;
-use crate::ast::{self, BoundedDisplay, EntityUID, Infallible};
+use crate::ast::{self, BoundedDisplay, EntityUID};
+#[cfg(feature = "tolerant-ast")]
+use crate::ast::Infallible;
 use crate::entities::json::{
     err::EscapeKind, err::JsonDeserializationError, err::JsonDeserializationErrorContext,
     CedarValueJson, FnAndArg,

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -15,7 +15,7 @@
  */
 
 use super::FromJsonError;
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 use crate::ast::expr_allows_errors::AstExprErrorKind;
 use crate::ast::{self, BoundedDisplay, EntityUID, Infallible};
 use crate::entities::json::{
@@ -27,7 +27,7 @@ use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use crate::parser::cst_to_ast;
 use crate::parser::err::ParseErrors;
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 use crate::parser::err::{ToASTError, ToASTErrorKind};
 use crate::parser::Node;
 use crate::parser::{cst, Loc};
@@ -388,7 +388,7 @@ pub enum ExprNoExt {
         BTreeMap<SmolStr, Expr>,
     ),
     /// AST Error node - this represents a parsing error in a partially generated AST
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     Error(AstExprErrorKind),
 }
 
@@ -699,7 +699,7 @@ impl ExprBuilder for Builder {
         })
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType> {
         Ok(Expr::ExprNoExt(ExprNoExt::Error(
             AstExprErrorKind::InvalidExpr(parse_errors.to_string()),
@@ -868,7 +868,7 @@ impl Expr {
                     }
                     Ok(Expr::ExprNoExt(ExprNoExt::Record(new_m)))
                 }
-                #[cfg(feature = "error-ast")]
+                #[cfg(feature = "tolerant-ast")]
                 ExprNoExt::Error(_) => Err(JsonDeserializationError::ASTErrorNode),
             },
             Expr::ExtFuncCall(e_fn_call) => {
@@ -1063,7 +1063,7 @@ impl Expr {
                     }),
                 }
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             Expr::ExprNoExt(ExprNoExt::Error(_)) => Err(FromJsonError::ASTErrorNode),
         }
     }
@@ -1132,7 +1132,7 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
                         .map(|(k, v)| (k, v.into())),
                 )
                 .unwrap(),
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             // PANIC SAFETY: error type is Infallible so can never happen
             #[allow(clippy::unwrap_used)]
             ast::ExprKind::Error { .. } => Builder::new()
@@ -1498,7 +1498,7 @@ impl BoundedDisplay for ExprNoExt {
                     }
                 }
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprNoExt::Error(e) => {
                 write!(f, "{e}")?;
                 Ok(())
@@ -1592,7 +1592,7 @@ fn maybe_with_parens(
             write!(f, ")")?;
             Ok(())
         },
-        #[cfg(feature = "error-ast")]
+        #[cfg(feature = "tolerant-ast")]
         Expr::ExprNoExt(ExprNoExt::Error { .. }) => {
             write!(f, "(")?;
             BoundedDisplay::fmt(expr, f, n)?;

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -691,8 +691,12 @@ impl ExprBuilder for Builder {
             call: HashMap::from([(fn_name.to_smolstr(), args.into_iter().collect())]),
         })
     }
-    
-    fn error(self, parse_errors: ParseErrors, _sub_expression: Option<Arc<Self::Expr>>) -> Result<Self::Expr, Self::ErrorType> {
+
+    fn error(
+        self,
+        parse_errors: ParseErrors,
+        _sub_expression: Option<Arc<Self::Expr>>,
+    ) -> Result<Self::Expr, Self::ErrorType> {
         Err(parse_errors)
     }
 }
@@ -1118,7 +1122,9 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
                         .map(|(k, v)| (k, v.into())),
                 )
                 .unwrap(),
+            #[allow(clippy::panic)]
             ast::ExprKind::Error { .. } => {
+                // PANIC SAFETY There is no reason to support having deliberate Errors in EST - This should never happen
                 panic!("We do not support converting an AST Error node into an EST");
             }
         }

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -420,6 +420,7 @@ impl ExprBuilder for Builder {
     type Expr = Expr;
 
     type Data = ();
+    #[cfg(feature = "tolerant-ast")]
     type ErrorType = Infallible;
 
     fn with_data(_data: Self::Data) -> Self {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -15,7 +15,8 @@
  */
 
 use super::FromJsonError;
-use crate::ast::{self, BoundedDisplay, EntityUID};
+use crate::ast::expr_allows_errors::AstExprErrorKind;
+use crate::ast::{self, BoundedDisplay, EntityUID, Infallible};
 use crate::entities::json::{
     err::EscapeKind, err::JsonDeserializationError, err::JsonDeserializationErrorContext,
     CedarValueJson, FnAndArg,
@@ -24,7 +25,7 @@ use crate::expr_builder::ExprBuilder;
 use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use crate::parser::cst_to_ast;
-use crate::parser::err::ParseErrors;
+use crate::parser::err::{ParseErrors, ToASTError, ToASTErrorKind};
 use crate::parser::Node;
 use crate::parser::{cst, Loc};
 use itertools::Itertools;
@@ -383,6 +384,9 @@ pub enum ExprNoExt {
         #[cfg_attr(feature = "wasm", tsify(type = "Record<string, Expr>"))]
         BTreeMap<SmolStr, Expr>,
     ),
+    /// AST Error node - this represents a parsing error in a partially generated AST
+    #[cfg(feature = "error-ast")]
+    Error(AstExprErrorKind),
 }
 
 /// Serde JSON structure for an extension function call in the EST format
@@ -413,7 +417,7 @@ impl ExprBuilder for Builder {
     type Expr = Expr;
 
     type Data = ();
-    type ErrorType = ParseErrors;
+    type ErrorType = Infallible;
 
     fn with_data(_data: Self::Data) -> Self {
         Self
@@ -693,7 +697,9 @@ impl ExprBuilder for Builder {
     }
 
     fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType> {
-        Err(parse_errors)
+        Ok(Expr::ExprNoExt(ExprNoExt::Error(
+            AstExprErrorKind::InvalidExpr(parse_errors.to_string()),
+        )))
     }
 }
 
@@ -858,6 +864,7 @@ impl Expr {
                     }
                     Ok(Expr::ExprNoExt(ExprNoExt::Record(new_m)))
                 }
+                ExprNoExt::Error(_) => Err(JsonDeserializationError::ErrorNode),
             },
             Expr::ExtFuncCall(e_fn_call) => {
                 let mut new_m = HashMap::new();
@@ -1051,6 +1058,7 @@ impl Expr {
                     }),
                 }
             }
+            Expr::ExprNoExt(ExprNoExt::Error(_)) => Err(FromJsonError::ErrorNode),
         }
     }
 }
@@ -1118,11 +1126,15 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
                         .map(|(k, v)| (k, v.into())),
                 )
                 .unwrap(),
-            // PANIC SAFETY: There is no reason to support having deliberate Errors in EST - This should never happen
-            #[allow(clippy::panic)]
-            ast::ExprKind::Error { .. } => {
-                panic!("We do not support converting an AST Error node into an EST");
-            }
+            // PANIC SAFETY: error type is Infallible so can never happen
+            #[cfg(feature = "error-ast")]
+            #[allow(clippy::unwrap_used)]
+            ast::ExprKind::Error { .. } => Builder::new()
+                .error(ParseErrors::singleton(ToASTError::new(
+                    ToASTErrorKind::ErrorNode,
+                    Loc::new(0..1, "AST_ERROR_NODE".into()),
+                )))
+                .unwrap(),
         }
     }
 }
@@ -1480,6 +1492,11 @@ impl BoundedDisplay for ExprNoExt {
                     }
                 }
             }
+            #[cfg(feature = "error-ast")]
+            ExprNoExt::Error(e) => {
+                write!(f, "{e}")?;
+                Ok(())
+            }
         }
     }
 }
@@ -1563,6 +1580,7 @@ fn maybe_with_parens(
         Expr::ExprNoExt(ExprNoExt::Like { .. }) |
         Expr::ExprNoExt(ExprNoExt::Is { .. }) |
         Expr::ExprNoExt(ExprNoExt::If { .. }) |
+        Expr::ExprNoExt(ExprNoExt::Error { .. }) |
         Expr::ExtFuncCall { .. } => {
             write!(f, "(")?;
             BoundedDisplay::fmt(expr, f, n)?;

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -17,9 +17,9 @@
 use super::FromJsonError;
 #[cfg(feature = "tolerant-ast")]
 use crate::ast::expr_allows_errors::AstExprErrorKind;
-use crate::ast::{self, BoundedDisplay, EntityUID};
 #[cfg(feature = "tolerant-ast")]
 use crate::ast::Infallible;
+use crate::ast::{self, BoundedDisplay, EntityUID};
 use crate::entities::json::{
     err::EscapeKind, err::JsonDeserializationError, err::JsonDeserializationErrorContext,
     CedarValueJson, FnAndArg,

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -1122,9 +1122,9 @@ impl<T: Clone> From<ast::Expr<T>> for Expr {
                         .map(|(k, v)| (k, v.into())),
                 )
                 .unwrap(),
+            // PANIC SAFETY: There is no reason to support having deliberate Errors in EST - This should never happen
             #[allow(clippy::panic)]
             ast::ExprKind::Error { .. } => {
-                // PANIC SAFETY There is no reason to support having deliberate Errors in EST - This should never happen
                 panic!("We do not support converting an AST Error node into an EST");
             }
         }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -760,10 +760,9 @@ impl<'e> Evaluator<'e> {
                     }
                 }
             }
+            // PANIC SAFETY: We should never be evaluating an error node - Will never happen because we do not use error-enabled parsing for evaluation
             #[allow(clippy::panic)]
             ExprKind::Error { .. } => {
-                // PANIC SAFETY We should never be evaluating an error node - Will never happen because we do not use error-enabled
-                //              parsing for evaluation
                 panic!("We cannot evaluate an error node - this should never happen")
             }
         }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 mod err;
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 use crate::evaluator::EvaluationError::ASTErrorExpr;
 pub use err::evaluation_errors;
 pub use err::EvaluationError;
@@ -762,7 +762,7 @@ impl<'e> Evaluator<'e> {
                     }
                 }
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => Err(ASTErrorExpr(ASTErrorExprError {
                 source_loc: loc.cloned(),
             })),

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -760,7 +760,12 @@ impl<'e> Evaluator<'e> {
                     }
                 }
             }
-            ExprKind::Error { .. } => panic!("We cannot evaluate an error node - this should never happen"),
+            #[allow(clippy::panic)]
+            ExprKind::Error { .. } => {
+                // PANIC SAFETY We should never be evaluating an error node - Will never happen because we do not use error-enabled 
+                //              parsing for evaluation
+                panic!("We cannot evaluate an error node - this should never happen")
+            }
         }
     }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 mod err;
+use crate::evaluator::EvaluationError::ErrorExpr;
 pub use err::evaluation_errors;
 pub use err::EvaluationError;
 pub(crate) use err::*;
@@ -760,11 +761,10 @@ impl<'e> Evaluator<'e> {
                     }
                 }
             }
-            // PANIC SAFETY: We should never be evaluating an error node - Will never happen because we do not use error-enabled parsing for evaluation
-            #[allow(clippy::panic)]
-            ExprKind::Error { .. } => {
-                panic!("We cannot evaluate an error node - this should never happen")
-            }
+            #[cfg(feature = "error-ast")]
+            ExprKind::Error { .. } => Err(ErrorExpr(ErrorExprError {
+                source_loc: loc.cloned(),
+            })),
         }
     }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -26,7 +26,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 mod err;
-use crate::evaluator::EvaluationError::ErrorExpr;
+#[cfg(feature = "error-ast")]
+use crate::evaluator::EvaluationError::ASTErrorExpr;
 pub use err::evaluation_errors;
 pub use err::EvaluationError;
 pub(crate) use err::*;
@@ -762,7 +763,7 @@ impl<'e> Evaluator<'e> {
                 }
             }
             #[cfg(feature = "error-ast")]
-            ExprKind::Error { .. } => Err(ErrorExpr(ErrorExprError {
+            ExprKind::Error { .. } => Err(ASTErrorExpr(ASTErrorExprError {
                 source_loc: loc.cloned(),
             })),
         }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -760,6 +760,7 @@ impl<'e> Evaluator<'e> {
                     }
                 }
             }
+            ExprKind::Error { error_kind, sub_expression } => todo!(),
         }
     }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -760,7 +760,7 @@ impl<'e> Evaluator<'e> {
                     }
                 }
             }
-            ExprKind::Error { error_kind, sub_expression } => todo!(),
+            ExprKind::Error { .. } => panic!("We cannot evaluate an error node - this should never happen"),
         }
     }
 

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -762,7 +762,7 @@ impl<'e> Evaluator<'e> {
             }
             #[allow(clippy::panic)]
             ExprKind::Error { .. } => {
-                // PANIC SAFETY We should never be evaluating an error node - Will never happen because we do not use error-enabled 
+                // PANIC SAFETY We should never be evaluating an error node - Will never happen because we do not use error-enabled
                 //              parsing for evaluation
                 panic!("We cannot evaluate an error node - this should never happen")
             }

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -89,7 +89,7 @@ pub enum EvaluationError {
     #[diagnostic(transparent)]
     NonValue(#[from] evaluation_errors::NonValueError),
 
-    /// This is an expression AST node that gets generated when parsing fails
+    /// Trying to evaluate an expression AST node that gets generated when parsing fails
     #[cfg(feature = "tolerant-ast")]
     #[error(transparent)]
     #[diagnostic(transparent)]

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -89,10 +89,11 @@ pub enum EvaluationError {
     #[diagnostic(transparent)]
     NonValue(#[from] evaluation_errors::NonValueError),
 
-    /// TODO
+    /// This is an expression AST node that gets generated when parsing fails
+    #[cfg(feature = "error-ast")]
     #[error(transparent)]
     #[diagnostic(transparent)]
-    ErrorExpr(#[from] evaluation_errors::ErrorExprError),
+    ASTErrorExpr(#[from] evaluation_errors::ASTErrorExprError),
 
     /// Maximum recursion limit reached for expression evaluation
     #[error(transparent)]
@@ -115,7 +116,8 @@ impl EvaluationError {
             Self::FailedExtensionFunctionExecution(e) => e.source_loc.as_ref(),
             Self::NonValue(e) => e.source_loc.as_ref(),
             Self::RecursionLimit(e) => e.source_loc.as_ref(),
-            Self::ErrorExpr(e) => e.source_loc.as_ref(),
+            #[cfg(feature = "error-ast")]
+            Self::ASTErrorExpr(e) => e.source_loc.as_ref(),
         }
     }
 
@@ -163,7 +165,10 @@ impl EvaluationError {
             Self::RecursionLimit(_) => {
                 Self::RecursionLimit(evaluation_errors::RecursionLimitError { source_loc })
             }
-            Self::ErrorExpr(_) => Self::ErrorExpr(evaluation_errors::ErrorExprError { source_loc }),
+            #[cfg(feature = "error-ast")]
+            Self::ASTErrorExpr(_) => {
+                Self::ASTErrorExpr(evaluation_errors::ASTErrorExprError { source_loc })
+            }
         }
     }
 
@@ -702,23 +707,25 @@ pub mod evaluation_errors {
         }
     }
 
-    /// TODO
+    /// Represents an AST node that failed to parse - cannot be evaluated
     //
     // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
+    #[cfg(feature = "error-ast")]
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
     #[error("the expression contains an error")]
-    pub struct ErrorExprError {
+    pub struct ASTErrorExprError {
         /// Source location
         pub(crate) source_loc: Option<Loc>,
     }
 
-    impl Diagnostic for ErrorExprError {
+    #[cfg(feature = "error-ast")]
+    impl Diagnostic for ASTErrorExprError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
 
         fn help<'a>(&'a self) -> Option<Box<dyn std::fmt::Display + 'a>> {
-            Some(Box::new("consider using the partial evaluation APIs"))
+            Some(Box::new("Represents an AST node that failed to parse"))
         }
     }
 

--- a/cedar-policy-core/src/evaluator/err.rs
+++ b/cedar-policy-core/src/evaluator/err.rs
@@ -90,7 +90,7 @@ pub enum EvaluationError {
     NonValue(#[from] evaluation_errors::NonValueError),
 
     /// This is an expression AST node that gets generated when parsing fails
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[error(transparent)]
     #[diagnostic(transparent)]
     ASTErrorExpr(#[from] evaluation_errors::ASTErrorExprError),
@@ -116,7 +116,7 @@ impl EvaluationError {
             Self::FailedExtensionFunctionExecution(e) => e.source_loc.as_ref(),
             Self::NonValue(e) => e.source_loc.as_ref(),
             Self::RecursionLimit(e) => e.source_loc.as_ref(),
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             Self::ASTErrorExpr(e) => e.source_loc.as_ref(),
         }
     }
@@ -165,7 +165,7 @@ impl EvaluationError {
             Self::RecursionLimit(_) => {
                 Self::RecursionLimit(evaluation_errors::RecursionLimitError { source_loc })
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             Self::ASTErrorExpr(_) => {
                 Self::ASTErrorExpr(evaluation_errors::ASTErrorExprError { source_loc })
             }
@@ -712,7 +712,7 @@ pub mod evaluation_errors {
     // CAUTION: this type is publicly exported in `cedar-policy`.
     // Don't make fields `pub`, don't make breaking changes, and use caution
     // when adding public methods.
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[derive(Debug, PartialEq, Eq, Clone, Error)]
     #[error("the expression contains an error")]
     pub struct ASTErrorExprError {
@@ -720,7 +720,7 @@ pub mod evaluation_errors {
         pub(crate) source_loc: Option<Loc>,
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     impl Diagnostic for ASTErrorExprError {
         impl_diagnostic_from_source_loc_opt_field!(source_loc);
 

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -26,7 +26,7 @@ use crate::{
         BinaryOp, EntityType, ExpressionConstructionError, Literal, Name, Pattern, SlotId, UnaryOp,
         Unknown, Var,
     },
-    parser::{cst, Loc, err::ParseErrors},
+    parser::{cst, err::ParseErrors, Loc},
 };
 
 /// Defines a generic interface for building different expression data
@@ -40,6 +40,9 @@ pub trait ExprBuilder: Clone {
     /// can be `()` if no data is stored.
     type Data: Default;
 
+    /// Type for what error we return if we cannot construct an error node 
+    ///  By default we fail on errors and this should be a ParseErrors
+    ///  But when we run with error parsing enabled, can be Infallible
     type ErrorType;
 
     /// Construct a new expression builder for an expression that will not carry any data.
@@ -50,7 +53,12 @@ pub trait ExprBuilder: Clone {
         Self::with_data(Self::Data::default())
     }
 
-    fn error(self, parse_errors: ParseErrors, sub_expression: Option<Arc<Self::Expr>>) -> Result<Self::Expr, Self::ErrorType>;
+    /// Build an expression that failed to parse - can optionally include subexpressions that parsed successfully 
+    fn error(
+        self,
+        parse_errors: ParseErrors,
+        sub_expression: Option<Arc<Self::Expr>>,
+    ) -> Result<Self::Expr, Self::ErrorType>;
 
     /// Build an expression storing this information
     fn with_data(data: Self::Data) -> Self;

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -17,6 +17,8 @@
 //! Contains the trait [`ExprBuilder`], defining a generic interface for
 //! building different expression data structures (e.g., AST and EST).
 
+use std::sync::Arc;
+
 use smol_str::SmolStr;
 
 use crate::{
@@ -24,7 +26,7 @@ use crate::{
         BinaryOp, EntityType, ExpressionConstructionError, Literal, Name, Pattern, SlotId, UnaryOp,
         Unknown, Var,
     },
-    parser::{cst, Loc},
+    parser::{cst, Loc, err::ParseErrors},
 };
 
 /// Defines a generic interface for building different expression data
@@ -38,6 +40,8 @@ pub trait ExprBuilder: Clone {
     /// can be `()` if no data is stored.
     type Data: Default;
 
+    type ErrorType;
+
     /// Construct a new expression builder for an expression that will not carry any data.
     fn new() -> Self
     where
@@ -45,6 +49,8 @@ pub trait ExprBuilder: Clone {
     {
         Self::with_data(Self::Data::default())
     }
+
+    fn error(self, parse_errors: ParseErrors, sub_expression: Option<Arc<Self::Expr>>) -> Result<Self::Expr, Self::ErrorType>;
 
     /// Build an expression storing this information
     fn with_data(data: Self::Data) -> Self;

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -45,6 +45,7 @@ pub trait ExprBuilder: Clone {
     ///
     ///  By default we fail on errors and this should be a ParseErrors
     ///  But when we run with error parsing enabled, can be Infallible
+    #[cfg(feature = "tolerant-ast")]
     type ErrorType;
 
     /// Construct a new expression builder for an expression that will not carry any data.

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -24,8 +24,11 @@ use crate::{
         BinaryOp, EntityType, ExpressionConstructionError, Literal, Name, Pattern, SlotId, UnaryOp,
         Unknown, Var,
     },
-    parser::{cst, err::ParseErrors, Loc},
+    parser::{cst, Loc},
 };
+
+#[cfg(feature = "error-ast")]
+use crate::parser::err::ParseErrors;
 
 /// Defines a generic interface for building different expression data
 /// structures.

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -53,6 +53,7 @@ pub trait ExprBuilder: Clone {
     }
 
     /// Build an expression that failed to parse - can optionally include subexpressions that parsed successfully
+    #[cfg(feature = "error-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType>;
 
     /// Build an expression storing this information

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -17,8 +17,6 @@
 //! Contains the trait [`ExprBuilder`], defining a generic interface for
 //! building different expression data structures (e.g., AST and EST).
 
-use std::sync::Arc;
-
 use smol_str::SmolStr;
 
 use crate::{
@@ -54,11 +52,7 @@ pub trait ExprBuilder: Clone {
     }
 
     /// Build an expression that failed to parse - can optionally include subexpressions that parsed successfully
-    fn error(
-        self,
-        parse_errors: ParseErrors,
-        sub_expression: Option<Arc<Self::Expr>>,
-    ) -> Result<Self::Expr, Self::ErrorType>;
+    fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType>;
 
     /// Build an expression storing this information
     fn with_data(data: Self::Data) -> Self;

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -27,7 +27,7 @@ use crate::{
     parser::{cst, Loc},
 };
 
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 use crate::parser::err::ParseErrors;
 
 /// Defines a generic interface for building different expression data
@@ -56,7 +56,7 @@ pub trait ExprBuilder: Clone {
     }
 
     /// Build an expression that failed to parse - can optionally include subexpressions that parsed successfully
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     fn error(self, parse_errors: ParseErrors) -> Result<Self::Expr, Self::ErrorType>;
 
     /// Build an expression storing this information

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -40,7 +40,7 @@ pub trait ExprBuilder: Clone {
     /// can be `()` if no data is stored.
     type Data: Default;
 
-    /// Type for what error we return if we cannot construct an error node 
+    /// Type for what error we return if we cannot construct an error node
     ///  By default we fail on errors and this should be a ParseErrors
     ///  But when we run with error parsing enabled, can be Infallible
     type ErrorType;
@@ -53,7 +53,7 @@ pub trait ExprBuilder: Clone {
         Self::with_data(Self::Data::default())
     }
 
-    /// Build an expression that failed to parse - can optionally include subexpressions that parsed successfully 
+    /// Build an expression that failed to parse - can optionally include subexpressions that parsed successfully
     fn error(
         self,
         parse_errors: ParseErrors,

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -39,6 +39,7 @@ pub trait ExprBuilder: Clone {
     type Data: Default;
 
     /// Type for what error we return if we cannot construct an error node
+    ///
     ///  By default we fail on errors and this should be a ParseErrors
     ///  But when we run with error parsing enabled, can be Infallible
     type ErrorType;

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -110,7 +110,7 @@ pub fn parse_policy_or_template(
 ) -> Result<ast::Template, err::ParseErrors> {
     let id = id.unwrap_or_else(|| ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
-    cst.to_policy_template(id)
+    cst.to_template(id)
 }
 
 /// Like `parse_policy_or_template()`, but also returns the (lossless) EST -- that
@@ -122,7 +122,7 @@ pub fn parse_policy_or_template_to_est_and_ast(
 ) -> Result<(est::Policy, ast::Template), err::ParseErrors> {
     let id = id.unwrap_or_else(|| ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
-    let ast = cst.to_policy_template(id)?;
+    let ast = cst.to_template(id)?;
     let est = cst.try_into_inner()?.try_into()?;
     Ok((est, ast))
 }
@@ -137,7 +137,7 @@ pub fn parse_template(
 ) -> Result<ast::Template, err::ParseErrors> {
     let id = id.unwrap_or_else(|| ast::PolicyID::from_string("policy0"));
     let cst = text_to_cst::parse_policy(text)?;
-    let template = cst.to_policy_template(id)?;
+    let template = cst.to_template(id)?;
     if template.slots().count() == 0 {
         Err(err::ToASTError::new(err::ToASTErrorKind::expected_template(), cst.loc).into())
     } else {

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -181,7 +181,7 @@ impl Node<Option<cst::Policy>> {
 
     /// Convert `cst::Policy` to `ast::Template`. Works for inline policies as
     /// well, which will become templates with 0 slots
-    pub fn to_policy_template(&self, id: ast::PolicyID) -> Result<ast::Template> {
+    pub fn to_template(&self, id: ast::PolicyID) -> Result<ast::Template> {
         self.to_policy_template_helper(id, false)
     }
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -888,15 +888,23 @@ impl Node<Option<cst::Str>> {
     }
 }
 
+#[cfg(feature = "error-ast")]
+fn error_ast_conversion<Build: ExprBuilder>(error: ParseErrors) -> Result<Build::Expr> {
+    let res = Build::new().error(error.clone());
+    return match res {
+        Ok(r) => Ok(r),
+        Err(_) => Err(error),
+    };
+}
+
 /// Since ExprBuilder ErrorType can be Infallible or ParseErrors, if we get an error from building the node pass the ParseErrors along
 fn convert_expr_error_to_parse_error<Build: ExprBuilder>(
     error: ParseErrors,
 ) -> Result<Build::Expr> {
-    let res = Build::new().error(error.clone());
-    match res {
-        Ok(r) => Ok(r),
-        Err(_) => Err(error),
-    }
+    #[cfg(feature = "error-ast")]
+    return error_ast_conversion::<Build>(error);
+    #[allow(unreachable_code)]
+    Err(error)
 }
 
 /// Result type of conversion when we expect an Expr, Var, Name, or String.

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -39,7 +39,7 @@ use super::loc::Loc;
 use super::node::Node;
 use super::unescape::{to_pattern, to_unescaped_string};
 use super::util::{flatten_tuple_2, flatten_tuple_3, flatten_tuple_4};
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 use crate::ast::expr_allows_errors::ExprWithErrsBuilder;
 use crate::ast::{
     self, ActionConstraint, CallStyle, Integer, PatternElem, PolicySetError, PrincipalConstraint,
@@ -273,7 +273,7 @@ impl Node<Option<cst::Policy>> {
     /// NOTE: This function allows partial parsing and can produce AST Error nodes
     /// These cannot be evaluated
     /// Should ONLY be used to examine a partially constructed AST from invalid Cedar
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     pub fn to_policy_with_errors(&self, id: ast::PolicyID) -> Result<ast::StaticPolicy> {
         let maybe_template = self.to_policy_template_with_errors(id);
         let maybe_policy = maybe_template.map(ast::StaticPolicy::try_from);
@@ -313,7 +313,7 @@ impl Node<Option<cst::Policy>> {
     /// NOTE: This function allows partial parsing and can produce AST Error nodes
     /// These cannot be evaluated
     /// Should ONLY be used to examine a partially constructed AST from invalid Cedar
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     pub fn to_policy_template_with_errors(&self, id: ast::PolicyID) -> Result<ast::Template> {
         let policy = self.try_as_inner()?;
 
@@ -894,7 +894,7 @@ impl Node<Option<cst::Str>> {
     }
 }
 
-#[cfg(feature = "error-ast")]
+#[cfg(feature = "tolerant-ast")]
 fn build_ast_error_node_if_possible<Build: ExprBuilder>(error: ParseErrors) -> Result<Build::Expr> {
     let res = Build::new().error(error.clone());
     match res {
@@ -907,7 +907,7 @@ fn build_ast_error_node_if_possible<Build: ExprBuilder>(error: ParseErrors) -> R
 fn convert_expr_error_to_parse_error<Build: ExprBuilder>(
     error: ParseErrors,
 ) -> Result<Build::Expr> {
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     return build_ast_error_node_if_possible::<Build>(error);
     #[allow(unreachable_code)]
     Err(error)
@@ -5263,7 +5263,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[track_caller]
     fn assert_parse_policy_allows_errors(text: &str) -> ast::StaticPolicy {
         text_to_cst::parse_policy(text)
@@ -5274,7 +5274,7 @@ mod tests {
             })
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[track_caller]
     fn assert_parse_policy_allows_errors_fails(text: &str) -> ParseErrors {
         let result = text_to_cst::parse_policy(text)
@@ -5289,7 +5289,7 @@ mod tests {
     }
 
     // Test parsing AST that allows Error nodes
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn parsing_with_errors_succeeds_with_empty_when() {
         let src = r#"
@@ -5298,7 +5298,7 @@ mod tests {
         assert_parse_policy_allows_errors(src);
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn show_policy1_errors_enabled() {
         let src = r#"
@@ -5356,7 +5356,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn show_policy2_errors_enabled() {
         let src = r#"
@@ -5365,7 +5365,7 @@ mod tests {
         assert_parse_policy_allows_errors(src);
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn show_policy3_errors_enabled() {
         let src = r#"
@@ -5374,7 +5374,7 @@ mod tests {
         assert_parse_policy_allows_errors(src);
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn show_policy4_errors_enabled() {
         let src = r#"
@@ -5385,7 +5385,7 @@ mod tests {
         assert_parse_policy_allows_errors(src);
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn single_annotation_errors_enabled() {
         // common use-case
@@ -5400,7 +5400,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[test]
     fn duplicate_annotations_error_errors_enabled() {
         // duplication is error

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -241,7 +241,7 @@ impl Node<Option<cst::Policy>> {
         }
     }
 
-    /// Convert `cst::Policy` to `ast::Template`. Works for inline policies as
+    /// Convert `cst::Policy` to `ast::Template`. Works for static policies as
     /// well, which will become templates with 0 slots
     pub fn to_policy_template_helper(
         &self,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -174,7 +174,7 @@ impl Node<Option<cst::Policy>> {
         self.to_policy_helper(id, false)
     }
 
-    /// Convert `cst::Policy` to an AST `InlinePolicy`. (Will fail if the CST is for a template)
+    /// Convert `cst::Policy` to an AST `StaticPolicy`. (Will fail if the CST is for a template)
     pub fn to_policy_with_errors(&self, id: ast::PolicyID) -> Result<ast::StaticPolicy> {
         self.to_policy_helper(id, true)
     }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -169,7 +169,7 @@ impl Node<Option<cst::Policy>> {
         self.to_policy_or_template_helper(id, false)
     }
 
-    /// Convert `cst::Policy` to an AST `InlinePolicy`. (Will fail if the CST is for a template)
+    /// Convert `cst::Policy` to an AST `StaticPolicy`. (Will fail if the CST is for a template)
     pub fn to_policy(&self, id: ast::PolicyID) -> Result<ast::StaticPolicy> {
         self.to_policy_helper(id, false)
     }

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -5410,7 +5410,7 @@ mod tests {
             @anno("oops, duplicate")
             permit(principal,action,resource);
         "#;
-        let errs = assert_parse_policy_fails(src);
+        let errs = assert_parse_policy_allows_errors_fails(src);
         // annotation duplication (anno)
         expect_n_errors(src, &errs, 1);
         expect_some_error_matches(

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -407,7 +407,7 @@ pub enum ToASTErrorKind {
     #[diagnostic(help("try `_ is _ in _`"))]
     InvertedIsIn,
     /// Represents a parsing error in a partially generated AST
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     #[error("Trying to convert AST error node")]
     ErrorNode,
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -406,6 +406,10 @@ pub enum ToASTErrorKind {
     #[error("when `is` and `in` are used together, `is` must come first")]
     #[diagnostic(help("try `_ is _ in _`"))]
     InvertedIsIn,
+    /// Represents a parsing error in a partially generated AST
+    #[cfg(feature = "error-ast")]
+    #[error("Trying to convert AST error node")]
+    ErrorNode,
 }
 
 fn invalid_is_help(lhs: &str, rhs: &str) -> String {

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -50,6 +50,7 @@ partial-validate = []
 level-validate = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 entity-manifest = []
+error-ast = []
 
 [dev-dependencies]
 similar-asserts = "1.6.1"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -50,7 +50,7 @@ partial-validate = []
 level-validate = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 entity-manifest = []
-error-ast = []
+error-ast = ["cedar-policy-core/error-ast"]
 
 [dev-dependencies]
 similar-asserts = "1.6.1"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -50,7 +50,7 @@ partial-validate = []
 level-validate = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 entity-manifest = []
-error-ast = ["cedar-policy-core/error-ast"]
+tolerant-ast = ["cedar-policy-core/tolerant-ast"]
 
 [dev-dependencies]
 similar-asserts = "1.6.1"

--- a/cedar-policy-validator/src/entity_manifest.rs
+++ b/cedar-policy-validator/src/entity_manifest.rs
@@ -666,10 +666,11 @@ fn entity_manifest_from_expr(
         ExprKind::HasAttr { expr, attr } => Ok(entity_manifest_from_expr(expr)?
             .get_or_has_attr(attr)
             .empty_paths()),
-        // PANIC SAFETY: We should never allow parse errors when constructing entity manifest
-        #[allow(clippy::panic)]
+        #[cfg(feature = "error-ast")]
         ExprKind::Error { .. } => {
-            panic!("We should never have parse errors in our AST when constructing entity manifest - this should never happen");
+          Err(EntityManifestError::UnsupportedCedarFeature(UnsupportedCedarFeatureError {
+            feature: "No support for AST error nodes".into()
+          }) )
         }
     }
 }

--- a/cedar-policy-validator/src/entity_manifest.rs
+++ b/cedar-policy-validator/src/entity_manifest.rs
@@ -666,6 +666,11 @@ fn entity_manifest_from_expr(
         ExprKind::HasAttr { expr, attr } => Ok(entity_manifest_from_expr(expr)?
             .get_or_has_attr(attr)
             .empty_paths()),
+        // PANIC SAFETY: We should never allow parse errors when constructing entity manifest
+        #[allow(clippy::panic)]
+        ExprKind::Error { .. } => {
+            panic!("We should never have parse errors in our AST when constructing entity manifest - this should never happen");
+        }
     }
 }
 

--- a/cedar-policy-validator/src/entity_manifest.rs
+++ b/cedar-policy-validator/src/entity_manifest.rs
@@ -667,11 +667,11 @@ fn entity_manifest_from_expr(
             .get_or_has_attr(attr)
             .empty_paths()),
         #[cfg(feature = "error-ast")]
-        ExprKind::Error { .. } => {
-          Err(EntityManifestError::UnsupportedCedarFeature(UnsupportedCedarFeatureError {
-            feature: "No support for AST error nodes".into()
-          }) )
-        }
+        ExprKind::Error { .. } => Err(EntityManifestError::UnsupportedCedarFeature(
+            UnsupportedCedarFeatureError {
+                feature: "No support for AST error nodes".into(),
+            },
+        )),
     }
 }
 

--- a/cedar-policy-validator/src/entity_manifest.rs
+++ b/cedar-policy-validator/src/entity_manifest.rs
@@ -666,7 +666,7 @@ fn entity_manifest_from_expr(
         ExprKind::HasAttr { expr, attr } => Ok(entity_manifest_from_expr(expr)?
             .get_or_has_attr(attr)
             .empty_paths()),
-        #[cfg(feature = "error-ast")]
+        #[cfg(feature = "tolerant-ast")]
         ExprKind::Error { .. } => Err(EntityManifestError::UnsupportedCedarFeature(
             UnsupportedCedarFeatureError {
                 feature: "No support for AST error nodes".into(),

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -238,6 +238,11 @@ impl Validator {
                     .collect();
                 Self::min(v)
             }
+            // PANIC SAFETY: We do not allow validation of AST's with error nodes
+            #[allow(clippy::panic)]
+            ExprKind::Error { .. } => {
+                panic!(" We do not allow validation of AST's with error nodes - this should never happen");
+            }
         }
     }
 }

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -246,7 +246,7 @@ impl Validator {
                     .collect();
                 Self::min(v)
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => (
                 EntityDerefLevel { level: 0 },
                 Some(ValidationError::InternalInvariantViolation(

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -67,7 +67,7 @@ impl Validator {
                 PolicyCheck::Success(e) | PolicyCheck::Irrelevant(_, e) => {
                     let res = Self::check_entity_deref_level_helper(&e, max_allowed_level, t.id());
                     if let Some(e) = res.1 {
-                        errs.push(ValidationError::EntityDerefLevelViolation(e))
+                        errs.push(e)
                     }
                 }
                 // PANIC SAFETY: We only validate the level after validation passed
@@ -140,12 +140,15 @@ impl Validator {
                 if new_level.level < 0 {
                     (
                         new_level,
-                        Some(EntityDerefLevelViolation {
-                            source_loc: e.source_loc().cloned(),
-                            policy_id: policy_id.clone(),
-                            actual_level: new_level,
-                            allowed_level: *max_allowed_level,
-                        }.into()),
+                        Some(
+                            EntityDerefLevelViolation {
+                                source_loc: e.source_loc().cloned(),
+                                policy_id: policy_id.clone(),
+                                actual_level: new_level,
+                                allowed_level: *max_allowed_level,
+                            }
+                            .into(),
+                        ),
                     )
                 } else {
                     (new_level, None)
@@ -199,12 +202,15 @@ impl Validator {
                             if new_level.level < 0 {
                                 (
                                     new_level,
-                                    Some(EntityDerefLevelViolation {
-                                        source_loc: e.source_loc().cloned(),
-                                        policy_id: policy_id.clone(),
-                                        actual_level: new_level,
-                                        allowed_level: *max_allowed_level,
-                                    }.into()),
+                                    Some(
+                                        EntityDerefLevelViolation {
+                                            source_loc: e.source_loc().cloned(),
+                                            policy_id: policy_id.clone(),
+                                            actual_level: new_level,
+                                            allowed_level: *max_allowed_level,
+                                        }
+                                        .into(),
+                                    ),
                                 )
                             } else {
                                 (new_level, None)
@@ -241,7 +247,15 @@ impl Validator {
                 Self::min(v)
             }
             #[cfg(feature = "error-ast")]
-            ExprKind::Error { .. } => ValidationError::InternalInvariantViolation(InternalInvariantViolation(source_loc: None, todo!()))
+            ExprKind::Error { .. } => (
+                EntityDerefLevel { level: 0 },
+                Some(ValidationError::InternalInvariantViolation(
+                    InternalInvariantViolation {
+                        source_loc: None,
+                        policy_id: policy_id.clone(),
+                    },
+                )),
+            ),
         }
     }
 }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1174,7 +1174,7 @@ impl<'a> SingleEnvTypechecker<'a> {
                     },
                 )
             }
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => TypecheckAnswer::ErrorAstNode,
         }
     }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1174,10 +1174,9 @@ impl<'a> SingleEnvTypechecker<'a> {
                     },
                 )
             }
+            // PANIC SAFETY: We should never be trying to type check or evaluate code that allows errors - This is avoided by using the default cst-to-ast parsing which fails on parse errors
             #[allow(clippy::panic)]
             ExprKind::Error { .. } => {
-                // PANIC SAFETY: We should never be trying to type check or evaluate code that allows errors
-                //       This is avoided by using the default cst-to-ast parsing which fails on parse errors
                 panic!("Cannot type check an Error Expression node - this should never happen")
             }
         }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1174,7 +1174,12 @@ impl<'a> SingleEnvTypechecker<'a> {
                     },
                 )
             }
-            ExprKind::Error { .. } => panic!("Cannot type check an Error Expression node - this should never happen") ,
+            #[allow(clippy::panic)]
+            ExprKind::Error { .. } => {
+                // PANIC SAFETY: We should never be trying to type check or evaluate code that allows errors
+                //       This is avoided by using the default cst-to-ast parsing which fails on parse errors
+                panic!("Cannot type check an Error Expression node - this should never happen")
+            }
         }
     }
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1174,6 +1174,7 @@ impl<'a> SingleEnvTypechecker<'a> {
                     },
                 )
             }
+            ExprKind::Error { .. } => panic!("Cannot type check an Error Expression node - this should never happen") ,
         }
     }
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -1174,11 +1174,8 @@ impl<'a> SingleEnvTypechecker<'a> {
                     },
                 )
             }
-            // PANIC SAFETY: We should never be trying to type check or evaluate code that allows errors - This is avoided by using the default cst-to-ast parsing which fails on parse errors
-            #[allow(clippy::panic)]
-            ExprKind::Error { .. } => {
-                panic!("Cannot type check an Error Expression node - this should never happen")
-            }
+            #[cfg(feature = "error-ast")]
+            ExprKind::Error { .. } => TypecheckAnswer::ErrorAstNode,
         }
     }
 

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -182,17 +182,21 @@ fn expr_typechecks_with_correct_annotation() {
     let euid = EntityUID::with_eid_and_type("Foo", "bar").unwrap();
     match tc.typecheck_expr(&Expr::val(euid.clone()), &expr_id_placeholder(), &mut errs) {
         crate::typecheck::TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
-            assert_eq!(
-                &expr_type,
-                &ExprBuilder::with_data(Some(Type::named_entity_reference_from_str("Foo")))
-                    .val(euid)
-            )
-        }
+                        assert_eq!(
+                            &expr_type,
+                            &ExprBuilder::with_data(Some(Type::named_entity_reference_from_str("Foo")))
+                                .val(euid)
+                        )
+            }
         crate::typecheck::TypecheckAnswer::TypecheckFail { .. } => {
-            panic!("Typechecking should succeed.")
-        }
+                panic!("Typechecking should succeed.")
+            }
         crate::typecheck::TypecheckAnswer::RecursionLimit => {
-            panic!("Should not have hit recursion limit")
-        }
+                panic!("Should not have hit recursion limit")
+            }
+        #[cfg(feature="error-ast")]
+        crate::typecheck::TypecheckAnswer::ErrorAstNode => {
+            panic!("Should not type check an AST with an error node")
+        },
     }
 }

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -194,7 +194,7 @@ fn expr_typechecks_with_correct_annotation() {
         crate::typecheck::TypecheckAnswer::RecursionLimit => {
             panic!("Should not have hit recursion limit")
         }
-        #[cfg(feature = "error-ast")]
+        #[cfg(feature = "tolerant-ast")]
         crate::typecheck::TypecheckAnswer::ErrorAstNode => {
             panic!("Should not type check an AST with an error node")
         }

--- a/cedar-policy-validator/src/typecheck/test/type_annotation.rs
+++ b/cedar-policy-validator/src/typecheck/test/type_annotation.rs
@@ -182,21 +182,21 @@ fn expr_typechecks_with_correct_annotation() {
     let euid = EntityUID::with_eid_and_type("Foo", "bar").unwrap();
     match tc.typecheck_expr(&Expr::val(euid.clone()), &expr_id_placeholder(), &mut errs) {
         crate::typecheck::TypecheckAnswer::TypecheckSuccess { expr_type, .. } => {
-                        assert_eq!(
-                            &expr_type,
-                            &ExprBuilder::with_data(Some(Type::named_entity_reference_from_str("Foo")))
-                                .val(euid)
-                        )
-            }
+            assert_eq!(
+                &expr_type,
+                &ExprBuilder::with_data(Some(Type::named_entity_reference_from_str("Foo")))
+                    .val(euid)
+            )
+        }
         crate::typecheck::TypecheckAnswer::TypecheckFail { .. } => {
-                panic!("Typechecking should succeed.")
-            }
+            panic!("Typechecking should succeed.")
+        }
         crate::typecheck::TypecheckAnswer::RecursionLimit => {
-                panic!("Should not have hit recursion limit")
-            }
-        #[cfg(feature="error-ast")]
+            panic!("Should not have hit recursion limit")
+        }
+        #[cfg(feature = "error-ast")]
         crate::typecheck::TypecheckAnswer::ErrorAstNode => {
             panic!("Should not type check an AST with an error node")
-        },
+        }
     }
 }

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -41,7 +41,7 @@ pub(crate) enum TypecheckAnswer<'a> {
     RecursionLimit,
 
     /// Trying to typescheck an error node
-    #[cfg(feature = "error-ast")]
+    #[cfg(feature = "tolerant-ast")]
     ErrorAstNode,
 }
 
@@ -81,7 +81,7 @@ impl<'a> TypecheckAnswer<'a> {
             TypecheckAnswer::TypecheckSuccess { expr_type, .. } => Some(expr_type),
             TypecheckAnswer::TypecheckFail { expr_recovery_type } => Some(expr_recovery_type),
             TypecheckAnswer::RecursionLimit => None,
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             TypecheckAnswer::ErrorAstNode => None,
         }
         .and_then(|e| e.data().as_ref())
@@ -93,7 +93,7 @@ impl<'a> TypecheckAnswer<'a> {
             TypecheckAnswer::TypecheckSuccess { expr_type, .. } => Some(expr_type),
             TypecheckAnswer::TypecheckFail { expr_recovery_type } => Some(expr_recovery_type),
             TypecheckAnswer::RecursionLimit => None,
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             TypecheckAnswer::ErrorAstNode => None,
         }
     }
@@ -104,7 +104,7 @@ impl<'a> TypecheckAnswer<'a> {
             TypecheckAnswer::TypecheckSuccess { .. } => true,
             TypecheckAnswer::TypecheckFail { .. } => false,
             TypecheckAnswer::RecursionLimit => false,
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             TypecheckAnswer::ErrorAstNode => false,
         }
     }
@@ -125,7 +125,7 @@ impl<'a> TypecheckAnswer<'a> {
             },
             TypecheckAnswer::TypecheckFail { .. } => self,
             TypecheckAnswer::RecursionLimit => self,
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             TypecheckAnswer::ErrorAstNode => self,
         }
     }
@@ -139,7 +139,7 @@ impl<'a> TypecheckAnswer<'a> {
             TypecheckAnswer::TypecheckSuccess { expr_type, .. } => TypecheckAnswer::fail(expr_type),
             TypecheckAnswer::TypecheckFail { .. } => self,
             TypecheckAnswer::RecursionLimit => self,
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             TypecheckAnswer::ErrorAstNode => self,
         }
     }
@@ -160,7 +160,7 @@ impl<'a> TypecheckAnswer<'a> {
                 f(expr_recovery_type, CapabilitySet::new()).into_fail()
             }
             TypecheckAnswer::RecursionLimit => self,
-            #[cfg(feature = "error-ast")]
+            #[cfg(feature = "tolerant-ast")]
             TypecheckAnswer::ErrorAstNode => self,
         }
     }
@@ -179,7 +179,7 @@ impl<'a> TypecheckAnswer<'a> {
         let mut unwrapped = Vec::new();
         let mut any_failed = false;
         let mut recusion_limit_reached = false;
-        #[cfg(feature = "error-ast")]
+        #[cfg(feature = "tolerant-ast")]
         let mut ast_has_errors = false;
         for ans in answers {
             any_failed |= !ans.typechecked();
@@ -195,7 +195,7 @@ impl<'a> TypecheckAnswer<'a> {
                     recusion_limit_reached = true;
                     break;
                 }
-                #[cfg(feature = "error-ast")]
+                #[cfg(feature = "tolerant-ast")]
                 TypecheckAnswer::ErrorAstNode => {
                     ast_has_errors = true;
                     break;
@@ -203,7 +203,7 @@ impl<'a> TypecheckAnswer<'a> {
             });
         }
 
-        #[cfg(feature = "error-ast")]
+        #[cfg(feature = "tolerant-ast")]
         if ast_has_errors {
             return TypecheckAnswer::ErrorAstNode;
         }

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -202,11 +202,14 @@ impl<'a> TypecheckAnswer<'a> {
             });
         }
 
+        #[cfg(feature = "error-ast")]
+        if ast_has_errors {
+            return TypecheckAnswer::ErrorAstNode;
+        }
+
         let ans = f(unwrapped);
         if recusion_limit_reached {
             TypecheckAnswer::RecursionLimit
-        } else if ast_has_errors {
-            TypecheckAnswer::ErrorAstNode
         } else if any_failed {
             ans.into_fail()
         } else {

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -179,6 +179,7 @@ impl<'a> TypecheckAnswer<'a> {
         let mut unwrapped = Vec::new();
         let mut any_failed = false;
         let mut recusion_limit_reached = false;
+        #[cfg(feature = "error-ast")]
         let mut ast_has_errors = false;
         for ans in answers {
             any_failed |= !ans.typechecked();

--- a/cedar-policy-validator/src/typecheck/typecheck_answer.rs
+++ b/cedar-policy-validator/src/typecheck/typecheck_answer.rs
@@ -40,7 +40,7 @@ pub(crate) enum TypecheckAnswer<'a> {
     /// Recursion limit reached
     RecursionLimit,
 
-    /// Trying to typescheck an error node
+    /// Trying to typecheck an error node
     #[cfg(feature = "tolerant-ast")]
     ErrorAstNode,
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,7 @@ Cedar Language Version: TBD
 - Added `Entities::remove_entities()` to remove `Entity`s from an `Entities` struct (resolving #701)
 - Added `PolicySet::merge_policyset()` to merge a `PolicySet` into another `PolicySet` struct (resolving #610)
 - Implemented [RFC 53 (enumerated entity types)](https://github.com/cedar-policy/rfcs/blob/main/text/0053-enum-entities.md)  (#1377)
+- Added the experimental feature `tolerant-ast` which allows certain errors to be propogated in AST expressions as an `ExprKind::Error` (#1470)
 
 ### Fixed
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -60,7 +60,7 @@ partial-validate = ["cedar-policy-validator/partial-validate"]
 protobufs = ["dep:prost", "dep:prost-build"]
 level-validate = ["cedar-policy-validator/level-validate"]
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
-tolerant-ast = [ "cedar-policy-core/tolerant-ast",  "cedar-policy-validator/tolerant-ast"]
+tolerant-ast = ["cedar-policy-core/tolerant-ast",  "cedar-policy-validator/tolerant-ast"]
 
 [lib]
 # cdylib required for wasm

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -52,7 +52,7 @@ corpus-timing = []
 
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
-experimental = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest", "protobufs", "datetime", "error-ast"]
+experimental = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest", "protobufs", "datetime", "tolerant-ast"]
 entity-manifest = ["cedar-policy-validator/entity-manifest"]
 partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []
@@ -60,7 +60,7 @@ partial-validate = ["cedar-policy-validator/partial-validate"]
 protobufs = ["dep:prost", "dep:prost-build"]
 level-validate = ["cedar-policy-validator/level-validate"]
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
-error-ast = [ "cedar-policy-core/error-ast",  "cedar-policy-validator/error-ast"]
+tolerant-ast = [ "cedar-policy-core/tolerant-ast",  "cedar-policy-validator/tolerant-ast"]
 
 [lib]
 # cdylib required for wasm

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -52,7 +52,7 @@ corpus-timing = []
 
 # Experimental features.
 # Enable all experimental features with `cargo build --features "experimental"`
-experimental = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest", "protobufs", "datetime"]
+experimental = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest", "protobufs", "datetime", "error-ast"]
 entity-manifest = ["cedar-policy-validator/entity-manifest"]
 partial-eval = ["cedar-policy-core/partial-eval", "cedar-policy-validator/partial-eval"]
 permissive-validate = []
@@ -60,6 +60,7 @@ partial-validate = ["cedar-policy-validator/partial-validate"]
 protobufs = ["dep:prost", "dep:prost-build"]
 level-validate = ["cedar-policy-validator/level-validate"]
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
+error-ast = [ "cedar-policy-core/error-ast",  "cedar-policy-validator/error-ast"]
 
 [lib]
 # cdylib required for wasm

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -466,7 +466,8 @@ impl From<&ast::Expr> for models::Expr {
                     .map(|(key, value)| (key.to_string(), models::Expr::from(value)))
                     .collect();
                 models::expr::expr_kind::Data::Record(models::expr::Record { items: precord })
-            }
+            },
+            #[cfg(feature="error-ast")]
             ast::ExprKind::Error { .. } => unimplemented!("Protobufs feature not compatible with ASTs that contain error nodes - this should never happen"),
         };
         Self {

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -467,6 +467,7 @@ impl From<&ast::Expr> for models::Expr {
                     .collect();
                 models::expr::expr_kind::Data::Record(models::expr::Record { items: precord })
             }
+            ast::ExprKind::Error { error_kind } => unimplemented!("Protobufs feature not compatible with ASTs that contain error nodes - this should never happen"),
         };
         Self {
             expr_kind: Some(Box::new(models::expr::ExprKind {

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -467,7 +467,7 @@ impl From<&ast::Expr> for models::Expr {
                     .collect();
                 models::expr::expr_kind::Data::Record(models::expr::Record { items: precord })
             },
-            #[cfg(feature="error-ast")]
+            #[cfg(feature="tolerant-ast")]
             ast::ExprKind::Error { .. } => unimplemented!("Protobufs feature not compatible with ASTs that contain error nodes - this should never happen"),
         };
         Self {

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -467,7 +467,7 @@ impl From<&ast::Expr> for models::Expr {
                     .collect();
                 models::expr::expr_kind::Data::Record(models::expr::Record { items: precord })
             }
-            ast::ExprKind::Error { error_kind } => unimplemented!("Protobufs feature not compatible with ASTs that contain error nodes - this should never happen"),
+            ast::ExprKind::Error { .. } => unimplemented!("Protobufs feature not compatible with ASTs that contain error nodes - this should never happen"),
         };
         Self {
             expr_kind: Some(Box::new(models::expr::ExprKind {


### PR DESCRIPTION
## Description of changes

This change allows us to parse AST's with expressions that are Errors. This will be useful in cases where we might want to parse an incomplete or invalid Cedar policy without generating an error. An example of where this might be useful would be in implementing auto-complete as part of an LSP or IDE plugin.

This particular change allows us to parse the following invalid policy 

`permit(principal, action, resource) when {};`

by calling the following:

```
 text_to_cst::parse_policy(text)
        .expect("failed parser")
        .to_policy_with_errors(ast::PolicyID::from_string("id"))
        .unwrap_or_else(|errs| {
            panic!("failed conversion to AST:\n{:?}", miette::Report::new(errs))
        })
```

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ x ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
