### PR TITLE
Adds ability to Merge policy sets with the option to rename policy id's upon duplicate ids.

### DIFF
--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -832,21 +832,15 @@ mod test {
         let pid0 = PolicyID::from_string("policy0");
         let pid1 = PolicyID::from_string("policy1");
         let pid2 = PolicyID::from_string("policy2");
-        let p1 = parser::parse_policy(
-            Some(pid0.clone()),
-            "permit(principal,action,resource);",
-        )
-        .expect("Failed to parse");
+        let p1 = parser::parse_policy(Some(pid0.clone()), "permit(principal,action,resource);")
+            .expect("Failed to parse");
         let p2 = parser::parse_policy(
             Some(pid1.clone()),
             "permit(principal,action,resource) when { false };",
         )
         .expect("Failed to parse");
-        let p3 = parser::parse_policy(
-            Some(pid1.clone()),
-            "permit(principal,action,resource);",
-        )
-        .expect("Failed to parse");
+        let p3 = parser::parse_policy(Some(pid1.clone()), "permit(principal,action,resource);")
+            .expect("Failed to parse");
         let p4 = parser::parse_policy(
             Some(pid2.clone()),
             "permit(principal,action,resource) when { true };",
@@ -891,7 +885,6 @@ mod test {
                     Some(new_p4) => assert_eq!(Policy::from(p4), new_p4.clone()),
                     None => (),
                 }
-
             }
             Err(PolicySetError::Occupied { id }) => panic!(
                 "There should not have been an error! Unexpected conflict for id {}",

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -264,7 +264,7 @@ impl PolicySet {
         Ok(())
     }
 
-    /// Helper function for merge_policyset to check if the `PolicyID` pid
+    /// Helper function for `merge_policyset` to check if the `PolicyID` pid
     /// appears in this `PolicySet`'s links or templates.
     fn policy_id_is_bound(&self, pid: &PolicyID) -> bool {
         match self.templates.get(pid) {
@@ -276,7 +276,7 @@ impl PolicySet {
         }
     }
 
-    /// Helper function for merge_policyset to construct a renaming
+    /// Helper function for `merge_policyset` to construct a renaming
     /// that would resolve any conflicting `PolicyID`s. We use the type parameter `T`
     /// to allow this code to be applied to both Templates and Policies.
     fn update_renaming<T>(
@@ -861,10 +861,10 @@ mod test {
         // should not conflict because of auto-renaming of conflicting policies
         match pset1.merge_policyset(&pset2, true) {
             Ok(renaming) => {
-                // ensure `policy1`` was renamed
+                // ensure `policy1` was renamed
                 let new_pid1 = match renaming.get(&pid1) {
                     Some(new_pid1) => new_pid1,
-                    None => panic!("Error: policy1 is a conflict and should be renamed"),
+                    None => panic!("Error: `policy1` is a conflict and should be renamed"),
                 };
                 // ensure no other policy was renamed
                 assert_eq!(renaming.keys().len(), 1);

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -20,6 +20,7 @@ Cedar Language Version: TBD
 ### Added
 
 - Added `Entities::remove_entities()` to remove `Entity`s from an `Entities` struct (resolving #701)
+- Added `PolicySet::merge_policyset()` to merge a `PolicySet` into another `PolicySet` struct (resolving #610)
 - Implemented [RFC 53 (enumerated entity types)](https://github.com/cedar-policy/rfcs/blob/main/text/0053-enum-entities.md)  (#1377)
 
 ### Fixed

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2257,6 +2257,11 @@ impl PolicySet {
                     if this.get(pid).is_none() {
                         this.insert(pid.clone(), ot.clone());
                     }
+                    // If pid is not in the renaming but is in both
+                    // this and other, then by assumption
+                    // the element at pid in this and other are equal
+                    // i.e., the renaming is expected to track all
+                    // conflicting pids.
                 }
             }
         }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2237,7 +2237,7 @@ impl PolicySet {
         Ok(set)
     }
 
-    /// Helper function for merge_policyset
+    /// Helper function for `merge_policyset`
     /// Merges two sets and avoids name clashes by using the provided
     /// renaming. The type parameter `T` allows this code to be used for
     /// both Templates and Policies.

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2241,17 +2241,16 @@ impl PolicySet {
     /// This `PolicySet` is modified while the other `PolicySet`
     /// remains unchanged.
     ///
-    /// If this `PolicySet` and the other provided `PolicySet` have
-    /// policies with conflicting `PolicyId`s the following will happen:
+    /// The flag `rename_duplicates` controls the expected behavior
+    /// when a `PolicyId` in this and the other `PolicySet` conflict.
     ///
-    /// 1.) If the two policies associated with the `PolicyId` are equal
-    /// then the policy from the other `PolicySet` will not be added.
-    /// 2.) If the two policies associated wit the `PolicyId` are not equal, and
-    /// 2a.) rename_duplicates is false, then this function will raise a `PolicySetError`.
-    /// 2b.) rename_duplicates is true, then this funtion will rename the policy
-    /// originating from the other `PolicySet`.
+    /// When `rename_duplicates` is false, conflicting `PolicyId`s result
+    /// in a AlreadyDefined `PolicySetError`.
     ///
-    /// The renaming of policies in the other `PolicySet` is returned upon succes.
+    /// Otherwise, when `rename_duplicates` is true, conflicting `PolicyId`s from
+    /// the other `PolicySet` are automatically renamed to avoid conflict.
+    /// This renaming is returned as a Hashmap from the old `PolicyId` to the
+    /// renamed `PolicyId`.
     pub fn merge_policyset(
         &mut self,
         other: &PolicySet,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2245,7 +2245,7 @@ impl PolicySet {
     /// when a `PolicyId` in this and the other `PolicySet` conflict.
     ///
     /// When `rename_duplicates` is false, conflicting `PolicyId`s result
-    /// in a AlreadyDefined `PolicySetError`.
+    /// in a `PolicySetError::AlreadyDefined` error.
     ///
     /// Otherwise, when `rename_duplicates` is true, conflicting `PolicyId`s from
     /// the other `PolicySet` are automatically renamed to avoid conflict.


### PR DESCRIPTION
## Description of changes

Adds the ability to merge a two policy sets. The user can choose to either have conflicting policy ids result in an error or to be automatically renamed. The renaming scheme is returned as a HashMap from the old id to the newly auto-generated id.

## Issue #610

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
