### PR TITLE
revert 1434 now that 1452 (hopefully) fixed the protobuf build

### DIFF
--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -104,7 +104,7 @@ name = "deeply_nested_est"
 harness = false
 
 [package.metadata.docs.rs]
-features = ["partial-eval", "permissive-validate", "partial-validate", "level-validate", "entity-manifest", "datetime"]
+features = ["experimental"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [lints]


### PR DESCRIPTION
## Description of changes

Reverts #1434 now that #1452 (hopefully) fixed the protobuf build.  This means that docs.rs will include docs on functions/traits/types that are behind the `protobufs` Cargo feature.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
