### PR TITLE
Implement a faster version of `FromNormalizedStr` for `Name`s

### DIFF
--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -416,28 +416,22 @@ impl FromStr for Name {
     }
 }
 
-lazy_static::lazy_static! {
-    // PANIC SAFETY: this is a valid regex
-    static ref VALID_NAME_REGEX: Regex = Regex::new(r"^[_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)*$").unwrap();
-    // All of Cedar's reserved keywords for identifiers.
-    // Notice this is only a subset of all reserved keywords.
-    static ref RESERVED_IDS: HashSet<&'static str> =
-        vec![
-            "true",
-            "false",
-            "if",
-            "then",
-            "else",
-            "in",
-            "is",
-            "like",
-            "has",
-            // Can only be used in [`InternalName`]
-            "__cedar"
-        ]
-        .into_iter()
-        .collect();
-}
+// PANIC SAFETY: this is a valid Regex pattern
+#[allow(clippy::unwrap_used)]
+static VALID_NAME_REGEX: std::sync::LazyLock<Regex> = std::sync::LazyLock::new(|| {
+    Regex::new("^[_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)*$").unwrap()
+});
+// All of Cedar's reserved keywords for identifiers.
+// Notice this is only a subset of all reserved keywords.
+static RESERVED_IDS: std::sync::LazyLock<HashSet<&'static str>> = std::sync::LazyLock::new(|| {
+    vec![
+        "true", "false", "if", "then", "else", "in", "is", "like", "has",
+        // Can only be used in [`InternalName`]
+        "__cedar",
+    ]
+    .into_iter()
+    .collect()
+});
 
 impl FromNormalizedStr for Name {
     fn from_normalized_str(s: &str) -> Result<Self, ParseErrors> {

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -19,14 +19,16 @@ use educe::Educe;
 use itertools::Itertools;
 use miette::Diagnostic;
 use ref_cast::RefCast;
+use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use smol_str::ToSmolStr;
+use std::collections::HashSet;
 use std::fmt::Display;
 use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
 
-use crate::parser::err::{ParseError, ParseErrors, ToASTError};
+use crate::parser::err::{ParseError, ParseErrors, ToASTError, ToASTErrorKind};
 use crate::parser::Loc;
 use crate::FromNormalizedStr;
 
@@ -414,7 +416,51 @@ impl FromStr for Name {
     }
 }
 
+lazy_static::lazy_static! {
+    // PANIC SAFETY: this is a valid regex
+    static ref VALID_NAME_REGEX: Regex = Regex::new(r"^[_a-zA-Z][_a-zA-Z0-9]*(?:::[_a-zA-Z][_a-zA-Z0-9]*)*$").unwrap();
+    // All of Cedar's reserved keywords for identifiers.
+    // Notice this is only a subset of all reserved keywords.
+    static ref RESERVED_IDS: HashSet<&'static str> =
+        vec![
+            "true",
+            "false",
+            "if",
+            "then",
+            "else",
+            "in",
+            "is",
+            "like",
+            "has",
+            // Can only be used in [`InternalName`]
+            "__cedar"
+        ]
+        .into_iter()
+        .collect();
+}
+
 impl FromNormalizedStr for Name {
+    fn from_normalized_str(s: &str) -> Result<Self, ParseErrors> {
+        if !VALID_NAME_REGEX.is_match(s) {
+            return Err(Self::parse_err_from_str(s));
+        }
+
+        let path_parts: Vec<&str> = s.split("::").collect();
+        if path_parts.iter().any(|s| RESERVED_IDS.contains(s)) {
+            return Err(Self::parse_err_from_str(s));
+        }
+
+        if let Some((last, prefix)) = path_parts.split_last() {
+            Ok(Self(InternalName::new(
+                Id::new_unchecked(*last),
+                prefix.iter().map(|part| Id::new_unchecked(*part)),
+                Some(Loc::new(0..(s.len()), s.into())),
+            )))
+        } else {
+            Err(Self::parse_err_from_str(s))
+        }
+    }
+
     fn describe_self() -> &'static str {
         "Name"
     }
@@ -486,6 +532,31 @@ impl Name {
     /// Get the source location
     pub fn loc(&self) -> Option<&Loc> {
         self.0.loc()
+    }
+
+    fn parse_err_from_str(s: &str) -> ParseErrors {
+        match Self::from_str(s) {
+            Err(parse_err) => parse_err,
+            Ok(parsed) => {
+                let normalized_src = parsed.to_string();
+                let diff_byte = s
+                    .bytes()
+                    .zip(normalized_src.bytes())
+                    .enumerate()
+                    .find(|(_, (b0, b1))| b0 != b1)
+                    .map(|(idx, _)| idx)
+                    .unwrap_or_else(|| s.len().min(normalized_src.len()));
+
+                ParseErrors::singleton(ParseError::ToAST(ToASTError::new(
+                    ToASTErrorKind::NonNormalizedString {
+                        kind: Self::describe_self(),
+                        src: s.to_string(),
+                        normalized_src,
+                    },
+                    Loc::new(diff_byte, s.into()),
+                )))
+            }
+        }
     }
 }
 
@@ -640,6 +711,28 @@ mod test {
 
         for n in ["__cedarr", "A::_cedar", "A::___cedar::B"] {
             assert!(!InternalName::from_normalized_str(n).unwrap().is_reserved());
+        }
+    }
+
+    #[test]
+    fn test_name_identifier_intersection() {
+        let not_reserved_for_ids = [
+            "permit",
+            "forbid",
+            "when",
+            "unless",
+            "principal",
+            "action",
+            "resource",
+            "context",
+        ];
+
+        for id in not_reserved_for_ids {
+            assert!(Name::from_normalized_str(&format!("A::{id}")).is_ok());
+        }
+
+        for id in RESERVED_IDS.iter() {
+            assert!(Name::from_normalized_str(&format!("A::{id}")).is_err());
         }
     }
 }

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -38,14 +38,14 @@ use thiserror::Error;
 ///   - bool, int, and string literals
 ///   - literal EntityUIDs such as User::"alice"
 ///   - extension function calls, where the arguments must be other things
-///       on this list
+///     on this list
 ///   - set and record literals, where the values must be other things on
-///       this list
+///     this list
 ///
 /// That means the following are not allowed in "restricted" expressions:
 ///   - `principal`, `action`, `resource`, `context`
 ///   - builtin operators and functions, including `.`, `in`, `has`, `like`,
-///       `.contains()`
+///     `.contains()`
 ///   - if-then-else expressions
 ///
 /// These restrictions represent the expressions that are allowed to appear as

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -429,12 +429,12 @@ impl CedarValueJson {
     ///
     /// Only throws errors in two cases:
     /// 1. `value` is (or contains) a record with a reserved key such as
-    ///     "__entity"
+    ///    "__entity"
     /// 2. `value` is (or contains) an extension value, and the argument to the
-    ///     extension constructor that produced that extension value can't
-    ///     itself be converted to `CedarJsonValue`. (Either because that
-    ///     argument falls into one of these two cases itself, or because the
-    ///     argument is a nontrivial residual.)
+    ///    extension constructor that produced that extension value can't
+    ///    itself be converted to `CedarJsonValue`. (Either because that
+    ///    argument falls into one of these two cases itself, or because the
+    ///    argument is a nontrivial residual.)
     pub fn from_value(value: Value) -> Result<Self, JsonSerializationError> {
         Self::from_valuekind(value.value)
     }

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -78,8 +78,8 @@ pub fn unary_app(op: UnaryOp, arg: Value, loc: Option<&Loc>) -> Result<Value> {
 /// Evaluate binary relations (i.e., `BinaryOp::Eq`, `BinaryOp::Less`, and `BinaryOp::LessEq`)
 pub fn binary_relation(
     op: BinaryOp,
-    arg1: Value,
-    arg2: Value,
+    arg1: &Value,
+    arg2: &Value,
     extensions: &Extensions<'_>,
 ) -> Result<Value> {
     match op {
@@ -109,28 +109,28 @@ pub fn binary_relation(
                 }
                 // throw type errors
                 (ValueKind::Lit(Literal::Long(_)), _) => {
-                    Err(EvaluationError::type_error_single(Type::Long, &arg2))
+                    Err(EvaluationError::type_error_single(Type::Long, arg2))
                 }
                 (_, ValueKind::Lit(Literal::Long(_))) => {
-                    Err(EvaluationError::type_error_single(Type::Long, &arg1))
+                    Err(EvaluationError::type_error_single(Type::Long, arg1))
                 }
                 (ValueKind::ExtensionValue(x), _) if x.supports_operator_overloading() => {
                     Err(EvaluationError::type_error_single(
                         Type::Extension { name: x.typename() },
-                        &arg2,
+                        arg2,
                     ))
                 }
                 (_, ValueKind::ExtensionValue(y)) if y.supports_operator_overloading() => {
                     Err(EvaluationError::type_error_single(
                         Type::Extension { name: y.typename() },
-                        &arg1,
+                        arg1,
                     ))
                 }
                 _ => {
                     let expected_types = valid_comparison_op_types(extensions);
                     Err(EvaluationError::type_error_with_advice(
                         expected_types.clone(),
-                        &arg1,
+                        arg1,
                         format!(
                             "Only types {} support comparison",
                             expected_types.into_iter().sorted().join(", ")
@@ -556,7 +556,7 @@ impl<'e> Evaluator<'e> {
                 };
                 match op {
                     BinaryOp::Eq | BinaryOp::Less | BinaryOp::LessEq => {
-                        binary_relation(*op, arg1, arg2, self.extensions).map(Into::into)
+                        binary_relation(*op, &arg1, &arg2, self.extensions).map(Into::into)
                     }
                     BinaryOp::Add | BinaryOp::Sub | BinaryOp::Mul => {
                         binary_arith(*op, arg1, arg2, loc).map(Into::into)


### PR DESCRIPTION
## Description of changes
In #1411 we discussed an approach to significantly improve performance of this code, which happens to be consuming quite a lot of CPU time in our team's use of Cedar. This is a more formal attempt to implement it. I've had this stashed locally for a while, but I won't be able to work on this for a few weeks, so I wanted to get the PR out and at least get some discussions started on whether this is a good idea and what might be missing if it is.

Performance does seem to be significantly better given benchmarking results, examples:

```
Benchmarking EntityTypeName parsing/Type Name size 23: Collecting 100 samples in estimated 5.0007 s (14M iEntityTypeName parsing/Type Name size 23
                        time:   [361.68 ns 362.18 ns 362.68 ns]
                        change: [-94.906% -94.889% -94.872%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking EntityTypeName parsing/Type Name size 63: Collecting 100 samples in estimated 5.0016 s (7.0M EntityTypeName parsing/Type Name size 63
                        time:   [709.22 ns 711.58 ns 714.34 ns]
                        change: [-93.066% -93.021% -92.977%] (p = 0.00 < 0.05)
                        Performance has improved.
```

This of course comes at the cost of having to maintain this somewhat *duplicated* specific parser for these bits. Given the performance gains, the benefit seems worth *to me*, but well, this is something that should be discussed for its long-term maintainability.

I also haven't researched if there are better ways to accomplish better performance with the current framework, so there might be some opportunities there.


## Issue #, if available
#1411 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [X] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
