### PR TITLE
renaming, inlining, and commenting in .proto files

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -355,9 +355,9 @@ fn describe_arity_error(
 }
 
 /// A Policy that contains:
-///   a pointer to its template
-///   an link ID (unless it's a static policy)
-///   the bound values for slots in the template
+///   - a pointer to its template
+///   - a link ID (unless it's a static policy)
+///   - the bound values for slots in the template
 ///
 /// Policies are not serializable (due to the pointer), and can be serialized
 /// by converting to/from LiteralPolicy
@@ -366,10 +366,12 @@ pub struct Policy {
     /// Reference to the template
     template: Arc<Template>,
     /// Id of this link
+    ///
     /// None in the case that this is an instance of a Static Policy
     link: Option<PolicyID>,
     // INVARIANT (values total map)
     // All of the slots in `template` MUST be bound by `values`
+    //
     /// values the slots are bound to.
     /// The constructor `new` is only visible in this module,
     /// so it is the responsibility of callers to maintain

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -356,7 +356,7 @@ fn describe_arity_error(
 
 /// A Policy that contains:
 ///   a pointer to its template
-///   an link ID (unless it's an static policy)
+///   an link ID (unless it's a static policy)
 ///   the bound values for slots in the template
 ///
 /// Policies are not serializable (due to the pointer), and can be serialized
@@ -561,7 +561,8 @@ impl std::fmt::Display for Policy {
 /// Map from Slot Ids to Entity UIDs which fill the slots
 pub type SlotEnv = HashMap<SlotId, EntityUID>;
 
-/// Represents either an static policy or a template linked policy
+/// Represents either a static policy or a template linked policy.
+///
 /// This is the serializable version because it simply refers to the `Template` by its Id
 /// and does not contain a reference to the `Template` itself
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,9 @@ Cedar Language Version: TBD
 ### Changed
 
 - Changed `Entities::add_entities` and `Entities::from_entities` to ignore structurally equal entities with the same Entity UID.
+- For `protobufs` experimental feature, a number of changes to the interface and
+  the Protobuf format definitions, as we continue to iterate towards making this
+  feature stable.
 
 ### Added
 

--- a/cedar-policy/protobuf_schema/core.proto
+++ b/cedar-policy/protobuf_schema/core.proto
@@ -105,7 +105,7 @@ message EntityReference {
     // so we don't need a `SlotId` and can just use this one-armed enum
     enum Slot {
         // the one option for the enum
-        x = 0;
+        unit = 0;
     }
 }
 
@@ -121,7 +121,7 @@ message PrincipalOrResourceConstraint {
     // Zero-arity constructors represented as enums with only one member
     enum Any {
         // the one option for the enum
-        x = 0;
+        unit = 0;
     }
 
     message InMessage {
@@ -154,7 +154,7 @@ message ActionConstraint {
     // Zero-arity constructors represented as enums with only one member
     enum Any {
         // the one option for the enum
-        x = 0;
+        unit = 0;
     }
 
     message InMessage {
@@ -279,7 +279,7 @@ message Expr {
             // Zero-arity constructors represented as enums with only one member
             enum Wildcard {
                 // the one option for the enum
-                x = 0;
+                unit = 0;
             }
         }
     }

--- a/cedar-policy/protobuf_schema/core.proto
+++ b/cedar-policy/protobuf_schema/core.proto
@@ -18,16 +18,26 @@ syntax = "proto3";
 package cedar_policy_core;
 
 message Request {
-    EntityUidEntry principal = 1;
-    EntityUidEntry action = 2;
-    EntityUidEntry resource = 3;
-    Context context = 4;
+    EntityUid principal = 1;
+    EntityUid action = 2;
+    EntityUid resource = 3;
+    Expr context = 4;
 }
 
-message LiteralPolicySet {
-    // Key is PolicyID as a string
+// the protobuf PolicySet message describes a complete policy set, including
+// templates, static policies, and/or template-linked policies.
+message PolicySet {
+    // Key is PolicyID as a string.
+    // Value is a `TemplateBody`.
+    // Both templates and static policies are included in this map, with static
+    // policies represented as templates with zero slots.
     map<string, TemplateBody> templates = 1;
-    map<string, LiteralPolicy> links = 2;
+    // Key is PolicyID as a string.
+    // Value is a `Policy`.
+    // All static policies and template-linked policies are included in this map.
+    // Static policies must have exactly one entry in this map, and the PolicyID
+    // of the static policy must be the same in this map and the above map.
+    map<string, Policy> links = 2;
 }
 
 enum Mode {
@@ -40,50 +50,33 @@ message Entities {
     Mode mode = 2;
 }
 
-message Context {
-    Expr context = 1;
-}
-
-// BEGIN REQUEST MESSAGES
-
-message EntityUidEntry {
-    EntityUid euid = 1;
-}
-
 message EntityUid {
-    EntityType ty = 1;
+    Name ty = 1;
     string eid = 2;
 }
 
-message EntityType {
-    Name name = 1;
-}
-
-// alias Id = string
 message Name {
     string id = 1;
     repeated string path = 2;
 }
 
-
-// END REQUEST MESSAGES
-
-
-// BEGIN POLICYSET MESSAGES
-
-message LiteralPolicy {
+// the protobuf Policy message describes either a static or a template-linked policy.
+message Policy {
+    // ID of the template associated with this policy.
+    // For static policies, this is the ID of a zero-slot template.
     string template_id = 1;
-    string link_id = 2;
-    bool link_id_specified = 3;
-    // map<SlotId, EntityUid> is not allowed since keys in map
-    // fields cannot be enum types
-    // map<SlotId, EntityUid> values = 4;
+    // ID of this policy itself.
+    // For static policies, this is omitted/ignored; the ID of the policy is the
+    // `template_id`.
+    optional string link_id = 2;
+    // Whether this policy is a static (false) or template-linked (true) policy
+    bool is_template_link = 3;
+    // Value of the `?principal` slot.
+    // Omitted/ignored for templates without the `?principal` slot.
     EntityUid principal_euid = 4;
+    // Value of the `?resource` slot.
+    // Omitted/ignored for templates without the `?resource` slot.
     EntityUid resource_euid = 5;
-}
-
-message Annotation {
-    string val = 1;
 }
 
 enum Effect {
@@ -93,48 +86,42 @@ enum Effect {
 
 message TemplateBody {
     string id = 1;
-    // alias AnyId = string
-    // alias Annotations = map<AnyId, Annotation>
-    map<string, Annotation> annotations = 3;
+    map<string, string> annotations = 3;
     Effect effect = 4;
-    PrincipalConstraint principal_constraint = 5;
+    PrincipalOrResourceConstraint principal_constraint = 5;
     ActionConstraint action_constraint = 6;
-    ResourceConstraint resource_constraint = 7;
+    PrincipalOrResourceConstraint resource_constraint = 7;
     Expr non_scope_constraints = 8;
 }
 
-message PrincipalConstraint {
-    PrincipalOrResourceConstraint constraint = 1;
-}
-
-message ResourceConstraint {
-    PrincipalOrResourceConstraint constraint = 1;
-}
-
+// an EntityReference may either be an EntityUid or a Slot.
 message EntityReference {
     oneof data {
-        Ty ty = 1;
+        Slot slot = 1;
         EntityUid euid = 2;
     }
 
-    // Zero-Arity constructors
-    enum Ty {
-        Slot = 0;
+    // if it's a Slot, we know from context which Slot it is,
+    // so we don't need a `SlotId` and can just use this one-armed enum
+    enum Slot {
+        // the one option for the enum
+        x = 0;
     }
 }
 
 message PrincipalOrResourceConstraint {
     oneof data {
-        Ty ty = 1;
+        Any any = 1;
         InMessage in = 2;
         EqMessage eq = 3;
         IsMessage is = 4;
         IsInMessage isIn = 5;
     }
 
-    // Zero-arity constructors
-    enum Ty {
-        Any = 0;
+    // Zero-arity constructors represented as enums with only one member
+    enum Any {
+        // the one option for the enum
+        x = 0;
     }
 
     message InMessage {
@@ -144,11 +131,11 @@ message PrincipalOrResourceConstraint {
         EntityReference er = 1;
     }
     message IsMessage {
-        EntityType et = 1;
+        Name entity_type = 1;
     }
     message IsInMessage {
         EntityReference er = 1;
-        EntityType et = 2;
+        Name entity_type = 2;
     }
 }
 
@@ -159,14 +146,17 @@ enum SlotId {
 
 message ActionConstraint {
     oneof data {
-        Ty ty = 1;
+        Any any = 1;
         InMessage in = 2;
         EqMessage eq = 3;
     }
 
-    enum Ty {
-        Any = 0;
+    // Zero-arity constructors represented as enums with only one member
+    enum Any {
+        // the one option for the enum
+        x = 0;
     }
+
     message InMessage {
         repeated EntityUid euids = 1;
     }
@@ -210,7 +200,7 @@ message Expr {
         Principal = 0;
         Action = 1;
         Resource = 2;
-        CONTEXT = 3;
+        Context = 3;
     }
 
     message If {
@@ -282,20 +272,21 @@ message Expr {
 
         message PatternElem {
             oneof data {
-                Ty ty = 1;
+                Wildcard wildcard = 1;
                 string c = 2;
             }
 
-            // Zero-arity constructors
-            enum Ty {
-                Wildcard = 0;
+            // Zero-arity constructors represented as enums with only one member
+            enum Wildcard {
+                // the one option for the enum
+                x = 0;
             }
         }
     }
 
     message Is {
         Expr expr = 1;
-        EntityType entity_type = 2;
+        Name entity_type = 2;
     }
 
     message Set {
@@ -307,16 +298,9 @@ message Expr {
     }
 }
 
-// END POLICYSET MESSAGES
-
-
-// ENTER ENTITIES MESSAGES
-
 message Entity {
     EntityUid uid = 1;
     map<string, Expr> attrs = 2;
     repeated EntityUid ancestors = 3;
     map<string, Expr> tags = 4;
 }
-
-// END ENTITIES MESSAGES

--- a/cedar-policy/protobuf_schema/validator.proto
+++ b/cedar-policy/protobuf_schema/validator.proto
@@ -92,7 +92,7 @@ message EntityRecordKind {
     // Zero-arity constructors represented as enums with only one member
     enum AnyEntity {
         // the one option for the enum
-        x = 0;
+        unit = 0;
     }
     message Record {
         map<string, AttributeType> attrs = 1;

--- a/cedar-policy/protobuf_schema/validator.proto
+++ b/cedar-policy/protobuf_schema/validator.proto
@@ -19,44 +19,49 @@ package cedar_policy_validator;
 
 import "core.proto";
 
-message ValidatorSchema {
-    repeated EntityTypeWithTypesMap entity_types = 1;
-    repeated EntityUidWithActionIdsMap action_ids = 2;
+// the protobuf Schema message describes a complete schema.
+message Schema {
+    // TODO: this need not be a map at all, since `EntityDecl` contains the `name` as well.
+    // It can be just `repeated EntityDecl`.
+    repeated EntityTypeToEntityDeclMap entity_decls = 1;
+    // TODO: this need not be a map at all, since `ActionDecl` contains the `name` as well.
+    // It can be just `repeated ActionDecl`.
+    repeated EntityUidToActionDeclMap action_decls = 2;
 }
 
-// Workaround since messages can't be dictionary keys
-message EntityTypeWithTypesMap {
-    cedar_policy_core.EntityType key = 1;
-    ValidatorEntityType value = 2;
+// This `message` with `key` and `value`, rather than a `map`, since messages can't be dictionary keys
+message EntityTypeToEntityDeclMap {
+    cedar_policy_core.Name key = 1;
+    EntityDecl value = 2;
 }
 
-message EntityUidWithActionIdsMap {
+// This `message` with `key` and `value`, rather than a `map`, since messages can't be dictionary keys
+message EntityUidToActionDeclMap {
     cedar_policy_core.EntityUid key = 1;
-    ValidatorActionId value = 2;
+    ActionDecl value = 2;
 }
 
-message ValidatorEntityType {
-    cedar_policy_core.EntityType name = 1;
-    repeated cedar_policy_core.EntityType descendants = 2;
-    Attributes attributes = 3;
+// the protobuf EntityDecl message contains all of the schema's
+// information about a single entity type.
+message EntityDecl {
+    cedar_policy_core.Name name = 1;
+    repeated cedar_policy_core.Name descendants = 2;
+    map<string, AttributeType> attributes = 3;
     OpenTag open_attributes = 4;
-    Tag tags = 5;
+    optional Type tags = 5;
     repeated string enum_choices = 6;
 }
 
-message ValidatorActionId {
+// the protobuf ActionDecl message contains all of the schema's
+// information about a single action.
+message ActionDecl {
     cedar_policy_core.EntityUid name = 1;
-    ValidatorApplySpec applies_to = 2;
     repeated cedar_policy_core.EntityUid descendants = 3;
     Type context = 4;
-    Attributes attribute_types = 5;
-    // Deserialize Expr as Value
+    map<string, AttributeType> attribute_types = 5;
     map<string, cedar_policy_core.Expr> attributes = 6;
-}
-
-message ValidatorApplySpec {
-    repeated cedar_policy_core.EntityType principal_apply_spec = 1;
-    repeated cedar_policy_core.EntityType resource_apply_spec = 2;
+    repeated cedar_policy_core.Name principal_types = 7;
+    repeated cedar_policy_core.Name resource_types = 8;
 }
 
 message Type {
@@ -80,25 +85,24 @@ message Type {
 
 message EntityRecordKind {
     oneof data {
-        Ty ty = 1;
+        AnyEntity any_entity = 1;
         Record record = 2;
-        Entity entity = 3;
+        cedar_policy_core.Name entity = 3;
         ActionEntity actionEntity = 4;
     }
 
-    enum Ty {
-        AnyEntity = 0; // AnyEntity
+    // Zero-arity constructors represented as enums with only one member
+    enum AnyEntity {
+        // the one option for the enum
+        x = 0;
     }
     message Record {
-        Attributes attrs = 1;
+        map<string, AttributeType> attrs = 1;
         OpenTag open_attributes = 2;
     }
-    message Entity {
-        cedar_policy_core.EntityType e = 1;
-    }
     message ActionEntity {
-        cedar_policy_core.EntityType name = 1;
-        Attributes attrs = 2;
+        cedar_policy_core.Name name = 1;
+        map<string, AttributeType> attrs = 2;
     }
 }
 
@@ -107,17 +111,9 @@ enum OpenTag {
     ClosedAttributes = 1;
 }
 
-message Attributes {
-    map<string, AttributeType> attrs = 1;
-}
-
 message AttributeType {
     Type attr_type = 1;
     bool is_required = 2;
-}
-
-message Tag {
-    Type optional_type = 1;
 }
 
 enum ValidationMode {

--- a/cedar-policy/protobuf_schema/validator.proto
+++ b/cedar-policy/protobuf_schema/validator.proto
@@ -58,8 +58,6 @@ message ActionDecl {
     cedar_policy_core.EntityUid name = 1;
     repeated cedar_policy_core.EntityUid descendants = 3;
     Type context = 4;
-    map<string, AttributeType> attribute_types = 5;
-    map<string, cedar_policy_core.Expr> attributes = 6;
     repeated cedar_policy_core.Name principal_types = 7;
     repeated cedar_policy_core.Name resource_types = 8;
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -40,7 +40,7 @@ macro_rules! standard_conversions {
 
 standard_conversions!(api::Entity, api::Entity, models::Entity);
 standard_conversions!(api::Entities, api::Entities, models::Entities);
-standard_conversions!(api::Schema, api::Schema, models::ValidatorSchema);
+standard_conversions!(api::Schema, api::Schema, models::Schema);
 standard_conversions!(api::EntityTypeName, api::EntityTypeName, models::Name);
 standard_conversions!(api::EntityNamespace, api::EntityNamespace, models::Name);
 standard_conversions!(api::Expression, api::Expression, models::Expr);
@@ -60,29 +60,29 @@ impl From<&models::TemplateBody> for api::Template {
     }
 }
 
-impl From<&api::Policy> for models::LiteralPolicy {
+impl From<&api::Policy> for models::Policy {
     fn from(v: &api::Policy) -> Self {
         Self::from(&v.ast)
     }
 }
 
-impl TryFrom<&models::LiteralPolicy> for api::Policy {
+impl TryFrom<&models::Policy> for api::Policy {
     type Error = cedar_policy_core::ast::ReificationError;
-    fn try_from(v: &models::LiteralPolicy) -> Result<Self, Self::Error> {
+    fn try_from(v: &models::Policy) -> Result<Self, Self::Error> {
         let p = cedar_policy_core::ast::Policy::try_from(v)?;
         Ok(Self::from_ast(p))
     }
 }
 
-impl From<&api::PolicySet> for models::LiteralPolicySet {
+impl From<&api::PolicySet> for models::PolicySet {
     fn from(v: &api::PolicySet) -> Self {
         Self::from(&v.ast)
     }
 }
 
-impl TryFrom<&models::LiteralPolicySet> for api::PolicySet {
+impl TryFrom<&models::PolicySet> for api::PolicySet {
     type Error = api::PolicySetError;
-    fn try_from(v: &models::LiteralPolicySet) -> Result<Self, Self::Error> {
+    fn try_from(v: &models::PolicySet) -> Result<Self, Self::Error> {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
         Self::from_ast(
@@ -111,7 +111,7 @@ macro_rules! standard_protobuf_impl {
 
 standard_protobuf_impl!(api::Entity, models::Entity);
 standard_protobuf_impl!(api::Entities, models::Entities);
-standard_protobuf_impl!(api::Schema, models::ValidatorSchema);
+standard_protobuf_impl!(api::Schema, models::Schema);
 standard_protobuf_impl!(api::EntityTypeName, models::Name);
 standard_protobuf_impl!(api::EntityNamespace, models::Name);
 standard_protobuf_impl!(api::Template, models::TemplateBody);
@@ -122,13 +122,13 @@ standard_protobuf_impl!(api::Request, models::Request);
 
 impl traits::Protobuf for api::PolicySet {
     fn encode(&self) -> Vec<u8> {
-        traits::encode_to_vec::<models::LiteralPolicySet>(self)
+        traits::encode_to_vec::<models::PolicySet>(self)
     }
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
         Ok(
-            traits::try_decode::<models::LiteralPolicySet, _, Self>(buf)?
+            traits::try_decode::<models::PolicySet, _, Self>(buf)?
                 .expect("protobuf-encoded policy set should be a valid policy set"),
         )
     }
@@ -136,12 +136,12 @@ impl traits::Protobuf for api::PolicySet {
 
 impl traits::Protobuf for api::Policy {
     fn encode(&self) -> Vec<u8> {
-        traits::encode_to_vec::<models::LiteralPolicy>(self)
+        traits::encode_to_vec::<models::Policy>(self)
     }
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
-        Ok(traits::try_decode::<models::LiteralPolicy, _, Self>(buf)?
+        Ok(traits::try_decode::<models::Policy, _, Self>(buf)?
             .expect("protobuf-encoded policy should be a valid policy"))
     }
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -127,10 +127,8 @@ impl traits::Protobuf for api::PolicySet {
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError> {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
-        Ok(
-            traits::try_decode::<models::PolicySet, _, Self>(buf)?
-                .expect("protobuf-encoded policy set should be a valid policy set"),
-        )
+        Ok(traits::try_decode::<models::PolicySet, _, Self>(buf)?
+            .expect("protobuf-encoded policy set should be a valid policy set"))
     }
 }
 

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -601,11 +601,11 @@ impl From<&models::expr::like::PatternElem> for ast::PatternElem {
                 ast::PatternElem::Char(c.chars().next().expect("c is non-empty"))
             }
 
-            models::expr::like::pattern_elem::Data::Wildcard(x) => {
-                match models::expr::like::pattern_elem::Wildcard::try_from(*x)
+            models::expr::like::pattern_elem::Data::Wildcard(unit) => {
+                match models::expr::like::pattern_elem::Wildcard::try_from(*unit)
                     .expect("decode should succeed")
                 {
-                    models::expr::like::pattern_elem::Wildcard::X => ast::PatternElem::Wildcard,
+                    models::expr::like::pattern_elem::Wildcard::Unit => ast::PatternElem::Wildcard,
                 }
             }
         }
@@ -620,7 +620,7 @@ impl From<&ast::PatternElem> for models::expr::like::PatternElem {
             },
             ast::PatternElem::Wildcard => Self {
                 data: Some(models::expr::like::pattern_elem::Data::Wildcard(
-                    models::expr::like::pattern_elem::Wildcard::X.into(),
+                    models::expr::like::pattern_elem::Wildcard::Unit.into(),
                 )),
             },
         }

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -106,10 +106,7 @@ impl From<&models::EntityUid> for ast::EntityUIDEntry {
     fn from(v: &models::EntityUid) -> Self {
         // PANIC SAFETY: experimental feature
         #[allow(clippy::expect_used)]
-        ast::EntityUIDEntry::known(
-            ast::EntityUID::from(v),
-            None,
-        )
+        ast::EntityUIDEntry::known(ast::EntityUID::from(v), None)
     }
 }
 
@@ -669,9 +666,7 @@ impl From<&models::Expr> for ast::Context {
 
 impl From<&ast::Context> for models::Expr {
     fn from(v: &ast::Context) -> Self {
-        models::Expr::from(&ast::Expr::from(
-            ast::PartialValue::from(v.to_owned()),
-        ))
+        models::Expr::from(&ast::Expr::from(ast::PartialValue::from(v.to_owned())))
     }
 }
 
@@ -853,10 +848,7 @@ mod test {
             Some(context.clone()),
         );
         let request_rt = ast::Request::from(&models::Request::from(&request));
-        assert_eq!(
-            context,
-            ast::Context::from(&models::Expr::from(&context))
-        );
+        assert_eq!(context, ast::Context::from(&models::Expr::from(&context)));
         assert_eq!(request.principal().uid(), request_rt.principal().uid());
         assert_eq!(request.action().uid(), request_rt.action().uid());
         assert_eq!(request.resource().uid(), request_rt.resource().uid());

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -349,7 +349,9 @@ impl From<&models::ActionConstraint> for ast::ActionConstraint {
     fn from(v: &models::ActionConstraint) -> Self {
         match v.data.as_ref().expect("data.as_ref()") {
             models::action_constraint::Data::Any(unit) => {
-                match models::action_constraint::Any::try_from(*unit).expect("decode should succeed") {
+                match models::action_constraint::Any::try_from(*unit)
+                    .expect("decode should succeed")
+                {
                     models::action_constraint::Any::Unit => ast::ActionConstraint::Any,
                 }
             }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -226,7 +226,7 @@ impl From<&models::EntityReference> for ast::EntityReference {
                 match models::entity_reference::Slot::try_from(*slot)
                     .expect("decode should succeed")
                 {
-                    models::entity_reference::Slot::X => ast::EntityReference::Slot(None),
+                    models::entity_reference::Slot::Unit => ast::EntityReference::Slot(None),
                 }
             }
             models::entity_reference::Data::Euid(euid) => {
@@ -246,7 +246,7 @@ impl From<&ast::EntityReference> for models::EntityReference {
             },
             ast::EntityReference::Slot(_) => Self {
                 data: Some(models::entity_reference::Data::Slot(
-                    models::entity_reference::Slot::X.into(),
+                    models::entity_reference::Slot::Unit.into(),
                 )),
             },
         }
@@ -258,11 +258,11 @@ impl From<&models::PrincipalOrResourceConstraint> for ast::PrincipalOrResourceCo
     #[allow(clippy::expect_used)]
     fn from(v: &models::PrincipalOrResourceConstraint) -> Self {
         match v.data.as_ref().expect("data field should exist") {
-            models::principal_or_resource_constraint::Data::Any(x) => {
-                match models::principal_or_resource_constraint::Any::try_from(*x)
+            models::principal_or_resource_constraint::Data::Any(unit) => {
+                match models::principal_or_resource_constraint::Any::try_from(*unit)
                     .expect("decode should succeed")
                 {
-                    models::principal_or_resource_constraint::Any::X => {
+                    models::principal_or_resource_constraint::Any::Unit => {
                         ast::PrincipalOrResourceConstraint::Any
                     }
                 }
@@ -307,7 +307,7 @@ impl From<&ast::PrincipalOrResourceConstraint> for models::PrincipalOrResourceCo
         match v {
             ast::PrincipalOrResourceConstraint::Any => Self {
                 data: Some(models::principal_or_resource_constraint::Data::Any(
-                    models::principal_or_resource_constraint::Any::X.into(),
+                    models::principal_or_resource_constraint::Any::Unit.into(),
                 )),
             },
             ast::PrincipalOrResourceConstraint::In(er) => Self {
@@ -348,9 +348,9 @@ impl From<&models::ActionConstraint> for ast::ActionConstraint {
     #[allow(clippy::expect_used)]
     fn from(v: &models::ActionConstraint) -> Self {
         match v.data.as_ref().expect("data.as_ref()") {
-            models::action_constraint::Data::Any(x) => {
-                match models::action_constraint::Any::try_from(*x).expect("decode should succeed") {
-                    models::action_constraint::Any::X => ast::ActionConstraint::Any,
+            models::action_constraint::Data::Any(unit) => {
+                match models::action_constraint::Any::try_from(*unit).expect("decode should succeed") {
+                    models::action_constraint::Any::Unit => ast::ActionConstraint::Any,
                 }
             }
             models::action_constraint::Data::In(msg) => ast::ActionConstraint::In(
@@ -371,7 +371,7 @@ impl From<&ast::ActionConstraint> for models::ActionConstraint {
         match v {
             ast::ActionConstraint::Any => Self {
                 data: Some(models::action_constraint::Data::Any(
-                    models::action_constraint::Any::X.into(),
+                    models::action_constraint::Any::Unit.into(),
                 )),
             },
             ast::ActionConstraint::In(euids) => {

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -128,7 +128,10 @@ impl From<&models::TemplateBody> for ast::TemplateBody {
                 .map(|(key, value)| {
                     (
                         ast::AnyId::from_normalized_str(key).unwrap(),
-                        ast::Annotation { val: value.into(), loc: None },
+                        ast::Annotation {
+                            val: value.into(),
+                            loc: None,
+                        },
                     )
                 })
                 .collect(),
@@ -168,9 +171,13 @@ impl From<&ast::TemplateBody> for models::TemplateBody {
             id: v.id().as_ref().to_string(),
             annotations,
             effect: models::Effect::from(&v.effect()).into(),
-            principal_constraint: Some(models::PrincipalOrResourceConstraint::from(v.principal_constraint())),
+            principal_constraint: Some(models::PrincipalOrResourceConstraint::from(
+                v.principal_constraint(),
+            )),
             action_constraint: Some(models::ActionConstraint::from(v.action_constraint())),
-            resource_constraint: Some(models::PrincipalOrResourceConstraint::from(v.resource_constraint())),
+            resource_constraint: Some(models::PrincipalOrResourceConstraint::from(
+                v.resource_constraint(),
+            )),
             non_scope_constraints: Some(models::Expr::from(v.non_scope_constraints())),
         }
     }
@@ -272,12 +279,22 @@ impl From<&models::PrincipalOrResourceConstraint> for ast::PrincipalOrResourceCo
             }
             models::principal_or_resource_constraint::Data::Is(msg) => {
                 ast::PrincipalOrResourceConstraint::Is(
-                    ast::EntityType::from(msg.entity_type.as_ref().expect("entity_type field should exist")).into(),
+                    ast::EntityType::from(
+                        msg.entity_type
+                            .as_ref()
+                            .expect("entity_type field should exist"),
+                    )
+                    .into(),
                 )
             }
             models::principal_or_resource_constraint::Data::IsIn(msg) => {
                 ast::PrincipalOrResourceConstraint::IsIn(
-                    ast::EntityType::from(msg.entity_type.as_ref().expect("entity_type field should exist")).into(),
+                    ast::EntityType::from(
+                        msg.entity_type
+                            .as_ref()
+                            .expect("entity_type field should exist"),
+                    )
+                    .into(),
                     ast::EntityReference::from(msg.er.as_ref().expect("er field should exist")),
                 )
             }
@@ -332,9 +349,7 @@ impl From<&models::ActionConstraint> for ast::ActionConstraint {
     fn from(v: &models::ActionConstraint) -> Self {
         match v.data.as_ref().expect("data.as_ref()") {
             models::action_constraint::Data::Any(x) => {
-                match models::action_constraint::Any::try_from(*x)
-                    .expect("decode should succeed")
-                {
+                match models::action_constraint::Any::try_from(*x).expect("decode should succeed") {
                     models::action_constraint::Any::X => ast::ActionConstraint::Any,
                 }
             }
@@ -594,8 +609,14 @@ mod test {
             ast::PolicyID::from_string("template"),
             None,
             ast::Annotations::from_iter([
-                (ast::AnyId::from_normalized_str("read").unwrap(), annotation1),
-                (ast::AnyId::from_normalized_str("write").unwrap(), annotation2),
+                (
+                    ast::AnyId::from_normalized_str("read").unwrap(),
+                    annotation1,
+                ),
+                (
+                    ast::AnyId::from_normalized_str("write").unwrap(),
+                    annotation2,
+                ),
             ]),
             ast::Effect::Permit,
             pc.clone(),

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -299,11 +299,11 @@ impl From<&models::EntityRecordKind> for types::EntityRecordKind {
     #[allow(clippy::expect_used)]
     fn from(v: &models::EntityRecordKind) -> Self {
         match v.data.as_ref().expect("data field should exist") {
-            models::entity_record_kind::Data::AnyEntity(x) => {
-                match models::entity_record_kind::AnyEntity::try_from(*x)
+            models::entity_record_kind::Data::AnyEntity(unit) => {
+                match models::entity_record_kind::AnyEntity::try_from(*unit)
                     .expect("decode should succeed")
                 {
-                    models::entity_record_kind::AnyEntity::X => Self::AnyEntity,
+                    models::entity_record_kind::AnyEntity::Unit => Self::AnyEntity,
                 }
             }
             models::entity_record_kind::Data::Record(r) => Self::Record {
@@ -336,7 +336,7 @@ impl From<&types::EntityRecordKind> for models::EntityRecordKind {
                 open_attributes: models::OpenTag::from(open_attributes).into(),
             }),
             types::EntityRecordKind::AnyEntity => models::entity_record_kind::Data::AnyEntity(
-                models::entity_record_kind::AnyEntity::X.into(),
+                models::entity_record_kind::AnyEntity::Unit.into(),
             ),
             types::EntityRecordKind::Entity(e) => {
                 models::entity_record_kind::Data::Entity(models::Name::from(

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -23,43 +23,43 @@ use nonempty::NonEmpty;
 use smol_str::SmolStr;
 use std::collections::HashMap;
 
-impl From<&cedar_policy_validator::ValidatorSchema> for models::ValidatorSchema {
+impl From<&cedar_policy_validator::ValidatorSchema> for models::Schema {
     fn from(v: &cedar_policy_validator::ValidatorSchema) -> Self {
         Self {
-            entity_types: v
+            entity_decls: v
                 .entity_types()
-                .map(|ety| models::EntityTypeWithTypesMap {
-                    key: Some(models::EntityType::from(ety.name())),
-                    value: Some(models::ValidatorEntityType::from(ety)),
+                .map(|ety| models::EntityTypeToEntityDeclMap {
+                    key: Some(models::Name::from(ety.name())),
+                    value: Some(models::EntityDecl::from(ety)),
                 })
                 .collect(),
-            action_ids: v
+            action_decls: v
                 .action_ids()
-                .map(|id| models::EntityUidWithActionIdsMap {
+                .map(|id| models::EntityUidToActionDeclMap {
                     key: Some(models::EntityUid::from(id.name())),
-                    value: Some(models::ValidatorActionId::from(id)),
+                    value: Some(models::ActionDecl::from(id)),
                 })
                 .collect(),
         }
     }
 }
 
-impl From<&models::ValidatorSchema> for cedar_policy_validator::ValidatorSchema {
+impl From<&models::Schema> for cedar_policy_validator::ValidatorSchema {
     // PANIC SAFETY: experimental feature
     #[allow(clippy::expect_used)]
-    fn from(v: &models::ValidatorSchema) -> Self {
+    fn from(v: &models::Schema) -> Self {
         Self::new(
-            v.entity_types
+            v.entity_decls
                 .iter()
-                .map(|models::EntityTypeWithTypesMap { key, value }| {
+                .map(|models::EntityTypeToEntityDeclMap { key, value }| {
                     let key = key.as_ref().expect("key field should exist");
                     let value = value.as_ref().expect("value field should exist");
                     assert_eq!(key, value.name.as_ref().expect("name field should exist"));
                     cedar_policy_validator::ValidatorEntityType::from(value)
                 }),
-            v.action_ids
+            v.action_decls
                 .iter()
-                .map(|models::EntityUidWithActionIdsMap { key, value }| {
+                .map(|models::EntityUidToActionDeclMap { key, value }| {
                     let key = key.as_ref().expect("key field should exist");
                     let value = value.as_ref().expect("value field should exist");
                     assert_eq!(key, value.name.as_ref().expect("name field should exist"));
@@ -95,23 +95,15 @@ impl From<&models::ValidationMode> for cedar_policy_validator::ValidationMode {
     }
 }
 
-impl From<&cedar_policy_validator::ValidatorActionId> for models::ValidatorActionId {
+impl From<&cedar_policy_validator::ValidatorActionId> for models::ActionDecl {
     fn from(v: &cedar_policy_validator::ValidatorActionId) -> Self {
         Self {
             name: Some(models::EntityUid::from(v.name())),
-            applies_to: Some(models::ValidatorApplySpec {
-                principal_apply_spec: v
-                    .applies_to_principals()
-                    .map(models::EntityType::from)
-                    .collect(),
-                resource_apply_spec: v
-                    .applies_to_resources()
-                    .map(models::EntityType::from)
-                    .collect(),
-            }),
+            principal_types: v.applies_to_principals().map(models::Name::from).collect(),
+            resource_types: v.applies_to_resources().map(models::Name::from).collect(),
             descendants: v.descendants().map(models::EntityUid::from).collect(),
             context: Some(models::Type::from(v.context())),
-            attribute_types: Some(models::Attributes::from(v.attribute_types())),
+            attribute_types: attributes_to_model(v.attribute_types()),
             attributes: v
                 .attributes()
                 .map(|(k, v)| {
@@ -124,33 +116,19 @@ impl From<&cedar_policy_validator::ValidatorActionId> for models::ValidatorActio
     }
 }
 
-impl From<&models::ValidatorActionId> for cedar_policy_validator::ValidatorActionId {
+impl From<&models::ActionDecl> for cedar_policy_validator::ValidatorActionId {
     // PANIC SAFETY: experimental feature
     #[allow(clippy::expect_used)]
-    fn from(v: &models::ValidatorActionId) -> Self {
+    fn from(v: &models::ActionDecl) -> Self {
         let extensions_none = extensions::Extensions::none();
         let eval = evaluator::RestrictedEvaluator::new(extensions_none);
         Self::new(
             ast::EntityUID::from(v.name.as_ref().expect("name field should exist")),
-            v.applies_to
-                .as_ref()
-                .expect("applies_to field should exist")
-                .principal_apply_spec
-                .iter()
-                .map(ast::EntityType::from),
-            v.applies_to
-                .as_ref()
-                .expect("applies_to field should exist")
-                .resource_apply_spec
-                .iter()
-                .map(ast::EntityType::from),
+            v.principal_types.iter().map(ast::EntityType::from),
+            v.resource_types.iter().map(ast::EntityType::from),
             v.descendants.iter().map(ast::EntityUID::from),
             types::Type::from(v.context.as_ref().expect("context field should exist")),
-            types::Attributes::from(
-                v.attribute_types
-                    .as_ref()
-                    .expect("attribute_types field should exist"),
-            ),
+            model_to_attributes(&v.attribute_types),
             v.attributes
                 .iter()
                 .map(|(k, v)| {
@@ -167,15 +145,13 @@ impl From<&models::ValidatorActionId> for cedar_policy_validator::ValidatorActio
     }
 }
 
-impl From<&cedar_policy_validator::ValidatorEntityType> for models::ValidatorEntityType {
+impl From<&cedar_policy_validator::ValidatorEntityType> for models::EntityDecl {
     fn from(v: &cedar_policy_validator::ValidatorEntityType) -> Self {
-        let name = Some(models::EntityType::from(v.name()));
-        let descendants = v.descendants.iter().map(models::EntityType::from).collect();
-        let attributes = Some(models::Attributes::from(v.attributes()));
+        let name = Some(models::Name::from(v.name()));
+        let descendants = v.descendants.iter().map(models::Name::from).collect();
+        let attributes = attributes_to_model(v.attributes());
         let open_attributes = models::OpenTag::from(&v.open_attributes()).into();
-        let tags = v.tag_type().map(|tags| models::Tag {
-            optional_type: Some(models::Type::from(tags)),
-        });
+        let tags = v.tag_type().map(models::Type::from);
         match &v.kind {
             cedar_policy_validator::ValidatorEntityTypeKind::Standard(_) => Self {
                 name,
@@ -197,10 +173,10 @@ impl From<&cedar_policy_validator::ValidatorEntityType> for models::ValidatorEnt
     }
 }
 
-impl From<&models::ValidatorEntityType> for cedar_policy_validator::ValidatorEntityType {
+impl From<&models::EntityDecl> for cedar_policy_validator::ValidatorEntityType {
     // PANIC SAFETY: experimental feature
     #[allow(clippy::expect_used)]
-    fn from(v: &models::ValidatorEntityType) -> Self {
+    fn from(v: &models::EntityDecl) -> Self {
         let name = ast::EntityType::from(v.name.as_ref().expect("name field should exist"));
         let descendants = v.descendants.iter().map(ast::EntityType::from);
         match NonEmpty::collect(v.enum_choices.iter().map(SmolStr::from)) {
@@ -208,38 +184,17 @@ impl From<&models::ValidatorEntityType> for cedar_policy_validator::ValidatorEnt
             None => Self::new_standard(
                 name,
                 descendants,
-                types::Attributes::from(
-                    v.attributes
-                        .as_ref()
-                        .expect("attributes field should exist"),
-                ),
+                model_to_attributes(&v.attributes),
                 types::OpenTag::from(
                     &models::OpenTag::try_from(v.open_attributes).expect("decode should succeed"),
                 ),
-                v.tags
-                    .as_ref()
-                    .and_then(|tags| tags.optional_type.as_ref().map(types::Type::from)),
+                v.tags.as_ref().map(types::Type::from),
             ),
             Some(enum_choices) => {
                 // `enum_choices` is not empty, so `v` represents an enumerated entity type.
-                if let Some(vec) = &v.attributes {
-                    // enumerated entity types must have no attributes
-                    assert_eq!(
-                        vec,
-                        &models::Attributes {
-                            attrs: HashMap::new()
-                        }
-                    );
-                }
-                if let Some(tag) = &v.tags {
-                    // enumerated entity types must have no tags
-                    assert_eq!(
-                        tag,
-                        &models::Tag {
-                            optional_type: None
-                        }
-                    );
-                }
+                // enumerated entity types must have no attributes or tags.
+                assert_eq!(&v.attributes, &HashMap::new());
+                assert_eq!(&v.tags, &None);
                 Self::new_enum(name, descendants, enum_choices)
             }
         }
@@ -321,25 +276,17 @@ impl From<&types::Type> for models::Type {
     }
 }
 
-impl From<&models::Attributes> for types::Attributes {
-    fn from(v: &models::Attributes) -> Self {
-        Self::with_attributes(
-            v.attrs
-                .iter()
-                .map(|(k, v)| (k.into(), types::AttributeType::from(v))),
-        )
-    }
+fn model_to_attributes(v: &HashMap<String, models::AttributeType>) -> types::Attributes {
+    types::Attributes::with_attributes(
+        v.iter().map(|(k, v)| (k.into(), v.into()))
+    )
 }
 
-impl From<&types::Attributes> for models::Attributes {
-    fn from(v: &types::Attributes) -> Self {
-        Self {
-            attrs: v
-                .iter()
-                .map(|(k, v)| (k.to_string(), models::AttributeType::from(v)))
-                .collect(),
-        }
-    }
+fn attributes_to_model(v: &types::Attributes) -> HashMap<String, models::AttributeType> {
+    v
+        .iter()
+        .map(|(k, v)| (k.to_string(), models::AttributeType::from(v)))
+        .collect()
 }
 
 impl From<&models::OpenTag> for types::OpenTag {
@@ -365,40 +312,31 @@ impl From<&models::EntityRecordKind> for types::EntityRecordKind {
     #[allow(clippy::expect_used)]
     fn from(v: &models::EntityRecordKind) -> Self {
         match v.data.as_ref().expect("data field should exist") {
-            models::entity_record_kind::Data::Ty(ty) => {
-                match models::entity_record_kind::Ty::try_from(ty.to_owned())
+            models::entity_record_kind::Data::AnyEntity(x) => {
+                match models::entity_record_kind::AnyEntity::try_from(*x)
                     .expect("decode should succeed")
                 {
-                    models::entity_record_kind::Ty::AnyEntity => Self::AnyEntity,
+                    models::entity_record_kind::AnyEntity::X => Self::AnyEntity,
                 }
             }
-            models::entity_record_kind::Data::Record(p_record) => Self::Record {
-                attrs: types::Attributes::from(
-                    p_record.attrs.as_ref().expect("attrs field should exist"),
-                ),
+            models::entity_record_kind::Data::Record(r) => Self::Record {
+                attrs: model_to_attributes(&r.attrs),
                 open_attributes: types::OpenTag::from(
-                    &models::OpenTag::try_from(p_record.open_attributes)
+                    &models::OpenTag::try_from(r.open_attributes)
                         .expect("decode should succeed"),
                 ),
             },
-            models::entity_record_kind::Data::Entity(p_entity) => {
-                Self::Entity(types::EntityLUB::single_entity(ast::EntityType::from(
-                    p_entity.e.as_ref().expect("e field should exist"),
-                )))
+            models::entity_record_kind::Data::Entity(name) => {
+                Self::Entity(types::EntityLUB::single_entity(ast::EntityType::from(name)))
             }
-            models::entity_record_kind::Data::ActionEntity(p_action_entity) => Self::ActionEntity {
+            models::entity_record_kind::Data::ActionEntity(act) => Self::ActionEntity {
                 name: ast::EntityType::from(
-                    p_action_entity
+                    act
                         .name
                         .as_ref()
                         .expect("name field should exist"),
                 ),
-                attrs: types::Attributes::from(
-                    p_action_entity
-                        .attrs
-                        .as_ref()
-                        .expect("attrs field should exist"),
-                ),
+                attrs: model_to_attributes(&act.attrs),
             },
         }
     }
@@ -413,26 +351,26 @@ impl From<&types::EntityRecordKind> for models::EntityRecordKind {
                 attrs,
                 open_attributes,
             } => models::entity_record_kind::Data::Record(models::entity_record_kind::Record {
-                attrs: Some(models::Attributes::from(attrs)),
+                attrs: attributes_to_model(attrs),
                 open_attributes: models::OpenTag::from(open_attributes).into(),
             }),
-            types::EntityRecordKind::AnyEntity => models::entity_record_kind::Data::Ty(
-                models::entity_record_kind::Ty::AnyEntity.into(),
+            types::EntityRecordKind::AnyEntity => models::entity_record_kind::Data::AnyEntity(
+                models::entity_record_kind::AnyEntity::X.into(),
             ),
             types::EntityRecordKind::Entity(e) => {
-                models::entity_record_kind::Data::Entity(models::entity_record_kind::Entity {
-                    e: Some(models::EntityType::from(
+                models::entity_record_kind::Data::Entity(
+                    models::Name::from(
                         &e.clone()
                             .into_single_entity()
                             .expect("will be single EntityType"),
-                    )),
-                })
+                    )
+                )
             }
             types::EntityRecordKind::ActionEntity { name, attrs } => {
                 models::entity_record_kind::Data::ActionEntity(
                     models::entity_record_kind::ActionEntity {
-                        name: Some(models::EntityType::from(name)),
-                        attrs: Some(models::Attributes::from(attrs)),
+                        name: Some(models::Name::from(name)),
+                        attrs: attributes_to_model(attrs),
                     },
                 )
             }


### PR DESCRIPTION
## Description of changes

Cleans up our official Protobuf formats and loosens the coupling between the official formats and internal implementation details.

- Removes a number of wrapper types from the Protobuf format, and inlines their contents at every use site.  The existence of these wrapper types in our current internal implementation need not be reflected in the official Protobuf formats, and could change in the future.  Furthermore, inlining these types makes the Protobuf formats simpler and thus faster to encode/decode (as well as smaller on-the-wire).
    - `Context` wrapper around `Expr`
    - `EntityUidEntry` wrapper around `EntityUid` (note the Protobuf format does not currently support partial evaluation in any way)
    - `EntityType` wrapper around `Name`
    - `Annotation` wrapper around `string`
    - `PrincipalConstraint` wrapper around `PrincipalOrResourceConstraint`
    - `ResourceConstraint` wrapper around `PrincipalOrResourceConstraint`
    - `Entity` wrapper around `EntityType` (in validator)
    - `Attributes` wrapper around `map<string, AttributeType>` (in validator)
    - `Tag` wrapper around `optional Type` (in validator)
    - `ValidatorApplySpec` wrapper around the principal types + resource types for an action, in favor of inlining those two fields in `ActionDecl`.
- Renames a number of types in the Protobuf format, to use names that make more sense for end-users and are not linked to current internal implementation details.
    - `LiteralPolicy` -> `Policy`. This is the official representation of a Cedar policy in Protobuf.
    - `LiteralPolicySet` -> `PolicySet`.  This is the official representation of a Cedar policy-set in Protobuf.
    - `ValidatorSchema` -> `Schema`.  This is the official representation of a Cedar schema in Protobuf.
    - `ValidatorEntityType` -> `EntityDecl`.  This represents one `entity` declaration in a Cedar schema.
    - `ValidatorActionId` -> `ActionDecl`.  This represents one `action` declaration in a Cedar schema.
    - `EntityTypeWithTypesMap` -> `EntityTypeToEntityDeclMap`. Clarity.
    - `EntityUidWithActionIdsMap` -> `EntityUidToActionDeclMap`.  Clarity.
- Renames a number of fields in the Protobuf format, for clarity (particularly for users unfamiliar with our internal implementation details).
    - in `Policy`, rename `link_id_specified` to `is_template_link`.  Also make `link_id` explicitly `optional`, rather than just `""` when not used.
    - in a few places, rename `et` to `entity_type`, favoring more explicit/descriptive names in official formats.
    - in `Var`, rename `CONTEXT` to `Context` for consistency.
    - Some renaming around the use of zero-arity constructors, for consistency and clarity.  For example, in `PrincipalOrResourceConstraint`, rename the `ty` field to `any`, and the associated one-armed enum from `Ty` to `Any`.
    - In `Schema`, rename `entity_types` to `entity_decls`, and `action_ids` to `action_decls`, in line with the type renames above.
- Added a lot of comments to the Protobuf format specs.

These are breaking changes for users of `proto::models`, and some of these (the inlining, but not the renames) are also breaking changes for the Protobuf wire format itself and thus users of `traits::Protobuf`.  However, the `protobufs` feature is experimental, and folks should expect these kinds of changes while we continue to hammer out the final form of the feature.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
