### PR TITLE
[main] bump version to 4.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -270,7 +270,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-cli"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -321,7 +321,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-core"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "cedar-policy-core",
  "insta",
@@ -365,7 +365,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-validator"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "arbitrary",
  "cedar-policy-core",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-testing"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-wasm"
-version = "4.3.0"
+version = "4.4.0"
 dependencies = [
  "cedar-policy",
  "cedar-policy-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ debug = "line-tables-only"  # this adds more debug symbols/info to the binary th
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)
 rust-version = "1.77"
-version = "4.3.0"
+version = "4.4.0"
 homepage = "https://cedarpolicy.com"
 keywords = ["cedar", "authorization", "policy", "security"]
 categories = ["compilers", "config"]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { version = "=4.3.0", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=4.4.0", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=4.4.0", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core" }
 pretty = "0.12.1"
 logos = "0.15.0"
 itertools = "0.14"

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_with = "3.12"
@@ -55,7 +55,7 @@ tolerant-ast = ["cedar-policy-core/tolerant-ast"]
 [dev-dependencies]
 similar-asserts = "1.6.1"
 cool_asserts = "2.0"
-cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core", features = ["test-util"] }
+cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core", features = ["test-util"] }
 miette = { version = "7.5.0", features = ["fancy"] }
 
 [build-dependencies]

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -11,9 +11,9 @@ homepage.workspace = true
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator" }
-cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
+cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.4.0", path = "../cedar-policy-validator" }
+cedar-policy-formatter = { version = "=4.4.0", path = "../cedar-policy-formatter" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -71,7 +71,7 @@ miette = { version = "7.5.0", features = ["fancy"] }
 cool_asserts = "2.0"
 criterion = "0.5"
 globset = "0.4"
-cedar-policy-core = { version = "=4.3.0", features = [
+cedar-policy-core = { version = "=4.4.0", features = [
     "test-util",
 ], path = "../cedar-policy-core" }
 # NON-CRYPTOGRAPHIC random number generators

--- a/cedar-policy/src/tests.rs
+++ b/cedar-policy/src/tests.rs
@@ -6536,7 +6536,7 @@ mod version_tests {
 
     #[test]
     fn test_sdk_version() {
-        assert_eq!(get_sdk_version().to_string(), "4.3.0");
+        assert_eq!(get_sdk_version().to_string(), "4.4.0");
     }
 
     #[test]

--- a/cedar-testing/Cargo.toml
+++ b/cedar-testing/Cargo.toml
@@ -6,9 +6,9 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cedar-policy = { version = "=4.3.0", path = "../cedar-policy" }
-cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core" }
-cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator" }
+cedar-policy = { version = "=4.4.0", path = "../cedar-policy" }
+cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core" }
+cedar-policy-validator = { version = "=4.4.0", path = "../cedar-policy-validator" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -9,10 +9,10 @@ license.workspace = true
 exclude = ['/build']
 
 [dependencies]
-cedar-policy = { version = "=4.3.0", path = "../cedar-policy", features = ["wasm"] }
-cedar-policy-core = { version = "=4.3.0", path = "../cedar-policy-core", features = ["wasm"] }
-cedar-policy-formatter = { version = "=4.3.0", path = "../cedar-policy-formatter" }
-cedar-policy-validator = { version = "=4.3.0", path = "../cedar-policy-validator", features = ["wasm"] }
+cedar-policy = { version = "=4.4.0", path = "../cedar-policy", features = ["wasm"] }
+cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core", features = ["wasm"] }
+cedar-policy-formatter = { version = "=4.4.0", path = "../cedar-policy-formatter" }
+cedar-policy-validator = { version = "=4.4.0", path = "../cedar-policy-validator", features = ["wasm"] }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
## Description of changes

At this point, `main` contains some features that will not be released until 4.4.0, so it seems appropriate to mark the version number and `get_sdk_version()` as 4.4.0.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.

