### PR TITLE
Added Coverage Reports to CI

### DIFF
--- a/.github/actions/create_coverage_comment/action.yml
+++ b/.github/actions/create_coverage_comment/action.yml
@@ -3,8 +3,6 @@ description: >
   Build a markdown comment to be posted to a PR by the "comment_pr" workflow.
   If threshold is set, fails the build if the reported coverage does not meet
   met expected criteria.
-  Downloads the cobertura coverage report for the current workflow run.
-  TODO
   Uploads the created markdown comment and the number of the PR that triggered this action as workflow artifacts.
 inputs:
   threshold:

--- a/.github/actions/create_coverage_comment/action.yml
+++ b/.github/actions/create_coverage_comment/action.yml
@@ -1,0 +1,98 @@
+name: "Create Coverage PR Comment"
+description: >
+  Build a markdown comment to be posted to a PR by the "comment_pr" workflow.
+  If threshold is set, fails the build if the reported coverage does not meet
+  met expected criteria.
+  Downloads the cobertura coverage report for the current workflow run.
+  TODO
+  Uploads the created markdown comment and the number of the PR that triggered this action as workflow artifacts.
+inputs:
+  threshold:
+    description: >
+      Minimum proportion of modified lines that need to be covered for acceptance or -1 if there is no minimum.
+    required: false
+    default: "-1"
+  report-artifact-prefix:
+    description: "Prefix of the name of the artifact to be downloaded"
+    required: false
+    default: "coverage_report"
+  comment-artifact-name:
+    description: "Name of the artifact to be uploaded"
+    required: false
+    default: "coverage_comment"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download report artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.report-artifact-prefix }}_cobertura
+    - name: Compute changed lines
+      id: changed_lines
+      uses: hestonhoffman/changed-lines@v1
+      with:
+        file_filter: ".rs"
+    - name: Set up python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.13
+    - name: Find last nightly run for BASE
+      shell: bash
+      run: |
+        gh run list \
+          --commit $BASE_SHA \
+          --status "success" \
+          --workflow  "Nightly Build" \
+          --limit 1 \
+          --json "databaseId" \
+          | jq --raw-output '.[0]["databaseId"]' \
+          > base_run_id.txt
+        echo "BASE_RUN_ID=$(cat base_run_id.txt)" >> $GITHUB_ENV
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        GH_TOKEN: ${{ github.token }}
+    - name: Find coverage report for BASE
+      if: ${{ env.BASE_RUN_ID != 'null' }}
+      shell: bash
+      run: |
+        echo TODO
+        mkdir -p base_coverage
+        gh run download $BASE_RUN_ID --name $NAME --dir base_coverage
+      env:
+        NAME: ${{ inputs.report-artifact-prefix }}_cobertura
+        GH_TOKEN: ${{ github.token }}
+    - name: Create result files
+      shell: bash
+      run: |
+        mkdir -p target/coverage/results
+        echo $ISSUE_NUMBER > target/coverage/results/issue_number.txt
+        echo $CHANGED_LINES > target/coverage/results/changed_lines.json
+        python .github/scripts/process_coverage.py \
+          cobertura.xml \
+          target/coverage/results/changed_lines.json \
+          $THRESHOLD \
+          $HEAD_SHA \
+          $BASE_SHA \
+          $(cat report_location.txt) \
+          base_coverage/cobertura.xml \
+          target/coverage/results
+        echo "STATUS=$(cat target/coverage/results/status.txt)" >> $GITHUB_ENV
+      env:
+        CHANGED_LINES: ${{ steps.changed_lines.outputs.changed_lines }}
+        THRESHOLD: ${{ inputs.threshold }}
+        ISSUE_NUMBER: ${{ github.event.number }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+    - name: Upload results
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.comment-artifact-name }}
+        path: target/coverage/results/
+        retention-days: 1
+    - name: Check status
+      if: ${{ env.STATUS == 'FAILED' }}
+      uses: actions/github-script@v3
+      with:
+        script: |
+          core.setFailed('Required coverage criteria were not met.')

--- a/.github/actions/create_coverage_comment/action.yml
+++ b/.github/actions/create_coverage_comment/action.yml
@@ -54,9 +54,8 @@ runs:
       if: ${{ env.BASE_RUN_ID != 'null' }}
       shell: bash
       run: |
-        echo TODO
         mkdir -p base_coverage
-        gh run download $BASE_RUN_ID --name $NAME --dir base_coverage
+        gh run download $BASE_RUN_ID --name $NAME --dir base_coverage || true
       env:
         NAME: ${{ inputs.report-artifact-prefix }}_cobertura
         GH_TOKEN: ${{ github.token }}

--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -39,7 +39,11 @@ runs:
             --binary-path ./target/debug/ \
             -t html,cobertura \
             --ignore 'target/debug/*' \
-            --ignore "/*" \
+            --ignore '/*' \
+            --ignore '*/build.rs' \
+            --ignore '*/tests/*' \
+            --excl-start '^\#\[cfg\(test\)\]' \
+            --excl-stop '^}' \
             --ignore-not-existing \
             -o ./target/coverage/
     - name: Upload HTML coverage report

--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -1,0 +1,65 @@
+name: "Create Coverage Reports"
+description: >
+  Searches the directory tree rooted at the current working directory for raw coverage profiles
+  ('.profraw' files).
+  Builds grcov HTML and cobertura XML coverage reports from the located profiles.
+  Uploads the built reports as workflow artifacts.
+inputs:
+  retention-days:
+    description: >
+      Duration after which the uploaded artifacts will expire in days, or 0 to use the default setting for the 
+      repository.
+    required: false
+    default: "0"
+  artifact-prefix:
+    description: "Prefix of the name for the artifacts to be uploaded"
+    required: false
+    default: "coverage_report"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install LLVM tools
+      shell: bash
+      run: rustup component add llvm-tools-preview
+    - name: Install grcov
+      shell: bash
+      run: cargo install grcov
+    - name: Collect coverage profiles
+      shell: bash
+      run: zip -0 raw_cov.zip $(find . -name "*.profraw") -q
+    # Note: source-based branch coverage is not supported for Rust
+    # (see http://github.com/rust-lang/rust/issues/79649)
+    - name: Build coverage report
+      shell: bash
+      run: |
+        mkdir -p ./target/coverage
+        grcov raw_cov.zip \
+            --source-dir . \
+            --binary-path ./target/debug/ \
+            -t html,cobertura \
+            --ignore 'target/debug/*' \
+            --ignore "/*" \
+            --ignore-not-existing \
+            -o ./target/coverage/
+    - name: Upload HTML coverage report
+      uses: actions/upload-artifact@v4
+      id: upload-artifact
+      with:
+        name: ${{ inputs.artifact-prefix }}_html
+        path: target/coverage/html
+        retention-days: ${{ inputs.retention-days }}
+    - name: Create directory for cobertura report
+      shell: bash
+      run: |
+        mkdir -p target/coverage/cobertura
+        mv target/coverage/cobertura.xml target/coverage/cobertura/
+        echo $REPORT_LOCATION > target/coverage/cobertura/report_location.txt
+      env:
+        REPORT_LOCATION: ${{ steps.upload-artifact.outputs.artifact-url }}
+    - name: Upload cobertura coverage report
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.artifact-prefix }}_cobertura
+        path: target/coverage/cobertura
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/scripts/process_coverage.py
+++ b/.github/scripts/process_coverage.py
@@ -175,7 +175,7 @@ def create_comparison_table(entries, base_entries, required_coverage):
         else:
             row.append("--")
         yield row
-    for name, base_group in base_groups:
+    for name, base_group in base_groups.items():
         if name in groups:
             continue
         row = create_row(name, list(group), required_coverage)[:-1]

--- a/.github/scripts/process_coverage.py
+++ b/.github/scripts/process_coverage.py
@@ -7,9 +7,9 @@ import xml.etree.ElementTree as ET
 
 TEMPLATE = """
 # Coverage Report
-Head Commit: $$HEAD_SHA$$
+Head Commit: ```$$HEAD_SHA$$```
 
-Base Commit: $$BASE_SHA$$
+Base Commit: ```$$BASE_SHA$$```
 
 [Download the full coverage report.]($$REPORT_LOCATION$$)
 

--- a/.github/scripts/process_coverage.py
+++ b/.github/scripts/process_coverage.py
@@ -1,0 +1,261 @@
+import json
+import os
+import itertools
+import pathlib
+import sys
+import xml.etree.ElementTree as ET
+
+TEMPLATE = """
+# Coverage Report
+Head Commit: $$HEAD_SHA$$
+
+Base Commit: $$BASE_SHA$$
+
+[Download the full coverage report.]($$REPORT_LOCATION$$)
+
+## Coverage of Added or Modified Lines of Rust Code
+$$MOD_SUMMARY$$
+
+<details>
+<summary><b>Details</b></summary>
+
+| File | Status | Covered | Coverage | Missed Lines |
+|:-----|:------:|:-------:|---------:|:-------------|
+$$MOD_TABLE$$
+</details>
+
+## Coverage of All Lines of Rust Code
+$$ALL_SUMMARY$$
+
+<details>
+<summary><b>Details</b></summary>
+
+| Package | Status | Covered | Coverage | Base Coverage |
+|:--------|:------:|:-------:|---------:|--------------:|
+$$ALL_TABLE$$
+</details>
+"""
+
+
+def to_ranges(iterable):
+    iterable = sorted(set(iterable))
+    # Group elements by the difference between the value and its index
+    for _, group in itertools.groupby(enumerate(iterable), lambda t: t[1] - t[0]):
+        group = list(group)
+        # Take the value of the first and last elements of the group
+        yield group[0][1], group[-1][1]
+
+
+def format_lines(lines):
+    x = [str(x) if x == y else f"{x}-{y}" for x, y in to_ranges(lines)]
+    return ", ".join(x)
+
+
+def collect_line_coverage(cobertura_file):
+    tree = ET.parse(cobertura_file)
+    root = tree.getroot()
+    for clazz in root.findall("packages/package/classes/class"):
+        file_name = clazz.attrib["filename"]
+        package = file_name.split(os.path.sep)[0]
+        for line in clazz.findall("lines/line"):
+            yield dict(
+                package=package,
+                file_name=file_name,
+                line_number=int(line.attrib["number"]),
+                hit_count=int(line.attrib["hits"]),
+            )
+
+
+def create_comment(template_variables):
+    result = TEMPLATE
+    for k, v in template_variables.items():
+        result = result.replace(f"$${k.upper()}$$", v)
+    return result
+
+
+def write_results(output_dir, passed, comment):
+    os.makedirs(pathlib.Path(output_dir), exist_ok=True)
+    status_file = os.path.join(output_dir, "status.txt")
+    with open(status_file, "w") as f:
+        f.write("PASSED" if passed else "FAILED")
+    comment_file = os.path.join(output_dir, "markdown.md")
+    with open(comment_file, "w") as f:
+        f.write(comment)
+
+
+def read_json(file):
+    with open(file) as f:
+        return json.load(f)
+
+
+def was_modified(entry, changed_lines):
+    file_name = entry["file_name"]
+    return (
+        file_name in changed_lines and entry["line_number"] in changed_lines[file_name]
+    )
+
+
+def santize_name(name):
+    allowed = ["-", "_", os.path.sep, "/", "."]
+    return "".join(filter(lambda c: str.isalnum(c) or c in allowed, name))
+
+
+def get_status(actual_coverage, required_coverage):
+    if required_coverage == -1:
+        return ":white_circle:"
+    elif actual_coverage >= required_coverage:
+        return ":green_circle:"
+    elif actual_coverage >= (required_coverage - 0.1):
+        return ":yellow_circle:"
+    else:
+        return ":red_circle:"
+
+
+def create_table(entries, required_coverage, list_missed, group_key):
+    entries = sorted(entries, key=lambda e: e[group_key])
+    groups = itertools.groupby(entries, lambda e: e[group_key])
+    for name, group in groups:
+        group = list(group)
+        missed_lines = [x["line_number"] for x in group if x["hit_count"] == 0]
+        total_lines = len(group)
+        if total_lines != 0:
+            num_covered = total_lines - len(missed_lines)
+            coverage = num_covered / total_lines
+            values = [
+                santize_name(name),
+                f"{coverage:.2%}",
+                f"{num_covered}/{total_lines}",
+                get_status(coverage, required_coverage),
+            ]
+            if list_missed:
+                values.append(format_lines(missed_lines))
+            yield " | ".join(values)
+
+
+def compute_actual_coverage(entries):
+    total = len(entries)
+    covered = len([x for x in entries if x["hit_count"] != 0])
+    return covered / total if total != 0 else 1.0
+
+
+def group_entries(entries, key):
+    entries = sorted(entries, key=lambda e: e[key])
+    groups = itertools.groupby(entries, lambda e: e[key])
+    result = {}
+    for name, group in groups:
+        group = list(group)
+        if len(group) != 0:
+            result[name] = group
+    return result
+
+
+def create_row(name, group, required_coverage):
+    missed_lines = [x["line_number"] for x in group if x["hit_count"] == 0]
+    total_lines = len(group)
+    num_covered = total_lines - len(missed_lines)
+    coverage = num_covered / total_lines if total_lines != 0 else 1.0
+    return [
+        santize_name(name),
+        get_status(coverage, required_coverage),
+        f"{num_covered}/{total_lines}",
+        f"{coverage:.2%}" if total_lines != 0 else "--",
+        format_lines(missed_lines),
+    ]
+
+
+def create_comparison_table(entries, base_entries, required_coverage):
+    group_key = "package"
+    base_groups = group_entries(base_entries, group_key)
+    groups = group_entries(entries, group_key)
+    for name, group in groups.items():
+        row = create_row(name, list(group), required_coverage)[:-1]
+        if name in base_groups:
+            base_coverage = compute_actual_coverage(base_groups[name])
+            row.append(f"{base_coverage:.2%}")
+        else:
+            row.append("--")
+        yield row
+    for name, base_group in base_groups:
+        if name in groups:
+            continue
+        row = create_row(name, list(group), required_coverage)[:-1]
+        base_coverage = compute_actual_coverage(base_group)
+        row.append(f"{base_coverage:.2%}")
+        yield row
+
+
+def format_table(rows):
+    return "\n".join([" | ".join(row) for row in rows])
+
+
+def create_summary(entries, required_coverage):
+    actual_coverage = 1.0 if len(entries) == 0 else compute_actual_coverage(entries)
+    if required_coverage == -1:
+        return f"**Overall coverage:** {actual_coverage:.2%}"
+    passed = actual_coverage >= required_coverage
+    return (
+        f"**Required coverage:** {required_coverage:.2%}"
+        + "\n\n"
+        + f"**Actual coverage:** {actual_coverage:.2%}"
+        + "\n\n"
+        + f"**Status:** {"PASSED" if passed else "FAILED"} {":white_check_mark:" if passed else ":x:"}"
+    )
+
+
+def check_criteria(entries, required_coverage):
+    return (
+        required_coverage == -1
+        or len(entries) == 0
+        or (compute_actual_coverage(entries) >= required_coverage)
+    )
+
+
+def process(
+    cobertura_file,
+    changed_lines_file,
+    required_coverage,
+    head_sha,
+    base_sha,
+    report_location,
+    base_cobertura_file,
+    output_dir,
+):
+    required_coverage = float(required_coverage)
+    entries = list(collect_line_coverage(cobertura_file))
+    changed_lines = read_json(changed_lines_file)
+    # Remove lines that were not modified
+    modified_entries = list(filter(lambda e: was_modified(e, changed_lines), entries))
+    # Read coverage for PR BASE
+    base_entries = []
+    if os.path.exists(base_cobertura_file):
+        base_entries = list(collect_line_coverage(base_cobertura_file))
+    # Create tables
+    all_table = create_comparison_table(entries, base_entries, required_coverage)
+    mod_table = [
+        create_row(name, list(group), required_coverage)
+        for name, group in group_entries(modified_entries, "file_name").items()
+    ]
+    template_variables = dict(
+        REPORT_LOCATION=report_location,
+        HEAD_SHA=head_sha,
+        BASE_SHA=base_sha,
+        ALL_SUMMARY=create_summary(entries, required_coverage),
+        MOD_SUMMARY=create_summary(modified_entries, required_coverage),
+        ALL_TABLE=format_table(all_table),
+        MOD_TABLE=format_table(mod_table),
+    )
+    passed = check_criteria(entries, required_coverage)
+    passed &= check_criteria(modified_entries, required_coverage)
+    write_results(
+        output_dir,
+        passed,
+        create_comment(template_variables),
+    )
+
+
+def main():
+    process(*sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -1,6 +1,18 @@
 name: Build and Test
 on:
-    workflow_call:
+  workflow_call:
+    inputs:
+      collect_coverage:
+        required: false
+        default: false
+        type: boolean
+      retention-days:
+        description: >
+          Duration after which the uploaded coverage artifacts will expire in days, or 0 to use the default setting 
+          for the repository.
+        required: false
+        default: "0"
+        type: string
 
 jobs:
   build_and_test:
@@ -17,6 +29,13 @@ jobs:
       RUSTFLAGS: '-D warnings -F unsafe-code'
 
     steps:
+      - name: Set environment variables for coverage collection
+        if: ${{ inputs.collect_coverage }} && ${{ matrix.toolchain }} == 'stable'
+        shell: bash
+        run: |
+          echo "RUSTFLAGS=${RUSTFLAGS} -C instrument-coverage" >> $GITHUB_ENV
+          echo "LLVM_PROFILE_FILE=cedar_%m_%p.profraw" >> $GITHUB_ENV
+
       - uses: actions/checkout@v4
       - run: sudo apt-get install protobuf-compiler
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
@@ -32,6 +51,12 @@ jobs:
       - run: cargo build --verbose --features "experimental"
       - run: cargo test --verbose --features "experimental"
       - run: cargo audit --deny warnings # For some reason this hangs if you don't cargo build first
+
+      - name: Create a coverage report
+        if: ${{ inputs.collect_coverage }} && ${{ matrix.toolchain }} == 'stable'
+        uses: ./.github/actions/create_coverage_reports
+        with:
+          retention-days: ${{ inputs.retention-days }}
 
   # Clippy in its own job so that the `RUSTFLAGS` set for `build_and_test`
   # don't effect it. As a side effect, this will run in parallel, saving some

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,18 @@ env:
 jobs:
   build_and_test:
     uses: ./.github/workflows/build_and_test.yml
+    with:
+      collect_coverage: true
+
+  check_coverage:
+    name: Check coverage criteria
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/create_coverage_comment
+        with:
+          threshold: 0.8
 
   cargo_semver_checks:
     name: Cargo SemVer Checks

--- a/.github/workflows/comment_pr.yml
+++ b/.github/workflows/comment_pr.yml
@@ -1,0 +1,44 @@
+name: Comment on the pull request
+ 
+on:
+  workflow_run:
+    workflows: [Cargo Build & Test]
+    types:
+      - completed
+
+jobs:
+  post_comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      (github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure')
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check build_and_test status
+        shell: bash
+        run: |
+          jobs=$(gh run view $RUN_ID --json jobs)
+          job_status=$(jq --raw-output '.[] | map(select(.name=="build_and_test / Build and Test (stable)"))[0] | .status' <<< "$jobs")
+          echo "STATUS=$job_status" >> $GITHUB_ENV
+        env:
+              RUN_ID: ${{github.event.workflow_run.id }}
+              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download artifacts
+        if: ${{ env.STATUS == 'completed' }}
+        shell: bash
+        run: gh run download $RUN_ID
+        env:
+          RUN_ID: ${{github.event.workflow_run.id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Read stored values
+        if: ${{ env.STATUS == 'completed' }}
+        shell: bash
+        run: |
+          echo "ISSUE_NUMBER=$(cat coverage_comment/issue_number.txt)" >> $GITHUB_ENV
+      - name: Add comment to PR
+        if: ${{ env.STATUS == 'completed' }}
+        shell: bash
+        run: gh pr comment $ISSUE_NUMBER --body-file coverage_comment/markdown.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,5 +1,6 @@
 name: Nightly build
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
 
@@ -8,3 +9,6 @@ env:
 jobs:
   build_and_test:
     uses: ./.github/workflows/build_and_test.yml
+    with:
+      collect_coverage: true
+      retention-days: 2


### PR DESCRIPTION
## Description of changes
Changed the "Nightly build" workflow to collect code coverage information and upload code coverage reports as workflow artifacts. These reports are only retained for 2 days to prevent storage build up. These reports are used to include information comparing the coverage of the HEAD of the PR to the coverage of the BASE of the PR.

Changed the CI "Cargo Build & Test" workflow that is run for pull requests to collect code coverage information and upload code coverage reports as workflow artifacts. These reports will be retained for the repository default of 90 days. These reports are processed as part of the "Cargo Build & Test" workflow to create a markdown comment summarizing the reports. Finally, a check is performed that fails the build if the observed coverage drops below a threshold value (currently set at 80%). Both the overall coverage for the repository and the coverage of added code is assessed for this check.

The produced markdown comment is posted to the PR that triggered the "Cargo Build & Test" workflow. This change will not be reflect until this change is merged into the default branch because the newly added "Comment on the pull request" workflow is triggered by a "workflow_run" event type and, therefore, must be present on the default branch to take effect. This separation and choice of event type is necessary for security reasons.

In order to demonstrate these changes, I created two pull requests within my fork of cedar:

In [Example PR 1](https://github.com/katherine-hough/cedar/pull/8), we see a PR that has added a new function, but not added any tests. The build is failed because less than 80% of the added code is covered by the test suite. 
[A comment is added the PR](https://github.com/katherine-hough/cedar/pull/8#issuecomment-2679773335) summarizing the coverage results. This comments shows a failure under the section "Coverage of Added or Modified Lines of Rust Code". If the "details" text is clicked, it shows that out of the ten lines of code added to the file "cedar-policy-core/src/entities.rs" zero of them were covered. It also listed which lines specifically were not covered. In the section "Coverage of All Lines of Rust Code", we can see the that overall coverage for the repository has not dropped below the 80% threshold. However, when the "details" text is clicked it reveals that coverage for the package "cedar-policy-core" has dropped from 91.50% to 91.47%.

In [Example PR 2](https://github.com/katherine-hough/cedar/pull/9), we see a PR that has added a new function with an accompanying test case. In this case the build succeeds, because at least 80% of the added code is covered by the test suite. A [report comment](https://github.com/katherine-hough/cedar/pull/9#issuecomment-2679774263) similar to the one for Example 1 is created summarizing the coverage results for this PR.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
