### PR TITLE
more simplification of protobuf schema format (followups to 1488)

### DIFF
--- a/cedar-policy-validator/src/types.rs
+++ b/cedar-policy-validator/src/types.rs
@@ -1075,13 +1075,14 @@ impl IntoIterator for Attributes {
 
 /// Used to tag record types to indicate if their attributes record is open or
 /// closed.
-#[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone, Serialize)]
+#[derive(Hash, Ord, PartialOrd, Eq, PartialEq, Debug, Copy, Clone, Serialize, Default)]
 pub enum OpenTag {
     /// The attributes are open. A value of this type may have attributes other
     /// than those listed.
     OpenAttributes,
     /// The attributes are closed. The attributes for a value of this type must
     /// exactly match the attributes listed in the type.
+    #[default]
     ClosedAttributes,
 }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -18,7 +18,7 @@ Cedar Language Version: TBD
 - Changed `Entities::add_entities` and `Entities::from_entities` to ignore structurally equal entities with the same Entity UID.
 - For `protobufs` experimental feature, a number of changes to the interface and
   the Protobuf format definitions, as we continue to iterate towards making this
-  feature stable. (#1488, #1489)
+  feature stable. (#1488, #1495)
 
 ### Added
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -18,7 +18,7 @@ Cedar Language Version: TBD
 - Changed `Entities::add_entities` and `Entities::from_entities` to ignore structurally equal entities with the same Entity UID.
 - For `protobufs` experimental feature, a number of changes to the interface and
   the Protobuf format definitions, as we continue to iterate towards making this
-  feature stable.
+  feature stable. (#1488, #1489)
 
 ### Added
 
@@ -27,7 +27,7 @@ Cedar Language Version: TBD
 - Implemented [RFC 53 (enumerated entity types)](https://github.com/cedar-policy/rfcs/blob/main/text/0053-enum-entities.md)  (#1377)
 - Added the experimental feature `tolerant-ast` which allows certain errors to be propogated in AST expressions as an `ExprKind::Error` (#1470)
 
-## [4.3.3] - Coming soon
+## [4.3.3] - 2025-02-25
 
 ### Changed
 

--- a/cedar-policy/protobuf_schema/validator.proto
+++ b/cedar-policy/protobuf_schema/validator.proto
@@ -21,24 +21,8 @@ import "core.proto";
 
 // the protobuf Schema message describes a complete schema.
 message Schema {
-    // TODO: this need not be a map at all, since `EntityDecl` contains the `name` as well.
-    // It can be just `repeated EntityDecl`.
-    repeated EntityTypeToEntityDeclMap entity_decls = 1;
-    // TODO: this need not be a map at all, since `ActionDecl` contains the `name` as well.
-    // It can be just `repeated ActionDecl`.
-    repeated EntityUidToActionDeclMap action_decls = 2;
-}
-
-// This `message` with `key` and `value`, rather than a `map`, since messages can't be dictionary keys
-message EntityTypeToEntityDeclMap {
-    cedar_policy_core.Name key = 1;
-    EntityDecl value = 2;
-}
-
-// This `message` with `key` and `value`, rather than a `map`, since messages can't be dictionary keys
-message EntityUidToActionDeclMap {
-    cedar_policy_core.EntityUid key = 1;
-    ActionDecl value = 2;
+    repeated EntityDecl entity_decls = 1;
+    repeated ActionDecl action_decls = 2;
 }
 
 // the protobuf EntityDecl message contains all of the schema's
@@ -47,7 +31,6 @@ message EntityDecl {
     cedar_policy_core.Name name = 1;
     repeated cedar_policy_core.Name descendants = 2;
     map<string, AttributeType> attributes = 3;
-    OpenTag open_attributes = 4;
     optional Type tags = 5;
     repeated string enum_choices = 6;
 }
@@ -57,56 +40,35 @@ message EntityDecl {
 message ActionDecl {
     cedar_policy_core.EntityUid name = 1;
     repeated cedar_policy_core.EntityUid descendants = 3;
-    Type context = 4;
-    repeated cedar_policy_core.Name principal_types = 7;
-    repeated cedar_policy_core.Name resource_types = 8;
+    map<string, AttributeType> context = 4;
+    repeated cedar_policy_core.Name principal_types = 5;
+    repeated cedar_policy_core.Name resource_types = 6;
 }
 
 message Type {
     oneof data {
-        Ty ty = 1;
-        Type set_type = 2;
-        EntityRecordKind entityOrRecord = 3;
-        cedar_policy_core.Name name = 4;
-    }
-
-    enum Ty {
-        Never = 0;
-        True = 1;
-        False = 2;
-        EmptySetType = 3;
-        Bool = 4;
-        String = 5;
-        Long = 6;
-    }
-}
-
-message EntityRecordKind {
-    oneof data {
-        AnyEntity any_entity = 1;
-        Record record = 2;
+        // Primitive types
+        Prim prim = 1;
+        // Set with the specified element type
+        Type set_elem = 2;
+        // Entity type
         cedar_policy_core.Name entity = 3;
-        ActionEntity actionEntity = 4;
+        // Record type
+        // Map types are not allowed inside oneof, so we can't inline the map here
+        Record record = 4;
+        // Extension type
+        cedar_policy_core.Name ext = 5;
     }
 
-    // Zero-arity constructors represented as enums with only one member
-    enum AnyEntity {
-        // the one option for the enum
-        unit = 0;
+    enum Prim {
+        String = 0;
+        Bool = 1;
+        Long = 2;
     }
+
     message Record {
         map<string, AttributeType> attrs = 1;
-        OpenTag open_attributes = 2;
     }
-    message ActionEntity {
-        cedar_policy_core.Name name = 1;
-        map<string, AttributeType> attrs = 2;
-    }
-}
-
-enum OpenTag {
-    OpenAttributes = 0;
-    ClosedAttributes = 1;
 }
 
 message AttributeType {

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -26,20 +26,8 @@ use std::collections::{BTreeMap, HashMap};
 impl From<&cedar_policy_validator::ValidatorSchema> for models::Schema {
     fn from(v: &cedar_policy_validator::ValidatorSchema) -> Self {
         Self {
-            entity_decls: v
-                .entity_types()
-                .map(|ety| models::EntityTypeToEntityDeclMap {
-                    key: Some(models::Name::from(ety.name())),
-                    value: Some(models::EntityDecl::from(ety)),
-                })
-                .collect(),
-            action_decls: v
-                .action_ids()
-                .map(|id| models::EntityUidToActionDeclMap {
-                    key: Some(models::EntityUid::from(id.name())),
-                    value: Some(models::ActionDecl::from(id)),
-                })
-                .collect(),
+            entity_decls: v.entity_types().map(models::EntityDecl::from).collect(),
+            action_decls: v.action_ids().map(models::ActionDecl::from).collect(),
         }
     }
 }
@@ -51,20 +39,10 @@ impl From<&models::Schema> for cedar_policy_validator::ValidatorSchema {
         Self::new(
             v.entity_decls
                 .iter()
-                .map(|models::EntityTypeToEntityDeclMap { key, value }| {
-                    let key = key.as_ref().expect("key field should exist");
-                    let value = value.as_ref().expect("value field should exist");
-                    assert_eq!(key, value.name.as_ref().expect("name field should exist"));
-                    cedar_policy_validator::ValidatorEntityType::from(value)
-                }),
+                .map(cedar_policy_validator::ValidatorEntityType::from),
             v.action_decls
                 .iter()
-                .map(|models::EntityUidToActionDeclMap { key, value }| {
-                    let key = key.as_ref().expect("key field should exist");
-                    let value = value.as_ref().expect("value field should exist");
-                    assert_eq!(key, value.name.as_ref().expect("name field should exist"));
-                    cedar_policy_validator::ValidatorActionId::from(value)
-                }),
+                .map(cedar_policy_validator::ValidatorActionId::from),
         )
     }
 }
@@ -95,7 +73,11 @@ impl From<&models::ValidationMode> for cedar_policy_validator::ValidationMode {
     }
 }
 
+// PANIC SAFETY: experimental feature
+#[allow(clippy::fallible_impl_from)]
 impl From<&cedar_policy_validator::ValidatorActionId> for models::ActionDecl {
+    // PANIC SAFETY: experimental feature
+    #[allow(clippy::panic)]
     fn from(v: &cedar_policy_validator::ValidatorActionId) -> Self {
         debug_assert_eq!(
             v.attribute_types().keys().collect::<Vec<&SmolStr>>(),
@@ -107,12 +89,19 @@ impl From<&cedar_policy_validator::ValidatorActionId> for models::ActionDecl {
             vec![],
             "action attributes are not currently supported in protobuf"
         );
+        let ctx_attrs = match v.context() {
+            types::Type::EntityOrRecord(types::EntityRecordKind::Record {
+                attrs,
+                open_attributes: types::OpenTag::ClosedAttributes,
+            }) => attrs,
+            ty => panic!("expected context to be a closed record, but got {ty:?}"),
+        };
         Self {
             name: Some(models::EntityUid::from(v.name())),
             principal_types: v.applies_to_principals().map(models::Name::from).collect(),
             resource_types: v.applies_to_resources().map(models::Name::from).collect(),
             descendants: v.descendants().map(models::EntityUid::from).collect(),
-            context: Some(models::Type::from(v.context())),
+            context: attributes_to_model(ctx_attrs),
         }
     }
 }
@@ -126,7 +115,10 @@ impl From<&models::ActionDecl> for cedar_policy_validator::ValidatorActionId {
             v.principal_types.iter().map(ast::EntityType::from),
             v.resource_types.iter().map(ast::EntityType::from),
             v.descendants.iter().map(ast::EntityUID::from),
-            types::Type::from(v.context.as_ref().expect("context field should exist")),
+            types::Type::EntityOrRecord(types::EntityRecordKind::Record {
+                attrs: model_to_attributes(&v.context),
+                open_attributes: types::OpenTag::default(),
+            }),
             // protobuf formats do not include action attributes, so we
             // translate into a `ValidatorActionId` with no action attributes
             types::Attributes::with_attributes([]),
@@ -140,14 +132,12 @@ impl From<&cedar_policy_validator::ValidatorEntityType> for models::EntityDecl {
         let name = Some(models::Name::from(v.name()));
         let descendants = v.descendants.iter().map(models::Name::from).collect();
         let attributes = attributes_to_model(v.attributes());
-        let open_attributes = models::OpenTag::from(&v.open_attributes()).into();
         let tags = v.tag_type().map(models::Type::from);
         match &v.kind {
             cedar_policy_validator::ValidatorEntityTypeKind::Standard(_) => Self {
                 name,
                 descendants,
                 attributes,
-                open_attributes,
                 tags,
                 enum_choices: vec![],
             },
@@ -155,7 +145,6 @@ impl From<&cedar_policy_validator::ValidatorEntityType> for models::EntityDecl {
                 name,
                 descendants,
                 attributes,
-                open_attributes,
                 tags,
                 enum_choices: enum_choices.into_iter().map(ToString::to_string).collect(),
             },
@@ -175,9 +164,7 @@ impl From<&models::EntityDecl> for cedar_policy_validator::ValidatorEntityType {
                 name,
                 descendants,
                 model_to_attributes(&v.attributes),
-                types::OpenTag::from(
-                    &models::OpenTag::try_from(v.open_attributes).expect("decode should succeed"),
-                ),
+                types::OpenTag::default(),
                 v.tags.as_ref().map(types::Type::from),
             ),
             Some(enum_choices) => {
@@ -196,71 +183,81 @@ impl From<&models::Type> for types::Type {
     #[allow(clippy::expect_used)]
     fn from(v: &models::Type) -> Self {
         match v.data.as_ref().expect("data field should exist") {
-            models::r#type::Data::Ty(vt) => {
-                match models::r#type::Ty::try_from(vt.to_owned()).expect("decode should succeed") {
-                    models::r#type::Ty::Never => types::Type::Never,
-                    models::r#type::Ty::True => types::Type::True,
-                    models::r#type::Ty::False => types::Type::False,
-                    models::r#type::Ty::EmptySetType => types::Type::Set { element_type: None },
-                    models::r#type::Ty::Bool => types::Type::primitive_boolean(),
-                    models::r#type::Ty::String => types::Type::primitive_string(),
-                    models::r#type::Ty::Long => types::Type::primitive_long(),
+            models::r#type::Data::Prim(vt) => {
+                match models::r#type::Prim::try_from(vt.to_owned()).expect("decode should succeed")
+                {
+                    models::r#type::Prim::Bool => types::Type::primitive_boolean(),
+                    models::r#type::Prim::String => types::Type::primitive_string(),
+                    models::r#type::Prim::Long => types::Type::primitive_long(),
                 }
             }
-            models::r#type::Data::SetType(tt) => types::Type::Set {
-                element_type: Some(Box::new(types::Type::from(tt.as_ref()))),
+            models::r#type::Data::SetElem(elty) => types::Type::Set {
+                element_type: Some(Box::new(types::Type::from(elty.as_ref()))),
             },
-            models::r#type::Data::EntityOrRecord(er) => {
-                types::Type::EntityOrRecord(types::EntityRecordKind::from(er))
+            models::r#type::Data::Entity(e) => {
+                types::Type::EntityOrRecord(types::EntityRecordKind::Entity(
+                    types::EntityLUB::single_entity(ast::EntityType::from(e)),
+                ))
             }
-            models::r#type::Data::Name(name) => types::Type::ExtensionType {
+            models::r#type::Data::Record(r) => {
+                types::Type::EntityOrRecord(types::EntityRecordKind::Record {
+                    attrs: model_to_attributes(&r.attrs),
+                    open_attributes: types::OpenTag::default(),
+                })
+            }
+            models::r#type::Data::Ext(name) => types::Type::ExtensionType {
                 name: ast::Name::from(name),
             },
         }
     }
 }
 
+// PANIC SAFETY: experimental feature
+#[allow(clippy::fallible_impl_from)]
 impl From<&types::Type> for models::Type {
     // PANIC SAFETY: experimental feature
-    #[allow(clippy::expect_used)]
+    #[allow(clippy::expect_used, clippy::panic)]
     fn from(v: &types::Type) -> Self {
         match v {
-            types::Type::Never => Self {
-                data: Some(models::r#type::Data::Ty(models::r#type::Ty::Never.into())),
-            },
-            types::Type::True => Self {
-                data: Some(models::r#type::Data::Ty(models::r#type::Ty::True.into())),
-            },
-
-            types::Type::False => Self {
-                data: Some(models::r#type::Data::Ty(models::r#type::Ty::False.into())),
-            },
+            types::Type::Never => panic!("can't encode Never type in protobuf; Never should never appear in a Schema"),
+            types::Type::True | types::Type::False => panic!("can't encode singleton boolean type in protobuf; singleton boolean types should never appear in a Schema"),
             types::Type::Primitive { primitive_type } => match primitive_type {
                 types::Primitive::Bool => Self {
-                    data: Some(models::r#type::Data::Ty(models::r#type::Ty::Bool.into())),
+                    data: Some(models::r#type::Data::Prim(models::r#type::Prim::Bool.into())),
                 },
                 types::Primitive::Long => Self {
-                    data: Some(models::r#type::Data::Ty(models::r#type::Ty::Long.into())),
+                    data: Some(models::r#type::Data::Prim(models::r#type::Prim::Long.into())),
                 },
                 types::Primitive::String => Self {
-                    data: Some(models::r#type::Data::Ty(models::r#type::Ty::String.into())),
+                    data: Some(models::r#type::Data::Prim(models::r#type::Prim::String.into())),
                 },
             },
             types::Type::Set { element_type } => Self {
-                data: Some(models::r#type::Data::SetType(Box::new(models::Type::from(
+                data: Some(models::r#type::Data::SetElem(Box::new(models::Type::from(
                     element_type
                         .as_ref()
-                        .expect("element_type field should exist")
+                        .expect("can't encode Set without element type in protobuf; Set-without-element-type should never appear in a Schema")
                         .as_ref(),
                 )))),
             },
-            types::Type::EntityOrRecord(er) => Self {
-                data: Some(models::r#type::Data::EntityOrRecord(
-                    models::EntityRecordKind::from(er),
-                )),
+            types::Type::EntityOrRecord(types::EntityRecordKind::Entity(lub)) => Self {
+                data: Some(models::r#type::Data::Entity(models::Name::from(lub.get_single_entity().expect("can't encode non-singleton LUB in protobuf; non-singleton LUB types should never appear in a Schema").as_ref()))),
             },
+            types::Type::EntityOrRecord(types::EntityRecordKind::Record { attrs, open_attributes }) => {
+                assert_eq!(open_attributes, &types::OpenTag::ClosedAttributes, "can't encode open record in protobuf");
+                Self {
+                    data: Some(models::r#type::Data::Record(models::r#type::Record { attrs: attributes_to_model(attrs) })),
+                }
+            }
+            types::Type::EntityOrRecord(types::EntityRecordKind::ActionEntity { name, attrs }) => {
+                debug_assert_eq!(attrs.keys().collect::<Vec<&SmolStr>>(), Vec::<&SmolStr>::new(), "can't encode action attributes in protobuf");
+                Self {
+                    data: Some(models::r#type::Data::Entity(models::Name::from(name.as_ref()))),
+                }
+            }
+            types::Type::EntityOrRecord(types::EntityRecordKind::AnyEntity) => panic!("can't encode AnyEntity type in protobuf; AnyEntity should never appear in a Schema"),
             types::Type::ExtensionType { name } => Self {
-                data: Some(models::r#type::Data::Name(models::Name::from(name))),
+                data: Some(models::r#type::Data::Ext(models::Name::from(name))),
             },
         }
     }
@@ -274,88 +271,6 @@ fn attributes_to_model(v: &types::Attributes) -> HashMap<String, models::Attribu
     v.iter()
         .map(|(k, v)| (k.to_string(), models::AttributeType::from(v)))
         .collect()
-}
-
-impl From<&models::OpenTag> for types::OpenTag {
-    fn from(v: &models::OpenTag) -> Self {
-        match v {
-            models::OpenTag::OpenAttributes => types::OpenTag::OpenAttributes,
-            models::OpenTag::ClosedAttributes => types::OpenTag::ClosedAttributes,
-        }
-    }
-}
-
-impl From<&types::OpenTag> for models::OpenTag {
-    fn from(v: &types::OpenTag) -> Self {
-        match v {
-            types::OpenTag::OpenAttributes => models::OpenTag::OpenAttributes,
-            types::OpenTag::ClosedAttributes => models::OpenTag::ClosedAttributes,
-        }
-    }
-}
-
-impl From<&models::EntityRecordKind> for types::EntityRecordKind {
-    // PANIC SAFETY: experimental feature
-    #[allow(clippy::expect_used)]
-    fn from(v: &models::EntityRecordKind) -> Self {
-        match v.data.as_ref().expect("data field should exist") {
-            models::entity_record_kind::Data::AnyEntity(unit) => {
-                match models::entity_record_kind::AnyEntity::try_from(*unit)
-                    .expect("decode should succeed")
-                {
-                    models::entity_record_kind::AnyEntity::Unit => Self::AnyEntity,
-                }
-            }
-            models::entity_record_kind::Data::Record(r) => Self::Record {
-                attrs: model_to_attributes(&r.attrs),
-                open_attributes: types::OpenTag::from(
-                    &models::OpenTag::try_from(r.open_attributes).expect("decode should succeed"),
-                ),
-            },
-            models::entity_record_kind::Data::Entity(name) => {
-                Self::Entity(types::EntityLUB::single_entity(ast::EntityType::from(name)))
-            }
-            models::entity_record_kind::Data::ActionEntity(act) => Self::ActionEntity {
-                name: ast::EntityType::from(act.name.as_ref().expect("name field should exist")),
-                attrs: model_to_attributes(&act.attrs),
-            },
-        }
-    }
-}
-
-impl From<&types::EntityRecordKind> for models::EntityRecordKind {
-    // PANIC SAFETY: experimental feature
-    #[allow(clippy::expect_used)]
-    fn from(v: &types::EntityRecordKind) -> Self {
-        let data = match v {
-            types::EntityRecordKind::Record {
-                attrs,
-                open_attributes,
-            } => models::entity_record_kind::Data::Record(models::entity_record_kind::Record {
-                attrs: attributes_to_model(attrs),
-                open_attributes: models::OpenTag::from(open_attributes).into(),
-            }),
-            types::EntityRecordKind::AnyEntity => models::entity_record_kind::Data::AnyEntity(
-                models::entity_record_kind::AnyEntity::Unit.into(),
-            ),
-            types::EntityRecordKind::Entity(e) => {
-                models::entity_record_kind::Data::Entity(models::Name::from(
-                    &e.clone()
-                        .into_single_entity()
-                        .expect("will be single EntityType"),
-                ))
-            }
-            types::EntityRecordKind::ActionEntity { name, attrs } => {
-                models::entity_record_kind::Data::ActionEntity(
-                    models::entity_record_kind::ActionEntity {
-                        name: Some(models::Name::from(name)),
-                        attrs: attributes_to_model(attrs),
-                    },
-                )
-            }
-        };
-        Self { data: Some(data) }
-    }
 }
 
 impl From<&models::AttributeType> for types::AttributeType {


### PR DESCRIPTION
## Description of changes

More simplifications of the Protobuf format for `Schema`, some suggested in #1488 and some based on conversations with @john-h-kastner-aws offline.

- resolving the TODO: `Schema` is just a list of `EntityDecl` and a list of `ActionDecl`, not a map, as this is simpler and sufficient
- removing the ability to have open attributes, as this is not a stable feature (in both entities and records)
- the `context` for an Action must be a record, so instead of `Type`, we require it to be a `map<string, AttributeType>`
- rename `Type.Ty` to `Type.Prim` which is more clear
- remove the `Never`, `True`, `False`, `EmptySet`, and `AnyEntity` types, as these should never appear in schemas
- remove the `ActionEntity` type as action entities can just be encoded as `Entity` type (we do not support action attributes in Protobuf, as that is not a stable feature)
- remove `EntityRecordKind` in favor of inlining it into `Type`
- a few field renumberings, which is a breaking change we can make now but not after stabilization

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
