### PR TITLE
Fixes issues with the comment PR workflows

### DIFF
--- a/.github/workflows/comment_pr.yml
+++ b/.github/workflows/comment_pr.yml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ env.STATUS == 'SUCCESS' }}
         shell: bash
         run: |
-          ISSUE_NUMBER=$(cat coverage_comment/issue_number.txt)
-          gh pr comment $ISSUE_NUMBER --body-file coverage_comment/markdown.md
+          ISSUE_NUMBER=$(cat issue_number.txt)
+          gh pr comment $ISSUE_NUMBER --body-file markdown.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/comment_pr.yml
+++ b/.github/workflows/comment_pr.yml
@@ -1,5 +1,9 @@
 name: Comment on the pull request
- 
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+  statuses: read
 on:
   workflow_run:
     workflows: [Cargo Build & Test]
@@ -9,36 +13,22 @@ on:
 jobs:
   post_comment:
     runs-on: ubuntu-latest
-    if: >
-      github.event.workflow_run.event == 'pull_request' &&
-      (github.event.workflow_run.conclusion == 'success' ||
-      github.event.workflow_run.conclusion == 'failure')
+    if: github.event.workflow_run.event == 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - name: Check build_and_test status
+      - name: Download artifacts
         shell: bash
         run: |
-          jobs=$(gh run view $RUN_ID --json jobs)
-          job_status=$(jq --raw-output '.[] | map(select(.name=="build_and_test / Build and Test (stable)"))[0] | .status' <<< "$jobs")
-          echo "STATUS=$job_status" >> $GITHUB_ENV
-        env:
-              RUN_ID: ${{github.event.workflow_run.id }}
-              GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Download artifacts
-        if: ${{ env.STATUS == 'completed' }}
-        shell: bash
-        run: gh run download $RUN_ID
+          STATUS=$(gh run download $RUN_ID --name coverage_comment && echo "SUCCESS" || echo "FAILURE")
+          echo "STATUS=$STATUS" >> $GITHUB_ENV
         env:
           RUN_ID: ${{github.event.workflow_run.id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Read stored values
-        if: ${{ env.STATUS == 'completed' }}
+      - name: Add comment to PR
+        if: ${{ env.STATUS == 'SUCCESS' }}
         shell: bash
         run: |
-          echo "ISSUE_NUMBER=$(cat coverage_comment/issue_number.txt)" >> $GITHUB_ENV
-      - name: Add comment to PR
-        if: ${{ env.STATUS == 'completed' }}
-        shell: bash
-        run: gh pr comment $ISSUE_NUMBER --body-file coverage_comment/markdown.md
+          ISSUE_NUMBER=$(cat coverage_comment/issue_number.txt)
+          gh pr comment $ISSUE_NUMBER --body-file coverage_comment/markdown.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description of changes
This change should fix the comment PR workflow which currently fails with the message "GraphQL: Resource not accessible by integration (addComment)" by adding the necessary permissions to the workflow. It also prevents the workflow from failing in situations in which the artifact containing the comment to be posted cannot be found (e.g., in the case of a test or build error).

## Issue #, if available
None 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
