### PR TITLE
more followups on Protobuf formats

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -18,7 +18,7 @@ Cedar Language Version: TBD
 - Changed `Entities::add_entities` and `Entities::from_entities` to ignore structurally equal entities with the same Entity UID.
 - For `protobufs` experimental feature, a number of changes to the interface and
   the Protobuf format definitions, as we continue to iterate towards making this
-  feature stable. (#1488, #1495)
+  feature stable. (#1488, #1495, #1506)
 
 ### Added
 

--- a/cedar-policy/protobuf_schema/core.proto
+++ b/cedar-policy/protobuf_schema/core.proto
@@ -40,14 +40,8 @@ message PolicySet {
     map<string, Policy> links = 2;
 }
 
-enum Mode {
-    Concrete = 0;
-    Partial = 1;
-}
-
 message Entities {
     repeated Entity entities = 1;
-    Mode mode = 2;
 }
 
 message EntityUid {
@@ -166,27 +160,24 @@ message ActionConstraint {
 }
 
 message Expr {
-    ExprKind expr_kind = 1;
-
-    message ExprKind {
-        oneof data {
-            Literal lit = 1;
-            Var var = 2;
-            SlotId slot = 3;
-            If if = 4;
-            And and = 5;
-            Or or = 6;
-            UnaryApp uApp = 7;
-            BinaryApp bApp = 8;
-            ExtensionFunctionApp extApp = 9;
-            GetAttr getAttr = 10;
-            HasAttr hasAttr = 11;
-            Like like = 12;
-            Is is = 13;
-            Set set = 14;
-            Record record = 15;
-        }
+    oneof expr_kind {
+        Literal lit = 1;
+        Var var = 2;
+        SlotId slot = 3;
+        If if = 4;
+        And and = 5;
+        Or or = 6;
+        UnaryApp uApp = 7;
+        BinaryApp bApp = 8;
+        ExtensionFunctionApp extApp = 9;
+        GetAttr getAttr = 10;
+        HasAttr hasAttr = 11;
+        Like like = 12;
+        Is is = 13;
+        Set set = 14;
+        Record record = 15;
     }
+
     message Literal {
         oneof lit {
             bool b = 1;

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -674,6 +674,24 @@ mod test {
     use super::*;
 
     #[test]
+    fn name_and_slot_roundtrip() {
+        let orig_name = ast::Name::from_normalized_str("B::C::D").unwrap();
+        assert_eq!(orig_name, ast::Name::from(&models::Name::from(&orig_name)));
+
+        let orig_slot1 = ast::SlotId::principal();
+        assert_eq!(
+            orig_slot1,
+            ast::SlotId::from(&models::SlotId::from(&orig_slot1))
+        );
+
+        let orig_slot2 = ast::SlotId::resource();
+        assert_eq!(
+            orig_slot2,
+            ast::SlotId::from(&models::SlotId::from(&orig_slot2))
+        );
+    }
+
+    #[test]
     fn entity_roundtrip() {
         let name = ast::Name::from_normalized_str("B::C::D").unwrap();
         let ety_specified = ast::EntityType::from(name);
@@ -752,6 +770,26 @@ mod test {
             "Type".parse().unwrap(),
         );
         assert_eq!(e9, ast::Expr::from(&models::Expr::from(&e9)));
+        let e10 = ast::Expr::slot(ast::SlotId::principal());
+        assert_eq!(e10, ast::Expr::from(&models::Expr::from(&e10)));
+        let e11 = ast::Expr::slot(ast::SlotId::resource());
+        assert_eq!(e11, ast::Expr::from(&models::Expr::from(&e11)));
+        let e12 = ast::Expr::and(ast::Expr::val(false), ast::Expr::not(ast::Expr::val(true)));
+        assert_eq!(e12, ast::Expr::from(&models::Expr::from(&e12)));
+        let e13 = ast::Expr::or(
+            ast::Expr::ite(
+                ast::Expr::get_attr(ast::Expr::var(ast::Var::Context), "a".into()),
+                ast::Expr::val(false),
+                ast::Expr::not(ast::Expr::val(true)),
+            ),
+            ast::Expr::greater(ast::Expr::val(33), ast::Expr::val(-33)),
+        );
+        assert_eq!(e13, ast::Expr::from(&models::Expr::from(&e13)));
+        let e14 = ast::Expr::contains(
+            ast::Expr::set([ast::Expr::val("beans"), ast::Expr::val("carrots")]),
+            ast::Expr::val("peas"),
+        );
+        assert_eq!(e14, ast::Expr::from(&models::Expr::from(&e14)));
     }
 
     #[test]
@@ -797,24 +835,6 @@ mod test {
         assert_eq!(
             euid_literal,
             ast::Literal::from(&models::expr::Literal::from(&euid_literal))
-        );
-    }
-
-    #[test]
-    fn name_and_slot_roundtrip() {
-        let orig_name = ast::Name::from_normalized_str("B::C::D").unwrap();
-        assert_eq!(orig_name, ast::Name::from(&models::Name::from(&orig_name)));
-
-        let orig_slot1 = ast::SlotId::principal();
-        assert_eq!(
-            orig_slot1,
-            ast::SlotId::from(&models::SlotId::from(&orig_slot1))
-        );
-
-        let orig_slot2 = ast::SlotId::resource();
-        assert_eq!(
-            orig_slot2,
-            ast::SlotId::from(&models::SlotId::from(&orig_slot2))
         );
     }
 


### PR DESCRIPTION
## Description of changes

- Remove the `Mode` for Entities, as we're not supported partial evaluation in protobuf currently.
- One more inlining, this time in `Expr`

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
