### PR TITLE
Updates Transitive closure algorithm.

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -18,8 +18,8 @@
 
 use crate::ast::*;
 use crate::extensions::Extensions;
-use crate::transitive_closure::{compute_tc, enforce_tc_and_dag};
-use std::collections::{hash_map, HashMap};
+use crate::transitive_closure::{compute_tc, enforce_tc_and_dag, repair_tc};
+use std::collections::{hash_map, HashMap, HashSet};
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -143,16 +143,30 @@ impl Entities {
         extensions: &Extensions<'_>,
     ) -> Result<Self> {
         let checker = schema.map(|schema| EntitySchemaConformanceChecker::new(schema, extensions));
+        let mut entities_touched: HashSet<EntityUID> = HashSet::new();
         for entity in collection.into_iter() {
             if let Some(checker) = checker.as_ref() {
                 checker.validate_entity(&entity)?;
             }
+            entities_touched.insert(entity.uid().clone());
             update_entity_map(&mut self.entities, entity)?;
         }
         match tc_computation {
             TCComputation::AssumeAlreadyComputed => (),
             TCComputation::EnforceAlreadyComputed => enforce_tc_and_dag(&self.entities)?,
-            TCComputation::ComputeNow => compute_tc(&mut self.entities, true)?,
+            TCComputation::ComputeNow => {
+                for entity in self.entities.values() {
+                    if !entities_touched.is_disjoint(
+                        &entity
+                            .ancestors()
+                            .map(EntityUID::clone)
+                            .collect::<HashSet<EntityUID>>(),
+                    ) {
+                        entities_touched.insert(entity.uid().clone());
+                    }
+                }
+                repair_tc(entities_touched, &mut self.entities, true)?
+            }
         };
         Ok(self)
     }
@@ -167,12 +181,14 @@ impl Entities {
         collection: impl IntoIterator<Item = EntityUID>,
         tc_computation: TCComputation,
     ) -> Result<Self> {
+        let mut entities_touched: HashSet<EntityUID> = HashSet::new();
         for uid_to_remove in collection.into_iter() {
             match self.entities.remove(&uid_to_remove) {
                 None => (),
                 Some(entity_to_remove) => {
                     for entity in self.entities.values_mut() {
                         if entity.is_descendant_of(&uid_to_remove) {
+                            entities_touched.insert(entity.uid().clone());
                             // remove any direct or indirect link between `entity` and `entity_to_remove`
                             Arc::make_mut(entity).remove_indirect_ancestor(&uid_to_remove);
                             Arc::make_mut(entity).remove_parent(&uid_to_remove);
@@ -188,7 +204,7 @@ impl Entities {
         match tc_computation {
             TCComputation::AssumeAlreadyComputed => (),
             TCComputation::EnforceAlreadyComputed => enforce_tc_and_dag(&self.entities)?,
-            TCComputation::ComputeNow => compute_tc(&mut self.entities, true)?,
+            TCComputation::ComputeNow => repair_tc(entities_touched, &mut self.entities, true)?,
         }
         Ok(self)
     }

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -159,22 +159,22 @@ where
         // a slight optimization to avoid adding the ancestors of `ancestor_id` if
         // `ancestor_id` was an ancestor of any parent already explored by this loop.
         if !ancestors.contains(&ancestor_id) {
-            let ancestor = if let Some(ancestor) = nodes.get(&ancestor_id) {
-                ancestor
-            } else {
-                return;
+            let ancestor = match nodes.get(&ancestor_id) {
+                Some(ancestor) => ancestor,
+                None => return,
             };
             for grand_ancestor_id in ancestor.out_edges() {
                 ancestors.insert(grand_ancestor_id.clone());
             }
         }
     }
-    // Do the actual saturation of out-going edges of `node` here to avoid
-    // issues with rust's borrow checker.
+    // PANIC SAFETY this node should always exist because of the check to get `out_edges`
     #[allow(clippy::expect_used)]
     let node = nodes
         .get_mut(node_id)
         .expect("This node should always exist.");
+    // Do the actual saturation of out-going edges of `node` here to avoid
+    // issues with rust's borrow checker.
     for ancestor_id in ancestors {
         node.add_edge_to(ancestor_id);
     }

--- a/cedar-policy-core/src/transitive_closure.rs
+++ b/cedar-policy-core/src/transitive_closure.rs
@@ -55,40 +55,128 @@ where
     K: Clone + Eq + Hash + Debug + Display,
     V: TCNode<K>,
 {
-    compute_tc_internal::<K, V>(nodes);
+    let all_node_ids = nodes.keys().map(K::clone).collect::<Vec<K>>();
+
+    // If the caller does not want to check that the graph is a DAG,
+    // we assume that the graph is acyclic during the below call.
+    // This allows the below call to do a single scan of each node
+    // rather than two scans of each node.
+    compute_tc_internal(all_node_ids.into_iter(), nodes, HashSet::new(), enforce_dag);
+
     if enforce_dag {
         return enforce_dag_from_tc(nodes);
     }
     Ok(())
 }
 
-/// Given graph as a map from keys with type `K` to implementations of `TCNode`
-/// with type `V`, compute the transitive closure of the hierarchy. In case of
-/// error, the result contains an error structure `Err<K>` which contains the
-/// keys (with type `K`) for the nodes in the graph which caused the error.
-fn compute_tc_internal<K, V>(nodes: &mut HashMap<K, V>)
+/// Given Graph as a map from keys with type `K` to implementations of `TCNode`
+/// with type `V`, repair the transitive closure of the hierarchy. The below code
+/// will assume that for each `node` in `nodes` except the nodes appearing in
+/// `nodes_to_fix`, the out-going edges of `node` will contain all ancestors of `node`.
+/// That is we may assume the transitive closure for all such nodes is correct while
+/// computing the transitive closure of each node appearing in `nodes_to_fix`.
+/// In case of error, the result contains an error structure `Err<K>` which contains
+/// the keys (with type `K`) for the nodes in the graph which caused the error.
+/// If `enforce_dag` then also check that the heirarchy is a DAG
+pub fn repair_tc<K, V>(
+    nodes_to_fix: HashSet<K>,
+    nodes: &mut HashMap<K, V>,
+    enforce_dag: bool,
+) -> Result<(), K>
+where
+    K: Clone + Eq + Hash + Debug + Display,
+    V: TCNode<K>,
+{
+    let seen: HashSet<K> = nodes
+        .keys()
+        .filter_map(|node_id| {
+            if nodes_to_fix.contains(node_id) {
+                None
+            } else {
+                Some(node_id.clone())
+            }
+        })
+        .collect();
+
+    // If the caller does not want to check that the graph is a DAG,
+    // we assume that the graph is acyclic during the below call.
+    // This allows the below call to do a single scan of each node
+    // rather than two scans of each node.
+    compute_tc_internal::<K, V>(nodes_to_fix.into_iter(), nodes, seen, enforce_dag);
+
+    if enforce_dag {
+        return enforce_dag_from_tc(nodes);
+    }
+    Ok(())
+}
+
+/// Saturate the out-going edges of each node in `node_ids` to include
+/// all reachable ancestors within the graph represnted by `nodes`.
+/// Assume that all nodes appearing in `seen` already satisfy this property.
+/// If `detect_cyles` is false, we assume the the graph represented by `nodes`
+/// is a DAG so that we may perform a single scan over the graph. Otherwise,
+/// we scan each node twice. This is sufficient for detecting cycles and for computing
+/// the exact TC for graphs containing simple cycles. For more complex cyclic graphs,
+/// the below code computes enough of the transtive closure to ensure that if one
+/// calls `enforce_dag_from_tc` on `nodes` after this function returns then it will
+/// correctly detect any cycles (simple or compelx).
+fn compute_tc_internal<K, V>(
+    node_ids: impl Iterator<Item = K>,
+    nodes: &mut HashMap<K, V>,
+    mut seen: HashSet<K>,
+    detect_cyles: bool,
+) where
+    K: Clone + Eq + Hash,
+    V: TCNode<K>,
+{
+    for node_id in node_ids {
+        if detect_cyles {
+            add_ancestors(&node_id, nodes, &mut seen);
+        } else if seen.insert(node_id.clone()) {
+            add_ancestors(&node_id, nodes, &mut seen);
+        }
+    }
+}
+
+/// Saturate the out-going edges of the node identified by `node_id` within the graph
+/// represented by `nodes` assuming that each node appearing in `seen` already satisfies
+/// this property. The process works by performing a depth-first search over the ancestors
+/// of `node_id` (and stopping if any ancestor is already in the `seen` set).
+fn add_ancestors<K, V>(node_id: &K, nodes: &mut HashMap<K, V>, seen: &mut HashSet<K>)
 where
     K: Clone + Eq + Hash,
     V: TCNode<K>,
 {
-    // To avoid needing both immutable and mutable borrows of `nodes`,
-    // we collect all the needed updates in this structure
-    // (maps keys to ancestor UIDs to add to it)
-    // and then do all the updates at once in a second loop
-    let mut ancestors: HashMap<K, HashSet<K>> = HashMap::new();
-    for node in nodes.values() {
-        let this_node_ancestors: &mut HashSet<K> = ancestors.entry(node.get_key()).or_default();
-        add_ancestors_to_set(node, nodes, this_node_ancestors);
-    }
-    for node in nodes.values_mut() {
-        // PANIC SAFETY All nodes in `ancestors` came from `nodes`
-        #[allow(clippy::expect_used)]
-        for ancestor_uid in ancestors
-            .get(&node.get_key())
-            .expect("shouldn't have added any new values to the `nodes` map")
-        {
-            node.add_edge_to(ancestor_uid.clone());
+    let mut ancestors: HashSet<K> = HashSet::new();
+    let out_edges: Vec<K> = match nodes.get(node_id) {
+        Some(node) => node.out_edges().map(K::clone).collect(),
+        None => return,
+    };
+    for ancestor_id in out_edges {
+        if seen.insert(ancestor_id.clone()) {
+            add_ancestors(&ancestor_id, nodes, seen);
         }
+        // a slight optimization to avoid adding the ancestors of `ancestor_id` if
+        // `ancestor_id` was an ancestor of any parent already explored by this loop.
+        if !ancestors.contains(&ancestor_id) {
+            let ancestor = if let Some(ancestor) = nodes.get(&ancestor_id) {
+                ancestor
+            } else {
+                return;
+            };
+            for grand_ancestor_id in ancestor.out_edges() {
+                ancestors.insert(grand_ancestor_id.clone());
+            }
+        }
+    }
+    // Do the actual saturation of out-going edges of `node` here to avoid
+    // issues with rust's borrow checker.
+    #[allow(clippy::expect_used)]
+    let node = nodes
+        .get_mut(node_id)
+        .expect("This node should always exist.");
+    for ancestor_id in ancestors {
+        node.add_edge_to(ancestor_id);
     }
 }
 
@@ -136,25 +224,6 @@ where
     Ok(())
 }
 
-/// For the given `node` in the given `hierarchy`, add all of the `node`'s
-/// transitive ancestors to the given set. Assume that any nodes already in
-/// `ancestors` don't need to be searched -- they have been already handled.
-fn add_ancestors_to_set<K, V>(node: &V, hierarchy: &HashMap<K, V>, ancestors: &mut HashSet<K>)
-where
-    K: Clone + Eq + Hash,
-    V: TCNode<K>,
-{
-    for ancestor_uid in node.out_edges() {
-        if ancestors.insert(ancestor_uid.clone()) {
-            // discovered a new ancestor, so add the ancestors of `ancestor` as
-            // well
-            if let Some(ancestor) = hierarchy.get(ancestor_uid) {
-                add_ancestors_to_set(ancestor, hierarchy, ancestors);
-            }
-        }
-    }
-}
-
 /// Once the transitive closure (as defined above) is computed/enforced for the graph, we have:
 /// \forall u,v,w \in Vertices . (u,v) \in Edges /\ (v,w) \in Edges -> (u,w) \in Edges
 ///
@@ -200,7 +269,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let c = &entities[&EntityUID::with_eid("C")];
@@ -232,7 +301,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let c = &entities[&EntityUID::with_eid("C")];
@@ -269,7 +338,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let c = &entities[&EntityUID::with_eid("C")];
@@ -312,7 +381,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let foo = &entities[&EntityUID::with_eid("foo")];
         let bar = &entities[&EntityUID::with_eid("bar")];
         let baz = &entities[&EntityUID::with_eid("baz")];
@@ -356,7 +425,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let d = &entities[&EntityUID::with_eid("D")];
@@ -411,7 +480,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let f = &entities[&EntityUID::with_eid("F")];
@@ -471,7 +540,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let c = &entities[&EntityUID::with_eid("C")];
@@ -523,7 +592,7 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         let a = &entities[&EntityUID::with_eid("A")];
         let b = &entities[&EntityUID::with_eid("B")];
         let d = &entities[&EntityUID::with_eid("D")];
@@ -562,7 +631,7 @@ mod tests {
         b.add_indirect_ancestor(EntityUID::with_eid("B"));
         let mut entities = HashMap::from([(a.uid().clone(), a), (b.uid().clone(), b)]);
         // computing TC should succeed without panicking, infinitely recursing, etc
-        compute_tc_internal(&mut entities);
+        compute_tc(&mut entities, false).expect("Failed to compute transitive closure");
         // fails cycle check
         match enforce_dag_from_tc(&entities) {
             Ok(_) => panic!("enforce_dag_from_tc should have returned an error"),
@@ -577,7 +646,7 @@ mod tests {
         assert!(a.is_descendant_of(&EntityUID::with_eid("B")));
         // but it shouldn't have added a B -> A edge
         assert!(!b.is_descendant_of(&EntityUID::with_eid("A")));
-        // we also check that, whatever compute_tc_internal did with this invalid input, the
+        // we also check that, whatever compute_tc did with this invalid input, the
         // final result still passes enforce_tc
         assert!(enforce_tc(&entities).is_ok());
         // still fails cycle check
@@ -613,7 +682,16 @@ mod tests {
             (d.uid().clone(), d),
         ]);
         // computing TC should succeed without panicking, infinitely recursing, etc
-        compute_tc_internal(&mut entities);
+        compute_tc_internal(
+            entities
+                .keys()
+                .map(EntityUID::clone)
+                .collect::<Vec<EntityUID>>()
+                .into_iter(),
+            &mut entities,
+            HashSet::new(),
+            true,
+        );
         // fails cycle check
         match enforce_dag_from_tc(&entities) {
             Ok(_) => panic!("enforce_dag_from_tc should have returned an error"),
@@ -634,7 +712,7 @@ mod tests {
         assert!(a.is_descendant_of(&EntityUID::with_eid("D")));
         // and we should also have added a B -> A edge
         assert!(b.is_descendant_of(&EntityUID::with_eid("A")));
-        // we also check that, whatever compute_tc_internal did with this invalid input, the
+        // we also check that, whatever compute_tc did with this invalid input, the
         // final result still passes enforce_tc
         assert!(enforce_tc(&entities).is_ok());
         // still fails cycle check
@@ -687,7 +765,16 @@ mod tests {
         // currently doesn't pass TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
+        compute_tc_internal(
+            entities
+                .keys()
+                .map(EntityUID::clone)
+                .collect::<Vec<EntityUID>>()
+                .into_iter(),
+            &mut entities,
+            HashSet::new(),
+            true,
+        );
         // now it should pass TC enforcement
         assert!(enforce_tc(&entities).is_ok());
         // still fails cycle check
@@ -743,10 +830,17 @@ mod tests {
         // fails TC enforcement
         assert!(enforce_tc(&entities).is_err());
         // compute TC
-        compute_tc_internal(&mut entities);
-        // now it should pass TC enforcement
-        assert!(enforce_tc(&entities).is_ok());
-        // but still fail cycle check
+        compute_tc_internal(
+            entities
+                .keys()
+                .map(EntityUID::clone)
+                .collect::<Vec<EntityUID>>()
+                .into_iter(),
+            &mut entities,
+            HashSet::new(),
+            true,
+        );
+        // the graph may or may not pass the TC check but it will always fail cycle check
         match enforce_dag_from_tc(&entities) {
             Ok(_) => panic!("enforce_dag_from_tc should have returned an error"),
             Err(TcError::HasCycle(_)) => (), // Every vertex is in a cycle


### PR DESCRIPTION
## Description of changes

Updates Cedar's transitive closure computation. The algorithm is only sound when computing the transitive closure of DAGs and graphs with simple cycles. However, the updated transitive closure algorithm when combined with `enforce_dag_from_tc` is sufficient for detecting cycles, even complex cycles. The implementation also uses a slightly more efficient algorithm (that does only one scan of the input graph) if one does not care to enforce that the graph is a DAG (while sound for computing the exact transitive closure of a DAG, this variant is not sufficient for detecting even simple cycles).

This pull request also adds the `remove_tc` that is capable of repairing an existing graph's transitive closure when only a sub-set of the nodes within the graph need recalculated. This is used within `add_entities` and `remove_entities` to avoid re-computing the entire graph's transitive closure. This change addresses the feature request in issu #612

## Issue #612

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
