### PR TITLE
Revert WASM build workaround

### DIFF
--- a/cedar-wasm/build-wasm.sh
+++ b/cedar-wasm/build-wasm.sh
@@ -26,14 +26,6 @@
 
 set -e
 main () {
-    # This should be enforced by `rust-toolchain.toml` in this directory, but we
-    # want to cause CI to fail-fast if that's not configured correctly.
-    echo 'Checking rustc version'
-    if ( cargo rustc -- --version | grep --invert-match "rustc 1.81" ) ; then
-      echo 'Unexpected rustc version. Wasm bindings expect to be built on Rust verison 1.81, check `cargo rustc --version`.'
-      exit 1
-    fi
-
     rm -rf pkg || true
     mkdir pkg
     cargo build

--- a/cedar-wasm/rust-toolchain.toml
+++ b/cedar-wasm/rust-toolchain.toml
@@ -1,6 +1,0 @@
-# Workaround for wasm-bindgen issue resulting in malformed return type `Array`
-# without any generic parameter when building with Rust version 1.82. We pin
-# this crate to 1.81 to avoid build failures. We plan to delete this once the
-# issue is resolved: https://github.com/cedar-policy/cedar/issues/1292
-[toolchain]
-channel = "1.81"


### PR DESCRIPTION
## Description of changes

In #1291 we fixed Rust to v1.81 as a workaround to the WASM build failure. This reverts those fixes which are now causing build failures themselves (#1513) and shouldn't be needed anymore.

Resolves #1292

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
