### PR TITLE
remove Serialize and Deserialize from many core/validator types

### DIFF
--- a/cedar-policy-core/src/ast/annotation.rs
+++ b/cedar-policy-core/src/ast/annotation.rs
@@ -25,14 +25,9 @@ use crate::parser::Loc;
 use super::AnyId;
 
 /// Struct which holds the annotations for a policy
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
+#[derive(Clone, Hash, Eq, PartialEq, PartialOrd, Ord, Debug)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-pub struct Annotations(
-    #[serde(default)]
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    #[serde(with = "::serde_with::rust::maps_duplicate_key_is_error")]
-    BTreeMap<AnyId, Annotation>,
-);
+pub struct Annotations(BTreeMap<AnyId, Annotation>);
 
 impl std::fmt::Display for Annotations {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -44,7 +44,7 @@ extern crate tsify;
 /// where the expression was written in policy source code, and some generic
 /// data which is stored on each node of the AST.
 /// Cloning is O(1).
-#[derive(Educe, Serialize, Deserialize, Debug, Clone)]
+#[derive(Educe, Debug, Clone)]
 #[educe(PartialEq, Eq, Hash)]
 pub struct Expr<T = ()> {
     expr_kind: ExprKind<T>,
@@ -56,7 +56,7 @@ pub struct Expr<T = ()> {
 
 /// The possible expression variants. This enum should be matched on by code
 /// recursively traversing the AST.
-#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
 pub enum ExprKind<T = ()> {
     /// Literal value
     Lit(Literal),
@@ -819,7 +819,7 @@ pub enum SubstitutionError {
 }
 
 /// Representation of a partial-evaluation Unknown at the AST level
-#[derive(Serialize, Deserialize, Hash, Debug, Clone, PartialEq, Eq)]
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
 pub struct Unknown {
     /// The name of the unknown
     pub name: SmolStr,

--- a/cedar-policy-core/src/ast/literal.rs
+++ b/cedar-policy-core/src/ast/literal.rs
@@ -16,7 +16,6 @@
 
 use crate::ast::{EntityUID, Integer, StaticallyTyped, Type};
 use crate::parser;
-use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use std::sync::Arc;
 
@@ -32,7 +31,7 @@ use std::sync::Arc;
 /// `Expr::Set`, not `Expr::Lit`.
 ///
 /// Cloning is O(1).
-#[derive(Serialize, Deserialize, Hash, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
+#[derive(Hash, Debug, PartialEq, Eq, Clone, PartialOrd, Ord)]
 pub enum Literal {
     /// Boolean value
     Bool(bool),

--- a/cedar-policy-core/src/ast/ops.rs
+++ b/cedar-policy-core/src/ast/ops.rs
@@ -14,10 +14,8 @@
  * limitations under the License.
  */
 
-use serde::{Deserialize, Serialize};
-
 /// Built-in operators with exactly one argument
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum UnaryOp {
     /// Logical negation
@@ -45,7 +43,7 @@ impl std::fmt::Display for UnaryOp {
 }
 
 /// Built-in operators with exactly two arguments
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum BinaryOp {
     /// Equality

--- a/cedar-policy-core/src/ast/pattern.rs
+++ b/cedar-policy-core/src/ast/pattern.rs
@@ -16,10 +16,8 @@
 
 use std::sync::Arc;
 
-use serde::{Deserialize, Serialize};
-
 /// Represent an element in a pattern literal (the RHS of the like operation)
-#[derive(Deserialize, Serialize, Hash, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Hash, Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum PatternElem {
     /// A character literal
@@ -30,8 +28,7 @@ pub enum PatternElem {
 
 /// Represent a pattern literal (the RHS of the like operator)
 /// Also provides an implementation of the Display trait as well as a wildcard matching method.
-#[derive(Debug, Clone, Hash, Eq, PartialEq, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct Pattern {
     /// A vector of pattern elements
     elems: Arc<Vec<PatternElem>>,

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -20,15 +20,12 @@ use super::{
 };
 use itertools::Itertools;
 use miette::Diagnostic;
-use serde::{Deserialize, Serialize};
 use std::collections::{hash_map::Entry, HashMap, HashSet};
 use std::{borrow::Borrow, sync::Arc};
 use thiserror::Error;
 
 /// Represents a set of `Policy`s
-#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(try_from = "LiteralPolicySet")]
-#[serde(into = "LiteralPolicySet")]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct PolicySet {
     /// `templates` contains all bodies of policies in the `PolicySet`.
     /// A body is either:
@@ -49,8 +46,12 @@ pub struct PolicySet {
     template_to_links_map: HashMap<PolicyID, HashSet<PolicyID>>,
 }
 
-/// A Policy Set that can be serialized, but does not contain as rich information as `PolicySet`
-#[derive(Debug, Serialize, Deserialize)]
+/// A Policy Set that contains less rich information than `PolicySet`.
+///
+/// In particular, this form is easier to convert to/from the Protobuf
+/// representation of a `PolicySet`, because policies are represented as
+/// `LiteralPolicy` instead of `Policy`.
+#[derive(Debug)]
 pub struct LiteralPolicySet {
     /// Like the `templates` field of `PolicySet`
     templates: HashMap<PolicyID, Template>,

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -33,7 +33,7 @@ use super::{
 };
 
 /// Represents the request tuple <P, A, R, C> (see the Cedar design doc).
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct Request {
     /// Principal associated with the request
     pub(crate) principal: EntityUIDEntry,
@@ -64,7 +64,7 @@ pub struct RequestType {
 /// An entry in a request for a Entity UID.
 /// It may either be a concrete EUID
 /// or an unknown in the case of partial evaluation
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub enum EntityUIDEntry {
     /// A concrete EntityUID
     Known {
@@ -275,10 +275,7 @@ impl std::fmt::Display for Request {
 }
 
 /// `Context` field of a `Request`
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-// Serialization is used for differential testing, which requires that `Context`
-// is serialized as a `RestrictedExpr`.
-#[serde(into = "RestrictedExpr")]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Context {
     /// The context is a concrete value.
     Value(Arc<BTreeMap<SmolStr, Value>>),

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -23,7 +23,6 @@ use crate::extensions::Extensions;
 use crate::parser::err::ParseErrors;
 use crate::parser::{self, Loc};
 use miette::Diagnostic;
-use serde::{Deserialize, Serialize};
 use smol_str::{SmolStr, ToSmolStr};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
@@ -51,8 +50,7 @@ use thiserror::Error;
 ///
 /// These restrictions represent the expressions that are allowed to appear as
 /// attribute values in `Slice` and `Context`.
-#[derive(Deserialize, Serialize, Hash, Debug, Clone, PartialEq, Eq)]
-#[serde(transparent)]
+#[derive(Hash, Debug, Clone, PartialEq, Eq)]
 pub struct RestrictedExpr(Expr);
 
 impl RestrictedExpr {
@@ -310,7 +308,7 @@ impl std::str::FromStr for RestrictedExpr {
 ///
 /// We derive `Copy` for this type because it's just a single reference, and
 /// `&T` is `Copy` for all `T`.
-#[derive(Serialize, Hash, Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Hash, Debug, Clone, PartialEq, Eq, Copy)]
 pub struct BorrowedRestrictedExpr<'a>(&'a Expr);
 
 impl<'a> BorrowedRestrictedExpr<'a> {

--- a/cedar-policy-core/src/ast/types.rs
+++ b/cedar-policy-core/src/ast/types.rs
@@ -15,13 +15,12 @@
  */
 
 use crate::ast::EntityType;
-use serde::{Deserialize, Serialize};
 
 use super::Name;
 
 /// This represents the runtime type of a Cedar value.
 /// Nominal types: two entity types are equal if they have the same Name.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, Debug, Clone, Hash, PartialOrd, Ord)]
 pub enum Type {
     /// Boolean type
     Bool,

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -23,16 +23,13 @@ use std::sync::Arc;
 use educe::Educe;
 use itertools::Itertools;
 use miette::Diagnostic;
-use serde::{Deserialize, Serialize};
 use smol_str::SmolStr;
 use thiserror::Error;
 
 /// This describes all the values which could be the dynamic result of evaluating an `Expr`.
 /// Cloning is O(1).
-#[derive(Educe, Debug, Clone, Serialize, Deserialize)]
+#[derive(Educe, Debug, Clone)]
 #[educe(PartialEq, Eq, PartialOrd, Ord)]
-#[serde(into = "Expr")]
-#[serde(try_from = "Expr")]
 pub struct Value {
     /// Underlying actual value
     pub value: ValueKind,
@@ -44,9 +41,7 @@ pub struct Value {
 
 /// This describes all the values which could be the dynamic result of evaluating an `Expr`.
 /// Cloning is O(1).
-#[derive(Debug, Clone, PartialOrd, Ord, Serialize, Deserialize)]
-#[serde(into = "Expr")]
-#[serde(try_from = "Expr")]
+#[derive(Debug, Clone, PartialOrd, Ord)]
 pub enum ValueKind {
     /// anything that is a Literal can also be the dynamic result of evaluating an `Expr`
     Lit(Literal),

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -22,9 +22,6 @@ use crate::transitive_closure::{compute_tc, enforce_tc_and_dag};
 use std::collections::{hash_map, HashMap};
 use std::sync::Arc;
 
-use serde::Serialize;
-use serde_with::serde_as;
-
 /// Module for checking that entities conform with a schema
 pub mod conformance;
 /// Module for error types
@@ -44,29 +41,20 @@ use err::*;
 /// Represents an entity hierarchy, and allows looking up `Entity` objects by
 /// UID.
 //
-/// Note that `Entities` is `Serialize`, but currently this is only used for the
-/// FFI layer in DRT. All others use (and should use) the `from_json_*()` and
-/// `write_to_json()` methods as necessary.
-#[serde_as]
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
+/// Note that `Entities` is not `Serialize` itself -- use either the
+/// `from_json_*()` and `write_to_json()` methods here, or the `proto` module in
+/// `cedar-policy`, which is capable of ser/de both Core types like this and
+/// `cedar-policy` types.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct Entities {
-    /// Serde cannot serialize a HashMap to JSON when the key to the map cannot
-    /// be serialized to a JSON string. This is a limitation of the JSON format.
-    /// `serde_as` annotation are used to serialize the data as associative
-    /// lists instead.
-    ///
     /// Important internal invariant: for any `Entities` object that exists,
     /// the `ancestor` relation is transitively closed.
-    #[serde_as(as = "Vec<(_, _)>")]
     entities: HashMap<EntityUID, Arc<Entity>>,
 
     /// The mode flag determines whether this store functions as a partial store or
     /// as a fully concrete store.
     /// Mode::Concrete means that the store is fully concrete, and failed dereferences are an error.
     /// Mode::Partial means the store is partial, and failed dereferences result in a residual.
-    #[serde(default)]
-    #[serde(skip_deserializing)]
-    #[serde(skip_serializing)]
     mode: Mode,
 }
 

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -335,7 +335,7 @@ mod tests {
     use super::*;
 
     use crate::ast::test_generators::*;
-    use crate::ast::{Eid, Literal, Template, Value};
+    use crate::ast::{Eid, Literal, Value};
     use crate::evaluator as eval;
     use crate::extensions::Extensions;
     use crate::parser::err::*;
@@ -347,7 +347,7 @@ mod tests {
 
     #[test]
     fn test_template_parsing() {
-        for template in all_templates().map(Template::from) {
+        for template in all_templates() {
             let id = template.id();
             let src = format!("{template}");
             let parsed =

--- a/cedar-policy-core/src/parser/loc.rs
+++ b/cedar-policy-core/src/parser/loc.rs
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// Represents a source location: index/range, and a reference to the source
 /// code which that index/range indexes into
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Loc {
     /// `SourceSpan` indicating a specific source code location or range
     pub span: miette::SourceSpan,

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -18,13 +18,12 @@ use std::fmt::{self, Debug, Display};
 
 use educe::Educe;
 use miette::Diagnostic;
-use serde::{Deserialize, Serialize};
 
 use super::err::{ToASTError, ToASTErrorKind};
 use super::loc::Loc;
 
 /// Metadata for our syntax trees
-#[derive(Educe, Debug, Clone, Deserialize, Serialize)]
+#[derive(Educe, Debug, Clone)]
 #[educe(PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct Node<T> {
     /// Main data represented

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1063,15 +1063,7 @@ mod tests {
 
         // In the tolerant AST we store the Policy Error node
         #[cfg(feature = "tolerant-ast")]
-        assert_eq!(
-            policies
-                .clone()
-                .0
-                .into_iter()
-                .filter_map(|p| p.node)
-                .count(),
-            3
-        );
+        assert_eq!(policies.0.into_iter().filter_map(|p| p.node).count(), 3);
 
         // If the AST is not tolerant, unparsable policy should be None
         #[cfg(not(feature = "tolerant-ast"))]
@@ -1475,7 +1467,7 @@ mod tests {
     #[cfg(feature = "tolerant-ast")]
     fn expr_tolerant_success() {
         let src = r#"
-            x == 
+            x ==
         "#;
         let e = assert_parse_succeeds(parse_expr_tolerant, src);
         assert!(matches!(e, Expr::ErrorExpr));

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -29,8 +29,7 @@ use cedar_policy_core::{
 };
 use namespace_def::EntityTypeFragment;
 use nonempty::NonEmpty;
-use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
+use serde::Deserialize;
 use smol_str::ToSmolStr;
 use std::collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
@@ -151,16 +150,12 @@ impl ValidatorSchemaFragment<ConditionalName, ConditionalName> {
 ///
 /// In this representation, all common types are fully expanded, and all entity
 /// type names are fully disambiguated (fully qualified).
-#[serde_as]
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct ValidatorSchema {
     /// Map from entity type names to the [`ValidatorEntityType`] object.
-    #[serde_as(as = "Vec<(_, _)>")]
     entity_types: HashMap<EntityType, ValidatorEntityType>,
 
     /// Map from action id names to the [`ValidatorActionId`] object.
-    #[serde_as(as = "Vec<(_, _)>")]
     action_ids: HashMap<EntityUID, ValidatorActionId>,
 
     /// For easy lookup, this is a map from action name to `Entity` object
@@ -168,7 +163,6 @@ pub struct ValidatorSchema {
     /// in the `ValidatorSchema`, but not efficient to extract -- getting the
     /// `Entity` from the `ValidatorSchema` is O(N) as of this writing, but with
     /// this cache it's O(1).
-    #[serde_as(as = "Vec<(_, _)>")]
     pub(crate) actions: HashMap<EntityUID, Arc<Entity>>,
 }
 
@@ -872,12 +866,12 @@ impl ValidatorSchema {
             }
         }
         action_ids.iter().map(move |(action_id, action)| {
-            Entity::new_with_attr_partial_value_serialized_as_expr(
+            Entity::new_with_attr_partial_value(
                 action_id.clone(),
                 action.attributes.clone(),
                 HashSet::new(),
                 action_ancestors.remove(action_id).unwrap_or_default(),
-                BTreeMap::new(), // actions cannot have entity tags
+                [], // actions cannot have entity tags
             )
         })
     }

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -17,10 +17,9 @@
 //! This module contains the definition of `ValidatorActionId` and the types it relies on
 
 use cedar_policy_core::{
-    ast::{self, EntityType, EntityUID, PartialValueSerializedAsExpr},
+    ast::{self, EntityType, EntityUID, PartialValue},
     transitive_closure::TCNode,
 };
-use serde::Serialize;
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, HashSet};
 
@@ -35,8 +34,7 @@ use crate::{
 /// Contains information about actions used by the validator.  The contents of
 /// the struct are the same as the schema entity type structure, but the
 /// `member_of` relation is reversed to instead be `descendants`.
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub struct ValidatorActionId {
     /// The name of the action.
     pub(crate) name: EntityUID,
@@ -59,10 +57,7 @@ pub struct ValidatorActionId {
     /// The actual attribute value for this action, used to construct an
     /// `Entity` for this action. Could also be used for more precise
     /// typechecking by partial evaluation.
-    ///
-    /// Attributes are serialized as `RestrictedExpr`s, so that roundtripping
-    /// works seamlessly.
-    pub(crate) attributes: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
+    pub(crate) attributes: BTreeMap<SmolStr, PartialValue>,
 }
 
 impl ValidatorActionId {
@@ -77,7 +72,7 @@ impl ValidatorActionId {
         descendants: impl IntoIterator<Item = EntityUID>,
         context: Type,
         attribute_types: Attributes,
-        attributes: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
+        attributes: BTreeMap<SmolStr, PartialValue>,
     ) -> Self {
         Self {
             name,
@@ -150,7 +145,7 @@ impl ValidatorActionId {
     }
 
     /// Attribute values for this action
-    pub fn attributes(&self) -> impl Iterator<Item = (&SmolStr, &PartialValueSerializedAsExpr)> {
+    pub fn attributes(&self) -> impl Iterator<Item = (&SmolStr, &PartialValue)> {
         self.attributes.iter()
     }
 }
@@ -183,8 +178,7 @@ impl TCNode<EntityUID> for ValidatorActionId {
 /// [`InternalName`] and [`Name`] always represents a fully-qualified name, but
 /// as of this writing we always use [`Name`] or [`InternalName`] for the
 /// parameter here when we want to indicate names have been fully qualified.)
-#[derive(Clone, Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Clone, Debug)]
 pub(crate) struct ValidatorApplySpec<N> {
     /// The principal entity types the action can be applied to.
     principal_apply_spec: HashSet<N>,

--- a/cedar-policy-validator/src/schema/namespace_def.rs
+++ b/cedar-policy-validator/src/schema/namespace_def.rs
@@ -21,8 +21,8 @@ use std::collections::{hash_map::Entry, BTreeMap, HashMap, HashSet};
 
 use cedar_policy_core::{
     ast::{
-        EntityAttrEvaluationError, EntityType, EntityUID, InternalName, Name,
-        PartialValueSerializedAsExpr, UnreservedId,
+        EntityAttrEvaluationError, EntityType, EntityUID, InternalName, Name, PartialValue,
+        UnreservedId,
     },
     entities::{json::err::JsonDeserializationErrorContext, CedarValueJson},
     evaluator::RestrictedEvaluator,
@@ -696,7 +696,7 @@ pub struct ActionFragment<N, A> {
     /// The values for the attributes defined for this actions entity, stored
     /// separately so that we can later extract these values to construct the
     /// actual `Entity` objects defined by the schema.
-    pub(super) attributes: BTreeMap<SmolStr, PartialValueSerializedAsExpr>,
+    pub(super) attributes: BTreeMap<SmolStr, PartialValue>,
 }
 
 impl ActionFragment<ConditionalName, ConditionalName> {
@@ -777,9 +777,9 @@ impl ActionFragment<ConditionalName, ConditionalName> {
         m: HashMap<SmolStr, CedarValueJson>,
         action_id: &EntityUID,
         extensions: &Extensions<'_>,
-    ) -> crate::err::Result<(Attributes, BTreeMap<SmolStr, PartialValueSerializedAsExpr>)> {
+    ) -> crate::err::Result<(Attributes, BTreeMap<SmolStr, PartialValue>)> {
         let mut attr_types: HashMap<SmolStr, Type> = HashMap::with_capacity(m.len());
-        let mut attr_values: BTreeMap<SmolStr, PartialValueSerializedAsExpr> = BTreeMap::new();
+        let mut attr_values: BTreeMap<SmolStr, PartialValue> = BTreeMap::new();
         let evaluator = RestrictedEvaluator::new(extensions);
 
         for (k, v) in m {
@@ -810,7 +810,7 @@ impl ActionFragment<ConditionalName, ConditionalName> {
                         err,
                     })
                 })?;
-            attr_values.insert(k.clone(), pv.into());
+            attr_values.insert(k, pv);
         }
         Ok((
             Attributes::with_required_attributes(attr_types),

--- a/cedar-testing/src/cedar_test_impl.rs
+++ b/cedar-testing/src/cedar_test_impl.rs
@@ -29,7 +29,7 @@ use cedar_policy_core::extensions::Extensions;
 use cedar_policy_validator::{ValidationMode, Validator, ValidatorSchema};
 use core::panic;
 use miette::miette;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::time::{Duration, Instant};
@@ -133,7 +133,7 @@ impl TestValidationResult {
     }
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub enum ExprOrValue {
     Expr(Expr),
     Value(Expr),


### PR DESCRIPTION
## Description of changes

Removed `Serialize` and `Deserialize` from many core/validator types.  This serialization format was undocumented, unstable, and used only by DRT (until https://github.com/cedar-policy/cedar-spec/pull/562 and https://github.com/cedar-policy/cedar-spec/pull/566 remove the last use of it in DRT).  We will still have `Serialize` and `Deserialize` for officially-supported formats, including in the `entities::json` module of Core, the `est` module of Core, etc; and we also have the ability (in `cedar-policy`) to ser/de via Protobuf for many of these types as well.

Specifically, this PR removes `Serialize` and `Deserialize` from the following core and validator structures (note none of these are publicly exported in `cedar-policy`):
- Expr-related structures: `Expr`, `ExprKind`, `RestrictedExpr`, `BorrowedRestrictedExpr`, `Literal`, `UnaryOp`, `BinaryOp`, `Pattern`, `PatternElem`, `Unknown`, `Value`, `ValueKind` (note those last two previously serialized as `Expr`)
- Policy-related structures: `PolicySet`, `LiteralPolicySet`, `Template`, `StaticPolicy`, `LiteralPolicy`, `TemplateBody`, `Annotations`, `PrincipalConstraint`, `ResourceConstraint`, `PrincipalOrResourceConstraint`, `ActionConstraint`, `PrincipalOrResource`, `EntityReference`
- Request-related structures: `Request`, `EntityUIDEntry`, `Context`
- Entity-related structures: `Entities`, `Entity`
- Type-related structures: `Type`
- Parser-related structures: `Node`, `Loc`
- Validator-related structures: `ValidatorSchema`, `ValidatorActionId`, `ValidatorApplySpec`

In addition, this PR removes entirely the following structures:
- Core's `PartialValueSeriailzedAsExpr`, in favor of simply using `PartialValue` directly
- Core's `BorrowedLiteralPolicy`, as no longer used

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
