### PR TITLE
Allow an invalid entity uid ref in principal and resource scope in the 'tolerant-ast' experimental feature

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -5638,7 +5638,7 @@ mod tests {
 
     #[cfg(feature = "tolerant-ast")]
     #[test]
-    fn parsing_with_errors_succeeds_with_invalid_uid_for_in() {
+    fn parsing_with_errors_succeeds_with_invalid_uid_resource_constraint() {
         let src = r#"
             permit (
                 principal,
@@ -5647,8 +5647,21 @@ mod tests {
             )
             when { true };
         "#;
-        let p = assert_parse_policy_allows_errors(src);
-        println!("{:?}", p);
+        assert_parse_policy_allows_errors(src);
+    }
+
+    #[cfg(feature = "tolerant-ast")]
+    #[test]
+    fn parsing_with_errors_succeeds_with_invalid_uid_principal_constraint() {
+        let src = r#"
+            permit (
+                principal in J,
+                action,
+                resource
+            )
+            when { true };
+        "#;
+        assert_parse_policy_allows_errors(src);
     }
 
     #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1117,7 +1117,7 @@ impl Node<Option<cst::VariableDef>> {
                             return Err(self.to_ast_err(ToASTErrorKind::IsInActionScope).into());
                         }
                     }
-                    match rel_expr.to_refs(ast::Var::Action)? {
+                    match rel_expr.to_refs_tolerant_ast(ast::Var::Action)? {
                         OneOrMultipleRefs::Single(single_ref) => {
                             Ok(ActionConstraint::is_in([single_ref]))
                         }
@@ -1125,7 +1125,7 @@ impl Node<Option<cst::VariableDef>> {
                     }
                 }
                 cst::RelOp::Eq => {
-                    let single_ref = rel_expr.to_ref(ast::Var::Action)?;
+                    let single_ref = rel_expr.to_ref_tolerant_ast(ast::Var::Action)?;
                     Ok(ActionConstraint::is_eq(single_ref))
                 }
                 cst::RelOp::InvalidSingleEq => {
@@ -5669,6 +5669,21 @@ mod tests {
             when { true };
         "#;
         assert_parse_policy_allows_errors(src);
+    }
+
+    #[cfg(feature = "tolerant-ast")]
+    #[test]
+    fn repro_coles_bug() {
+        let src = r#"
+            permit (
+                principal,
+                action in A,
+                resource
+            )
+            when { true };
+        "#;
+        let p = assert_parse_policy_allows_errors(src);
+        println!("{:?}", p);
     }
 
     #[cfg(feature = "tolerant-ast")]

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -218,7 +218,7 @@ impl Node<Option<cst::Policy>> {
     /// well, which will become templates with 0 slots
     #[cfg(feature = "tolerant-ast")]
     pub fn to_template_tolerant(&self, id: ast::PolicyID) -> Result<ast::Template> {
-        self.to_policy_template_with_errors(id)
+        self.to_policy_template_tolerant(id)
     }
 
     /// Convert `cst::Policy` to an AST `StaticPolicy` or `Template`

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -5629,7 +5629,7 @@ mod tests {
 
     #[cfg(feature = "tolerant-ast")]
     #[test]
-    fn repro_coles_bug() {
+    fn invalid_action_constraint_in_a_list() {
         let src = r#"
             permit (
                 principal,

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -5677,7 +5677,7 @@ mod tests {
         let src = r#"
             permit (
                 principal,
-                action in A,
+                action in [A],
                 resource
             )
             when { true };

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -6347,61 +6347,6 @@ mod tests {
         });
     }
 
-    // #[cfg(feature = "tolerant-ast")]
-    // #[test]
-    // fn scope_unexpected_nested_sets_tolerant() {
-    //     let policy = r#"
-    //         permit (
-    //             principal == [[User::"alice"]],
-    //             action,
-    //             resource
-    //         );
-    //     "#;
-    //     assert_matches!(
-    //         parse_policy(None, policy),
-    //         Err(e) => {
-    //             expect_n_errors(policy, &e, 1);
-    //             expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error(
-    //                 "expected single entity uid or template slot, found set of entity uids",
-    //             ).exactly_one_underline(r#"[[User::"alice"]]"#).build());
-    //         }
-    //     );
-
-    //     let policy = r#"
-    //         permit (
-    //             principal,
-    //             action,
-    //             resource == [[?resource]]
-    //         );
-    //     "#;
-    //     assert_matches!(
-    //         parse_policy(None, policy),
-    //         Err(e) => {
-    //             expect_n_errors(policy, &e, 1);
-    //             expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error(
-    //                 "expected single entity uid or template slot, found set of entity uids",
-    //             ).exactly_one_underline("[[?resource]]").build());
-    //         }
-    //     );
-
-    //     let policy = r#"
-    //         permit (
-    //             principal,
-    //             action in [[[Action::"act"]]],
-    //             resource
-    //         );
-    //     "#;
-    //     assert_matches!(
-    //         parse_policy(None, policy),
-    //         Err(e) => {
-    //             expect_n_errors(policy, &e, 1);
-    //             expect_some_error_matches(policy, &e, &ExpectedErrorMessageBuilder::error(
-    //                 "expected single entity uid, found set of entity uids",
-    //             ).exactly_one_underline(r#"[[Action::"act"]]"#).build());
-    //         }
-    //     );
-    // }
-
     #[cfg(feature = "tolerant-ast")]
     fn parse_policy_or_template_tolerant(
         id: Option<ast::PolicyID>,

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -363,7 +363,7 @@ impl Node<Option<cst::Primary>> {
                 // Calling `create_multiple_refs` first so that we error
                 // immediately if we see a set when we don't expect one.
                 let create_multiple_refs = T::create_multiple_refs(&self.loc)?;
-                let v = ParseErrors::transpose(lst.iter().map(|expr| expr.to_ref(var)))?;
+                let v = ParseErrors::transpose(lst.iter().map(|expr| expr.to_ref_tolerant_ast(var)))?;
                 Ok(create_multiple_refs(v))
             }
             cst::Primary::RInits(_) => Err(self

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -154,6 +154,14 @@ impl Node<Option<cst::Expr>> {
         self.to_ref_or_refs::<SingleEntity>(var).map(|x| x.0)
     }
 
+    /// Extract a single `EntityUID` from this expression. The expression must
+    /// be exactly a single entity literal expression.
+    #[cfg(feature = "tolerant-ast")]
+    pub fn to_ref_tolerant_ast(&self, var: ast::Var) -> Result<EntityUID> {
+        self.to_ref_or_refs_tolerant_ast::<SingleEntity>(var)
+            .map(|x| x.0)
+    }
+
     /// Extract a single `EntityUID` or a template slot from this expression.
     /// The expression must be exactly a single entity literal expression or
     /// a single template slot.
@@ -175,6 +183,15 @@ impl Node<Option<cst::Expr>> {
     /// number of entity literals.
     pub fn to_refs(&self, var: ast::Var) -> Result<OneOrMultipleRefs> {
         self.to_ref_or_refs::<OneOrMultipleRefs>(var)
+    }
+
+    /// Extract a single `EntityUID` or set of `EntityUID`s from this
+    /// expression. The expression must either be exactly a single entity
+    /// literal expression a single set literal expression, containing some
+    /// number of entity literals.
+    #[cfg(feature = "tolerant-ast")]
+    pub fn to_refs_tolerant_ast(&self, var: ast::Var) -> Result<OneOrMultipleRefs> {
+        self.to_ref_or_refs_tolerant_ast::<OneOrMultipleRefs>(var)
     }
 
     fn to_ref_or_refs<T: RefKind>(&self, var: ast::Var) -> Result<T> {

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -17,14 +17,14 @@
 use std::sync::Arc;
 
 use super::Result;
-use crate::ast::EntityUID;
-use crate::ast::EntityReference;
 use crate::ast;
+use crate::ast::EntityReference;
+use crate::ast::EntityUID;
 use crate::parser::{
-        cst::{self, Literal},
-        err::{self, ParseErrors, ToASTError, ToASTErrorKind},
-        Loc, Node,
-    };
+    cst::{self, Literal},
+    err::{self, ParseErrors, ToASTError, ToASTErrorKind},
+    Loc, Node,
+};
 
 /// Type level marker for parsing sets of entity uids or single uids
 /// This presents having either a large level of code duplication
@@ -221,22 +221,6 @@ impl Node<Option<cst::Expr>> {
     }
 }
 
-#[cfg(feature = "tolerant-ast")]
-fn create_refkind_error<T: RefKind>() -> T {
-    T::error_node()
-}
-
-/// Since ExprBuilder ErrorType can be Infallible or ParseErrors, if we get an error from building the node pass the ParseErrors along
-#[cfg_attr(not(feature = "tolerant-ast"), allow(unused_variables))]
-fn convert_refkind_error_to_parse_error<T: RefKind>(
-    error: ParseErrors,
-) -> Result<T> {
-    #[cfg(feature = "tolerant-ast")]
-    return Ok(create_refkind_error());
-    #[allow(unreachable_code)]
-    Err(error)
-}
-
 impl Node<Option<cst::Primary>> {
     fn to_ref_or_refs<T: RefKind>(&self, var: ast::Var) -> Result<T> {
         let prim = self.try_as_inner()?;
@@ -370,7 +354,7 @@ impl Node<Option<cst::Primary>> {
                         },
                     ))
                     .into();
-                convert_refkind_error_to_parse_error::<T>(error)
+                Ok(T::error_node())
             }
             cst::Primary::Expr(x) => x.to_ref_or_refs::<T>(var),
             cst::Primary::EList(lst) => {
@@ -432,7 +416,7 @@ impl Node<Option<cst::Unary>> {
         }
     }
 
-    #[cfg(feature="tolerant-ast")]
+    #[cfg(feature = "tolerant-ast")]
     fn to_ref_or_refs_tolerant_ast<T: RefKind>(&self, var: ast::Var) -> Result<T> {
         let unary = self.try_as_inner()?;
 
@@ -583,7 +567,6 @@ impl Node<Option<cst::Relation>> {
                 .into()),
         }
     }
-    
 }
 
 impl Node<Option<cst::Or>> {

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -337,23 +337,8 @@ impl Node<Option<cst::Primary>> {
                     .into())
             }
             cst::Primary::Ref(x) => T::create_single_ref(x.to_ref()?),
-            cst::Primary::Name(name) => {
-                let found = match name.as_inner() {
-                    Some(name) => format!("name `{name}`"),
-                    None => "name".to_string(),
-                };
-                let error: ParseErrors = self
-                    .to_ast_err(ToASTErrorKind::wrong_node(
-                        T::err_str(),
-                        found,
-                        if var != ast::Var::Action {
-                            Some("try using `is` to test for an entity type or including an identifier string if you intended this name to be an entity uid".to_string())
-                        } else {
-                            // We don't allow `is` in the action scope, so we won't suggest trying it.
-                            Some("try including an identifier string if you intended this name to be an entity uid".to_string())
-                        },
-                    ))
-                    .into();
+            cst::Primary::Name(_) => {
+                // Tolerant AST supports invalid entity uid name - create an AST error node
                 Ok(T::error_node())
             }
             cst::Primary::Expr(x) => x.to_ref_or_refs::<T>(var),

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -635,3 +635,31 @@ impl Node<Option<cst::And>> {
         }
     }
 }
+
+
+#[cfg(test)]
+mod test {
+    #[cfg(feature = "tolerant-ast")]
+    #[test]
+    fn to_ref_or_refs_tolerant_ast() {
+        use crate::ast;
+        use crate::parser::cst::Name;
+        use crate::parser::cst::Relation;
+        use crate::parser::cst_to_ast::to_ref_or_refs::SingleEntity;
+        use crate::parser::Node;
+        use crate::parser::cst;
+
+        let n:  Node<Option<cst::Primary>> = Node {
+            node:Some(cst::Primary::Name(
+                Node {
+                    node: Some(
+                        Name {
+                            path: vec![],
+                            name: todo!(),
+                        }),
+                    loc: todo!()})),
+            loc: todo!()
+        };
+        n.to_ref_or_refs_tolerant_ast::<SingleEntity>(ast::Var::Principal);
+    }
+}


### PR DESCRIPTION
## Description of changes

This change extends the `tolerant-ast` feature to support invalid entity refs in the resource and principal constraints of a policy. Currently, these result in errors when converting from CST to AST. This is a common case that comes up when doing autocomplete in the context of an LSP or IDE extension.

We will now support the following cases:

```
#[cfg(feature = "tolerant-ast")]
    #[test]
    fn parsing_with_errors_succeeds_with_invalid_uid_resource_constraint() {
        let src = r#"
            permit (
                principal,
                action,
                resource in H
            )
            when { true };
        "#;
        assert_parse_policy_allows_errors(src);
    }

    #[cfg(feature = "tolerant-ast")]
    #[test]
    fn parsing_with_errors_succeeds_with_invalid_uid_principal_constraint() {
        let src = r#"
            permit (
                principal in J,
                action,
                resource
            )
            when { true };
        "#;
        assert_parse_policy_allows_errors(src);
    }
``` 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [  ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ x ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ x ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ x ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ x ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
