### PR TITLE
Add getter for Schema to Validator

### DIFF
--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -104,6 +104,11 @@ impl Validator {
         Self { schema }
     }
 
+    /// Get the `ValidatorSchema` this `Validator` is using.
+    pub fn schema(&self) -> &ValidatorSchema {
+        &self.schema
+    }
+
     /// Validate all templates, links, and static policies in a policy set.
     /// Return a `ValidationResult`.
     pub fn validate(&self, policies: &PolicySet, mode: ValidationMode) -> ValidationResult {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -29,6 +29,8 @@ Cedar Language Version: TBD
 - Added `to_cedar` functions for `PolicySet`, `Policy`, and `Template` that
   render the policy in the human-readable Cedar syntax. These functions can be used
   to convert JSON formatted policies into the human-readable syntax.
+- Added `Validator::schema()` to get a reference to the `Schema` even after it has been
+  consumed to construct a `Validator` (#1523)
 
 ## [4.3.3] - 2025-02-25
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -30,7 +30,7 @@ Cedar Language Version: TBD
   render the policy in the human-readable Cedar syntax. These functions can be used
   to convert JSON formatted policies into the human-readable syntax.
 - Added `Validator::schema()` to get a reference to the `Schema` even after it has been
-  consumed to construct a `Validator` (#1523)
+  consumed to construct a `Validator` (#1524)
 
 ## [4.3.3] - 2025-02-25
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1320,7 +1320,7 @@ impl Validator {
 
     /// Get the `Schema` this `Validator` is using.
     pub fn schema(&self) -> &Schema {
-        self.0.schema().ref_cast()
+        RefCast::ref_cast(self.0.schema())
     }
 
     /// Validate all policies in a policy set, collecting all validation errors

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1318,6 +1318,11 @@ impl Validator {
         Self(cedar_policy_validator::Validator::new(schema.0))
     }
 
+    /// Get the `Schema` this `Validator` is using.
+    pub fn schema(&self) -> &Schema {
+        self.0.schema().ref_cast()
+    }
+
     /// Validate all policies in a policy set, collecting all validation errors
     /// found into the returned `ValidationResult`. Each error is returned together with the
     /// policy id of the policy where the error was found. If a policy id


### PR DESCRIPTION
## Description of changes

Allows callers who have already constructed a `Validator`, to take advantage of the getters on `Schema` (and its `Protobuf` trait implementation).  This is necessary because constructing a `Validator` consumes the `Schema`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
