### PR TITLE
parser::cst::Policies to est::PolicySet Conversion

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -124,6 +124,14 @@ impl Policy {
             annotations: self.annotations,
         })
     }
+
+    /// Returns true if this policy is a template, i.e., it has at least one slot.
+    pub fn is_template(&self) -> bool {
+        self.principal.has_slot()
+            || self.action.has_slot()
+            || self.resource.has_slot()
+            || self.conditions.iter().any(|c| c.has_slot())
+    }
 }
 
 impl Clause {
@@ -145,6 +153,12 @@ impl Clause {
             When(e) => Ok(When(e.sub_entity_literals(mapping)?)),
             Unless(e) => Ok(Unless(e.sub_entity_literals(mapping)?)),
         }
+    }
+
+    /// Returns true if this clause has a slot.
+    pub fn has_slot(&self) -> bool {
+        // currently, slots are not allowed in clauses
+        false
     }
 }
 

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -4613,6 +4613,82 @@ mod test {
             .unwrap()
         );
     }
+
+    #[test]
+    fn is_template_principal_slot() {
+        let template = r#"
+            permit(
+                principal == ?principal,
+                action == Action::"view",
+                resource
+            );
+        "#;
+        let cst = parser::text_to_cst::parse_policy(template)
+            .unwrap()
+            .node
+            .unwrap();
+        let est: Policy = cst.try_into().unwrap();
+        assert!(
+            est.is_template(),
+            "Policy with principal slot not marked as template"
+        );
+    }
+
+    #[test]
+    fn is_template_resource_slot() {
+        let template = r#"
+            permit(
+                principal,
+                action == Action::"view",
+                resource in ?resource
+            );
+        "#;
+        let cst = parser::text_to_cst::parse_policy(template)
+            .unwrap()
+            .node
+            .unwrap();
+        let est: Policy = cst.try_into().unwrap();
+        assert!(
+            est.is_template(),
+            "Policy with resource slot not marked as template"
+        );
+    }
+
+    #[test]
+    fn is_template_static_policy() {
+        let template = r#"
+            permit(
+                principal,
+                action == Action::"view",
+                resource
+            );
+        "#;
+        let cst = parser::text_to_cst::parse_policy(template)
+            .unwrap()
+            .node
+            .unwrap();
+        let est: Policy = cst.try_into().unwrap();
+        assert!(!est.is_template(), "Static policy marked as template");
+    }
+
+    #[test]
+    fn is_template_static_policy_with_condition() {
+        let template = r#"
+            permit(
+                principal,
+                action == Action::"view",
+                resource
+            ) when {
+                principal in resource.owners
+            };
+        "#;
+        let cst = parser::text_to_cst::parse_policy(template)
+            .unwrap()
+            .node
+            .unwrap();
+        let est: Policy = cst.try_into().unwrap();
+        assert!(!est.is_template(), "Static policy marked as template");
+    }
 }
 
 #[cfg(test)]

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -272,6 +272,25 @@ impl PrincipalConstraint {
             }
         }
     }
+
+    /// Returns true if this constraint has a slot.
+    pub fn has_slot(&self) -> bool {
+        match self {
+            PrincipalConstraint::All => false,
+            PrincipalConstraint::Eq(EqConstraint::Entity { entity: _ }) => false,
+            PrincipalConstraint::Eq(EqConstraint::Slot { slot: _ }) => true,
+            PrincipalConstraint::In(PrincipalOrResourceInConstraint::Entity { entity: _ }) => false,
+            PrincipalConstraint::In(PrincipalOrResourceInConstraint::Slot { slot: _ }) => true,
+            PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
+                entity_type: _,
+                in_entity: None | Some(PrincipalOrResourceInConstraint::Entity { .. }),
+            }) => false,
+            PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
+                entity_type: _,
+                in_entity: Some(PrincipalOrResourceInConstraint::Slot { slot: _ }),
+            }) => true,
+        }
+    }
 }
 
 impl ResourceConstraint {
@@ -376,6 +395,25 @@ impl ResourceConstraint {
             }
         }
     }
+
+    /// Returns true if this constraint has a slot.
+    pub fn has_slot(&self) -> bool {
+        match self {
+            ResourceConstraint::All => false,
+            ResourceConstraint::Eq(EqConstraint::Entity { entity: _ }) => false,
+            ResourceConstraint::In(PrincipalOrResourceInConstraint::Entity { entity: _ }) => false,
+            ResourceConstraint::Eq(EqConstraint::Slot { slot: _ }) => true,
+            ResourceConstraint::In(PrincipalOrResourceInConstraint::Slot { slot: _ }) => true,
+            ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
+                entity_type: _,
+                in_entity: None | Some(PrincipalOrResourceInConstraint::Entity { .. }),
+            }) => false,
+            ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
+                entity_type: _,
+                in_entity: Some(PrincipalOrResourceInConstraint::Slot { slot: _ }),
+            }) => true,
+        }
+    }
 }
 
 impl ActionConstraint {
@@ -430,6 +468,12 @@ impl ActionConstraint {
             #[cfg(feature = "tolerant-ast")]
             ActionConstraint::ErrorConstraint => Ok(self),
         }
+    }
+
+    /// Returns true if this constraint has a slot.
+    pub fn has_slot(&self) -> bool {
+        // currently, slots are not allowed in action constraints
+        false
     }
 }
 

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -279,15 +279,15 @@ impl PrincipalConstraint {
             PrincipalConstraint::All => false,
             PrincipalConstraint::Eq(EqConstraint::Entity { .. }) => false,
             PrincipalConstraint::Eq(EqConstraint::Slot { .. }) => true,
-            PrincipalConstraint::In(PrincipalOrResourceInConstraint::Entity { entity: _ }) => false,
-            PrincipalConstraint::In(PrincipalOrResourceInConstraint::Slot { slot: _ }) => true,
+            PrincipalConstraint::In(PrincipalOrResourceInConstraint::Entity { .. }) => false,
+            PrincipalConstraint::In(PrincipalOrResourceInConstraint::Slot { .. }) => true,
             PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
                 in_entity: None | Some(PrincipalOrResourceInConstraint::Entity { .. }),
                 ..
             }) => false,
             PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
-                entity_type: _,
-                in_entity: Some(PrincipalOrResourceInConstraint::Slot { slot: _ }),
+                in_entity: Some(PrincipalOrResourceInConstraint::Slot { .. }),
+                ..
             }) => true,
         }
     }
@@ -400,17 +400,17 @@ impl ResourceConstraint {
     pub fn has_slot(&self) -> bool {
         match self {
             ResourceConstraint::All => false,
-            ResourceConstraint::Eq(EqConstraint::Entity { entity: _ }) => false,
-            ResourceConstraint::In(PrincipalOrResourceInConstraint::Entity { entity: _ }) => false,
-            ResourceConstraint::Eq(EqConstraint::Slot { slot: _ }) => true,
-            ResourceConstraint::In(PrincipalOrResourceInConstraint::Slot { slot: _ }) => true,
+            ResourceConstraint::Eq(EqConstraint::Entity { .. }) => false,
+            ResourceConstraint::In(PrincipalOrResourceInConstraint::Entity { .. }) => false,
+            ResourceConstraint::Eq(EqConstraint::Slot { .. }) => true,
+            ResourceConstraint::In(PrincipalOrResourceInConstraint::Slot { .. }) => true,
             ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
-                entity_type: _,
                 in_entity: None | Some(PrincipalOrResourceInConstraint::Entity { .. }),
+                ..
             }) => false,
             ResourceConstraint::Is(PrincipalOrResourceIsConstraint {
-                entity_type: _,
-                in_entity: Some(PrincipalOrResourceInConstraint::Slot { slot: _ }),
+                in_entity: Some(PrincipalOrResourceInConstraint::Slot { .. }),
+                ..
             }) => true,
         }
     }

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -277,13 +277,13 @@ impl PrincipalConstraint {
     pub fn has_slot(&self) -> bool {
         match self {
             PrincipalConstraint::All => false,
-            PrincipalConstraint::Eq(EqConstraint::Entity { entity: _ }) => false,
-            PrincipalConstraint::Eq(EqConstraint::Slot { slot: _ }) => true,
+            PrincipalConstraint::Eq(EqConstraint::Entity { .. }) => false,
+            PrincipalConstraint::Eq(EqConstraint::Slot { .. }) => true,
             PrincipalConstraint::In(PrincipalOrResourceInConstraint::Entity { entity: _ }) => false,
             PrincipalConstraint::In(PrincipalOrResourceInConstraint::Slot { slot: _ }) => true,
             PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
-                entity_type: _,
                 in_entity: None | Some(PrincipalOrResourceInConstraint::Entity { .. }),
+                ..
             }) => false,
             PrincipalConstraint::Is(PrincipalOrResourceIsConstraint {
                 entity_type: _,

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -933,3 +933,96 @@ impl TryFrom<ActionConstraint> for ast::ActionConstraint {
             })
     }
 }
+
+#[cfg(test)]
+mod test {
+    fn parse_policy(template: &str) -> crate::est::Policy {
+        let cst = crate::parser::text_to_cst::parse_policy(template)
+            .unwrap()
+            .node
+            .unwrap();
+        cst.try_into().unwrap()
+    }
+
+    fn principal_has_slot(principal_text: &str) -> bool {
+        let text = format!("permit({principal_text}, action, resource);");
+        parse_policy(&text).principal.has_slot()
+    }
+
+    fn resource_has_slot(resource_text: &str) -> bool {
+        let text = format!("permit(principal, action, {resource_text});");
+        parse_policy(&text).resource.has_slot()
+    }
+
+    #[test]
+    fn has_slot_principal_all() {
+        assert!(!principal_has_slot(r#"principal"#));
+    }
+
+    #[test]
+    fn has_slot_principal_eq_entity() {
+        assert!(!principal_has_slot(r#"principal == User::"alice""#));
+    }
+
+    #[test]
+    fn has_slot_principal_eq_slot() {
+        assert!(principal_has_slot(r#"principal == ?principal"#));
+    }
+
+    #[test]
+    fn has_slot_principal_in_entity() {
+        assert!(!principal_has_slot(r#"principal in Group::"friends""#));
+    }
+
+    #[test]
+    fn has_slot_principal_in_slot() {
+        assert!(principal_has_slot(r#"principal in ?principal"#));
+    }
+
+    #[test]
+    fn has_slot_principal_is_entity() {
+        assert!(!principal_has_slot(r#"principal is User"#));
+    }
+
+    #[test]
+    fn has_slot_principal_is_slot() {
+        assert!(principal_has_slot(r#"principal is User in ?principal"#));
+    }
+
+    #[test]
+    fn has_slot_resource_all() {
+        assert!(!resource_has_slot(r#"resource"#));
+    }
+
+    #[test]
+    fn has_slot_resource_eq_entity() {
+        assert!(!resource_has_slot(
+            r#"resource == Photo::"VacationPhoto94.jpg""#
+        ));
+    }
+
+    #[test]
+    fn has_slot_resource_eq_slot() {
+        assert!(resource_has_slot(r#"resource == ?resource"#));
+    }
+
+    #[test]
+    fn has_slot_resource_in_entity() {
+        assert!(!resource_has_slot(r#"resource in Group::"vacation""#));
+    }
+
+    #[test]
+    fn has_slot_resource_in_slot() {
+        assert!(resource_has_slot(r#"resource in ?resource"#));
+    }
+
+    #[test]
+    fn has_slot_resource_is_entity() {
+        assert!(!resource_has_slot(r#"resource is Photo"#));
+    }
+
+    #[test]
+    fn has_slot_resource_is_slot() {
+        assert!(resource_has_slot(r#"resource is Photo in ?resource"#));
+    }
+}


### PR DESCRIPTION
## Description of changes
Added a method for converting a cedar_policy_core::parser::cst::Policies directly into a cedar_policy_core::est::PolicySet. 
Added a method for checking whether a cedar_policy_core::est::Policy is a template, i.e., contains slots.

## Issue #, if available
None.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
