### PR TITLE
Allow upsert on Entities (#1479)

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -135,7 +135,7 @@ impl Entities {
             if let Some(checker) = checker.as_ref() {
                 checker.validate_entity(&entity)?;
             }
-            update_entity_map(&mut self.entities, entity)?;
+            update_entity_map(&mut self.entities, entity, false)?;
         }
         match tc_computation {
             TCComputation::AssumeAlreadyComputed => (),
@@ -181,6 +181,40 @@ impl Entities {
         Ok(self)
     }
 
+    /// Adds the [`crate::ast::Entity`]s in the iterator to this [`Entities`].
+    /// Fails if any error is encountered in the transitive closure computation.
+    ///
+    /// When a duplicate is encountered, the value is overwritten by the latest version.
+    ///
+    /// If `schema` is present, then the added entities will be validated
+    /// against the `schema`, returning an error if they do not conform to the
+    /// schema.
+    /// (This method will not add action entities from the `schema`.)
+    ///
+    /// If you pass [`TCComputation::AssumeAlreadyComputed`], then the caller is
+    /// responsible for ensuring that TC and DAG hold before calling this method.
+    pub fn upsert_entities(
+        mut self,
+        collection: impl IntoIterator<Item = Arc<Entity>>,
+        schema: Option<&impl Schema>,
+        tc_computation: TCComputation,
+        extensions: &Extensions<'_>,
+    ) -> Result<Self> {
+        let checker = schema.map(|schema| EntitySchemaConformanceChecker::new(schema, extensions));
+        for entity in collection.into_iter() {
+            if let Some(checker) = checker.as_ref() {
+                checker.validate_entity(&entity)?;
+            }
+            update_entity_map(&mut self.entities, entity, true)?;
+        }
+        match tc_computation {
+            TCComputation::AssumeAlreadyComputed => (),
+            TCComputation::EnforceAlreadyComputed => enforce_tc_and_dag(&self.entities)?,
+            TCComputation::ComputeNow => compute_tc(&mut self.entities, true)?,
+        };
+        Ok(self)
+    }
+
     /// Create an `Entities` object with the given entities.
     ///
     /// If `schema` is present, then action entities from that schema will also
@@ -196,7 +230,7 @@ impl Entities {
     ///   `entities` with the same Entity UID, or there is an entity in `entities` with the same
     ///   Entity UID as a non-identical entity in this structure
     /// - [`EntitiesError::TransitiveClosureError`] if `tc_computation ==
-    ///   TCComputation::EnforceAlreadyComputed` and the entities are not transitivly closed
+    ///   TCComputation::EnforceAlreadyComputed` and the entities are not transitively closed
     /// - [`EntitiesError::InvalidEntity`] if `schema` is not none and any entities do not conform
     ///   to the schema
     pub fn from_entities(
@@ -374,7 +408,7 @@ fn create_entity_map(
 ) -> Result<HashMap<EntityUID, Arc<Entity>>> {
     let mut map: HashMap<EntityUID, Arc<Entity>> = HashMap::new();
     for e in es {
-        update_entity_map(&mut map, e)?;
+        update_entity_map(&mut map, e, false)?;
     }
     Ok(map)
 }
@@ -384,14 +418,22 @@ fn create_entity_map(
 /// with the same EntityUID as the specified entity. If such an entity is found and is
 /// not structurally equal to the specified entity produces an error. Otherwise,
 /// if a structurally equal entity is found, the state of the map is unchanged.
-fn update_entity_map(map: &mut HashMap<EntityUID, Arc<Entity>>, entity: Arc<Entity>) -> Result<()> {
+fn update_entity_map(
+    map: &mut HashMap<EntityUID, Arc<Entity>>,
+    entity: Arc<Entity>,
+    allow_override: bool,
+) -> Result<()> {
     match map.entry(entity.uid().clone()) {
-        hash_map::Entry::Occupied(occupied_entry) => {
-            // Check whether the occupying entity is structurally equal to the
-            // entity being processed
-            if !entity.deep_eq(occupied_entry.get()) {
-                let entry = occupied_entry.remove_entry();
-                return Err(EntitiesError::duplicate(entry.0));
+        hash_map::Entry::Occupied(mut occupied_entry) => {
+            if allow_override {
+                occupied_entry.insert(entity);
+            } else {
+                // Check whether the occupying entity is structurally equal to the
+                // entity being processed
+                if !entity.deep_eq(occupied_entry.get()) {
+                    let entry = occupied_entry.remove_entry();
+                    return Err(EntitiesError::duplicate(entry.0));
+                }
             }
         }
         hash_map::Entry::Vacant(v) => {
@@ -2144,8 +2186,8 @@ mod entities_tests {
         let mut e1 = Entity::with_uid(EntityUID::with_eid("a"));
         let mut e2 = Entity::with_uid(EntityUID::with_eid("b"));
         let e3 = Entity::with_uid(EntityUID::with_eid("c"));
-        e1.add_indirect_ancestor(EntityUID::with_eid("b"));
-        e2.add_indirect_ancestor(EntityUID::with_eid("c"));
+        e1.add_parent(EntityUID::with_eid("b"));
+        e2.add_parent(EntityUID::with_eid("c"));
 
         let es = Entities::from_entities(
             vec![e1, e2, e3],
@@ -2169,9 +2211,9 @@ mod entities_tests {
         let mut e1 = Entity::with_uid(EntityUID::with_eid("a"));
         let mut e2 = Entity::with_uid(EntityUID::with_eid("b"));
         let e3 = Entity::with_uid(EntityUID::with_eid("c"));
-        e1.add_indirect_ancestor(EntityUID::with_eid("b"));
+        e1.add_parent(EntityUID::with_eid("b"));
         e1.add_indirect_ancestor(EntityUID::with_eid("c"));
-        e2.add_indirect_ancestor(EntityUID::with_eid("c"));
+        e2.add_parent(EntityUID::with_eid("c"));
 
         Entities::from_entities(
             vec![e1, e2, e3],

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2315,7 +2315,10 @@ mod entities_tests {
         let mut g = Entity::with_uid(gid.clone());
         g.add_parent(fid.clone());
 
-        let updates = vec![f_updated, g].into_iter().map(Arc::new).collect::<Vec<_>>();
+        let updates = vec![f_updated, g]
+            .into_iter()
+            .map(Arc::new)
+            .collect::<Vec<_>>();
         // Construct original hierarchy
         let entities = Entities::from_entities(
             vec![a, b, c, d, e, f],
@@ -2325,7 +2328,12 @@ mod entities_tests {
         )
         .expect("Failed to construct entities")
         // Apply updates
-        .upsert_entities(updates, None::<&NoEntitiesSchema>, TCComputation::ComputeNow, &Extensions::all_available())
+        .upsert_entities(
+            updates,
+            None::<&NoEntitiesSchema>,
+            TCComputation::ComputeNow,
+            &Extensions::all_available(),
+        )
         .expect("Failed to remove entities");
         // Post-Update Hierarchy
         // G -> F -> C

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -1235,14 +1235,14 @@ pub(crate) mod test {
         let grandparent = Entity::with_uid(EntityUID::with_eid("grandparent"));
         let mut sibling = Entity::with_uid(EntityUID::with_eid("sibling"));
         let unrelated = Entity::with_uid(EntityUID::with_eid("unrelated"));
-        child.add_indirect_ancestor(parent.uid().clone());
-        sibling.add_indirect_ancestor(parent.uid().clone());
-        parent.add_indirect_ancestor(grandparent.uid().clone());
+        child.add_parent(parent.uid().clone());
+        sibling.add_parent(parent.uid().clone());
+        parent.add_parent(grandparent.uid().clone());
         let mut child_diff_type = Entity::with_uid(
             EntityUID::with_eid_and_type("other_type", "other_child")
                 .expect("should be a valid identifier"),
         );
-        child_diff_type.add_indirect_ancestor(parent.uid().clone());
+        child_diff_type.add_parent(parent.uid().clone());
         child_diff_type.add_indirect_ancestor(grandparent.uid().clone());
 
         Entities::from_entities(
@@ -4071,7 +4071,7 @@ pub(crate) mod test {
         //Alice has parent "Friends" but we don't add "Friends" to the slice
         let mut alice = Entity::with_uid(EntityUID::with_eid("Alice"));
         let parent = Entity::with_uid(EntityUID::with_eid("Friends"));
-        alice.add_indirect_ancestor(parent.uid().clone());
+        alice.add_parent(parent.uid().clone());
         let entities = Entities::from_entities(
             vec![alice],
             None::<&NoEntitiesSchema>,

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -176,6 +176,9 @@ impl TCNode<EntityUID> for ValidatorActionId {
     fn has_edge_to(&self, e: &EntityUID) -> bool {
         self.descendants.contains(e)
     }
+
+    // No-op as schema based TCs do not update
+    fn reset_edges(&mut self) {}
 }
 
 /// The principals and resources that an action can be applied to.

--- a/cedar-policy-validator/src/schema/entity_type.rs
+++ b/cedar-policy-validator/src/schema/entity_type.rs
@@ -192,4 +192,7 @@ impl TCNode<EntityType> for ValidatorEntityType {
     fn has_edge_to(&self, e: &EntityType) -> bool {
         self.descendants.contains(e)
     }
+
+    // No-op as schema based TCs do not update
+    fn reset_edges(&mut self) {}
 }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -41,6 +41,7 @@ Cedar Language Version: 4.3
   alias for `EntityId::as_ref()` with the `AsRef` impl that produces `&str`. (#1555)
 - Added `PartialResponse::unknown_entities` method (#1557)
 - Added `Entities::len` and `Entities::is_empty` methods (#1562, resolving #1523)
+- Added `Entities::upsert_entities()` to add or update `Entity`s in an `Entities` struct (resolving #1479)
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -873,6 +873,45 @@ impl IntoIterator for Entities {
     }
 }
 
+#[cfg(test)]
+mod test_entities_api {
+    use std::collections::HashSet;
+
+    use super::Entity;
+    use super::Entities;
+    use super::EntityUid;
+
+    #[test]
+    fn test_upsert_entities() {
+        let e1 = Entity::new_no_attrs(
+            EntityUid::from_strs("User", "alice"),
+            HashSet::new()
+        );
+        let e1_uid = e1.uid();
+        let e2 = Entity::new_no_attrs(
+            EntityUid::from_strs("User", "bob"),
+            HashSet::new(),
+        );
+        let e2_uid = e2.uid();
+        let e1_updated = Entity::new_no_attrs(
+            EntityUid::from_strs("User", "alice"),
+            HashSet::from([e2.uid()]),
+        );
+        let mut entities = Entities::empty();
+        entities = entities.upsert_entities(vec![e1], None).unwrap();
+        assert_eq!(entities.len(), 1);
+        entities = entities.upsert_entities(vec![e2], None).unwrap();
+        assert_eq!(entities.len(), 2);
+        assert!(!entities.is_ancestor_of(&e2_uid, &e1_uid));
+
+        entities = entities.upsert_entities(vec![e1_updated], None).unwrap();
+        assert_eq!(entities.len(), 2);
+        assert!(entities.is_ancestor_of(&e2_uid, &e1_uid));
+    }
+
+
+}
+
 /// Authorizer object, which provides responses to authorization queries
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
@@ -5249,3 +5288,4 @@ pub fn compute_entity_manifest(
 ) -> Result<EntityManifest, EntityManifestError> {
     entity_manifest::compute_entity_manifest(&schema.0, &pset.ast).map_err(std::convert::Into::into)
 }
+

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -873,45 +873,6 @@ impl IntoIterator for Entities {
     }
 }
 
-#[cfg(test)]
-mod test_entities_api {
-    use std::collections::HashSet;
-
-    use super::Entity;
-    use super::Entities;
-    use super::EntityUid;
-
-    #[test]
-    fn test_upsert_entities() {
-        let e1 = Entity::new_no_attrs(
-            EntityUid::from_strs("User", "alice"),
-            HashSet::new()
-        );
-        let e1_uid = e1.uid();
-        let e2 = Entity::new_no_attrs(
-            EntityUid::from_strs("User", "bob"),
-            HashSet::new(),
-        );
-        let e2_uid = e2.uid();
-        let e1_updated = Entity::new_no_attrs(
-            EntityUid::from_strs("User", "alice"),
-            HashSet::from([e2.uid()]),
-        );
-        let mut entities = Entities::empty();
-        entities = entities.upsert_entities(vec![e1], None).unwrap();
-        assert_eq!(entities.len(), 1);
-        entities = entities.upsert_entities(vec![e2], None).unwrap();
-        assert_eq!(entities.len(), 2);
-        assert!(!entities.is_ancestor_of(&e2_uid, &e1_uid));
-
-        entities = entities.upsert_entities(vec![e1_updated], None).unwrap();
-        assert_eq!(entities.len(), 2);
-        assert!(entities.is_ancestor_of(&e2_uid, &e1_uid));
-    }
-
-
-}
-
 /// Authorizer object, which provides responses to authorization queries
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
@@ -5288,4 +5249,3 @@ pub fn compute_entity_manifest(
 ) -> Result<EntityManifest, EntityManifestError> {
     entity_manifest::compute_entity_manifest(&schema.0, &pset.ast).map_err(std::convert::Into::into)
 }
-


### PR DESCRIPTION
## Description of changes

Updates transitive closure to build ancestors list based on direct edge relationships rather than all edge relationships. All indirect edges are reset prior to adding back the newly computed indirect edges.

Updates entities update_entity_map to allow overrides with a passed in boolean flag.

Updates several tests to use `.add_parent()` rather than `.add_indirect_ancestor()` to account for transitive closure changes.

## Issue #1479

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.

## Note
I opened a PR (#1481) before, but accidentally lost it when trying to sync the forks. This has the latest version of the implementation and should be fully synced with the upstream.
