### PR TITLE
a few more tweaks to protobuf format

### DIFF
--- a/cedar-policy/protobuf_schema/core.proto
+++ b/cedar-policy/protobuf_schema/core.proto
@@ -21,23 +21,19 @@ message Request {
     EntityUid principal = 1;
     EntityUid action = 2;
     EntityUid resource = 3;
-    Expr context = 4;
+    map<string, Expr> context = 4;
 }
 
 // the protobuf PolicySet message describes a complete policy set, including
 // templates, static policies, and/or template-linked policies.
 message PolicySet {
-    // Key is PolicyID as a string.
-    // Value is a `TemplateBody`.
-    // Both templates and static policies are included in this map, with static
+    // Both templates and static policies are included here, with static
     // policies represented as templates with zero slots.
-    map<string, TemplateBody> templates = 1;
-    // Key is PolicyID as a string.
-    // Value is a `Policy`.
-    // All static policies and template-linked policies are included in this map.
-    // Static policies must have exactly one entry in this map, and the PolicyID
-    // of the static policy must be the same in this map and the above map.
-    map<string, Policy> links = 2;
+    repeated TemplateBody templates = 1;
+    // All static policies and template-linked policies are included here.
+    // Static policies must appear exactly once, and the PolicyID of the static
+    // policy must be the same in this list and the above list.
+    repeated Policy links = 2;
 }
 
 message Entities {

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -645,6 +645,8 @@ impl From<&models::Request> for ast::Request {
 }
 
 impl From<&ast::Request> for models::Request {
+    // PANIC SAFETY: experimental feature
+    #[allow(clippy::unimplemented)]
     fn from(v: &ast::Request) -> Self {
         Self {
             principal: Some(models::EntityUid::from(v.principal())),

--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -20,6 +20,7 @@ use super::models;
 use cedar_policy_core::{
     ast, evaluator::RestrictedEvaluator, extensions::Extensions, FromNormalizedStr,
 };
+use smol_str::ToSmolStr;
 use std::{collections::HashSet, sync::Arc};
 
 // PANIC SAFETY: experimental feature
@@ -436,6 +437,12 @@ impl From<&ast::Expr> for models::Expr {
     }
 }
 
+impl From<&ast::Value> for models::Expr {
+    fn from(v: &ast::Value) -> Self {
+        (&ast::Expr::from(v.clone())).into()
+    }
+}
+
 impl From<&models::expr::Var> for ast::Var {
     fn from(v: &models::expr::Var) -> Self {
         match v {
@@ -620,7 +627,19 @@ impl From<&models::Request> for ast::Request {
             ast::EntityUIDEntry::from(v.principal.as_ref().expect("principal.as_ref()")),
             ast::EntityUIDEntry::from(v.action.as_ref().expect("action.as_ref()")),
             ast::EntityUIDEntry::from(v.resource.as_ref().expect("resource.as_ref()")),
-            v.context.as_ref().map(ast::Context::from),
+            Some(
+                ast::Context::from_pairs(
+                    v.context.iter().map(|(k, v)| {
+                        (
+                            k.to_smolstr(),
+                            ast::RestrictedExpr::new(ast::Expr::from(v))
+                                .expect("encoded context should be a valid RestrictedExpr"),
+                        )
+                    }),
+                    Extensions::all_available(),
+                )
+                .expect("encoded context should be valid"),
+            ),
         )
     }
 }
@@ -631,7 +650,24 @@ impl From<&ast::Request> for models::Request {
             principal: Some(models::EntityUid::from(v.principal())),
             action: Some(models::EntityUid::from(v.action())),
             resource: Some(models::EntityUid::from(v.resource())),
-            context: v.context().map(models::Expr::from),
+            context: {
+                let ctx = match v.context() {
+                    Some(ctx) => ctx,
+                    None => unimplemented!(
+                        "Requests with unknown context currently cannot be modeled in protobuf"
+                    ),
+                };
+                match ctx {
+                    ast::Context::Value(map) => map
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), models::Expr::from(v)))
+                        .collect(),
+                    ast::Context::RestrictedResidual(map) => map
+                        .iter()
+                        .map(|(k, v)| (k.to_string(), models::Expr::from(v)))
+                        .collect(),
+                }
+            },
         }
     }
 }
@@ -642,10 +678,10 @@ impl From<&models::Expr> for ast::Context {
         #[allow(clippy::expect_used)]
         ast::Context::from_expr(
             ast::BorrowedRestrictedExpr::new(&ast::Expr::from(v))
-                .expect("context should be valid restricted expr"),
+                .expect("encoded context should be valid restricted expr"),
             Extensions::none(),
         )
-        .expect("Context::from_expr")
+        .expect("encoded context should be valid")
     }
 }
 


### PR DESCRIPTION
## Description of changes

Makes two more changes to the protobuf format:
1. changes the request `context` from `Expr` to `map<string, Expr>`, since it's required to be a record anyway.  This aligns with the format for entity attributes which is also `map<string, Expr>`.
2. in `PolicySet`, changes both `templates` and `links` from a (map from id to object) to (just a list of object), since the objects in question already contain the ids.  This makes the encoding faster and more compact.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
