### PR TITLE
add public API to get the valid request envs for a schema

### DIFF
--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -39,7 +39,8 @@ use crate::{
     cedar_schema::SchemaWarning,
     json_schema,
     partition_nonempty::PartitionNonEmpty,
-    types::{Attributes, EntityRecordKind, OpenTag, Type},
+    types::{Attributes, EntityRecordKind, OpenTag, RequestEnv, Type},
+    ValidationMode,
 };
 
 mod action;
@@ -269,6 +270,44 @@ impl ValidatorSchema {
         self.action_ids
             .get(action)
             .map(ValidatorActionId::resources)
+    }
+
+    /// Returns an iterator over every valid `RequestEnv` in the schema
+    pub fn unlinked_request_envs(
+        &self,
+        mode: ValidationMode,
+    ) -> impl Iterator<Item = RequestEnv<'_>> + '_ {
+        // Gather all of the actions declared in the schema.
+        let all_actions = self
+            .action_ids()
+            .filter_map(|a| self.get_action_id(a.name()));
+
+        // For every action compute the cross product of the principal and
+        // resource applies_to sets.
+        all_actions
+            .flat_map(|action| {
+                action.applies_to_principals().flat_map(|principal| {
+                    action
+                        .applies_to_resources()
+                        .map(|resource| RequestEnv::DeclaredAction {
+                            principal,
+                            action: &action.name,
+                            resource,
+                            context: &action.context,
+                            principal_slot: None,
+                            resource_slot: None,
+                        })
+                })
+            })
+            .chain(if mode.is_partial() {
+                // A partial schema might not list all actions, and may not
+                // include all principal and resource types for the listed ones.
+                // So we typecheck with a fully unknown request to handle these
+                // missing cases.
+                Some(RequestEnv::UndeclaredAction)
+            } else {
+                None
+            })
     }
 
     /// Returns an iterator over all the entity types that can be a parent of `ty`

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -277,14 +277,9 @@ impl ValidatorSchema {
         &self,
         mode: ValidationMode,
     ) -> impl Iterator<Item = RequestEnv<'_>> + '_ {
-        // Gather all of the actions declared in the schema.
-        let all_actions = self
-            .action_ids()
-            .filter_map(|a| self.get_action_id(a.name()));
-
         // For every action compute the cross product of the principal and
         // resource applies_to sets.
-        all_actions
+        self.action_ids()
             .flat_map(|action| {
                 action.applies_to_principals().flat_map(|principal| {
                     action

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -80,7 +80,7 @@ impl<'a> Typechecker<'a> {
             schema,
             extensions: ExtensionSchemas::all_available(),
             mode,
-            unlinked_envs: Self::unlinked_request_envs(schema, mode).collect(),
+            unlinked_envs: schema.unlinked_request_envs(mode).collect(),
         }
     }
 
@@ -199,43 +199,6 @@ impl<'a> Typechecker<'a> {
                 })
             })
             .collect()
-    }
-
-    fn unlinked_request_envs(
-        schema: &ValidatorSchema,
-        mode: ValidationMode,
-    ) -> impl Iterator<Item = RequestEnv<'_>> + '_ {
-        // Gather all of the actions declared in the schema.
-        let all_actions = schema
-            .action_ids()
-            .filter_map(|a| schema.get_action_id(a.name()));
-
-        // For every action compute the cross product of the principal and
-        // resource applies_to sets.
-        all_actions
-            .flat_map(|action| {
-                action.applies_to_principals().flat_map(|principal| {
-                    action
-                        .applies_to_resources()
-                        .map(|resource| RequestEnv::DeclaredAction {
-                            principal,
-                            action: &action.name,
-                            resource,
-                            context: &action.context,
-                            principal_slot: None,
-                            resource_slot: None,
-                        })
-                })
-            })
-            .chain(if mode.is_partial() {
-                // A partial schema might not list all actions, and may not
-                // include all principal and resource types for the listed ones.
-                // So we typecheck with a fully unknown request to handle these
-                // missing cases.
-                Some(RequestEnv::UndeclaredAction)
-            } else {
-                None
-            })
     }
 
     /// Given a request environment and a template, return new environments

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -33,6 +33,10 @@ Cedar Language Version: TBD
   to convert JSON formatted policies into the human-readable syntax.
 - Added `Validator::schema()` to get a reference to the `Schema` even after it has been
   consumed to construct a `Validator` (#1524)
+- Added `Schema::request_envs()` to get all of the `RequestEnv`s that are valid
+  according to the schema. (This joins the existing `Policy::get_valid_request_envs()`
+  and `Template::get_valid_request_envs()` that return the subset of request envs that
+  are valid for a particular policy or template.) (#1547)
 
 ## [4.3.3] - 2025-02-25
 


### PR DESCRIPTION
## Description of changes

We already had `Policy::get_valid_request_envs()` and `Template::get_valid_request_envs()`, but these return only the request envs in which a particular policy/template is not trivially false. (They also involve a bunch of typechecking work.)  This PR provides a public API to simply get all of the request envs for a schema.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
