### PR TITLE
[CLI] improve check-parse command

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -8,8 +8,10 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 ### Added
 
 - Added `json-to-cedar` direction to `translate-policy` command. (#1510, resolving #461)
-- Add `--level` option to the `validate` command, exposing the `level-validate`
+- Added `--level` option to the `validate` command, exposing the `level-validate`
   experimental feature through the CLI. (#1508, resolving #1501)
+- Improved the `check-parse` command, which now checks the parse of policies, schema,
+  and/or entities (whatever is passed). (#1548)
 
 ## 4.3.3
 


### PR DESCRIPTION
## Description of changes

Makes the improvements to CLI `check-parse` that were suggested in #415.  Specifically, allows the `check-parse` command to check the parse of policies, schema, and/or entities, whatever the user chooses to pass to the command.

For backwards compatibility, preserves the behavior that if no policies, schema, or entities are passed, `check-parse` will read policies from stdin and check that they parse.

## Issue #, if available

Fixes #415

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
