### PR TITLE
improve a schema parsing error message

### DIFF
--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -132,6 +132,20 @@ impl<'a> ExpectedErrorMessageBuilder<'a> {
         }
     }
 
+    /// Add expected underlined text. The error message will be expected to have
+    /// exactly this many miette labels, and for each label (a, b), the underlined
+    /// portion should be `a` and the label text should be `b` (or `None` for no
+    /// label text).
+    pub fn with_underlines_or_labels(
+        self,
+        labels: impl IntoIterator<Item = (&'a str, Option<&'a str>)>,
+    ) -> Self {
+        Self {
+            underlines: labels.into_iter().collect(),
+            ..self
+        }
+    }
+
     /// Add expected contents of `source()`, or expected prefix of `source()` if
     /// this builder was originally constructed with `error_starts_with()`
     pub fn source(self, msg: &'a str) -> Self {

--- a/cedar-policy-validator/src/cedar_schema/ast.rs
+++ b/cedar-policy-validator/src/cedar_schema/ast.rs
@@ -359,8 +359,8 @@ impl std::fmt::Display for PR {
 pub struct PRAppDecl {
     /// Is this constraining the `principal` or the `resource`
     pub kind: Node<PR>,
-    /// What entity types are allowed?
-    pub entity_tys: NonEmpty<Path>,
+    /// What entity types are allowed? `None` means none
+    pub entity_tys: Option<NonEmpty<Path>>,
 }
 
 /// A declaration of constraints on an action type

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -485,19 +485,39 @@ impl ToJsonSchemaError {
         })
     }
 
-    pub(crate) fn no_principal(name: &impl ToSmolStr, loc: Loc) -> Self {
+    pub(crate) fn no_principal(name: &impl ToSmolStr, name_loc: Loc) -> Self {
         Self::NoPrincipalOrResource(NoPrincipalOrResource {
             kind: PR::Principal,
             name: name.to_smolstr(),
-            loc,
+            missing_or_empty: MissingOrEmpty::Missing,
+            name_loc,
         })
     }
 
-    pub(crate) fn no_resource(name: &impl ToSmolStr, loc: Loc) -> Self {
+    pub(crate) fn no_resource(name: &impl ToSmolStr, name_loc: Loc) -> Self {
         Self::NoPrincipalOrResource(NoPrincipalOrResource {
             kind: PR::Resource,
             name: name.to_smolstr(),
-            loc,
+            missing_or_empty: MissingOrEmpty::Missing,
+            name_loc,
+        })
+    }
+
+    pub(crate) fn empty_principal(name: &impl ToSmolStr, name_loc: Loc, loc: Loc) -> Self {
+        Self::NoPrincipalOrResource(NoPrincipalOrResource {
+            kind: PR::Principal,
+            name: name.to_smolstr(),
+            missing_or_empty: MissingOrEmpty::Empty { loc },
+            name_loc,
+        })
+    }
+
+    pub(crate) fn empty_resource(name: &impl ToSmolStr, name_loc: Loc, loc: Loc) -> Self {
+        Self::NoPrincipalOrResource(NoPrincipalOrResource {
+            kind: PR::Resource,
+            name: name.to_smolstr(),
+            missing_or_empty: MissingOrEmpty::Empty { loc },
+            name_loc,
         })
     }
 
@@ -615,18 +635,57 @@ impl Diagnostic for DuplicateDeclarations {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("missing `{kind}` declaration for `{name}`")]
+#[error("{}", match .missing_or_empty {
+    MissingOrEmpty::Missing => format!("missing `{kind}` declaration for `{name}`"),
+    MissingOrEmpty::Empty { .. } => format!("for action `{name}`, `{kind}` is `[]`, which is invalid")
+})]
 pub struct NoPrincipalOrResource {
     kind: PR,
     name: SmolStr,
-    loc: Loc,
+    missing_or_empty: MissingOrEmpty,
+    /// Loc of the action name
+    name_loc: Loc,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum MissingOrEmpty {
+    /// The declaration was entirely missing
+    Missing,
+    /// The declaration was present but defined as `[]`
+    Empty {
+        /// `Loc` of the declaration
+        loc: Loc,
+    },
 }
 
 pub const NO_PR_HELP_MSG: &str =
-    "Every action must define both `principal` and `resource` targets.";
+    "Every action must define both `principal` and `resource` targets, and the `principal` and `resource` lists must not be `[]`.";
 
 impl Diagnostic for NoPrincipalOrResource {
-    impl_diagnostic_from_source_loc_field!(loc);
+    fn source_code(&self) -> Option<&dyn miette::SourceCode> {
+        Some(&self.name_loc.src as &dyn miette::SourceCode)
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
+        match &self.missing_or_empty {
+            MissingOrEmpty::Missing => {
+                // just the action name
+                Some(Box::new(std::iter::once(miette::LabeledSpan::underline(
+                    self.name_loc.span,
+                ))))
+            }
+            MissingOrEmpty::Empty { loc } => {
+                // also underline the bad declaration
+                let action_name = miette::LabeledSpan::new_with_span(
+                    Some("for this action".into()),
+                    self.name_loc.span,
+                );
+                let decl =
+                    miette::LabeledSpan::new_with_span(Some("must not be `[]`".into()), loc.span);
+                Some(Box::new([action_name, decl].into_iter()))
+            }
+        }
+    }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(NO_PR_HELP_MSG))

--- a/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
@@ -157,24 +157,20 @@ TypeDecl: Node<Declaration> = {
 // AppDecls := ('principal' | 'resource') ':' EntTypes [',' | ',' AppDecls]
 //          | 'context' ':' (Path | RecType) [',' | ',' AppDecls]
 AppDecls: Node<NonEmpty<Node<AppDecl>>> = {
-    <l:@L> <pr: PrincipalOrResource> ":" <ets:EntTypes> ","? <r:@R>
-        =>?
-                NonEmpty::collect(ets.into_iter()).ok_or(ParseError::User {
-                    error: UserError::EmptyList(Node::with_source_loc((), Loc::new(l..r, Arc::clone(src))))})
-                    .map(|ets|
-                        Node::with_source_loc(
-                            nonempty![Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys: ets}), Loc::new(l..r, Arc::clone(src)))],
-                            Loc::new(l..r, Arc::clone(src)))),
-    <l:@L> <pr: PrincipalOrResource> ":" <ets:EntTypes> "," <r:@R> <mut ds: AppDecls>
-        =>?
-                NonEmpty::collect(ets.into_iter()).ok_or(ParseError::User {
-                    error: UserError::EmptyList(Node::with_source_loc((), Loc::new(l..r, Arc::clone(src))))})
-                    .map(|ets|
-                        {
-                            let (mut ds, _) = ds.into_inner();
-                            ds.insert(0, Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys: ets}), Loc::new(l..r, Arc::clone(src))));
-                            Node::with_source_loc(ds, Loc::new(l..r, Arc::clone(src)))
-                        }),
+    <l:@L> <pr: PrincipalOrResource> ":" <ets:EntTypes> <r:@R> ","?
+        => {
+            let entity_tys: Option<NonEmpty<Path>> = NonEmpty::collect(ets.into_iter());
+            Node::with_source_loc(
+                nonempty![Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys }), Loc::new(l..r, Arc::clone(src)))],
+                Loc::new(l..r, Arc::clone(src)))
+        },
+    <l:@L> <pr: PrincipalOrResource> ":" <ets:EntTypes> <r:@R> "," <mut ds: AppDecls>
+        => {
+            let (mut ds, _) = ds.into_inner();
+            let entity_tys: Option<NonEmpty<Path>> = NonEmpty::collect(ets.into_iter());
+            ds.insert(0, Node::with_source_loc(AppDecl::PR(PRAppDecl { kind:pr, entity_tys }), Loc::new(l..r, Arc::clone(src))));
+            Node::with_source_loc(ds, Loc::new(l..r, Arc::clone(src)))
+        },
     <l:@L> CONTEXT ":" <p:Path> ","? <r:@R>
         =>  Node::with_source_loc(
                 nonempty![Node::with_source_loc(AppDecl::Context(Either::Left(p)), Loc::new(l..r, Arc::clone(src)))],

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -311,12 +311,19 @@ fn convert_app_decls(
                     )
                     .into());
                 }
-                None => {
-                    principal_types = Some(Node::with_source_loc(
-                        entity_tys.iter().map(|n| n.clone().into()).collect(),
-                        loc,
-                    ))
-                }
+                None => match entity_tys {
+                    None => {
+                        return Err(
+                            ToJsonSchemaError::empty_principal(name, name_loc.clone(), loc).into(),
+                        )
+                    }
+                    Some(entity_tys) => {
+                        principal_types = Some(Node::with_source_loc(
+                            entity_tys.iter().map(|n| n.clone().into()).collect(),
+                            loc,
+                        ))
+                    }
+                },
             },
             Node {
                 node:
@@ -334,12 +341,19 @@ fn convert_app_decls(
                         ToJsonSchemaError::duplicate_resource(name, existing_tys.loc, loc).into(),
                     );
                 }
-                None => {
-                    resource_types = Some(Node::with_source_loc(
-                        entity_tys.iter().map(|n| n.clone().into()).collect(),
-                        loc,
-                    ))
-                }
+                None => match entity_tys {
+                    None => {
+                        return Err(
+                            ToJsonSchemaError::empty_resource(name, name_loc.clone(), loc).into(),
+                        )
+                    }
+                    Some(entity_tys) => {
+                        resource_types = Some(Node::with_source_loc(
+                            entity_tys.iter().map(|n| n.clone().into()).collect(),
+                            loc,
+                        ))
+                    }
+                },
             },
         }
     }


### PR DESCRIPTION
## Description of changes

Improves the schema parsing error message which #1335 is complaining about.  Combined with previous improvements which give a source location for this error, this PR's improvements to the error message text and labels close off #1335.

## Issue #, if available

Fixes #1335

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
