### PR TITLE
relax trait bounds on structs and enums where possible

### DIFF
--- a/cedar-policy-core/src/entities/conformance.rs
+++ b/cedar-policy-core/src/entities/conformance.rs
@@ -32,19 +32,21 @@ use err::{EntitySchemaConformanceError, InvalidEnumEntityError, UnexpectedEntity
 
 /// Struct used to check whether entities conform to a schema
 #[derive(Debug, Clone)]
-pub struct EntitySchemaConformanceChecker<'a, S: Schema> {
+pub struct EntitySchemaConformanceChecker<'a, S> {
     /// Schema to check conformance with
     schema: &'a S,
     /// Extensions which are active for the conformance checks
     extensions: &'a Extensions<'a>,
 }
 
-impl<'a, S: Schema> EntitySchemaConformanceChecker<'a, S> {
+impl<'a, S> EntitySchemaConformanceChecker<'a, S> {
     /// Create a new checker
     pub fn new(schema: &'a S, extensions: &'a Extensions<'a>) -> Self {
         Self { schema, extensions }
     }
+}
 
+impl<S: Schema> EntitySchemaConformanceChecker<'_, S> {
     /// Validate an entity against the schema, returning an
     /// [`EntitySchemaConformanceError`] if it does not comply.
     pub fn validate_entity(&self, entity: &Entity) -> Result<(), EntitySchemaConformanceError> {

--- a/cedar-policy-core/src/entities/json/context.rs
+++ b/cedar-policy-core/src/entities/json/context.rs
@@ -44,7 +44,7 @@ impl ContextSchema for NullContextSchema {
 
 /// Struct used to parse context from JSON.
 #[derive(Debug, Clone)]
-pub struct ContextJsonParser<'e, 's, S: ContextSchema = NullContextSchema> {
+pub struct ContextJsonParser<'e, 's, S = NullContextSchema> {
     /// If a `schema` is present, this will inform the parsing: for instance, it
     /// will allow `__entity` and `__extn` escapes to be implicit.
     /// It will also ensure that the produced `Context` fully conforms to the
@@ -57,7 +57,7 @@ pub struct ContextJsonParser<'e, 's, S: ContextSchema = NullContextSchema> {
     extensions: &'e Extensions<'e>,
 }
 
-impl<'e, 's, S: ContextSchema> ContextJsonParser<'e, 's, S> {
+impl<'e, 's, S> ContextJsonParser<'e, 's, S> {
     /// Create a new `ContextJsonParser`.
     ///
     /// If a `schema` is present, this will inform the parsing: for instance, it
@@ -69,7 +69,9 @@ impl<'e, 's, S: ContextSchema> ContextJsonParser<'e, 's, S> {
     pub fn new(schema: Option<&'s S>, extensions: &'e Extensions<'e>) -> Self {
         Self { schema, extensions }
     }
+}
 
+impl<S: ContextSchema> ContextJsonParser<'_, '_, S> {
     /// Parse context JSON (in `&str` form) into a `Context` object
     pub fn from_json_str(&self, json: &str) -> Result<Context, ContextJsonDeserializationError> {
         let val =

--- a/cedar-policy-core/src/entities/json/entities.rs
+++ b/cedar-policy-core/src/entities/json/entities.rs
@@ -69,7 +69,7 @@ pub struct EntityJson {
 
 /// Struct used to parse entities from JSON.
 #[derive(Debug, Clone)]
-pub struct EntityJsonParser<'e, 's, S: Schema = NoEntitiesSchema> {
+pub struct EntityJsonParser<'e, 's, S = NoEntitiesSchema> {
     /// See comments on [`EntityJsonParser::new()`] for the interpretation and
     /// effects of this `schema` field.
     ///
@@ -87,7 +87,7 @@ pub struct EntityJsonParser<'e, 's, S: Schema = NoEntitiesSchema> {
 
 /// Schema information about a single entity can take one of these forms:
 #[derive(Debug)]
-enum EntitySchemaInfo<E: EntityTypeDescription> {
+enum EntitySchemaInfo<E> {
     /// There is no schema, i.e. we're not doing schema-based parsing. We don't
     /// have attribute type information in the schema for action entities, so
     /// these are also parsed without schema-based parsing.
@@ -97,7 +97,7 @@ enum EntitySchemaInfo<E: EntityTypeDescription> {
     NonAction(E),
 }
 
-impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
+impl<'e, 's, S> EntityJsonParser<'e, 's, S> {
     /// Create a new `EntityJsonParser`.
     ///
     /// `schema` represents a source of `Action` entities, which will be added
@@ -128,7 +128,9 @@ impl<'e, 's, S: Schema> EntityJsonParser<'e, 's, S> {
             tc_computation,
         }
     }
+}
 
+impl<S: Schema> EntityJsonParser<'_, '_, S> {
     /// Parse an entities JSON file (in [`&str`] form) into an [`Entities`] object.
     ///
     /// If the `EntityJsonParser` has a `schema`, this also adds `Action`

--- a/cedar-policy-core/src/transitive_closure/err.rs
+++ b/cedar-policy-core/src/transitive_closure/err.rs
@@ -51,7 +51,7 @@ impl<K: Debug + Display> TcError<K> {
 /// Error raised when `TCComputation::EnforceAlreadyComputed` finds that the
 /// TC was in fact not already computed
 #[derive(Debug, PartialEq, Eq)]
-pub struct MissingTcEdge<K: Debug + Display> {
+pub struct MissingTcEdge<K> {
     child: K,
     parent: K,
     grandparent: K,
@@ -59,12 +59,12 @@ pub struct MissingTcEdge<K: Debug + Display> {
 
 /// Error raised when enforce_dag finds that the graph is not a DAG
 #[derive(Debug, PartialEq, Eq)]
-pub struct HasCycle<K: Debug + Display> {
+pub struct HasCycle<K> {
     /// Because DAG enforcement can only be called after compute_tc/enforce_tc, a cycle will manifest as a vertex with a loop
     vertex_with_loop: K,
 }
 
-impl<K: Debug + Display> HasCycle<K> {
+impl<K> HasCycle<K> {
     /// Graph vertex that contained a loop
     pub fn vertex_with_loop(&self) -> &K {
         &self.vertex_with_loop


### PR DESCRIPTION
## Description of changes

For some reasoning why this is a good idea, see [this post](https://stackoverflow.com/questions/49229332/should-trait-bounds-be-duplicated-in-struct-and-impl/66369912#66369912). 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
