### PR TITLE
add `AsRef` impls to a bunch of public-api types

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -91,6 +91,13 @@ pub(crate) mod version {
 #[derive(Debug, Clone, PartialEq, Eq, RefCast, Hash)]
 pub struct Entity(pub(crate) ast::Entity);
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Entity> for Entity {
+    fn as_ref(&self) -> &ast::Entity {
+        &self.0
+    }
+}
+
 impl Entity {
     /// Create a new `Entity` with this Uid, attributes, and parents (and no tags).
     ///
@@ -347,6 +354,13 @@ impl std::fmt::Display for Entity {
 #[repr(transparent)]
 #[derive(Debug, Clone, Default, PartialEq, Eq, RefCast)]
 pub struct Entities(pub(crate) cedar_policy_core::entities::Entities);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<cedar_policy_core::entities::Entities> for Entities {
+    fn as_ref(&self) -> &cedar_policy_core::entities::Entities {
+        &self.0
+    }
+}
 
 use entities_errors::EntitiesError;
 
@@ -818,6 +832,13 @@ impl IntoIterator for Entities {
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
 pub struct Authorizer(authorizer::Authorizer);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<authorizer::Authorizer> for Authorizer {
+    fn as_ref(&self) -> &authorizer::Authorizer {
+        &self.0
+    }
+}
 
 impl Default for Authorizer {
     fn default() -> Self {
@@ -1311,6 +1332,13 @@ impl From<ValidationMode> for cedar_policy_validator::ValidationMode {
 #[derive(Debug, Clone, RefCast)]
 pub struct Validator(cedar_policy_validator::Validator);
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<cedar_policy_validator::Validator> for Validator {
+    fn as_ref(&self) -> &cedar_policy_validator::Validator {
+        &self.0
+    }
+}
+
 impl Validator {
     /// Construct a new `Validator` to validate policies using the given
     /// `Schema`.
@@ -1364,6 +1392,25 @@ pub struct SchemaFragment {
         cedar_policy_validator::ConditionalName,
     >,
     lossless: cedar_policy_validator::json_schema::Fragment<cedar_policy_validator::RawName>,
+}
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl
+    AsRef<
+        cedar_policy_validator::ValidatorSchemaFragment<
+            cedar_policy_validator::ConditionalName,
+            cedar_policy_validator::ConditionalName,
+        >,
+    > for SchemaFragment
+{
+    fn as_ref(
+        &self,
+    ) -> &cedar_policy_validator::ValidatorSchemaFragment<
+        cedar_policy_validator::ConditionalName,
+        cedar_policy_validator::ConditionalName,
+    > {
+        &self.value
+    }
 }
 
 fn get_annotation_by_key(
@@ -1508,7 +1555,7 @@ impl SchemaFragment {
         let ns_def = self.lossless.0.get(&namespace.map(|n| n.0))?;
         ns_def
             .actions
-            .get(id.as_ref())
+            .get(<EntityId as AsRef<str>>::as_ref(id))
             .map(|a| annotations_to_pairs(&a.annotations))
     }
 
@@ -1527,7 +1574,10 @@ impl SchemaFragment {
     ) -> Option<&str> {
         let ns_def = self.lossless.0.get(&namespace.map(|n| n.0))?;
         get_annotation_by_key(
-            &ns_def.actions.get(id.as_ref())?.annotations,
+            &ns_def
+                .actions
+                .get(<EntityId as AsRef<str>>::as_ref(id))?
+                .annotations,
             annotation_key,
         )
     }
@@ -1669,6 +1719,13 @@ impl FromStr for SchemaFragment {
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
 pub struct Schema(pub(crate) cedar_policy_validator::ValidatorSchema);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<cedar_policy_validator::ValidatorSchema> for Schema {
+    fn as_ref(&self) -> &cedar_policy_validator::ValidatorSchema {
+        &self.0
+    }
+}
 
 impl FromStr for Schema {
     type Err = CedarSchemaError;
@@ -2060,6 +2117,13 @@ pub fn confusable_string_checker<'a>(
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct EntityNamespace(pub(crate) ast::Name);
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Name> for EntityNamespace {
+    fn as_ref(&self) -> &ast::Name {
+        &self.0
+    }
+}
+
 /// This `FromStr` implementation requires the _normalized_ representation of the
 /// namespace. See <https://github.com/cedar-policy/rfcs/pull/9/>.
 impl FromStr for EntityNamespace {
@@ -2097,6 +2161,13 @@ impl PartialEq for PolicySet {
     }
 }
 impl Eq for PolicySet {}
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::PolicySet> for PolicySet {
+    fn as_ref(&self) -> &ast::PolicySet {
+        &self.ast
+    }
+}
 
 impl FromStr for PolicySet {
     type Err = ParseErrors;
@@ -2784,6 +2855,13 @@ impl PartialEq for Template {
 }
 impl Eq for Template {}
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Template> for Template {
+    fn as_ref(&self) -> &ast::Template {
+        &self.ast
+    }
+}
+
 impl Template {
     /// Attempt to parse a [`Template`] from source.
     /// Returns an error if the input is a static policy (i.e., has no slots).
@@ -3118,6 +3196,13 @@ impl PartialEq for Policy {
     }
 }
 impl Eq for Policy {}
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Policy> for Policy {
+    fn as_ref(&self) -> &ast::Policy {
+        &self.ast
+    }
+}
 
 impl Policy {
     /// Get the `PolicyId` of the `Template` this is linked to.
@@ -3639,6 +3724,13 @@ impl std::fmt::Display for LosslessPolicy {
 #[derive(Debug, Clone, RefCast)]
 pub struct Expression(pub(crate) ast::Expr);
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Expr> for Expression {
+    fn as_ref(&self) -> &ast::Expr {
+        &self.0
+    }
+}
+
 impl Expression {
     /// Create an expression representing a literal string.
     pub fn new_string(value: String) -> Self {
@@ -3732,6 +3824,13 @@ impl FromStr for Expression {
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
 pub struct RestrictedExpression(ast::RestrictedExpr);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::RestrictedExpr> for RestrictedExpression {
+    fn as_ref(&self) -> &ast::RestrictedExpr {
+        &self.0
+    }
+}
 
 impl RestrictedExpression {
     /// Create an expression representing a literal string.
@@ -3990,6 +4089,13 @@ impl RequestBuilder<&Schema> {
 #[derive(Debug, Clone, RefCast)]
 pub struct Request(pub(crate) ast::Request);
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Request> for Request {
+    fn as_ref(&self) -> &ast::Request {
+        &self.0
+    }
+}
+
 impl Request {
     /// Create a [`RequestBuilder`]
     #[doc = include_str!("../experimental_warning.md")]
@@ -4065,6 +4171,13 @@ impl Request {
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
 pub struct Context(ast::Context);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Context> for Context {
+    fn as_ref(&self) -> &ast::Context {
+        &self.0
+    }
+}
 
 impl Context {
     /// Create an empty `Context`

--- a/cedar-policy/src/api/id.rs
+++ b/cedar-policy/src/api/id.rs
@@ -38,7 +38,7 @@ use std::str::FromStr;
 /// ```
 /// # use cedar_policy::EntityId;
 /// let id : EntityId = "my-id".parse().unwrap_or_else(|never| match never {});
-/// # assert_eq!(id.as_ref(), "my-id");
+/// # assert_eq!(<EntityId as AsRef<str>>::as_ref(&id), "my-id");
 /// ```
 ///
 /// `EntityId` does not implement `Display`, partly because it is unclear
@@ -50,6 +50,13 @@ use std::str::FromStr;
 #[allow(clippy::module_name_repetitions)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
 pub struct EntityId(ast::Eid);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::Eid> for EntityId {
+    fn as_ref(&self) -> &ast::Eid {
+        &self.0
+    }
+}
 
 impl EntityId {
     /// Construct an [`EntityId`] from a source string
@@ -96,6 +103,13 @@ impl AsRef<str> for EntityId {
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
 pub struct EntityTypeName(pub(crate) ast::EntityType);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::EntityType> for EntityTypeName {
+    fn as_ref(&self) -> &ast::EntityType {
+        &self.0
+    }
+}
 
 impl EntityTypeName {
     /// Get the basename of the `EntityTypeName` (ie, with namespaces stripped).
@@ -177,6 +191,13 @@ impl From<ast::EntityType> for EntityTypeName {
 #[repr(transparent)]
 #[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, RefCast)]
 pub struct EntityUid(pub(crate) ast::EntityUID);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::EntityUID> for EntityUid {
+    fn as_ref(&self) -> &ast::EntityUID {
+        &self.0
+    }
+}
 
 impl EntityUid {
     /// Returns the portion of the Euid that represents namespace and entity type
@@ -288,13 +309,6 @@ impl std::fmt::Display for EntityUid {
 }
 
 #[doc(hidden)]
-impl AsRef<ast::EntityUID> for EntityUid {
-    fn as_ref(&self) -> &ast::EntityUID {
-        &self.0
-    }
-}
-
-#[doc(hidden)]
 impl From<EntityUid> for ast::EntityUID {
     fn from(uid: EntityUid) -> Self {
         uid.0
@@ -327,6 +341,13 @@ impl From<ast::EntityUID> for EntityUid {
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PolicyId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] ast::PolicyID);
 
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::PolicyID> for PolicyId {
+    fn as_ref(&self) -> &ast::PolicyID {
+        &self.0
+    }
+}
+
 impl PolicyId {
     /// Construct a [`PolicyId`] from a source string
     pub fn new(id: impl AsRef<str>) -> Self {
@@ -356,13 +377,6 @@ impl AsRef<str> for PolicyId {
 }
 
 #[doc(hidden)]
-impl AsRef<ast::PolicyID> for PolicyId {
-    fn as_ref(&self) -> &ast::PolicyID {
-        &self.0
-    }
-}
-
-#[doc(hidden)]
 impl From<PolicyId> for ast::PolicyID {
     fn from(uid: PolicyId) -> Self {
         uid.0
@@ -376,6 +390,13 @@ impl From<PolicyId> for ast::PolicyID {
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct SlotId(#[cfg_attr(feature = "wasm", tsify(type = "string"))] ast::SlotId);
+
+#[doc(hidden)] // because this converts to a private/internal type
+impl AsRef<ast::SlotId> for SlotId {
+    fn as_ref(&self) -> &ast::SlotId {
+        &self.0
+    }
+}
 
 impl SlotId {
     /// Get the slot for `principal`

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -36,7 +36,7 @@ mod entity_uid_tests {
         let entity_type_name = EntityTypeName::from_str("Chess::Master")
             .expect("failed at constructing EntityTypeName");
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
-        assert_eq!(euid.id().as_ref(), "bobby");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(euid.id()), "bobby");
         assert_eq!(euid.type_name().to_string(), "Chess::Master");
         assert_eq!(euid.type_name().basename(), "Master");
         assert_eq!(euid.type_name().namespace(), "Chess");
@@ -50,7 +50,7 @@ mod entity_uid_tests {
         let entity_type_name =
             EntityTypeName::from_str("User").expect("failed at constructing EntityTypeName");
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
-        assert_eq!(euid.id().as_ref(), "bobby");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(euid.id()), "bobby");
         assert_eq!(euid.type_name().to_string(), "User");
         assert_eq!(euid.type_name().basename(), "User");
         assert_eq!(euid.type_name().namespace(), String::new());
@@ -64,7 +64,7 @@ mod entity_uid_tests {
         let entity_type_name = EntityTypeName::from_str("A::B::C::D::Z")
             .expect("failed at constructing EntityTypeName");
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
-        assert_eq!(euid.id().as_ref(), "bobby");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(euid.id()), "bobby");
         assert_eq!(euid.type_name().to_string(), "A::B::C::D::Z");
         assert_eq!(euid.type_name().basename(), "Z");
         assert_eq!(euid.type_name().namespace(), "A::B::C::D");
@@ -82,7 +82,10 @@ mod entity_uid_tests {
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
         // these are passed through (no escape interpretation):
         //   the EntityId has the literal backslash characters in it
-        assert_eq!(euid.id().as_ref(), r"bobby\'s sister:\nVeronica");
+        assert_eq!(
+            <EntityId as AsRef<str>>::as_ref(euid.id()),
+            r"bobby\'s sister:\nVeronica"
+        );
         assert_eq!(euid.type_name().to_string(), "Hockey::Master");
         assert_eq!(euid.type_name().basename(), "Master");
         assert_eq!(euid.type_name().namespace(), "Hockey");
@@ -99,7 +102,10 @@ mod entity_uid_tests {
             EntityTypeName::from_str("Test::User").expect("failed at constructing EntityTypeName");
         let euid = EntityUid::from_type_name_and_id(entity_type_name, entity_id);
         // the backslashes appear the same way in the EntityId
-        assert_eq!(euid.id().as_ref(), r#"\ \a \b \' \" \\"#);
+        assert_eq!(
+            <EntityId as AsRef<str>>::as_ref(euid.id()),
+            r#"\ \a \b \' \" \\"#
+        );
         assert_eq!(euid.type_name().to_string(), "Test::User");
     }
 
@@ -112,7 +118,10 @@ mod entity_uid_tests {
         );
         // EntityId is passed through (no escape interpretation):
         //   the EntityId has all the same literal characters in it
-        assert_eq!(euid.id().as_ref(), r#"b'ob"by\'s sis\"ter"#);
+        assert_eq!(
+            <EntityId as AsRef<str>>::as_ref(euid.id()),
+            r#"b'ob"by\'s sis\"ter"#
+        );
         assert_eq!(euid.type_name().to_string(), r"Test::User");
     }
 
@@ -130,7 +139,10 @@ mod entity_uid_tests {
         let PrincipalConstraint::Eq(euid) = policy.principal_constraint() else {
             panic!("expected `Eq` constraint");
         };
-        assert_eq!(euid.id().as_ref(), " hi there are spaces ");
+        assert_eq!(
+            <EntityId as AsRef<str>>::as_ref(euid.id()),
+            " hi there are spaces "
+        );
         assert_eq!(euid.type_name().to_string(), "A::B::C"); // expect to have been normalized
         assert_eq!(euid.type_name().basename(), "C");
         assert_eq!(euid.type_name().namespace(), "A::B");
@@ -150,7 +162,7 @@ permit(principal ==  A :: B
             panic!("expected `Eq` constraint")
         };
         assert_eq!(
-            euid.id().as_ref(),
+            <EntityId as AsRef<str>>::as_ref(euid.id()),
             " hi there are\n    spaces and\n    newlines "
         );
         assert_eq!(euid.type_name().to_string(), "A::B::C::D"); // expect to have been normalized
@@ -179,7 +191,7 @@ permit(principal ==  A :: B
     #[test]
     fn parse_euid() {
         let parsed_eid: EntityUid = r#"Test::User::"bobby""#.parse().expect("Failed to parse");
-        assert_eq!(parsed_eid.id().as_ref(), r"bobby");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(parsed_eid.id()), r"bobby");
         assert_eq!(parsed_eid.type_name().to_string(), r"Test::User");
     }
 
@@ -190,7 +202,10 @@ permit(principal ==  A :: B
         let parsed_eid: EntityUid = r#"Test::User::"b\'ob\"by""#.parse().expect("Failed to parse");
         // the escapes were interpreted:
         //   the EntityId has single-quote and double-quote characters (but no backslash characters)
-        assert_eq!(parsed_eid.id().as_ref(), r#"b'ob"by"#);
+        assert_eq!(
+            <EntityId as AsRef<str>>::as_ref(parsed_eid.id()),
+            r#"b'ob"by"#
+        );
         assert_eq!(parsed_eid.type_name().to_string(), r"Test::User");
     }
 
@@ -208,7 +223,10 @@ permit(principal ==  A :: B
         };
         // the escape was interpreted:
         //   the EntityId has both single-quote characters (but no backslash characters)
-        assert_eq!(parsed_euid.id().as_ref(), r"b'obby's sister");
+        assert_eq!(
+            <EntityId as AsRef<str>>::as_ref(parsed_euid.id()),
+            r"b'obby's sister"
+        );
         assert_eq!(parsed_euid.type_name().to_string(), r"Test::User");
     }
 
@@ -223,7 +241,7 @@ permit(principal ==  A :: B
         let PrincipalConstraint::Eq(parsed_euid) = policy.principal_constraint() else {
             panic!("Expected an Eq constraint");
         };
-        assert_eq!(parsed_euid.id().as_ref(), "hi");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(parsed_euid.id()), "hi");
         assert_eq!(parsed_euid.type_name().to_string(), "A::B::C::D::E"); // expect to have been normalized
         assert_eq!(parsed_euid.type_name().basename(), "E");
         assert_eq!(parsed_euid.type_name().namespace(), "A::B::C::D");
@@ -234,11 +252,11 @@ permit(principal ==  A :: B
     #[test]
     fn euid_roundtrip() {
         let parsed_euid: EntityUid = r#"Test::User::"b\'ob""#.parse().expect("Failed to parse");
-        assert_eq!(parsed_euid.id().as_ref(), r"b'ob");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(parsed_euid.id()), r"b'ob");
         let reparsed: EntityUid = format!("{parsed_euid}")
             .parse()
             .expect("failed to roundtrip");
-        assert_eq!(reparsed.id().as_ref(), r"b'ob");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(reparsed.id()), r"b'ob");
     }
 }
 
@@ -250,7 +268,7 @@ mod scope_constraints_tests {
         let p = Policy::from_str("permit(principal,action,resource);").unwrap();
         assert_eq!(p.principal_constraint(), PrincipalConstraint::Any);
         let euid = EntityUid::from_strs("T", "a");
-        assert_eq!(euid.id().as_ref(), "a");
+        assert_eq!(<EntityId as AsRef<str>>::as_ref(euid.id()), "a");
         assert_eq!(
             euid.type_name(),
             &EntityTypeName::from_str("T").expect("Failed to parse EntityTypeName")


### PR DESCRIPTION
## Description of changes

Adds `AsRef` impls to a bunch of public-api types, that convert into the corresponding Core/Validator types.  This is possibly controversial because it could allow folks to peek behind our abstraction layer and get at the (internal, unstable) Core/Validator types.  However, I claim this PR is at least worth consideration because:

- I guarded all of these with `doc(hidden)` so they won't show in the docs -- you have to know they're there or read the code
- The reverse transformations for most of these are already publicly available via the `RefCast` trait (which even appears in the docs! it's not `doc(hidden)`
- Transforming between the public types and the Core/Validator types is already possible with the public Protobuf API, by converting to the appropriate `proto::model` type and back, since we have public conversions from (eg) `Policy` to/from `model::Policy` to/from `ast::Policy`.  This PR just makes that more official and much more efficient than going via the `proto::model` types.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
