### PR TITLE
add a proto conversion which was missed earlier

### DIFF
--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -39,6 +39,7 @@ macro_rules! standard_conversions {
 // standard conversions
 
 standard_conversions!(api::Entity, api::Entity, models::Entity);
+standard_conversions!(api::EntityUid, api::EntityUid, models::EntityUid);
 standard_conversions!(api::Entities, api::Entities, models::Entities);
 standard_conversions!(api::Schema, api::Schema, models::Schema);
 standard_conversions!(api::EntityTypeName, api::EntityTypeName, models::Name);


### PR DESCRIPTION
## Description of changes

We missed adding conversions from `api::EntityUid` to/from `proto::models::EntityUid`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
