### PR TITLE
Add unknown_entities method to PartialResponse

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -26,6 +26,7 @@ Cedar Language Version: TBD
   edge cases, policies that previously failed to validate under strict validation
   will now pass validation, probably with an `ImpossiblePolicy` warning. (#1355,
   resolving #638)
+- Added `PartialResponse::unknown_entities` method (#1557)
 
 ### Added
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1059,6 +1059,15 @@ impl PartialResponse {
         self.0.all_residuals().map(Policy::from_ast)
     }
 
+    /// Returns all unknown entities during the evaluation of the response
+    pub fn unknown_entities(&self) -> HashSet<EntityUid> {
+        let mut entity_uids = HashSet::new();
+        for policy in self.0.all_residuals() {
+            entity_uids.extend(policy.unknown_entities().into_iter().map(Into::into));
+        }
+        entity_uids
+    }
+
     /// Return the residual for a given [`PolicyId`], if it exists in the response
     pub fn get(&self, id: &PolicyId) -> Option<Policy> {
         self.0.get(id.as_ref()).map(Policy::from_ast)
@@ -3569,20 +3578,9 @@ impl Policy {
     #[cfg(feature = "partial-eval")]
     pub fn unknown_entities(&self) -> HashSet<EntityUid> {
         self.ast
-            .condition()
-            .unknowns()
-            .filter_map(
-                |ast::Unknown {
-                     name,
-                     type_annotation,
-                 }| {
-                    if matches!(type_annotation, Some(ast::Type::Entity { .. })) {
-                        EntityUid::from_str(name.as_str()).ok()
-                    } else {
-                        None
-                    }
-                },
-            )
+            .unknown_entities()
+            .into_iter()
+            .map(Into::into)
             .collect()
     }
 


### PR DESCRIPTION
Introduces unknown_entities method to the PartialResponse.

## Description of changes

Introduces a method  `uknown_entities` on the `PartialResponse`.
During partial evaluation, knowing unknown entity ids can help clients to fetch the missing entities
and run the evaluation again.

This is achievable using the existing code via:
```rust
    let unknowns = partial_response
        .all_residuals()
        .fold(HashSet::new(), |mut unknowns, p| {
            unknowns.extend(p.unknown_entities().into_iter());
            unknowns
        });

```

Unfortunately this is slow for large policy sets due to `Policy::from_ast` [relying on pretty printing.](https://github.com/cedar-policy/cedar/blob/5dd810be8cf74cf71500f4c2723751a66ff51f34/cedar-policy/src/api.rs#L3599)

so calling that in a loop  doing entity discovery is just very expensive.

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
