### PR TITLE
Add `Entities::len` and `Entities::is_empty`

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -260,7 +260,7 @@ impl Entities {
 
     /// Returns `true` if the `Entities` object is empty
     pub fn is_empty(&self) -> bool {
-        self.entities.len() == 0
+        self.entities.is_empty()
     }
 
     /// Convert an `Entities` object into a JSON value suitable for parsing in

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -258,6 +258,11 @@ impl Entities {
         self.entities.len()
     }
 
+    /// Returns `true` if the `Entities` object is empty
+    pub fn is_empty(&self) -> bool {
+        self.entities.len() == 0
+    }
+
     /// Convert an `Entities` object into a JSON value suitable for parsing in
     /// via `EntityJsonParser`.
     ///
@@ -2096,6 +2101,20 @@ mod entities_tests {
         )
         .expect("Failed to construct entities");
         assert_eq!(es.len(), 4);
+        assert!(!es.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let es = Entities::from_entities(
+            vec![],
+            None::<&NoEntitiesSchema>,
+            TCComputation::ComputeNow,
+            Extensions::all_available(),
+        )
+        .expect("Failed to construct entities");
+        assert_eq!(es.len(), 0);
+        assert!(es.is_empty());
     }
 
     #[test]

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -253,6 +253,11 @@ impl Entities {
         })
     }
 
+    /// Returns the length of the `Entities` object
+    pub fn len(&self) -> usize {
+        self.entities.len()
+    }
+
     /// Convert an `Entities` object into a JSON value suitable for parsing in
     /// via `EntityJsonParser`.
     ///
@@ -2077,6 +2082,20 @@ mod entities_tests {
             Entity::with_uid(EntityUID::with_eid("test_resource")),
             Entity::with_uid(EntityUID::with_eid("test")),
         )
+    }
+
+    #[test]
+    fn test_len() {
+        let (e0, e1, e2, e3) = test_entities();
+        let v = vec![e0.clone(), e1.clone(), e2.clone(), e3.clone()];
+        let es = Entities::from_entities(
+            v,
+            None::<&NoEntitiesSchema>,
+            TCComputation::ComputeNow,
+            Extensions::all_available(),
+        )
+        .expect("Failed to construct entities");
+        assert_eq!(es.len(), 4);
     }
 
     #[test]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -26,7 +26,6 @@ Cedar Language Version: TBD
   edge cases, policies that previously failed to validate under strict validation
   will now pass validation, probably with an `ImpossiblePolicy` warning. (#1355,
   resolving #638)
-- Added `PartialResponse::unknown_entities` method (#1557)
 
 ### Added
 
@@ -45,6 +44,8 @@ Cedar Language Version: TBD
   are valid for a particular policy or template.) (#1547)
 - Added `EntityId::unescaped()`, analogous to `EntityId::escaped()`. This is simply an
   alias for `EntityId::as_ref()` with the `AsRef` impl that produces `&str`. (#1555)
+- Added `PartialResponse::unknown_entities` method (#1557)
+- Added `Entities::num_of_entities` method (#1562, resolving #1523)
 
 ## [4.3.3] - 2025-02-25
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -45,7 +45,7 @@ Cedar Language Version: TBD
 - Added `EntityId::unescaped()`, analogous to `EntityId::escaped()`. This is simply an
   alias for `EntityId::as_ref()` with the `AsRef` impl that produces `&str`. (#1555)
 - Added `PartialResponse::unknown_entities` method (#1557)
-- Added `Entities::num_of_entities` method (#1562, resolving #1523)
+- Added `Entities::len` method (#1562, resolving #1523)
 
 ## [4.3.3] - 2025-02-25
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -45,7 +45,7 @@ Cedar Language Version: TBD
 - Added `EntityId::unescaped()`, analogous to `EntityId::escaped()`. This is simply an
   alias for `EntityId::as_ref()` with the `AsRef` impl that produces `&str`. (#1555)
 - Added `PartialResponse::unknown_entities` method (#1557)
-- Added `Entities::len` method (#1562, resolving #1523)
+- Added `Entities::len` and `Entities::is_empty` methods (#1562, resolving #1523)
 
 ## [4.3.3] - 2025-02-25
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -776,6 +776,11 @@ impl Entities {
         Some(entity.ancestors().map(EntityUid::ref_cast))
     }
 
+    /// Returns the number of `Entity`s in the `Entities`
+    pub fn num_of_entities(&self) -> usize {
+        self.0.len()
+    }
+
     /// Dump an `Entities` object into an entities JSON file.
     ///
     /// The resulting JSON will be suitable for parsing in via

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -777,7 +777,7 @@ impl Entities {
     }
 
     /// Returns the number of `Entity`s in the `Entities`
-    pub fn num_of_entities(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -781,7 +781,7 @@ impl Entities {
         self.0.len()
     }
 
-    /// Returns the number of `Entity`s in the `Entities`
+    /// Returns true if the `Entities` contains no `Entity`s
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -781,6 +781,11 @@ impl Entities {
         self.0.len()
     }
 
+    /// Returns the number of `Entity`s in the `Entities`
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Dump an `Entities` object into an entities JSON file.
     ///
     /// The resulting JSON will be suitable for parsing in via

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -1389,7 +1389,7 @@ mod ancestors_tests {
         let b = Entity::new_no_attrs(b_euid.clone(), HashSet::from([a_euid.clone()]));
         let c = Entity::new_no_attrs(c_euid.clone(), HashSet::from([b_euid.clone()]));
         let es = Entities::from_entities([a, b, c], None).unwrap();
-        assert_eq!(es.num_of_entities(), 3);
+        assert_eq!(es.len(), 3);
         let ans = es.ancestors(&c_euid).unwrap().collect::<HashSet<_>>();
         assert_eq!(ans.len(), 2);
         assert!(ans.contains(&b_euid));
@@ -1512,11 +1512,11 @@ mod entity_validate_tests {
         .unwrap();
         let es = validate_entity(entity.clone(), &schema()).unwrap();
         // Note: `es` includes the action entity defined in the schema
-        assert_eq!(es.num_of_entities(), 2);
+        assert_eq!(es.len(), 2);
         let (uid, attrs, parents) = entity.into_inner();
         let es = validate_entity(Entity::new(uid, attrs, parents).unwrap(), &schema()).unwrap();
         // Note: `es` includes the action entity defined in the schema
-        assert_eq!(es.num_of_entities(), 2);
+        assert_eq!(es.len(), 2);
     }
 
     #[test]
@@ -2759,7 +2759,7 @@ mod schema_based_parsing_tests {
         let parsed = Entities::from_json_value(entitiesjson.clone(), None)
             .expect("Should parse without error");
         assert_eq!(parsed.iter().count(), 1);
-        assert_eq!(parsed.num_of_entities(), 1);
+        assert_eq!(parsed.len(), 1);
         let parsed = parsed
             .get(&EntityUid::from_strs("Employee", "12UA45"))
             .expect("that should be the employee id");
@@ -2797,7 +2797,7 @@ mod schema_based_parsing_tests {
         let parsed = Entities::from_json_value(entitiesjson, Some(&schema))
             .expect("Should parse without error");
         assert_eq!(parsed.iter().count(), 2); // Employee::"12UA45" and the one action
-        assert_eq!(parsed.num_of_entities(), 2);
+        assert_eq!(parsed.len(), 2);
         assert_eq!(
             parsed
                 .iter()
@@ -3205,7 +3205,7 @@ mod schema_based_parsing_tests {
                 .count(),
             1
         );
-        assert_eq!(parsed.num_of_entities(), 2);
+        assert_eq!(parsed.len(), 2);
         let parsed = parsed
             .get(&EntityUid::from_strs("XYZCorp::Employee", "12UA45"))
             .expect("that should be the employee type and id");
@@ -3297,7 +3297,7 @@ mod schema_based_parsing_tests {
                 .count(),
             1
         );
-        assert_eq!(parsed.num_of_entities(), 2);
+        assert_eq!(parsed.len(), 2);
 
         // "department" shouldn't be required
         let entitiesjson = json!(
@@ -3322,7 +3322,7 @@ mod schema_based_parsing_tests {
                 .count(),
             1
         );
-        assert_eq!(parsed.num_of_entities(), 2);
+        assert_eq!(parsed.len(), 2);
     }
 
     #[test]
@@ -3534,7 +3534,7 @@ mod schema_based_parsing_tests {
         let schema = Schema::from_schema_fragments([fragment]).unwrap();
         let action_entities = schema.action_entities().unwrap();
 
-        assert_eq!(action_entities.num_of_entities(), 5);
+        assert_eq!(action_entities.len(), 5);
 
         let a_euid = EntityUid::from_strs("Action", "A");
         let b_euid = EntityUid::from_strs("Action", "B");

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -1390,6 +1390,7 @@ mod ancestors_tests {
         let c = Entity::new_no_attrs(c_euid.clone(), HashSet::from([b_euid.clone()]));
         let es = Entities::from_entities([a, b, c], None).unwrap();
         assert_eq!(es.len(), 3);
+        assert!(!es.is_empty());
         let ans = es.ancestors(&c_euid).unwrap().collect::<HashSet<_>>();
         assert_eq!(ans.len(), 2);
         assert!(ans.contains(&b_euid));


### PR DESCRIPTION
## Description of changes

Add the `Entities::len` method requested in #1523. This new API returns the number of `Entity`s in the `Entities`.
Also add the `Entities::is_empty` method as recommended by `clippy`.

The PR uses both `len` and `is_empty` in some existing unit tests and includes new tests specific to them.

Resolves #1523 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
