### PR TITLE
Updates code to fix lifetime elision errors in newer rustc versions.

### DIFF
--- a/cedar-policy-validator/src/rbac.rs
+++ b/cedar-policy-validator/src/rbac.rs
@@ -300,7 +300,7 @@ impl Validator {
     pub(crate) fn get_apply_specs_for_action<'a>(
         &'a self,
         action_constraint: &'a ActionConstraint,
-    ) -> impl Iterator<Item = &ValidatorApplySpec<ast::EntityType>> + 'a {
+    ) -> impl Iterator<Item = &'a ValidatorApplySpec<ast::EntityType>> + 'a {
         self.get_actions_satisfying_constraint(action_constraint)
             // Get the action type if the id string exists, and then the
             // applies_to list.

--- a/cedar-policy-validator/src/schema.rs
+++ b/cedar-policy-validator/src/schema.rs
@@ -247,7 +247,7 @@ impl ValidatorSchema {
     pub fn ancestors<'a>(
         &'a self,
         ty: &'a EntityType,
-    ) -> Option<impl Iterator<Item = &EntityType> + 'a> {
+    ) -> Option<impl Iterator<Item = &'a EntityType> + 'a> {
         if self.entity_types.contains_key(ty) {
             Some(self.entity_types.values().filter_map(|ety| {
                 if ety.descendants.contains(ty) {
@@ -747,7 +747,7 @@ impl ValidatorSchema {
     /// includes all entity types that are descendants of the type of `entity`
     /// according  to the schema, and the type of `entity` itself because
     /// `entity in entity` evaluates to `true`.
-    pub(crate) fn get_entity_types_in<'a>(&'a self, entity: &'a EntityUID) -> Vec<&EntityType> {
+    pub(crate) fn get_entity_types_in<'a>(&'a self, entity: &'a EntityUID) -> Vec<&'a EntityType> {
         let mut descendants = self
             .get_entity_type(entity.entity_type())
             .map(|v_ety| v_ety.descendants.iter().collect::<Vec<_>>())
@@ -762,7 +762,7 @@ impl ValidatorSchema {
     pub(crate) fn get_entity_types_in_set<'a>(
         &'a self,
         euids: impl IntoIterator<Item = &'a EntityUID> + 'a,
-    ) -> impl Iterator<Item = &EntityType> {
+    ) -> impl Iterator<Item = &'a EntityType> {
         euids.into_iter().flat_map(|e| self.get_entity_types_in(e))
     }
 

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -137,7 +137,7 @@ impl<'a> Typechecker<'a> {
     pub fn typecheck_by_request_env<'b>(
         &'b self,
         t: &'b Template,
-    ) -> Vec<(RequestEnv<'_>, PolicyCheck)> {
+    ) -> Vec<(RequestEnv<'b>, PolicyCheck)> {
         self.apply_typecheck_fn_by_request_env(t, |request, expr| {
             let mut type_errors = Vec::new();
             let empty_prior_capability = CapabilitySet::new();
@@ -166,7 +166,7 @@ impl<'a> Typechecker<'a> {
         &'b self,
         t: &'b Template,
         typecheck_fn: F,
-    ) -> Vec<(RequestEnv<'_>, C)>
+    ) -> Vec<(RequestEnv<'b>, C)>
     where
         F: Fn(&RequestEnv<'_>, &Expr) -> C,
     {
@@ -268,7 +268,7 @@ impl<'a> Typechecker<'a> {
         &'b self,
         env: RequestEnv<'b>,
         t: &'b Template,
-    ) -> Box<dyn Iterator<Item = RequestEnv<'_>> + 'b> {
+    ) -> Box<dyn Iterator<Item = RequestEnv<'b>> + 'b> {
         match env {
             RequestEnv::UndeclaredAction => Box::new(std::iter::once(RequestEnv::UndeclaredAction)),
             RequestEnv::DeclaredAction {

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -1561,7 +1561,7 @@ impl Schema {
     pub fn ancestors<'a>(
         &'a self,
         ty: &'a EntityTypeName,
-    ) -> Option<impl Iterator<Item = &EntityTypeName> + 'a> {
+    ) -> Option<impl Iterator<Item = &'a EntityTypeName> + 'a> {
         self.0
             .ancestors(&ty.0)
             .map(|iter| iter.map(RefCast::ref_cast))


### PR DESCRIPTION
## Description of changes

Fixes a compilation error in newer versions of rust which treat lifetime elision as a warning (and we treat warnings are errors).

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
