### PR TITLE
Update level checking to match Lean model

### DIFF
--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -401,8 +401,8 @@ impl ValidationError {
     pub(crate) fn maximum_level_exceeded(
         source_loc: Option<Loc>,
         policy_id: PolicyID,
-        allowed_level: validation_errors::EntityDerefLevel,
-        actual_level: validation_errors::EntityDerefLevel,
+        allowed_level: crate::level_validate::EntityDerefLevel,
+        actual_level: crate::level_validate::EntityDerefLevel,
     ) -> Self {
         validation_errors::EntityDerefLevelViolation {
             source_loc,

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -166,7 +166,6 @@ pub enum ValidationError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InvalidEnumEntity(#[from] validation_errors::InvalidEnumEntity),
-    #[cfg(feature = "level-validate")]
     /// If a entity dereference level was provided, the policies cannot deref
     /// more than `level` hops away from PARX
     #[error(transparent)]
@@ -397,7 +396,6 @@ impl ValidationError {
         .into()
     }
 
-    #[cfg(feature = "level-validate")]
     pub(crate) fn maximum_level_exceeded(
         source_loc: Option<Loc>,
         policy_id: PolicyID,
@@ -415,7 +413,6 @@ impl ValidationError {
         .into()
     }
 
-    #[cfg(feature = "level-validate")]
     pub(crate) fn literal_dereference_target(source_loc: Option<Loc>, policy_id: PolicyID) -> Self {
         validation_errors::EntityDerefLevelViolation {
             source_loc,

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -407,11 +407,10 @@ impl ValidationError {
         validation_errors::EntityDerefLevelViolation {
             source_loc,
             policy_id,
-            violation_kind:
-                validation_errors::EntityDerefLevelViolationKind::MaximumLevelExceeded {
-                    allowed_level,
-                    actual_level,
-                },
+            violation_kind: validation_errors::EntityDerefViolationKind::MaximumLevelExceeded {
+                allowed_level,
+                actual_level,
+            },
         }
         .into()
     }
@@ -421,7 +420,7 @@ impl ValidationError {
         validation_errors::EntityDerefLevelViolation {
             source_loc,
             policy_id,
-            violation_kind: validation_errors::EntityDerefLevelViolationKind::LiteralDerefTarget,
+            violation_kind: validation_errors::EntityDerefViolationKind::LiteralDerefTarget,
         }
         .into()
     }

--- a/cedar-policy-validator/src/diagnostics.rs
+++ b/cedar-policy-validator/src/diagnostics.rs
@@ -396,6 +396,35 @@ impl ValidationError {
         }
         .into()
     }
+
+    #[cfg(feature = "level-validate")]
+    pub(crate) fn maximum_level_exceeded(
+        source_loc: Option<Loc>,
+        policy_id: PolicyID,
+        allowed_level: validation_errors::EntityDerefLevel,
+        actual_level: validation_errors::EntityDerefLevel,
+    ) -> Self {
+        validation_errors::EntityDerefLevelViolation {
+            source_loc,
+            policy_id,
+            violation_kind:
+                validation_errors::EntityDerefLevelViolationKind::MaximumLevelExceeded {
+                    allowed_level,
+                    actual_level,
+                },
+        }
+        .into()
+    }
+
+    #[cfg(feature = "level-validate")]
+    pub(crate) fn literal_dereference_target(source_loc: Option<Loc>, policy_id: PolicyID) -> Self {
+        validation_errors::EntityDerefLevelViolation {
+            source_loc,
+            policy_id,
+            violation_kind: validation_errors::EntityDerefLevelViolationKind::LiteralDerefTarget,
+        }
+        .into()
+    }
 }
 
 /// Represents the different kinds of validation warnings and information

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -21,7 +21,6 @@ use miette::Diagnostic;
 use thiserror::Error;
 
 use std::fmt::Display;
-use std::ops::{Add, Neg};
 
 use cedar_policy_core::fuzzy_match::fuzzy_search;
 use cedar_policy_core::impl_diagnostic_from_source_loc_opt_field;
@@ -493,38 +492,18 @@ impl Display for EntityDerefLevel {
     }
 }
 
-impl From<u32> for EntityDerefLevel {
-    fn from(value: u32) -> Self {
+impl<I: Into<i64>> From<I> for EntityDerefLevel {
+    fn from(value: I) -> Self {
         EntityDerefLevel {
-            level: i64::from(value),
+            level: value.into(),
         }
-    }
-}
-
-impl Add for EntityDerefLevel {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        EntityDerefLevel {
-            level: self.level + rhs.level,
-        }
-    }
-}
-
-impl Neg for EntityDerefLevel {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        EntityDerefLevel { level: -self.level }
     }
 }
 
 impl EntityDerefLevel {
-    /// Decrement the entity deref level
-    pub fn decrement(&self) -> Self {
-        EntityDerefLevel {
-            level: self.level - 1,
-        }
+    /// Increment the entity deref level
+    pub fn increment(&self) -> Self {
+        (self.level + 1).into()
     }
 }
 

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -498,7 +498,7 @@ pub struct EntityDerefLevelViolation {
 pub enum EntityDerefViolationKind {
     /// The policy exceeded the maximum allowed level
     #[error(
-        "the maximum allowed level {allowed_level} is violated. Actual level is {actual_level}"
+        "this policy requires level {actual_level}, which exceeds the maximum allowed level ({allowed_level})"
     )]
     MaximumLevelExceeded {
         /// The maximum level allowed by the schema
@@ -507,9 +507,7 @@ pub enum EntityDerefViolationKind {
         actual_level: crate::level_validate::EntityDerefLevel,
     },
     /// The policy dereferences an entity literal, which isn't allowed at any level
-    #[error(
-        "entity literals are not valid targets for entity dereferencing operations at any level"
-    )]
+    #[error("entity literals cannot be dereferenced at any level")]
     LiteralDerefTarget,
 }
 

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -479,58 +479,32 @@ impl Diagnostic for HierarchyNotRespected {
     }
 }
 
-/// Represents how many entity dereferences can be applied to a node.
-#[derive(Default, Debug, Clone, Hash, Eq, PartialEq, Error, Copy, Ord, PartialOrd)]
-pub struct EntityDerefLevel {
-    /// A negative value `-n` represents `n` too many dereferences
-    pub level: i64,
-}
-
-impl Display for EntityDerefLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
-        write!(f, "{}", self.level)
-    }
-}
-
-impl<I: Into<i64>> From<I> for EntityDerefLevel {
-    fn from(value: I) -> Self {
-        EntityDerefLevel {
-            level: value.into(),
-        }
-    }
-}
-
-impl EntityDerefLevel {
-    /// Increment the entity deref level
-    pub fn increment(&self) -> Self {
-        (self.level + 1).into()
-    }
-}
-
 /// Structure containing details about entity dereference level violation
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Error)]
 #[error("for policy `{policy_id}`, {violation_kind}")]
+#[cfg(feature = "level-validate")]
 pub struct EntityDerefLevelViolation {
     /// Location of outer most dereference
     pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
-    /// Provides more information about the specific kind of violatoin
-    pub violation_kind: EntityDerefLevelViolationKind,
+    /// Provides more information about the specific kind of violation
+    pub violation_kind: EntityDerefViolationKind,
 }
 
 /// Details for specific kinds of entity deref level violations
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Error)]
-pub enum EntityDerefLevelViolationKind {
+#[cfg(feature = "level-validate")]
+pub enum EntityDerefViolationKind {
     /// The policy exceeded the maximum allowed level
     #[error(
         "the maximum allowed level {allowed_level} is violated. Actual level is {actual_level}"
     )]
     MaximumLevelExceeded {
         /// The maximum level allowed by the schema
-        allowed_level: EntityDerefLevel,
+        allowed_level: crate::level_validate::EntityDerefLevel,
         /// The actual level this policy uses
-        actual_level: EntityDerefLevel,
+        actual_level: crate::level_validate::EntityDerefLevel,
     },
     /// The policy dereferences an entity literal, which isn't allowed at any level
     #[error(

--- a/cedar-policy-validator/src/diagnostics/validation_errors.rs
+++ b/cedar-policy-validator/src/diagnostics/validation_errors.rs
@@ -31,6 +31,7 @@ use std::collections::BTreeSet;
 use cedar_policy_core::ast::{Eid, EntityType, EntityUID, Expr, ExprKind, PolicyID, Var};
 use cedar_policy_core::parser::join_with_conjunction;
 
+use crate::level_validate::EntityDerefLevel;
 use crate::types::{EntityLUB, EntityRecordKind, RequestEnv, Type};
 use crate::ValidatorSchema;
 use itertools::Itertools;
@@ -482,7 +483,6 @@ impl Diagnostic for HierarchyNotRespected {
 /// Structure containing details about entity dereference level violation
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Error)]
 #[error("for policy `{policy_id}`, {violation_kind}")]
-#[cfg(feature = "level-validate")]
 pub struct EntityDerefLevelViolation {
     /// Location of outer most dereference
     pub source_loc: Option<Loc>,
@@ -494,7 +494,6 @@ pub struct EntityDerefLevelViolation {
 
 /// Details for specific kinds of entity deref level violations
 #[derive(Debug, Clone, Hash, Eq, PartialEq, Error)]
-#[cfg(feature = "level-validate")]
 pub enum EntityDerefViolationKind {
     /// The policy exceeded the maximum allowed level
     #[error(
@@ -502,9 +501,9 @@ pub enum EntityDerefViolationKind {
     )]
     MaximumLevelExceeded {
         /// The maximum level allowed by the schema
-        allowed_level: crate::level_validate::EntityDerefLevel,
+        allowed_level: EntityDerefLevel,
         /// The actual level this policy uses
-        actual_level: crate::level_validate::EntityDerefLevel,
+        actual_level: EntityDerefLevel,
     },
     /// The policy dereferences an entity literal, which isn't allowed at any level
     #[error("entity literals cannot be dereferenced at any level")]

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -741,6 +741,16 @@ mod levels_validation_tests {
             [r#"(if principal.bool then principal.user.user else resource.user).bool"#],
             3,
         );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { (if principal.user.bool then principal.user.user else resource.user.user).bool };"#,
+            [r#"(if principal.user.bool then principal.user.user else resource.user.user).bool"#],
+            3,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { (if principal.user.user.bool then principal.user.user else resource.user.user).bool };"#,
+            ["(if principal.user.user.bool then principal.user.user else resource.user.user).bool", "principal.user.user.bool"],
+            3,
+        );
     }
 
     #[test]
@@ -754,6 +764,15 @@ mod levels_validation_tests {
             r#"permit(principal, action, resource) when { {foo: principal, bar: principal.user.user, baz: resource.user.user}.foo.bool };"#,
             ["principal.user.user", "resource.user.user"],
             2,
+        );
+    }
+
+    #[test]
+    fn unaccessed_record_is_checked() {
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { {foo: principal.user, bar: principal.bool} == {foo: principal.nested.user, bar: false} };"#,
+            ["principal.user", "principal.bool", "principal.nested.user"],
+            1,
         );
     }
 

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -629,6 +629,11 @@ mod levels_validation_tests {
             [r#"context.nested.user.bool"#],
             1,
         );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { Action::"view" in action };"#,
+            [r#"Action::"view" in action"#],
+            1,
+        );
     }
 
     #[test]
@@ -677,7 +682,17 @@ mod levels_validation_tests {
         );
         assert_requires_level(
             r#"permit(principal, action, resource) when { principal.nested.user.nested.user.bool };"#,
-            [r#"principal.nested.user.nested.user.bool"#],
+            ["principal.nested.user.nested.user.bool"],
+            3,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { principal has user.user.bool && principal.user.user.bool };"#,
+            ["principal has user.user.bool", "principal.user.user.bool"],
+            3,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { principal.hasTag("foo") && principal.getTag("foo").hasTag("bar") && principal.getTag("foo").getTag("bar").bool };"#,
+            [r#"principal.getTag("foo").getTag("bar").bool"#],
             3,
         );
     }
@@ -839,6 +854,11 @@ mod levels_validation_tests {
             1,
         );
         assert_derefs_entity_lit(
+            r#"permit(principal, action, resource) when { User::"alice" has user.user }; "#,
+            [r#"User::"alice""#],
+            2,
+        );
+        assert_derefs_entity_lit(
             r#"permit(principal, action, resource) when { User::"alice".hasTag("foo") }; "#,
             [r#"User::"alice""#],
             1,
@@ -856,6 +876,11 @@ mod levels_validation_tests {
         assert_derefs_entity_lit(
             r#"permit(principal, action, resource) when { (if principal.bool then User::"alice" else User::"bob").bool}; "#,
             [r#"User::"alice""#, r#"User::"bob""#],
+            1,
+        );
+        assert_derefs_entity_lit(
+            r#"permit(principal, action, resource) when { {foo: User::"alice", bar: User::"bob"}.foo.bool }; "#,
+            [r#"User::"alice""#],
             1,
         );
     }

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -117,9 +117,9 @@ impl LevelChecker<'_> {
     /// initially called on a non-entity-type expression it will return in an
     /// `InternalInvariantViolation`.
     ///
-    /// In order to handle attribtues access on records containing entities
+    /// In order to handle attributes access on records containing entities
     /// (e.g., `{foo: principal}.foo.bar`), this function track an `access_path`
-    /// of record attribtues accessed by the expression. This generalizes the
+    /// of record attributes accessed by the expression. This generalizes the
     /// precondition on `e` so that this function can be called if `e` is a
     /// record literal with a attribute `a` such that `access_path.pop() == some(a)`
     /// and the expression for `a` recursively satisfies the precondition.
@@ -144,7 +144,7 @@ impl LevelChecker<'_> {
                 EntityDerefLevel::zero()
             }
             ExprKind::Lit(Literal::EntityUID(euid)) => {
-                // Allow a literal if it's the current requests env action entity. This is mainly
+                // Allow a literal if it's the current request env's action entity. This is mainly
                 // an artifact of what is convenient in the Lean implementation.
                 if Some(euid.as_ref()) != env.action_entity_uid() {
                     self.level_checking_errors
@@ -462,10 +462,10 @@ mod levels_validation_tests {
         }
 
         let msg = format!(
-            "for policy `{}`, the maximum allowed level {} is violated. Actual level is {}",
+             "for policy `{}`, this policy requires level {}, which exceeds the maximum allowed level ({})",
             p.id(),
-            level,
             actual_level,
+            level,
         );
 
         if underlines.len() == 1 {
@@ -823,7 +823,10 @@ mod levels_validation_tests {
             );
         }
 
-        let msg = format!("for policy `{}`, entity literals are not valid targets for entity dereferencing operations at any level", p.id());
+        let msg = format!(
+            "for policy `{}`, entity literals cannot be dereferenced at any level",
+            p.id()
+        );
 
         if underlines.len() == 1 {
             let expected = ExpectedErrorMessageBuilder::error(&msg)

--- a/cedar-policy-validator/src/lib.rs
+++ b/cedar-policy-validator/src/lib.rs
@@ -30,7 +30,6 @@
 use cedar_policy_core::ast::{Policy, PolicySet, Template};
 use serde::Serialize;
 use std::collections::HashSet;
-#[cfg(feature = "level-validate")]
 mod level_validate;
 
 mod coreschema;
@@ -129,7 +128,6 @@ impl Validator {
         )
     }
 
-    #[cfg(feature = "level-validate")]
     /// Validate all templates, links, and static policies in a policy set.
     /// If validation passes, also run level validation with `max_deref_level`
     /// (see RFC 76).

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -47,6 +47,12 @@ Cedar Language Version: TBD
 - Added `PartialResponse::unknown_entities` method (#1557)
 - Added `Entities::len` and `Entities::is_empty` methods (#1562, resolving #1523)
 
+### Fixed
+
+- Fixed bugs in experimental `level-validate` feature. Level validation is now
+  more permissive when checking `if` expressions (fixing #1507), and stricter when
+  checking of record literals and entity tag operations (fixing #1505 and #1503). (#1567)
+
 ## [4.3.3] - 2025-02-25
 
 ### Changed

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -51,7 +51,7 @@ Cedar Language Version: TBD
 
 - Fixed bugs in experimental `level-validate` feature. Level validation is now
   more permissive when checking `if` expressions (fixing #1507), and stricter when
-  checking of record literals and entity tag operations (fixing #1505 and #1503). (#1567)
+  checking record literals and entity tag operations (fixing #1505 and #1503). (#1567)
 
 ## [4.3.3] - 2025-02-25
 

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -520,7 +520,6 @@ impl From<cedar_policy_validator::ValidationError> for ValidationError {
             cedar_policy_validator::ValidationError::InvalidEnumEntity(e) => {
                 Self::InvalidEnumEntity(e.into())
             }
-            #[cfg(feature = "level-validate")]
             cedar_policy_validator::ValidationError::EntityDerefLevelViolation(e) => {
                 Self::EntityDerefLevelViolation(e.into())
             }

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -4308,7 +4308,7 @@ mod level_validation_tests {
             src,
             &miette::Report::new(result),
             &ExpectedErrorMessageBuilder::error(
-                "for policy `policy0`, the maximum allowed level 1 is violated. Actual level is 2",
+                "for policy `policy0`, this policy requires level 2, which exceeds the maximum allowed level (1)",
             )
             .exactly_one_underline("resource.foo.profile_pic")
             .build(),
@@ -4341,7 +4341,7 @@ mod level_validation_tests {
             src,
             &miette::Report::new(result),
             &ExpectedErrorMessageBuilder::error(
-                "for policy `policy0`, the maximum allowed level 1 is violated. Actual level is 2",
+                "for policy `policy0`, this policy requires level 2, which exceeds the maximum allowed level (1)",
             )
             .exactly_one_underline("resource.foo.profile_pic")
             .build(),
@@ -4438,7 +4438,7 @@ mod level_validation_tests {
             src,
             &miette::Report::new(result),
             &ExpectedErrorMessageBuilder::error(
-                "for policy `policy0`, the maximum allowed level 1 is violated. Actual level is 2",
+                "for policy `policy0`, this policy requires level 2, which exceeds the maximum allowed level (1)",
             )
             .exactly_one_underline("resource.foo.profile_pic")
             .build(),
@@ -4489,7 +4489,7 @@ mod level_validation_tests {
             src,
             &miette::Report::new(result),
             &ExpectedErrorMessageBuilder::error(
-                "for policy `policy0`, the maximum allowed level 1 is violated. Actual level is 2",
+                "for policy `policy0`, this policy requires level 2, which exceeds the maximum allowed level (1)",
             )
             .exactly_one_underline("resource.foo.is_admin")
             .build(),


### PR DESCRIPTION
## Description of changes

Updates level checking to match the Lean model, specifically fixing problems identified in `if` (fixing #1507) and record literals (fixing #1505) while modeling and completing the proof in Lean. It also adds checking for `getTag` and `hasTag` (fixing #1503). Additionally fixes #1500, #1502, and #1504.

This PR contains changes making level validation more restrictive in some cases, but this is acceptable since it is an experimental feature.

Passed an overnight local differential testing run against the current Lean model for level validation. This requires https://github.com/cedar-policy/cedar-spec/pull/606 to adjust the test target to allow the Rust implementation to be more restrictive then Lean implementation due to https://github.com/cedar-policy/cedar-spec/issues/126. I originally thought level validation could have a differential test target than level validation, but this is not the case. We still test that any error reported by Lean is also reported by Rust, preserving soundness.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
