### PR TITLE
Script to normalize changelogs in release branches

### DIFF
--- a/scripts/normalize_changelogs.sh
+++ b/scripts/normalize_changelogs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Replace the changelog files by the static changelog files used for release branches.
+# Only replace the files if they could be found in their expected location. Do nothing otherwise.
+
+CEDAR_POLICY_CHANGELOG="cedar-policy/CHANGELOG.md"
+CEDAR_POLICY_CLI_CHANGELOG="cedar-policy-cli/CHANGELOG.md"
+CEDAR_WASM_CHANGELOG="cedar-wasm/CHANGELOG.md"
+
+STATIC_CEDAR_POLICY_CHANGELOG="scripts/static_changelogs/cedar-policy_CHANGELOG.md"
+STATIC_CEDAR_POLICY_CLI_CHANGELOG="scripts/static_changelogs/cedar-policy-cli_CHANGELOG.md"
+STATIC_CEDAR_WASM_CHANGELOG="scripts/static_changelogs/cedar-wasm_CHANGELOG.md"
+
+if [ -f "$CEDAR_POLICY_CHANGELOG" ] && [ -f "$CEDAR_POLICY_CLI_CHANGELOG" ] && [ -f "$CEDAR_WASM_CHANGELOG" ]; then
+    cp $STATIC_CEDAR_POLICY_CHANGELOG $CEDAR_POLICY_CHANGELOG
+    cp $STATIC_CEDAR_POLICY_CLI_CHANGELOG $CEDAR_POLICY_CLI_CHANGELOG
+    cp $STATIC_CEDAR_WASM_CHANGELOG $CEDAR_WASM_CHANGELOG
+
+    echo "Success! The changelog files have been normalized"
+else
+    echo "Error: The changelogs files could not be located. No actions taken."
+    echo "This script must be run from the root directory. Did you run it from another directory?"
+fi

--- a/scripts/static_changelogs/cedar-policy-cli_CHANGELOG.md
+++ b/scripts/static_changelogs/cedar-policy-cli_CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+The changelog for all the release branches of `cedar-policy-cli` is maintained on
+the `main` branch. You can view the most up-to-date changelog
+[here](https://github.com/cedar-policy/cedar/blob/main/cedar-policy-cli/CHANGELOG.md).
+

--- a/scripts/static_changelogs/cedar-policy_CHANGELOG.md
+++ b/scripts/static_changelogs/cedar-policy_CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+The changelog for all the release branches of `cedar-policy` is maintained on
+the `main` branch. You can view the most up-to-date changelog
+[here](https://github.com/cedar-policy/cedar/blob/main/cedar-policy/CHANGELOG.md).
+

--- a/scripts/static_changelogs/cedar-wasm_CHANGELOG.md
+++ b/scripts/static_changelogs/cedar-wasm_CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+The changelog for all the release branches of `cedar-wasm` is maintained on
+the `main` branch. You can view the most up-to-date changelog
+[here](https://github.com/cedar-policy/cedar/blob/main/cedar-wasm/CHANGELOG.md).


### PR DESCRIPTION
## Description of changes

This PR adds a new script to "normalize" the changelogs in release branches. Moving forward, we'll run this script right after cutting off a new release branch so the changelogs point to their associated versions in `main`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
