### PR TITLE
Pretty-print the Cedarschema files using two spaces

### DIFF
--- a/cedar-policy-core/src/est/annotation.rs
+++ b/cedar-policy-core/src/est/annotation.rs
@@ -43,6 +43,22 @@ impl Annotations {
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+    /// Format the annotations using a given level of base indentation
+    pub fn fmt_indented(
+        &self,
+        f: &mut std::fmt::Formatter<'_>,
+        base_indentation: usize,
+    ) -> std::fmt::Result {
+        let base_indent = " ".repeat(base_indentation);
+        for (k, v) in &self.0 {
+            if let Some(anno) = v {
+                writeln!(f, "{base_indent}@{k}({anno})")?
+            } else {
+                writeln!(f, "{base_indent}@{k}")?
+            }
+        }
+        Ok(())
+    }
 }
 
 impl From<Annotations> for ast::Annotations {
@@ -69,14 +85,7 @@ impl From<ast::Annotations> for Annotations {
 
 impl std::fmt::Display for Annotations {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        for (k, v) in &self.0 {
-            if let Some(anno) = v {
-                writeln!(f, "@{k}({anno})")?
-            } else {
-                writeln!(f, "@{k}")?
-            }
-        }
-        Ok(())
+        self.fmt_indented(f, 0)
     }
 }
 

--- a/cedar-policy-validator/src/cedar_schema/testfiles/example.cedarschema
+++ b/cedar-policy-validator/src/cedar_schema/testfiles/example.cedarschema
@@ -1,0 +1,35 @@
+entity TopLevel = {
+  "obj": {
+    "nestedStr": String
+  }
+};
+
+namespace EmptyNs {
+}
+
+namespace Ns {
+  type Bar = {
+    "obj": {
+      "nestedLong": Long,
+      "nestedObj": {
+        "nestedStr": String
+      }
+    },
+    "setWithAnonymousType": Set<{
+      "key": String,
+      "val": String
+    }>
+  };
+
+  entity Resource = {
+    "bar": Bar
+  };
+
+  entity User;
+
+  action "get" appliesTo {
+    principal: [User],
+    resource: [Resource],
+    context: {}
+  };
+}

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -495,7 +495,16 @@ mod test {
         assert_matches!(result, SchemaToTextAnswer::Success { text, warnings:_ } => {
             assert_eq!(
                 &text,
-                "entity User = {\"name\": __cedar::String};\naction \"sendMessage\" appliesTo {\n  principal: [User],\n  resource: [User],\n  context: {}\n};\n"
+                r#"entity User = {
+  "name": __cedar::String
+};
+
+action "sendMessage" appliesTo {
+  principal: [User],
+  resource: [User],
+  context: {}
+};
+"#
             );
         });
     }


### PR DESCRIPTION
## Description of changes

The Cedarschema output from generated code is hard to read, e.g. from `cedar translate-schema --direction json-to-cedar -s output.json`

Example from Cedar for Kubernetes:

```
namespace k8s {
type ExtraAttribute = {"key": __cedar::String, 
"values": Set < __cedar::String >};
type FieldRequirement = {"field": __cedar::String, 
"operator": __cedar::String, 
"value": __cedar::String};
type LabelRequirement = {"key": __cedar::String, 
"operator": __cedar::String, 
"values": Set < __cedar::String >};
entity Extra = {"key": __cedar::String, 
"value"?: __cedar::String};
entity Group = {"name": __cedar::String};
entity Node in [Group] = {"extra"?: Set < ExtraAttribute >, 
"name": __cedar::String};
entity NonResourceURL = {"path": __cedar::String};
entity PrincipalUID;
entity Resource = {"apiGroup": __cedar::String, 
"fieldSelector"?: Set < FieldRequirement >, 
"labelSelector"?: Set < LabelRequirement >, 
"name"?: __cedar::String, 
"namespace"?: __cedar::String, 
"resource": __cedar::String, 
"subresource"?: __cedar::String};
entity ServiceAccount in [Group] = {"extra"?: Set < ExtraAttribute >, 
"name": __cedar::String, 
"namespace": __cedar::String};
entity User in [Group] = {"extra"?: Set < ExtraAttribute >, 
"name": __cedar::String};
action "approve" appliesTo {
  principal: [Group, Node, ServiceAccount, User],
  resource: [Resource],
  context: {}
};
action "attest" appliesTo {
  principal: [Group, Node, ServiceAccount, User],
  resource: [Resource],
  context: {}
};
action "bind" appliesTo {
  principal: [Group, Node, ServiceAccount, User],
  resource: [Resource],
  context: {}
};
action "create" appliesTo {
  principal: [Group, Node, ServiceAccount, User],
  resource: [Resource],
  context: {}
};
}
```

I quickly implemented JSON-like "pretty-printing" with four spaces as an example of how it could look like.

The same snippet:

```
namespace k8s {
    type ExtraAttribute = {
        "key": __cedar::String, 
        "values": Set<__cedar::String>
    };

    type FieldRequirement = {
        "field": __cedar::String, 
        "operator": __cedar::String, 
        "value": __cedar::String
    };

    type LabelRequirement = {
        "key": __cedar::String, 
        "operator": __cedar::String, 
        "values": Set<__cedar::String>
    };

    entity Extra = {
        "key": __cedar::String, 
        "value"?: __cedar::String
    };

    entity Group = {
        "name": __cedar::String
    };

    entity Node in [Group] = {
        "extra"?: Set<ExtraAttribute>, 
        "name": __cedar::String
    };

    entity NonResourceURL = {
        "path": __cedar::String
    };

    entity PrincipalUID;

    entity Resource = {
        "apiGroup": __cedar::String, 
        "fieldSelector"?: Set<FieldRequirement>, 
        "labelSelector"?: Set<LabelRequirement>, 
        "name"?: __cedar::String, 
        "namespace"?: __cedar::String, 
        "resource": __cedar::String, 
        "subresource"?: __cedar::String
    };

    entity ServiceAccount in [Group] = {
        "extra"?: Set<ExtraAttribute>, 
        "name": __cedar::String, 
        "namespace": __cedar::String
    };

    entity User in [Group] = {
        "extra"?: Set<ExtraAttribute>, 
        "name": __cedar::String
    };

    action "approve" appliesTo {
        principal: [Group, Node, ServiceAccount, User],
        resource: [Resource],
        context: {}
    };

    action "attest" appliesTo {
        principal: [Group, Node, ServiceAccount, User],
        resource: [Resource],
        context: {}
    };

    action "bind" appliesTo {
        principal: [Group, Node, ServiceAccount, User],
        resource: [Resource],
        context: {}
    };

    action "create" appliesTo {
        principal: [Group, Node, ServiceAccount, User],
        resource: [Resource],
        context: {}
    };
}
```

Happy to discuss if we want configurable indenting, etc., or other style suggestions.

If accepted, I can move on to updating tests, etc.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

Not sure if this output is considered by compability guarantees. It's just spacing

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
