### PR TITLE
More `clippy` fixes

### DIFF
--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -92,14 +92,14 @@ impl Authorizer {
         entities: &Entities,
     ) -> PartialResponse {
         let eval = Evaluator::new(q.clone(), entities, self.extensions);
-        self.is_authorized_core_internal(eval, q, pset)
+        self.is_authorized_core_internal(&eval, q, pset)
     }
 
     /// The same as is_authorized_core, but for any Evaluator.
     /// A PartialResponse caller constructs its own evaluator, with an unknown mapper function.
     pub(crate) fn is_authorized_core_internal(
         &self,
-        eval: Evaluator<'_>,
+        eval: &Evaluator<'_>,
         q: Request,
         pset: &PolicySet,
     ) -> PartialResponse {

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -338,7 +338,7 @@ impl PartialResponse {
         // Construct an evaluator resolving these specific unknown mappings
         let eval = Evaluator::new(new_request.clone(), es, auth.extensions)
             .with_unknowns_mapper(Box::new(unknowns_mapper));
-        Ok(auth.is_authorized_core_internal(eval, new_request, &policyset))
+        Ok(auth.is_authorized_core_internal(&eval, new_request, &policyset))
     }
 
     #[cfg(feature = "partial-eval")]

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -222,10 +222,7 @@ impl<'e> Evaluator<'e> {
 
     // Constructs an Evaluator for a given unknowns mapper function.
     #[cfg(feature = "partial-eval")]
-    pub(crate) fn with_unknowns_mapper(
-        self,
-        unknowns_mapper: UnknownsMapper<'e>,
-    ) -> Self {
+    pub(crate) fn with_unknowns_mapper(self, unknowns_mapper: UnknownsMapper<'e>) -> Self {
         Self {
             principal: self.principal,
             action: self.action,

--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -37,6 +37,9 @@ use smol_str::SmolStr;
 
 const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 
+#[cfg(feature = "partial-eval")]
+type UnknownsMapper<'e> = Box<dyn Fn(&str) -> Option<Value> + 'e>;
+
 // PANIC SAFETY `Name`s in here are valid `Name`s
 #[allow(clippy::expect_used)]
 mod names {
@@ -70,7 +73,7 @@ pub struct Evaluator<'e> {
     extensions: &'e Extensions<'e>,
     /// Mapper of unknown values into concrete ones, if recognized
     #[cfg(feature = "partial-eval")]
-    unknowns_mapper: Box<dyn Fn(&str) -> Option<Value> + 'e>,
+    unknowns_mapper: UnknownsMapper<'e>,
 }
 
 /// Evaluator for "restricted" expressions. See notes on `RestrictedExpr`.
@@ -221,7 +224,7 @@ impl<'e> Evaluator<'e> {
     #[cfg(feature = "partial-eval")]
     pub(crate) fn with_unknowns_mapper(
         self,
-        unknowns_mapper: Box<dyn Fn(&str) -> Option<Value> + 'e>,
+        unknowns_mapper: UnknownsMapper<'e>,
     ) -> Self {
         Self {
             principal: self.principal,
@@ -230,7 +233,7 @@ impl<'e> Evaluator<'e> {
             context: self.context,
             entities: self.entities,
             extensions: self.extensions,
-            unknowns_mapper: unknowns_mapper,
+            unknowns_mapper,
         }
     }
 

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -44,7 +44,7 @@ impl<I: Into<u32>> From<I> for EntityDerefLevel {
 }
 
 impl EntityDerefLevel {
-    fn increment(&self) -> Self {
+    fn increment(self) -> Self {
         (self.level + 1).into()
     }
 
@@ -265,7 +265,7 @@ impl LevelChecker<'_> {
                 arg1,
                 arg2,
             } => {
-                let deref_target_lvl = self.check_entity_deref_target_level(&arg1, Vec::new(), env);
+                let deref_target_lvl = self.check_entity_deref_target_level(arg1, Vec::new(), env);
                 if deref_target_lvl >= self.max_level {
                     self.level_checking_errors
                         .insert(ValidationError::maximum_level_exceeded(
@@ -289,7 +289,7 @@ impl LevelChecker<'_> {
             ExprKind::HasAttr { expr, .. } | ExprKind::GetAttr { expr, .. } => match expr.data() {
                 Some(Type::EntityOrRecord(EntityRecordKind::Entity { .. })) => {
                     let deref_target_lvl =
-                        self.check_entity_deref_target_level(&expr, Vec::new(), env);
+                        self.check_entity_deref_target_level(expr, Vec::new(), env);
                     if deref_target_lvl >= self.max_level {
                         self.level_checking_errors
                             .insert(ValidationError::maximum_level_exceeded(
@@ -315,10 +315,10 @@ impl LevelChecker<'_> {
                 }
             },
             ExprKind::Like { expr, .. } => {
-                self.check_expr_level(&expr, env);
+                self.check_expr_level(expr, env);
             }
             ExprKind::Is { expr, .. } => {
-                self.check_expr_level(&expr, env);
+                self.check_expr_level(expr, env);
             }
             ExprKind::Set(exprs) => {
                 for e in exprs.iter() {

--- a/cedar-policy-validator/src/schema/action.rs
+++ b/cedar-policy-validator/src/schema/action.rs
@@ -68,6 +68,7 @@ impl ValidatorActionId {
     ///
     /// This constructor assumes that `descendants` has TC already computed.
     /// That is, caller is responsible for TC.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         name: EntityUID,
         principal_entity_types: impl IntoIterator<Item = ast::EntityType>,

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -539,6 +539,11 @@ pub struct PolicySet {
 
 impl PolicySet {
     /// Parse a [`PolicySet`] into a [`crate::PolicySet`]
+    ///
+    /// # Errors
+    ///
+    /// Will return errors if any of the policies, templates or template links
+    /// in [`PolicySet`] cannot be parsed or added to the [`crate::PolicySet`].
     pub fn parse(self) -> Result<crate::PolicySet, Vec<miette::Report>> {
         let mut errs = Vec::new();
         // Parse static policies

--- a/cedar-policy/src/ffi/version.rs
+++ b/cedar-policy/src/ffi/version.rs
@@ -4,6 +4,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use crate::api;
 
 /// Get language version of Cedar
+#[allow(clippy::module_name_repetitions)]
 #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "getCedarLangVersion"))]
 pub fn get_lang_version() -> String {
     let version = api::version::get_lang_version();
@@ -11,6 +12,7 @@ pub fn get_lang_version() -> String {
 }
 
 /// Get SDK version of Cedar
+#[allow(clippy::module_name_repetitions)]
 pub fn get_sdk_version() -> String {
     let version = api::version::get_sdk_version();
     format!("{version}")

--- a/cedar-policy/src/proto.rs
+++ b/cedar-policy/src/proto.rs
@@ -20,7 +20,8 @@ pub mod models {
         #![allow(
             missing_docs,
             clippy::doc_markdown,
-            clippy::derive_partial_eq_without_eq
+            clippy::derive_partial_eq_without_eq,
+            clippy::module_name_repetitions
         )]
         include!(concat!(env!("OUT_DIR"), "/cedar_policy_core.rs"));
     }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -19,7 +19,7 @@ pub trait Protobuf: Sized {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
     fn encode(&self) -> Vec<u8>;
     /// Decode the binary data in `buf`, producing something of type `Self`
-    /// 
+    ///
     /// # Errors
     ///
     /// Will return a `prost::DecodeError` when the input buffer not contain a

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -22,7 +22,7 @@ pub trait Protobuf: Sized {
     ///
     /// # Errors
     ///
-    /// Will return a `prost::DecodeError` when the input buffer not contain a
+    /// Will return a `prost::DecodeError` when the input buffer does not contain a
     /// valid Protobuf message.
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError>;
 }

--- a/cedar-policy/src/proto/traits.rs
+++ b/cedar-policy/src/proto/traits.rs
@@ -19,6 +19,11 @@ pub trait Protobuf: Sized {
     /// Encode into protobuf format. Returns a freshly-allocated buffer containing binary data.
     fn encode(&self) -> Vec<u8>;
     /// Decode the binary data in `buf`, producing something of type `Self`
+    /// 
+    /// # Errors
+    ///
+    /// Will return a `prost::DecodeError` when the input buffer not contain a
+    /// valid Protobuf message.
     fn decode(buf: impl prost::bytes::Buf) -> Result<Self, prost::DecodeError>;
 }
 


### PR DESCRIPTION
## Description of changes

CI has been throwing some `clippy` errors such as [these ones](https://github.com/cedar-policy/cedar/actions/runs/14814859352/job/41594070350?pr=1486) (but also more than those). I've dealt with all of them except for `clippy::module_name_repetitions`, which was being thrown for two FFI API functions (their twins in the main API already have the annotation) and one `protobuf`-generated type.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
