### PR TITLE
Refactor set operations

### DIFF
--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -437,6 +437,10 @@ impl Set {
             // both sets are in fast form, ie, they only contain literals.
             // Fast hashset-based implementation.
             (Some(ls1), Some(ls2)) => ls1.is_subset(ls2.as_ref()),
+            // `self` contains non-literal(s), `other` is all-literal.
+            // The invariant about `Set::fast` should allow us to conclude that
+            // the result is `false`
+            (None, Some(_)) => false,
             // one or both sets are in slow form, ie, contain a non-literal.
             // Fallback to slow implementation.
             _ => self.authoritative.is_subset(&other.authoritative),

--- a/cedar-policy-core/src/ast/value.rs
+++ b/cedar-policy-core/src/ast/value.rs
@@ -430,6 +430,46 @@ impl Set {
     pub fn iter(&self) -> impl Iterator<Item = &Value> {
         self.authoritative.iter()
     }
+
+    /// Subset test
+    pub fn is_subset(&self, other: &Set) -> bool {
+        match (&self.fast, &other.fast) {
+            // both sets are in fast form, ie, they only contain literals.
+            // Fast hashset-based implementation.
+            (Some(ls1), Some(ls2)) => ls1.is_subset(ls2.as_ref()),
+            // one or both sets are in slow form, ie, contain a non-literal.
+            // Fallback to slow implementation.
+            _ => self.authoritative.is_subset(&other.authoritative),
+        }
+    }
+
+    /// Disjointness test
+    pub fn is_disjoint(&self, other: &Set) -> bool {
+        match (&self.fast, &other.fast) {
+            // both sets are in fast form, ie, they only contain literals.
+            // Fast hashset-based implementation.
+            (Some(ls1), Some(ls2)) => ls1.is_disjoint(ls2.as_ref()),
+            // one or both sets are in slow form, ie, contain a non-literal.
+            // Fallback to slow implementation.
+            _ => self.authoritative.is_disjoint(&other.authoritative),
+        }
+    }
+
+    /// Membership test
+    pub fn contains(&self, value: &Value) -> bool {
+        match (&self.fast, &value.value) {
+            // both sets are in fast form, ie, they only contain literals.
+            // Fast hashset-based implementation.
+            (Some(ls), ValueKind::Lit(lit)) => ls.contains(lit),
+            // Set is all-literal but `value` is not a literal
+            // The invariant about `Set::fast` should allow us to conclude that
+            // the result is `false`
+            (Some(_), _) => false,
+            // Set contains a non-literal
+            // Fallback to slow implementation.
+            _ => self.authoritative.contains(value),
+        }
+    }
 }
 
 impl FromIterator<Value> for Set {


### PR DESCRIPTION
## Description of changes
This PR puts the operations on sets into `Set` from the evaluator, which allows consumers of core to reuse them easily. This PR also makes changes in the implementations of these operations.

* Use `BTreeSet` methods instead of iterators
* Optimize the case where a set is all-literal and the other operand is a non-literal value
* Optimize the case where a set is not all-literal and the other operand is all-literal
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
