### PR TITLE
Adding ability to convert from Expr<T> to Expr

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -15,7 +15,11 @@
  */
 
 #[cfg(feature = "tolerant-ast")]
-use super::expr_allows_errors::AstExprErrorKind;
+use {
+    super::expr_allows_errors::AstExprErrorKind, crate::parser::err::ToASTError,
+    crate::parser::err::ToASTErrorKind,
+};
+
 use crate::{
     ast::*,
     expr_builder::{self, ExprBuilder as _},
@@ -395,6 +399,90 @@ impl<T> Expr<T> {
             ExprKind::Record(_) => Some(Type::Record),
             #[cfg(feature = "tolerant-ast")]
             ExprKind::Error { .. } => None,
+        }
+    }
+
+    /// Converts an `Expr<V>` to `B::Expr` using the provided builder.
+    ///
+    /// Preserves source location information and recursively transforms each expression node.
+    /// Note: Data may be cloned if the source expression is retained elsewhere.
+    pub fn into_expr<B: expr_builder::ExprBuilder>(self) -> B::Expr
+    where
+        T: Clone,
+    {
+        let builder = B::new().with_maybe_source_loc(self.source_loc().cloned().as_ref());
+        match self.into_expr_kind() {
+            ExprKind::Lit(lit) => builder.val(lit),
+            ExprKind::Var(var) => builder.var(var),
+            ExprKind::Slot(slot) => builder.slot(slot),
+            ExprKind::Unknown(u) => builder.unknown(u),
+            ExprKind::If {
+                test_expr,
+                then_expr,
+                else_expr,
+            } => builder.ite(
+                Arc::unwrap_or_clone(test_expr).into_expr::<B>(),
+                Arc::unwrap_or_clone(then_expr).into_expr::<B>(),
+                Arc::unwrap_or_clone(else_expr).into_expr::<B>(),
+            ),
+            ExprKind::And { left, right } => builder.and(
+                Arc::unwrap_or_clone(left).into_expr::<B>(),
+                Arc::unwrap_or_clone(right).into_expr::<B>(),
+            ),
+            ExprKind::Or { left, right } => builder.or(
+                Arc::unwrap_or_clone(left).into_expr::<B>(),
+                Arc::unwrap_or_clone(right).into_expr::<B>(),
+            ),
+            ExprKind::UnaryApp { op, arg } => {
+                let arg = Arc::unwrap_or_clone(arg).into_expr::<B>();
+                builder.unary_app(op, arg)
+            }
+            ExprKind::BinaryApp { op, arg1, arg2 } => {
+                let arg1 = Arc::unwrap_or_clone(arg1).into_expr::<B>();
+                let arg2 = Arc::unwrap_or_clone(arg2).into_expr::<B>();
+                builder.binary_app(op, arg1, arg2)
+            }
+            ExprKind::ExtensionFunctionApp { fn_name, args } => {
+                let args = Arc::unwrap_or_clone(args)
+                    .into_iter()
+                    .map(|e| e.into_expr::<B>());
+                builder.call_extension_fn(fn_name, args)
+            }
+            ExprKind::GetAttr { expr, attr } => {
+                builder.get_attr(Arc::unwrap_or_clone(expr).into_expr::<B>(), attr)
+            }
+            ExprKind::HasAttr { expr, attr } => {
+                builder.has_attr(Arc::unwrap_or_clone(expr).into_expr::<B>(), attr)
+            }
+            ExprKind::Like { expr, pattern } => {
+                builder.like(Arc::unwrap_or_clone(expr).into_expr::<B>(), pattern)
+            }
+            ExprKind::Is { expr, entity_type } => {
+                builder.is_entity_type(Arc::unwrap_or_clone(expr).into_expr::<B>(), entity_type)
+            }
+            ExprKind::Set(set) => builder.set(
+                Arc::unwrap_or_clone(set)
+                    .into_iter()
+                    .map(|e| e.into_expr::<B>()),
+            ),
+            // PANIC SAFETY: `map` is a map, so it will not have duplicates keys, so the `record` constructor cannot error.
+            #[allow(clippy::unwrap_used)]
+            ExprKind::Record(map) => builder
+                .record(
+                    Arc::unwrap_or_clone(map)
+                        .into_iter()
+                        .map(|(k, v)| (k, v.into_expr::<B>())),
+                )
+                .unwrap(),
+            #[cfg(feature = "tolerant-ast")]
+            // PANIC SAFETY: error type is Infallible so can never happen
+            #[allow(clippy::unwrap_used)]
+            ExprKind::Error { .. } => builder
+                .error(ParseErrors::singleton(ToASTError::new(
+                    ToASTErrorKind::ASTErrorNode,
+                    Loc::new(0..1, "AST_ERROR_NODE".into()),
+                )))
+                .unwrap(),
         }
     }
 }
@@ -793,7 +881,7 @@ impl<T: Clone> std::fmt::Display for Expr<T> {
         // To avoid code duplication between pretty-printers for AST Expr and EST Expr,
         // we just convert to EST and use the EST pretty-printer.
         // Note that converting AST->EST is lossless and infallible.
-        write!(f, "{}", crate::est::Expr::from(self.clone()))
+        write!(f, "{}", &self.clone().into_expr::<crate::est::Builder>())
     }
 }
 
@@ -801,7 +889,7 @@ impl<T: Clone> BoundedDisplay for Expr<T> {
     fn fmt(&self, f: &mut impl std::fmt::Write, n: Option<usize>) -> std::fmt::Result {
         // Like the `std::fmt::Display` impl, we convert to EST and use the EST
         // pretty-printer. Note that converting AST->EST is lossless and infallible.
-        BoundedDisplay::fmt(&crate::est::Expr::from(self.clone()), f, n)
+        BoundedDisplay::fmt(&self.clone().into_expr::<crate::est::Builder>(), f, n)
     }
 }
 
@@ -860,7 +948,11 @@ impl std::fmt::Display for Unknown {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Like the Display impl for Expr, we delegate to the EST pretty-printer,
         // to avoid code duplication
-        write!(f, "{}", crate::est::Expr::from(Expr::unknown(self.clone())))
+        write!(
+            f,
+            "{}",
+            Expr::unknown(self.clone()).into_expr::<crate::est::Builder>()
+        )
     }
 }
 

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -379,7 +379,7 @@ impl From<ast::Template> for Policy {
 
 impl<T: Clone> From<ast::Expr<T>> for Clause {
     fn from(expr: ast::Expr<T>) -> Clause {
-        Clause::When(expr.into())
+        Clause::When(expr.into_expr::<Builder>())
     }
 }
 

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -29,8 +29,6 @@ use crate::extensions::Extensions;
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
 use crate::parser::cst_to_ast;
 use crate::parser::err::ParseErrors;
-#[cfg(feature = "tolerant-ast")]
-use crate::parser::err::{ToASTError, ToASTErrorKind};
 use crate::parser::Node;
 use crate::parser::{cst, Loc};
 use itertools::Itertools;
@@ -1064,82 +1062,6 @@ impl Expr {
     }
 }
 
-// PANIC SAFETY: See comment on `unwrap`
-#[allow(clippy::fallible_impl_from)]
-impl<T: Clone> From<ast::Expr<T>> for Expr {
-    fn from(expr: ast::Expr<T>) -> Expr {
-        match expr.into_expr_kind() {
-            ast::ExprKind::Lit(lit) => lit.into(),
-            ast::ExprKind::Var(var) => var.into(),
-            ast::ExprKind::Slot(slot) => slot.into(),
-            ast::ExprKind::Unknown(u) => Builder::new().unknown(u),
-            ast::ExprKind::If {
-                test_expr,
-                then_expr,
-                else_expr,
-            } => Builder::new().ite(
-                Arc::unwrap_or_clone(test_expr).into(),
-                Arc::unwrap_or_clone(then_expr).into(),
-                Arc::unwrap_or_clone(else_expr).into(),
-            ),
-            ast::ExprKind::And { left, right } => Builder::new().and(
-                Arc::unwrap_or_clone(left).into(),
-                Arc::unwrap_or_clone(right).into(),
-            ),
-            ast::ExprKind::Or { left, right } => Builder::new().or(
-                Arc::unwrap_or_clone(left).into(),
-                Arc::unwrap_or_clone(right).into(),
-            ),
-            ast::ExprKind::UnaryApp { op, arg } => {
-                let arg = Arc::unwrap_or_clone(arg).into();
-                Builder::new().unary_app(op, arg)
-            }
-            ast::ExprKind::BinaryApp { op, arg1, arg2 } => {
-                let arg1 = Arc::unwrap_or_clone(arg1).into();
-                let arg2 = Arc::unwrap_or_clone(arg2).into();
-                Builder::new().binary_app(op, arg1, arg2)
-            }
-            ast::ExprKind::ExtensionFunctionApp { fn_name, args } => {
-                let args = Arc::unwrap_or_clone(args).into_iter().map(Into::into);
-                Builder::new().call_extension_fn(fn_name, args)
-            }
-            ast::ExprKind::GetAttr { expr, attr } => {
-                Builder::new().get_attr(Arc::unwrap_or_clone(expr).into(), attr)
-            }
-            ast::ExprKind::HasAttr { expr, attr } => {
-                Builder::new().has_attr(Arc::unwrap_or_clone(expr).into(), attr)
-            }
-            ast::ExprKind::Like { expr, pattern } => {
-                Builder::new().like(Arc::unwrap_or_clone(expr).into(), pattern)
-            }
-            ast::ExprKind::Is { expr, entity_type } => {
-                Builder::new().is_entity_type(Arc::unwrap_or_clone(expr).into(), entity_type)
-            }
-            ast::ExprKind::Set(set) => {
-                Builder::new().set(Arc::unwrap_or_clone(set).into_iter().map(Into::into))
-            }
-            // PANIC SAFETY: `map` is a map, so it will not have duplicates keys, so the `record` constructor cannot error.
-            #[allow(clippy::unwrap_used)]
-            ast::ExprKind::Record(map) => Builder::new()
-                .record(
-                    Arc::unwrap_or_clone(map)
-                        .into_iter()
-                        .map(|(k, v)| (k, v.into())),
-                )
-                .unwrap(),
-            #[cfg(feature = "tolerant-ast")]
-            // PANIC SAFETY: error type is Infallible so can never happen
-            #[allow(clippy::unwrap_used)]
-            ast::ExprKind::Error { .. } => Builder::new()
-                .error(ParseErrors::singleton(ToASTError::new(
-                    ToASTErrorKind::ASTErrorNode,
-                    Loc::new(0..1, "AST_ERROR_NODE".into()),
-                )))
-                .unwrap(),
-        }
-    }
-}
-
 impl From<ast::Literal> for Expr {
     fn from(lit: ast::Literal) -> Expr {
         Builder::new().val(lit)
@@ -1629,7 +1551,9 @@ mod test {
 
     #[test]
     fn display_and_bounded_display() {
-        let expr = Expr::from(parse_expr(r#"[100, [3, 4, 5], -20, "foo"]"#).unwrap());
+        let expr = parse_expr(r#"[100, [3, 4, 5], -20, "foo"]"#)
+            .unwrap()
+            .into_expr::<Builder>();
         assert_eq!(format!("{expr}"), r#"[100, [3, 4, 5], (-20), "foo"]"#);
         assert_eq!(
             BoundedToString::to_string(&expr, None),
@@ -1650,17 +1574,16 @@ mod test {
         assert_eq!(BoundedToString::to_string(&expr, Some(1)), r#"[100, ..]"#);
         assert_eq!(BoundedToString::to_string(&expr, Some(0)), r#"[..]"#);
 
-        let expr = Expr::from(
-            parse_expr(
-                r#"{
+        let expr = parse_expr(
+            r#"{
             a: 12,
             b: [3, 4, true],
             c: -20,
             "hello ∞ world": "∂µß≈¥"
         }"#,
-            )
-            .unwrap(),
-        );
+        )
+        .unwrap()
+        .into_expr::<Builder>();
         assert_eq!(
             format!("{expr}"),
             r#"{"a": 12, "b": [3, 4, true], "c": (-20), "hello ∞ world": "∂µß≈¥"}"#

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -28,7 +28,7 @@ use crate::{
 };
 
 #[cfg(feature = "tolerant-ast")]
-use crate::parser::err::ParseErrors;
+use {crate::parser::err::ParseErrors, std::fmt::Debug};
 
 /// Defines a generic interface for building different expression data
 /// structures.
@@ -46,7 +46,7 @@ pub trait ExprBuilder: Clone {
     ///  By default we fail on errors and this should be a ParseErrors
     ///  But when we run with error parsing enabled, can be Infallible
     #[cfg(feature = "tolerant-ast")]
-    type ErrorType;
+    type ErrorType: Debug;
 
     /// Construct a new expression builder for an expression that will not carry any data.
     fn new() -> Self


### PR DESCRIPTION
## Description of changes

Added a function to convert from `Expr<T>` to `Expr` by dropping the data to allow creating a new `PolicySet` from a type-checked `Expr` using `Policy::from_when_clause`. I considered updating `from_when_clause` to take `Expr<T>` but that required a lot of invasive changes. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.