### PR TITLE
Optimize `ParseErrors::transpose` method

### DIFF
--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -863,14 +863,14 @@ impl ParseErrors {
 
         let mut oks = Vec::with_capacity(capacity);
         let mut errs = Vec::new();
-    
+
         for r in iter {
             match r {
                 Ok(v) => oks.push(v),
                 Err(e) => errs.push(e),
             }
         }
-    
+
         if errs.is_empty() {
             Ok(oks)
         } else {


### PR DESCRIPTION
## Description of changes

Optimize the `ParseErrors::transpose` method which I've noticed is spending a good amount of time while parsing. The implementation may look quite basic (at least in the actual iteration) but it collects and extract both kind of values in one pass. The size hint also helps optimize this code as it allows us to allocate the estimated space for `oks` in one go and avoid re-allocations.

I wasn't sure the `size_hint` part was actually helping but I ran a comparison just to be sure:
```
example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_before                   │               │               │               │         │
   ├─ 1             23.74 µs      │ 905.1 µs      │ 24.45 µs      │ 25.67 µs      │ 1000    │ 1000
   ├─ 100           247.5 µs      │ 472.9 µs      │ 253.9 µs      │ 257.3 µs      │ 1000    │ 1000
   ├─ 1000          2.306 ms      │ 2.998 ms      │ 2.415 ms      │ 2.444 ms      │ 1000    │ 1000
   ├─ 5000          13 ms         │ 46.47 ms      │ 13.49 ms      │ 13.86 ms      │ 1000    │ 1000
   ├─ 10000         27.28 ms      │ 43.87 ms      │ 28.17 ms      │ 28.52 ms      │ 1000    │ 1000
   ╰─ 20000         57.65 ms      │ 76.06 ms      │ 59.8 ms       │ 60.28 ms      │ 1000    │ 1000
 
example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_only-pushes              │               │               │               │         │
   ├─ 1             24.99 µs      │ 1.205 ms      │ 27.79 µs      │ 29.17 µs      │ 1000    │ 1000
   ├─ 100           245 µs        │ 284.8 µs      │ 247.2 µs      │ 248.8 µs      │ 1000    │ 1000
   ├─ 1000          2.226 ms      │ 2.563 ms      │ 2.289 ms      │ 2.292 ms      │ 1000    │ 1000
   ├─ 5000          12.69 ms      │ 15.05 ms      │ 12.96 ms      │ 13.08 ms      │ 1000    │ 1000
   ├─ 10000         26.67 ms      │ 41.74 ms      │ 27.36 ms      │ 27.63 ms      │ 1000    │ 1000
   ╰─ 20000         56.3 ms       │ 74.88 ms      │ 57.77 ms      │ 58.21 ms      │ 1000    │ 1000
   
 example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_hint+pushes              │               │               │               │         │
   ├─ 1             23.7 µs       │ 995.5 µs      │ 28.91 µs      │ 29.6 µs       │ 1000    │ 1000
   ├─ 100           237.5 µs      │ 350.5 µs      │ 239.3 µs      │ 242.4 µs      │ 1000    │ 1000
   ├─ 1000          2.22 ms       │ 2.6 ms        │ 2.268 ms      │ 2.288 ms      │ 1000    │ 1000
   ├─ 5000          12.15 ms      │ 14.78 ms      │ 12.41 ms      │ 12.55 ms      │ 1000    │ 1000
   ├─ 10000         25.99 ms      │ 71.53 ms      │ 26.55 ms      │ 26.97 ms      │ 1000    │ 1000
   ╰─ 20000         54.16 ms      │ 76.12 ms      │ 55.53 ms      │ 55.94 ms      │ 1000    │ 1000
```

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
