### PR TITLE
Avoid calling `transpose` in `maybe_to_var`

### DIFF
--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2043,17 +2043,11 @@ impl Node<Option<cst::Name>> {
     // so it's fine to return an `Option` instead of a `Result`.
     fn maybe_to_var(&self) -> Option<ast::Var> {
         let name = self.as_inner()?;
-
-        let ident = match ParseErrors::transpose(name.path.iter().map(|id| id.to_valid_ident())) {
-            Ok(path) => {
-                if !path.is_empty() {
-                    // The path should be empty for a variable
-                    None
-                } else {
-                    name.name.as_inner()
-                }
-            }
-            Err(_) => None,
+        let ident = if name.path.is_empty() {
+            name.name.as_inner()
+        } else {
+            // The path should be empty for a variable
+            None
         }?;
 
         match ident {


### PR DESCRIPTION
## Description of changes

My observation is that `ParseErrors::transpose` can only return `Err` (causing this function to return `None`) if `name.path` is non-empty, but the function should unconditionally return `None` if `name.path` is non-empty, so we can skip the whole `transpose` call. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
