### PR TITLE
Updates coverage creation action to use grcov 0.8.20

### DIFF
--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -24,7 +24,7 @@ runs:
       run: rustup component add llvm-tools-preview
     - name: Install grcov
       shell: bash
-      run: cargo install grcov
+      run: cargo install grcov --version 0.8.20
     - name: Collect coverage profiles
       shell: bash
       run: zip -0 raw_cov.zip $(find . -name "*.profraw") -q


### PR DESCRIPTION
## Description of changes

Updates coverage creation action to use grcov 0.8.20 to avoid issues with newest grcov version that depends on a yanked zip dependency.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
