### PR TITLE
Add `into_smolstr` for `UnreservedId`

### DIFF
--- a/cedar-policy-core/src/ast/id.rs
+++ b/cedar-policy-core/src/ast/id.rs
@@ -153,6 +153,11 @@ impl UnreservedId {
         #[allow(clippy::unwrap_used)]
         Id("".into()).try_into().unwrap()
     }
+
+    /// Get the underlying string
+    pub fn into_smolstr(self) -> SmolStr {
+        self.0.into_smolstr()
+    }
 }
 
 struct IdVisitor;

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1392,7 +1392,7 @@ impl Node<Option<cst::Relation>> {
                 let maybe_target = target.to_expr::<Build>();
                 let maybe_field = Ok(match field.to_has_rhs::<Build>()? {
                     Either::Left(s) => nonempty![s],
-                    Either::Right(ids) => ids.map(|id| id.to_smolstr()),
+                    Either::Right(ids) => ids.map(|id| id.into_smolstr()),
                 });
                 let (target, field) = flatten_tuple_2(maybe_target, maybe_field)?;
                 Ok(ExprOrSpecial::Expr {
@@ -1757,7 +1757,7 @@ impl Node<Option<cst::Member>> {
                 Ok((
                     Build::new()
                         .with_source_loc(&self.loc)
-                        .get_attr(head, id.to_smolstr()),
+                        .get_attr(head, id.into_smolstr()),
                     rest,
                 ))
             }
@@ -1836,7 +1836,7 @@ impl Node<Option<cst::Member>> {
                     (
                         Build::new().with_source_loc(&self.loc).get_attr(
                             Build::new().with_source_loc(&var_loc).var(var),
-                            id.to_smolstr(),
+                            id.into_smolstr(),
                         ),
                         rest,
                     )
@@ -1846,7 +1846,7 @@ impl Node<Option<cst::Member>> {
                     return Err(self
                         .to_ast_err(ToASTErrorKind::InvalidAccess {
                             lhs: name,
-                            field: f.to_smolstr(),
+                            field: f.clone().into_smolstr(),
                         })
                         .into());
                 }


### PR DESCRIPTION
## Description of changes

Another tweak to improve usage of `SmolStr`. Our `Id` struct is a wrapper around `SmolStr`  and has a method `into_smolstr` to efficiently get the underlying string. `UnreservedId` is a wrapper around `Id`, so it can also have an `into_smolstr` method. IIUC, using `into_smolstr` instead of `to_smolstr` saves a `O(n)` string copy which we can benefit from in four places in cst-to-ast conversion. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
