### PR TITLE
Make typed expression generation consistent with Lean

### DIFF
--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -974,4 +974,62 @@ mod levels_validation_tests {
             6,
         );
     }
+
+    #[test]
+    fn short_circuiting_checks_evaluated_expr() {
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { (principal.bool || true) || true};"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { (principal.bool && false) && false};"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if (principal.bool && false) then true else false };"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if (principal.bool && false) then true else false };"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if true then principal.bool else false };"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if false then true else principal.bool };"#,
+            ["principal.bool"],
+            1,
+        );
+    }
+
+    #[test]
+    fn short_circuiting_skips_unevaluated_expr() {
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { true || principal.bool};"#,
+            [],
+            0,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { false && principal.bool};"#,
+            [],
+            0,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if false then principal.bool else false };"#,
+            [],
+            0,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if true then true else principal.bool };"#,
+            [],
+            0,
+        );
+    }
 }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -577,12 +577,10 @@ impl<'a> SingleEnvTypechecker<'a> {
                 );
                 ans_left.then_typecheck(|typ_left, capability_left| {
                     match typ_left.data() {
-                        // LHS argument is false, so short circuit the `&&` to `False` _without_
-                        // typechecking the RHS.
+                        // LHS argument is false, so short circuit the `&&` to
+                        // `False` _without_ typechecking the RHS.
                         Some(Type::False) => TypecheckAnswer::success(
-                            ExprBuilder::with_data(Some(Type::False))
-                                .with_same_source_loc(e)
-                                .val(false),
+                            typ_left.with_maybe_source_loc(e.source_loc().cloned()),
                         ),
                         _ => {
                             // Similar to the `then` branch of an `if`
@@ -670,12 +668,11 @@ impl<'a> SingleEnvTypechecker<'a> {
                     |_| None,
                 );
                 ans_left.then_typecheck(|ty_expr_left, capability_left| match ty_expr_left.data() {
-                    // LHS argument is true, so short circuit the `|| to `True` _without_
-                    // typechecking the RHS.
+                    // LHS argument is true, so short circuit the `|| to `True`
+                    // _without_ typechecking the RHS. Contrary to `&&`, we
+                    // keep a capability  when short circuiting `||`.
                     Some(Type::True) => TypecheckAnswer::success_with_capability(
-                        ExprBuilder::with_data(Some(Type::True))
-                            .with_same_source_loc(e)
-                            .val(true),
+                        ty_expr_left.with_maybe_source_loc(e.source_loc().cloned()),
                         capability_left,
                     ),
                     _ => {

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -578,13 +578,11 @@ impl<'a> SingleEnvTypechecker<'a> {
                 ans_left.then_typecheck(|typ_left, capability_left| {
                     match typ_left.data() {
                         // LHS argument is false, so short circuit the `&&` to `False` _without_
-                        // typechecking the RHS.  We still need to build an annotated `&&` with
-                        // some RHS, so we use a literal `true`. The `&&` expression typechecks
-                        // with an empty capability rather than the capability of the lhs.
+                        // typechecking the RHS.
                         Some(Type::False) => TypecheckAnswer::success(
                             ExprBuilder::with_data(Some(Type::False))
                                 .with_same_source_loc(e)
-                                .and(typ_left, ExprBuilder::new().val(true)),
+                                .val(false),
                         ),
                         _ => {
                             // Similar to the `then` branch of an `if`
@@ -673,15 +671,11 @@ impl<'a> SingleEnvTypechecker<'a> {
                 );
                 ans_left.then_typecheck(|ty_expr_left, capability_left| match ty_expr_left.data() {
                     // LHS argument is true, so short circuit the `|| to `True` _without_
-                    // typechecking the RHS. We still need to build an annotated `||` with
-                    // some RHS, so we use a literal `true`.  Contrary to `&&`, we keep a
-                    // capability  when short circuiting `||`. The left operand is `true`,
-                    // so its capability is maintained. The right operand is not evaluated,
-                    // so its capability is not considered.
+                    // typechecking the RHS.
                     Some(Type::True) => TypecheckAnswer::success_with_capability(
                         ExprBuilder::with_data(Some(Type::True))
                             .with_same_source_loc(e)
-                            .or(ty_expr_left, ExprBuilder::new().val(true)),
+                            .val(true),
                         capability_left,
                     ),
                     _ => {


### PR DESCRIPTION
We produce Boolean literals when and/or operations short-circuit.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.