### PR TITLE
Make location info optional

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -480,7 +480,7 @@ impl<T> Expr<T> {
             ExprKind::Error { .. } => builder
                 .error(ParseErrors::singleton(ToASTError::new(
                     ToASTErrorKind::ASTErrorNode,
-                    Loc::new(0..1, "AST_ERROR_NODE".into()),
+                    Some(Loc::new(0..1, "AST_ERROR_NODE".into())),
                 )))
                 .unwrap(),
         }

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -547,7 +547,7 @@ impl Name {
                         src: s.to_string(),
                         normalized_src,
                     },
-                    Loc::new(diff_byte, s.into()),
+                    Some(Loc::new(diff_byte, s.into())),
                 )))
             }
         }
@@ -570,11 +570,11 @@ impl From<ReservedNameError> for ParseError {
     fn from(value: ReservedNameError) -> Self {
         ParseError::ToAST(ToASTError::new(
             value.clone().into(),
-            match &value.0.loc {
-                Some(loc) => loc.clone(),
+            match value.0.loc {
+                loc @ Some(_) => loc,
                 None => {
                     let name_str = value.0.to_string();
-                    Loc::new(0..(name_str.len()), name_str.into())
+                    Some(Loc::new(0..(name_str.len()), name_str.into()))
                 }
             },
         ))

--- a/cedar-policy-core/src/ast/name.rs
+++ b/cedar-policy-core/src/ast/name.rs
@@ -570,13 +570,10 @@ impl From<ReservedNameError> for ParseError {
     fn from(value: ReservedNameError) -> Self {
         ParseError::ToAST(ToASTError::new(
             value.clone().into(),
-            match value.0.loc {
-                loc @ Some(_) => loc,
-                None => {
-                    let name_str = value.0.to_string();
-                    Some(Loc::new(0..(name_str.len()), name_str.into()))
-                }
-            },
+            value.0.loc.clone().or_else(|| {
+                let name_str = value.0.to_string();
+                Some(Loc::new(0..(name_str.len()), name_str.into()))
+            }),
         ))
     }
 }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -2380,7 +2380,7 @@ mod test {
         let expected_error = <ExprWithErrsBuilder as ExprBuilder>::new()
             .error(ParseErrors::singleton(ToASTError::new(
                 ToASTErrorKind::ASTErrorNode,
-                Loc::new(0..1, "ASTErrorNode".into()),
+                Some(Loc::new(0..1, "ASTErrorNode".into())),
             )))
             .unwrap();
 

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -71,7 +71,7 @@ cfg_tolerant_ast! {
             <ExprWithErrsBuilder as ExprBuilder>::new()
                 .error(ParseErrors::singleton(ToASTError::new(
                     ToASTErrorKind::ASTErrorNode,
-                    Loc::new(0..1, "ASTErrorNode".into()),
+                    Some(Loc::new(0..1, "ASTErrorNode".into())),
                 )))
                 .unwrap(),
         )

--- a/cedar-policy-core/src/ast/restricted_expr.rs
+++ b/cedar-policy-core/src/ast/restricted_expr.rs
@@ -761,7 +761,7 @@ mod test {
                         }
                         .into()
                     ),
-                    Loc::new(0..32, Arc::from(str))
+                    Some(Loc::new(0..32, Arc::from(str)))
                 )))
             )),
         )

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -68,10 +68,10 @@ macro_rules! impl_diagnostic_from_two_source_loc_fields {
 
         fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
             let spans: Vec<_> = [&self.$i, &self.$j]
-            .into_iter()
-            .filter_map(|loc| loc.as_ref())
-            .map(|loc| miette::LabeledSpan::underline(loc.span))
-            .collect();
+                .into_iter()
+                .filter_map(|loc| loc.as_ref())
+                .map(|loc| miette::LabeledSpan::underline(loc.span))
+                .collect();
 
             if spans.is_empty() {
                 None

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -21,13 +21,14 @@
 macro_rules! impl_diagnostic_from_source_loc_field {
     ( $i:ident ) => {
         fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            Some(&self.$i.src as &dyn miette::SourceCode)
+            self.$i.as_ref().map(|l| &l.src as &dyn miette::SourceCode)
         }
 
         fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            Some(Box::new(std::iter::once(miette::LabeledSpan::underline(
-                self.$i.span,
-            ))) as _)
+            self.$i.as_ref().map(|l| {
+                Box::new(std::iter::once(miette::LabeledSpan::underline(l.span)))
+                    as Box<dyn Iterator<Item = miette::LabeledSpan> + '_>
+            })
         }
     };
 }
@@ -62,17 +63,21 @@ macro_rules! impl_diagnostic_from_two_source_loc_fields {
         fn source_code(&self) -> Option<&dyn miette::SourceCode> {
             // use the `src` from the first location and assume it is the same
             // as the `src` from the second location
-            Some(&self.$i.src as &dyn miette::SourceCode)
+            self.$i.as_ref().map(|l| &l.src as &dyn miette::SourceCode)
         }
 
         fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            Some(Box::new(
-                [
-                    miette::LabeledSpan::underline(self.$i.span),
-                    miette::LabeledSpan::underline(self.$j.span),
-                ]
-                .into_iter(),
-            ) as _)
+            let spans: Vec<_> = [&self.$i, &self.$j]
+            .into_iter()
+            .filter_map(|loc| loc.as_ref())
+            .map(|loc| miette::LabeledSpan::underline(loc.span))
+            .collect();
+
+            if spans.is_empty() {
+                None
+            } else {
+                Some(Box::new(spans.into_iter()))
+            }
         }
     };
 }

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -21,14 +21,13 @@
 macro_rules! impl_diagnostic_from_source_loc_field {
     ( $i:ident ) => {
         fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            self.$i.as_ref().map(|l| &l.src as &dyn miette::SourceCode)
+            Some(&self.$i.src as &dyn miette::SourceCode)
         }
 
         fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            self.$i.as_ref().map(|l| {
-                Box::new(std::iter::once(miette::LabeledSpan::underline(l.span)))
-                    as Box<dyn Iterator<Item = miette::LabeledSpan> + '_>
-            })
+            Some(Box::new(std::iter::once(miette::LabeledSpan::underline(
+                self.$i.span,
+            ))) as _)
         }
     };
 }

--- a/cedar-policy-core/src/error_macros.rs
+++ b/cedar-policy-core/src/error_macros.rs
@@ -16,24 +16,6 @@
 
 /// Macro which implements the `.labels()` and `.source_code()` methods of
 /// `miette::Diagnostic` by using the parameter `$i` which must be the name
-/// of a field of type `Loc`
-#[macro_export]
-macro_rules! impl_diagnostic_from_source_loc_field {
-    ( $i:ident ) => {
-        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            Some(&self.$i.src as &dyn miette::SourceCode)
-        }
-
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            Some(Box::new(std::iter::once(miette::LabeledSpan::underline(
-                self.$i.span,
-            ))) as _)
-        }
-    };
-}
-
-/// Macro which implements the `.labels()` and `.source_code()` methods of
-/// `miette::Diagnostic` by using the parameter `$i` which must be the name
 /// of a field of type `Option<Loc>`
 #[macro_export]
 macro_rules! impl_diagnostic_from_source_loc_opt_field {
@@ -48,35 +30,6 @@ macro_rules! impl_diagnostic_from_source_loc_opt_field {
             self.$($id).+
                 .as_ref()
                 .map(|loc| Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span))) as _)
-        }
-    };
-}
-
-/// Macro which implements the `.labels()` and `.source_code()` methods of
-/// `miette::Diagnostic` by using the parameters `$i` and `$j` which must be
-/// names of fields of type `Loc`.
-/// Both locations will be underlined. It is assumed they have the same `src`.
-#[macro_export]
-macro_rules! impl_diagnostic_from_two_source_loc_fields {
-    ( $i:ident, $j:ident ) => {
-        fn source_code(&self) -> Option<&dyn miette::SourceCode> {
-            // use the `src` from the first location and assume it is the same
-            // as the `src` from the second location
-            self.$i.as_ref().map(|l| &l.src as &dyn miette::SourceCode)
-        }
-
-        fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-            let spans: Vec<_> = [&self.$i, &self.$j]
-                .into_iter()
-                .filter_map(|loc| loc.as_ref())
-                .map(|loc| miette::LabeledSpan::underline(loc.span))
-                .collect();
-
-            if spans.is_empty() {
-                None
-            } else {
-                Some(Box::new(spans.into_iter()))
-            }
         }
     };
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -181,7 +181,7 @@ impl TryFrom<cst::Policy> for Policy {
         let maybe_annotations = policy.get_ast_annotations(|v, l| {
             Some(Annotation {
                 val: v?,
-                loc: Some(l.clone()),
+                loc: l.cloned(),
             })
         });
         let maybe_conditions = ParseErrors::transpose(policy.conds.into_iter().map(|node| {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -172,7 +172,7 @@ impl TryFrom<cst::Policy> for Policy {
                 return Err(ParseErrors::singleton(ToASTError::new(
                     ToASTErrorKind::CSTErrorNode,
                     // Since we don't have a loc when doing this transformation, we create an arbitrary one
-                    Loc::new(0..1, "CSTErrorNode".into()),
+                    Some(Loc::new(0..1, "CSTErrorNode".into())),
                 )));
             }
         };

--- a/cedar-policy-core/src/from_normalized_str.rs
+++ b/cedar-policy-core/src/from_normalized_str.rs
@@ -56,7 +56,7 @@ pub trait FromNormalizedStr: FromStr<Err = ParseErrors> + Display {
                     src: s.to_string(),
                     normalized_src,
                 },
-                Loc::new(diff_byte, s.into()),
+                Some(Loc::new(diff_byte, s.into())),
             ))))
         }
     }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -73,8 +73,14 @@ pub fn parse_policyset_and_also_return_policy_text(
     // `PolicyId` present as a key in this map.
     let texts = cst
         .with_generated_policyids()
-        .expect("shouldn't be None since parse_policies() and to_policyset() didn't return Err")
-        .map(|(id, policy)| (id, &text[policy.loc.start()..policy.loc.end()]))
+        .expect("shouldn't be `None` since `parse_policies` and `to_policyset` didn't return `Err`")
+        .map(|(id, policy)| {
+            if let Some(loc) = &policy.loc {
+                (id, &text[loc.start()..loc.end()])
+            } else {
+                (id, "<undefined>")
+            }
+        })
         .collect::<HashMap<ast::PolicyID, &str>>();
     Ok((texts, pset))
 }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -75,11 +75,11 @@ pub fn parse_policyset_and_also_return_policy_text(
         .with_generated_policyids()
         .expect("shouldn't be `None` since `parse_policies` and `to_policyset` didn't return `Err`")
         .map(|(id, policy)| {
-            if let Some(loc) = &policy.loc {
-                (id, &text[loc.start()..loc.end()])
-            } else {
-                (id, "<undefined>")
-            }
+            let loc = policy
+                .loc
+                .as_ref()
+                .expect("shouldn't be `None` since we parse with locations");
+            (id, &text[loc.start()..loc.end()])
         })
         .collect::<HashMap<ast::PolicyID, &str>>();
     Ok((texts, pset))

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -427,7 +427,7 @@ impl Node<Option<cst::Policy>> {
                         slot.clone(),
                         if is_when { "when" } else { "unless" },
                     ),
-                    slot.loc.or_else(|| self.loc.clone()),
+                    slot.loc.or_else(|| c.loc.clone()),
                 )
                 .into()
             });
@@ -545,7 +545,7 @@ impl cst::PolicyImpl {
         let mut vars = self.variables.iter();
         let maybe_principal = if let Some(scope1) = vars.next() {
             end_of_last_var = scope1.loc.as_ref().map(|loc| loc.end()).or(end_of_last_var);
-            scope1.to_principal_constraint(TolerantAstSetting::NotTolerant)
+            scope1.to_principal_constraint(TolerantAstSetting::Tolerant)
         } else {
             let effect_span = self
                 .effect
@@ -560,7 +560,7 @@ impl cst::PolicyImpl {
         };
         let maybe_action = if let Some(scope2) = vars.next() {
             end_of_last_var = scope2.loc.as_ref().map(|loc| loc.end()).or(end_of_last_var);
-            scope2.to_action_constraint(TolerantAstSetting::NotTolerant)
+            scope2.to_action_constraint(TolerantAstSetting::Tolerant)
         } else {
             let effect_span = self
                 .effect
@@ -574,7 +574,7 @@ impl cst::PolicyImpl {
             .into())
         };
         let maybe_resource = if let Some(scope3) = vars.next() {
-            scope3.to_resource_constraint(TolerantAstSetting::NotTolerant)
+            scope3.to_resource_constraint(TolerantAstSetting::Tolerant)
         } else {
             let effect_span = self
                 .effect

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1903,8 +1903,8 @@ impl Node<Option<cst::Member>> {
                                 Build::new()
                                     .with_maybe_source_loc(var_loc.as_ref())
                                     .var(var),
-                            id.into_smolstr(),
-                        ),
+                                id.into_smolstr(),
+                            ),
                         rest,
                     )
                 }

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -540,7 +540,7 @@ mod test {
     fn test_primary_rinits_node() -> Node<Option<cst::Primary>> {
         Node {
             node: Some(cst::Primary::RInits(vec![])),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -548,9 +548,9 @@ mod test {
         Node {
             node: Some(cst::Primary::Expr(Node {
                 node: Some(cst::Expr::ErrorExpr),
-                loc: Loc::new(0..1, "This is a test".into()),
+                loc: Some(Loc::new(0..1, "This is a test".into())),
             })),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -559,14 +559,14 @@ mod test {
             node: Some(cst::Primary::EList(vec![
                 Node {
                     node: Some(test_expr()),
-                    loc: Loc::new(0..1, "This is also a test".into()),
+                    loc: Some(Loc::new(0..1, "This is also a test".into())),
                 },
                 Node {
                     node: Some(test_expr()),
-                    loc: Loc::new(0..1, "This is also a test".into()),
+                    loc: Some(Loc::new(0..1, "This is also a test".into())),
                 },
             ])),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -579,10 +579,10 @@ mod test {
                         item: test_primary_ref_node(),
                         access: vec![],
                     }),
-                    loc: Loc::new(0..1, "This is a test".into()),
+                    loc: Some(Loc::new(0..1, "This is a test".into())),
                 },
             }),
-            loc: Loc::new(0..1, "This is a test".into()),
+            loc: Some(Loc::new(0..1, "This is a test".into())),
         }
     }
 
@@ -592,7 +592,7 @@ mod test {
                 initial: test_unary_node(),
                 extended: vec![],
             }),
-            loc: Loc::new(0..1, "This is a test".into()),
+            loc: Some(Loc::new(0..1, "This is a test".into())),
         }
     }
 
@@ -602,7 +602,7 @@ mod test {
                 initial: test_mult_node(),
                 extended: vec![],
             }),
-            loc: Loc::new(0..1, "This is a test".into()),
+            loc: Some(Loc::new(0..1, "This is a test".into())),
         }
     }
 
@@ -612,7 +612,7 @@ mod test {
                 initial: test_add_node(),
                 extended: vec![],
             }),
-            loc: Loc::new(0..1, "This is a test".into()),
+            loc: Some(Loc::new(0..1, "This is a test".into())),
         }
     }
 
@@ -625,10 +625,10 @@ mod test {
                         initial: test_relation_node(),
                         extended: vec![],
                     }),
-                    loc: Loc::new(0..1, "This is a test".into()),
+                    loc: Some(Loc::new(0..1, "This is a test".into())),
                 },
             }),
-            loc: Loc::new(0..1, "This is a test".into()),
+            loc: Some(Loc::new(0..1, "This is a test".into())),
         })
     }
 
@@ -642,9 +642,9 @@ mod test {
         Node {
             node: Some(cst::Primary::Expr(Node {
                 node: Some(test_expr()),
-                loc: Loc::new(0..1, "This is a test".into()),
+                loc: Some(Loc::new(0..1, "This is a test".into())),
             })),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -654,13 +654,13 @@ mod test {
                 node: Some(Name {
                     path: vec![],
                     name: Node {
-                        loc: Loc::new(0..1, "So much testing".into()),
+                        loc: Some(Loc::new(0..1, "So much testing".into())),
                         node: Some(cst::Ident::Ident("test".into())),
                     },
                 }),
-                loc: Loc::new(0..1, "This is a test".into()),
+                loc: Some(Loc::new(0..1, "This is a test".into())),
             })),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -668,9 +668,9 @@ mod test {
         Node {
             node: Some(cst::Primary::Literal(Node {
                 node: Some(cst::Literal::True),
-                loc: Loc::new(0..1, "This is a test".into()),
+                loc: Some(Loc::new(0..1, "This is a test".into())),
             })),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -678,9 +678,9 @@ mod test {
         Node {
             node: Some(cst::Primary::Slot(Node {
                 node: Some(cst::Slot::Principal),
-                loc: Loc::new(0..1, "This is a test".into()),
+                loc: Some(Loc::new(0..1, "This is a test".into())),
             })),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 
@@ -692,20 +692,20 @@ mod test {
                         node: Some(Name {
                             path: vec![],
                             name: Node {
-                                loc: Loc::new(0..1, "So much testing".into()),
+                                loc: Some(Loc::new(0..1, "So much testing".into())),
                                 node: Some(cst::Ident::Ident("test".into())),
                             },
                         }),
-                        loc: Loc::new(0..1, "This is a test".into()),
+                        loc: Some(Loc::new(0..1, "This is a test".into())),
                     },
                     eid: Node {
                         node: Some(cst::Str::String("test".into())),
-                        loc: Loc::new(0..1, "This is a test".into()),
+                        loc: Some(Loc::new(0..1, "This is a test".into())),
                     },
                 }),
-                loc: Loc::new(0..1, "This is a test".into()),
+                loc: Some(Loc::new(0..1, "This is a test".into())),
             })),
-            loc: Loc::new(0..1, "This is also a test".into()),
+            loc: Some(Loc::new(0..1, "This is also a test".into())),
         }
     }
 }

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -82,7 +82,7 @@ pub struct ToASTError {
 // Construct `labels` and `source_code` based on the `loc` in this
 // struct; and everything else forwarded directly to `kind`.
 impl Diagnostic for ToASTError {
-    impl_diagnostic_from_source_loc_field!(loc);
+    impl_diagnostic_from_source_loc_opt_field!(loc);
 
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.kind.code()

--- a/cedar-policy-core/src/parser/err.rs
+++ b/cedar-policy-core/src/parser/err.rs
@@ -76,7 +76,7 @@ pub enum LiteralParseError {
 #[error("{kind}")]
 pub struct ToASTError {
     kind: ToASTErrorKind,
-    loc: Loc,
+    loc: Option<Loc>,
 }
 
 // Construct `labels` and `source_code` based on the `loc` in this
@@ -107,7 +107,7 @@ impl Diagnostic for ToASTError {
 
 impl ToASTError {
     /// Construct a new `ToASTError`.
-    pub fn new(kind: ToASTErrorKind, loc: Loc) -> Self {
+    pub fn new(kind: ToASTErrorKind, loc: Option<Loc>) -> Self {
         Self { kind, loc }
     }
 
@@ -116,8 +116,8 @@ impl ToASTError {
         &self.kind
     }
 
-    pub(crate) fn source_loc(&self) -> &Loc {
-        &self.loc
+    pub(crate) fn source_loc(&self) -> Option<&Loc> {
+        self.loc.as_ref()
     }
 }
 
@@ -618,18 +618,20 @@ pub struct ToCSTError {
 
 impl ToCSTError {
     /// Extract a primary source span locating the error.
-    pub fn primary_source_span(&self) -> SourceSpan {
+    pub fn primary_source_span(&self) -> Option<SourceSpan> {
         match &self.err {
-            OwnedRawParseError::InvalidToken { location } => SourceSpan::from(*location),
-            OwnedRawParseError::UnrecognizedEof { location, .. } => SourceSpan::from(*location),
+            OwnedRawParseError::InvalidToken { location } => Some(SourceSpan::from(*location)),
+            OwnedRawParseError::UnrecognizedEof { location, .. } => {
+                Some(SourceSpan::from(*location))
+            }
             OwnedRawParseError::UnrecognizedToken {
                 token: (token_start, _, token_end),
                 ..
-            } => SourceSpan::from(*token_start..*token_end),
+            } => Some(SourceSpan::from(*token_start..*token_end)),
             OwnedRawParseError::ExtraToken {
                 token: (token_start, _, token_end),
-            } => SourceSpan::from(*token_start..*token_end),
-            OwnedRawParseError::User { error } => error.loc.span,
+            } => Some(SourceSpan::from(*token_start..*token_end)),
+            OwnedRawParseError::User { error } => error.loc.clone().map(|loc| loc.span),
         }
     }
 
@@ -669,19 +671,17 @@ impl Diagnostic for ToCSTError {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
-        let primary_source_span = self.primary_source_span();
+        let span = self.primary_source_span()?;
         let labeled_span = match &self.err {
-            OwnedRawParseError::InvalidToken { .. } => LabeledSpan::underline(primary_source_span),
-            OwnedRawParseError::UnrecognizedEof { expected, .. } => LabeledSpan::new_with_span(
-                expected_to_string(expected, &POLICY_TOKEN_CONFIG),
-                primary_source_span,
-            ),
-            OwnedRawParseError::UnrecognizedToken { expected, .. } => LabeledSpan::new_with_span(
-                expected_to_string(expected, &POLICY_TOKEN_CONFIG),
-                primary_source_span,
-            ),
-            OwnedRawParseError::ExtraToken { .. } => LabeledSpan::underline(primary_source_span),
-            OwnedRawParseError::User { .. } => LabeledSpan::underline(primary_source_span),
+            OwnedRawParseError::InvalidToken { .. } => LabeledSpan::underline(span),
+            OwnedRawParseError::UnrecognizedEof { expected, .. } => {
+                LabeledSpan::new_with_span(expected_to_string(expected, &POLICY_TOKEN_CONFIG), span)
+            }
+            OwnedRawParseError::UnrecognizedToken { expected, .. } => {
+                LabeledSpan::new_with_span(expected_to_string(expected, &POLICY_TOKEN_CONFIG), span)
+            }
+            OwnedRawParseError::ExtraToken { .. } => LabeledSpan::underline(span),
+            OwnedRawParseError::User { .. } => LabeledSpan::underline(span),
         };
         Some(Box::new(iter::once(labeled_span)))
     }

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -33,12 +33,20 @@ pub struct Node<T> {
     #[educe(PartialEq(ignore))]
     #[educe(PartialOrd(ignore))]
     #[educe(Hash(ignore))]
-    pub loc: Loc,
+    pub loc: Option<Loc>,
 }
 
 impl<T> Node<T> {
     /// Create a new Node with the given source location
     pub fn with_source_loc(node: T, loc: Loc) -> Self {
+        Node {
+            node,
+            loc: Some(loc),
+        }
+    }
+
+    /// Create a new Node with optional source location
+    pub fn with_maybe_source_loc(node: T, loc: Option<Loc>) -> Self {
         Node { node, loc }
     }
 
@@ -67,7 +75,7 @@ impl<T> Node<T> {
     }
 
     /// Consume the `Node`, yielding the node and attached source info.
-    pub fn into_inner(self) -> (T, Loc) {
+    pub fn into_inner(self) -> (T, Option<Loc>) {
         (self.node, self.loc)
     }
 
@@ -161,16 +169,16 @@ impl<T> Node<Option<T>> {
     /// if no main data or if `f` returns `None`.
     pub fn apply<F, R>(&self, f: F) -> Option<R>
     where
-        F: FnOnce(&T, &Loc) -> Option<R>,
+        F: FnOnce(&T, Option<&Loc>) -> Option<R>,
     {
-        f(self.node.as_ref()?, &self.loc)
+        f(self.node.as_ref()?, self.loc.as_ref())
     }
 
     /// Apply the function `f` to the main data and `Loc`, consuming them.
     /// Returns `None` if no main data or if `f` returns `None`.
     pub fn into_apply<F, R>(self, f: F) -> Option<R>
     where
-        F: FnOnce(T, Loc) -> Option<R>,
+        F: FnOnce(T, Option<Loc>) -> Option<R>,
     {
         f(self.node?, self.loc)
     }

--- a/cedar-policy-core/src/parser/node.rs
+++ b/cedar-policy-core/src/parser/node.rs
@@ -123,7 +123,7 @@ impl<T: std::error::Error> std::error::Error for Node<T> {
 
 // impl Diagnostic by taking `labels()` and `source_code()` from .loc and everything else from .node
 impl<T: Diagnostic> Diagnostic for Node<T> {
-    impl_diagnostic_from_source_loc_field!(loc);
+    impl_diagnostic_from_source_loc_opt_field!(loc);
 
     fn code<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         self.node.code()

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -38,7 +38,8 @@ impl Doc for Node<Option<VariableDef>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let vd = self.as_inner()?;
 
-        let start_comment = get_comment_at_start(self.loc.span, &mut context.tokens)?;
+        let start_comment =
+            get_comment_at_start(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
         let var_doc = vd.variable.as_inner()?.to_doc(context)?;
 
         let is_doc = match &vd.entity_type {
@@ -46,13 +47,19 @@ impl Doc for Node<Option<VariableDef>> {
                 RcDoc::line()
                     .append(add_comment(
                         RcDoc::text("is"),
-                        get_comment_after_end(vd.variable.loc.span, &mut context.tokens)?,
+                        get_comment_after_end(
+                            vd.variable.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     ))
                     .group()
                     .append(RcDoc::line().append(add_comment(
                         entity_type.to_doc(context)?,
-                        get_comment_at_start(entity_type.loc.span, &mut context.tokens)?,
+                        get_comment_at_start(
+                            entity_type.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     )))
                     .nest(context.config.indent_width)
@@ -64,10 +71,14 @@ impl Doc for Node<Option<VariableDef>> {
         Some(match &vd.ineq {
             Some((op, rhs)) => {
                 let op_comment = match &vd.entity_type {
-                    Some(entity_type) => {
-                        get_comment_after_end(entity_type.loc.span, &mut context.tokens)?
-                    }
-                    None => get_comment_after_end(vd.variable.loc.span, &mut context.tokens)?,
+                    Some(entity_type) => get_comment_after_end(
+                        entity_type.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
+                    None => get_comment_after_end(
+                        vd.variable.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                 };
                 get_leading_comment_doc_from_str(start_comment.leading_comment()).append(
                     var_doc
@@ -95,16 +106,20 @@ impl Doc for Node<Option<VariableDef>> {
 impl Doc for Node<Option<Cond>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let cond = self.as_inner()?;
-        let lb_comment = get_comment_after_end(cond.cond.loc.span, &mut context.tokens)?;
-        let rb_comment = get_comment_at_end(self.loc.span, &mut context.tokens)?;
-        let cond_comment = get_comment_at_start(cond.cond.loc.span, &mut context.tokens)?;
+        let lb_comment =
+            get_comment_after_end(cond.cond.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
+        let rb_comment = get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
+        let cond_comment =
+            get_comment_at_start(cond.cond.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
 
         let rb_doc = add_comment(RcDoc::text("}"), rb_comment, RcDoc::nil());
         let cond_doc = cond.cond.to_doc(context)?;
         Some(match cond.expr.as_ref() {
             Some(expr) => {
-                let expr_leading_comment =
-                    get_leading_comment_at_start(expr.loc.span, &mut context.tokens)?;
+                let expr_leading_comment = get_leading_comment_at_start(
+                    expr.loc.as_ref().map(|loc| loc.span),
+                    &mut context.tokens,
+                )?;
                 let expr_doc = expr.to_doc(context)?;
                 get_leading_comment_doc_from_str(cond_comment.leading_comment()).append(
                     cond_doc
@@ -173,9 +188,18 @@ impl Doc for Node<Option<Expr>> {
                                 .nest(context.config.indent_width),
                         )
                     }
-                    let if_comment = get_comment_at_start(self.loc.span, &mut context.tokens)?;
-                    let then_comment = get_comment_after_end(c.loc.span, &mut context.tokens)?;
-                    let else_comment = get_comment_after_end(t.loc.span, &mut context.tokens)?;
+                    let if_comment = get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?;
+                    let then_comment = get_comment_after_end(
+                        c.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?;
+                    let else_comment = get_comment_after_end(
+                        t.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?;
                     Some(
                         pp_group("if", if_comment, c, context)
                             .append(RcDoc::line())
@@ -203,7 +227,7 @@ impl Doc for Node<Option<Or>> {
         let es: Vec<_> = std::iter::once(initial).chain(extended.iter()).collect();
         let mut d: RcDoc<'_> = RcDoc::nil();
         for e in es.iter().take(es.len() - 1) {
-            let op_comment = get_comment_after_end(e.loc.span, &mut context.tokens)?;
+            let op_comment = get_comment_after_end(e.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
             d = d
                 .append(e.to_doc(context))
                 .append(RcDoc::space())
@@ -223,7 +247,7 @@ impl Doc for Node<Option<And>> {
         let es: Vec<_> = std::iter::once(initial).chain(extended.iter()).collect();
         let mut d: RcDoc<'_> = RcDoc::nil();
         for e in es.iter().take(es.len() - 1) {
-            let op_comment = get_comment_after_end(e.loc.span, &mut context.tokens)?;
+            let op_comment = get_comment_after_end(e.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
             d = d
                 .append(e.to_doc(context))
                 .append(RcDoc::space())
@@ -249,7 +273,10 @@ impl Doc for Node<Option<Relation>> {
                                 .append(RcDoc::space())
                                 .append(add_comment(
                                     RcDoc::as_string(op),
-                                    get_comment_after_end(initial.loc.span, &mut context.tokens)?,
+                                    get_comment_after_end(
+                                        initial.loc.as_ref().map(|loc| loc.span),
+                                        &mut context.tokens,
+                                    )?,
                                     RcDoc::nil(),
                                 ))
                                 .append(RcDoc::space())
@@ -265,7 +292,7 @@ impl Doc for Node<Option<Relation>> {
                     .append(RcDoc::line())
                     .append(add_comment(
                         RcDoc::text("has"),
-                        get_comment_after_end(target.loc.span, &mut context.tokens)?,
+                        get_comment_after_end(target.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                         RcDoc::nil(),
                     ))
                     .append(RcDoc::line())
@@ -278,7 +305,7 @@ impl Doc for Node<Option<Relation>> {
                     .append(RcDoc::line())
                     .append(add_comment(
                         RcDoc::text("like"),
-                        get_comment_after_end(target.loc.span, &mut context.tokens)?,
+                        get_comment_after_end(target.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                         RcDoc::nil(),
                     ))
                     .append(RcDoc::line())
@@ -295,7 +322,7 @@ impl Doc for Node<Option<Relation>> {
                     .append(RcDoc::space())
                     .append(add_comment(
                         RcDoc::text("is"),
-                        get_comment_after_end(target.loc.span, &mut context.tokens)?,
+                        get_comment_after_end(target.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                         RcDoc::nil(),
                     ))
                     .append(RcDoc::space())
@@ -310,7 +337,10 @@ impl Doc for Node<Option<Relation>> {
                             .append(RcDoc::line())
                             .append(add_comment(
                                 RcDoc::text("in"),
-                                get_comment_after_end(entity_type.loc.span, &mut context.tokens)?,
+                                get_comment_after_end(
+                                    entity_type.loc.as_ref().map(|loc| loc.span),
+                                    &mut context.tokens,
+                                )?,
                                 RcDoc::nil(),
                             ))
                             .append(RcDoc::space())
@@ -346,7 +376,10 @@ impl Doc for Node<Option<Add>> {
                             .append(RcDoc::space())
                             .append(add_comment(
                                 op.to_doc(context)?,
-                                get_comment_after_end(pair.1.loc.span, &mut context.tokens)?,
+                                get_comment_after_end(
+                                    pair.1.loc.as_ref().map(|loc| loc.span),
+                                    &mut context.tokens,
+                                )?,
                                 RcDoc::nil(),
                             ))
                             .append(RcDoc::line())
@@ -382,7 +415,10 @@ impl Doc for Node<Option<Mult>> {
                             .append(RcDoc::space())
                             .append(add_comment(
                                 op.to_doc(context)?,
-                                get_comment_after_end(pair.1.loc.span, &mut context.tokens)?,
+                                get_comment_after_end(
+                                    pair.1.loc.as_ref().map(|loc| loc.span),
+                                    &mut context.tokens,
+                                )?,
                                 RcDoc::nil(),
                             ))
                             .append(RcDoc::line())
@@ -403,10 +439,12 @@ impl Doc for Node<Option<Unary>> {
             match op {
                 NegOp::OverBang | NegOp::OverDash => None,
                 NegOp::Bang(n) | NegOp::Dash(n) => {
+                    let sloc = self.loc.as_ref()?;
+                    let eloc = e.item.loc.as_ref()?;
                     let comment = get_comment_in_range(
-                        (self.loc.start()..e.item.loc.start()).into(),
+                        Some((sloc.start()..eloc.start()).into()),
                         &mut context.tokens,
-                    );
+                    )?;
                     if comment.len() != n as usize {
                         return None;
                     }
@@ -464,7 +502,10 @@ impl Doc for Node<Option<RecInit>> {
                 .append(RcDoc::line_())
                 .append(add_comment(
                     RcDoc::text(":"),
-                    get_comment_after_end(e.0.loc.span, &mut context.tokens)?,
+                    get_comment_after_end(
+                        e.0.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 ))
                 .append(value_doc),
@@ -490,7 +531,10 @@ impl Doc for Node<Option<Name>> {
                             Some((
                                 d.append(add_comment(
                                     RcDoc::text("::"),
-                                    get_comment_after_end(e.loc.span, &mut context.tokens)?,
+                                    get_comment_after_end(
+                                        e.loc.as_ref().map(|loc| loc.span),
+                                        &mut context.tokens,
+                                    )?,
                                     RcDoc::nil(),
                                 ))
                                 .append(p.to_doc(context)?),
@@ -501,7 +545,10 @@ impl Doc for Node<Option<Name>> {
                     .0
                     .append(add_comment(
                         RcDoc::text("::"),
-                        get_comment_after_end(path.last()?.loc.span, &mut context.tokens)?,
+                        get_comment_after_end(
+                            path.last()?.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     ))
                     .append(n.to_doc(context)),
@@ -518,7 +565,7 @@ impl Doc for Node<Option<Str>> {
         // on newlines, which may alter the string content.
         Some(add_comment(
             RcDoc::as_string(e),
-            get_comment_at_start(self.loc.span, &mut context.tokens)?,
+            get_comment_at_start(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
             RcDoc::nil(),
         ))
     }
@@ -531,7 +578,10 @@ impl Doc for Node<Option<Ref>> {
                 path.to_doc(context)?
                     .append(add_comment(
                         RcDoc::text("::"),
-                        get_comment_after_end(path.loc.span, &mut context.tokens)?,
+                        get_comment_after_end(
+                            path.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     ))
                     .append(eid.to_doc(context)?),
@@ -545,7 +595,7 @@ impl Doc for Node<Option<Literal>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(add_comment(
             RcDoc::as_string(self.as_inner()?),
-            get_comment_at_start(self.loc.span, &mut context.tokens)?,
+            get_comment_at_start(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
             RcDoc::nil(),
         ))
     }
@@ -555,7 +605,7 @@ impl Doc for Node<Option<Slot>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(add_comment(
             RcDoc::as_string(self.as_inner()?),
-            get_comment_at_start(self.loc.span, &mut context.tokens)?,
+            get_comment_at_start(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
             RcDoc::nil(),
         ))
     }
@@ -571,7 +621,10 @@ impl Doc for Node<Option<Primary>> {
             Primary::Expr(e) => Some(
                 add_comment(
                     RcDoc::text("("),
-                    get_comment_at_start(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 )
                 .append(RcDoc::nil())
@@ -579,7 +632,7 @@ impl Doc for Node<Option<Primary>> {
                 .append(RcDoc::nil())
                 .append(add_comment(
                     RcDoc::text(")"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 ))
                 .group(),
@@ -595,7 +648,10 @@ impl Doc for Node<Option<Primary>> {
                             Some((
                                 d.append(add_comment(
                                     RcDoc::text(","),
-                                    get_comment_after_end(e.loc.span, &mut context.tokens)?,
+                                    get_comment_after_end(
+                                        e.loc.as_ref().map(|loc| loc.span),
+                                        &mut context.tokens,
+                                    )?,
                                     RcDoc::nil(),
                                 ))
                                 .append(RcDoc::line())
@@ -607,12 +663,15 @@ impl Doc for Node<Option<Primary>> {
                 },
                 add_comment(
                     RcDoc::text("["),
-                    get_comment_at_start(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 ),
                 add_comment(
                     RcDoc::text("]"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 ),
             )),
@@ -627,7 +686,10 @@ impl Doc for Node<Option<Primary>> {
                             Some((
                                 d.append(add_comment(
                                     RcDoc::text(","),
-                                    get_comment_after_end(e.loc.span, &mut context.tokens)?,
+                                    get_comment_after_end(
+                                        e.loc.as_ref().map(|loc| loc.span),
+                                        &mut context.tokens,
+                                    )?,
                                     RcDoc::nil(),
                                 ))
                                 .append(RcDoc::line())
@@ -639,12 +701,15 @@ impl Doc for Node<Option<Primary>> {
                 },
                 add_comment(
                     RcDoc::text("{"),
-                    get_comment_at_start(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 ),
                 add_comment(
                     RcDoc::text("}"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 ),
             )),
@@ -660,7 +725,10 @@ impl Doc for Node<Option<MemAccess>> {
             MemAccess::Field(f) => Some(
                 add_comment(
                     RcDoc::text("."),
-                    get_comment_at_start(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 )
                 .append(f.to_doc(context)),
@@ -668,7 +736,10 @@ impl Doc for Node<Option<MemAccess>> {
             MemAccess::Call(args) => Some(
                 add_comment(
                     RcDoc::text("("),
-                    get_comment_at_start(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 )
                 .append(RcDoc::line_())
@@ -684,7 +755,10 @@ impl Doc for Node<Option<MemAccess>> {
                                 Some((
                                     d.append(add_comment(
                                         RcDoc::text(","),
-                                        get_comment_after_end(e.loc.span, &mut context.tokens)?,
+                                        get_comment_after_end(
+                                            e.loc.as_ref().map(|loc| loc.span),
+                                            &mut context.tokens,
+                                        )?,
                                         RcDoc::nil(),
                                     ))
                                     .append(RcDoc::line())
@@ -699,14 +773,17 @@ impl Doc for Node<Option<MemAccess>> {
                 .append(RcDoc::line_())
                 .append(add_comment(
                     RcDoc::text(")"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 )),
             ),
             MemAccess::Index(idx) => Some(
                 add_comment(
                     RcDoc::text("["),
-                    get_comment_at_start(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_start(
+                        self.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 )
                 .append(RcDoc::line_())
@@ -714,7 +791,7 @@ impl Doc for Node<Option<MemAccess>> {
                 .append(RcDoc::line_())
                 .append(add_comment(
                     RcDoc::text("]"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 )),
             ),
@@ -728,20 +805,23 @@ impl Doc for Node<Option<Annotation>> {
         let id_doc = annotation.key.to_doc(context);
         let at_doc = add_comment(
             RcDoc::text("@"),
-            get_comment_at_start(self.loc.span, &mut context.tokens)?,
+            get_comment_at_start(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
             RcDoc::nil(),
         );
         let val_doc = match annotation.value.as_ref() {
             Some(value) => {
                 let lp_doc = add_comment(
                     RcDoc::text("("),
-                    get_comment_after_end(annotation.key.loc.span, &mut context.tokens)?,
+                    get_comment_after_end(
+                        annotation.key.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::nil(),
                 );
                 let val_doc = value.to_doc(context);
                 let rp_doc = add_comment(
                     RcDoc::text(")"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::hardline(),
                 );
                 lp_doc.append(val_doc).append(rp_doc)
@@ -757,7 +837,7 @@ impl Doc for Node<Option<Ident>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         Some(add_comment(
             self.as_inner()?.to_doc(context)?,
-            get_comment_at_start(self.loc.span, &mut context.tokens)?,
+            get_comment_at_start(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
             RcDoc::nil(),
         ))
     }
@@ -776,8 +856,10 @@ impl Doc for Node<Option<Policy>> {
             policy.annotations.iter().map(|a| a.to_doc(context)),
             RcDoc::nil(),
         );
-        let eff_leading_comment =
-            get_leading_comment_at_start(policy.effect.loc.span, &mut context.tokens)?;
+        let eff_leading_comment = get_leading_comment_at_start(
+            policy.effect.loc.as_ref().map(|loc| loc.span),
+            &mut context.tokens,
+        )?;
         let eff_doc = policy.effect.to_doc(context)?;
         let vars = &policy.variables;
         let principal_doc = vars.first()?.to_doc(context)?;
@@ -793,13 +875,19 @@ impl Doc for Node<Option<Policy>> {
             principal_doc
                 .append(add_comment(
                     RcDoc::text(","),
-                    get_comment_after_end(vars.first()?.loc.span, &mut context.tokens)?,
+                    get_comment_after_end(
+                        vars.first()?.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::space(),
                 ))
                 .append(action_doc)
                 .append(add_comment(
                     RcDoc::text(","),
-                    get_comment_after_end(vars.get(1)?.loc.span, &mut context.tokens)?,
+                    get_comment_after_end(
+                        vars.get(1)?.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     RcDoc::space(),
                 ))
                 .append(resource_doc)
@@ -811,13 +899,19 @@ impl Doc for Node<Option<Policy>> {
                     principal_doc
                         .append(add_comment(
                             RcDoc::text(","),
-                            get_comment_after_end(vars.first()?.loc.span, &mut context.tokens)?,
+                            get_comment_after_end(
+                                vars.first()?.loc.as_ref().map(|loc| loc.span),
+                                &mut context.tokens,
+                            )?,
                             RcDoc::hardline(),
                         ))
                         .append(action_doc)
                         .append(add_comment(
                             RcDoc::text(","),
-                            get_comment_after_end(vars.get(1)?.loc.span, &mut context.tokens)?,
+                            get_comment_after_end(
+                                vars.get(1)?.loc.as_ref().map(|loc| loc.span),
+                                &mut context.tokens,
+                            )?,
                             RcDoc::hardline(),
                         ))
                         .append(resource_doc),
@@ -836,7 +930,10 @@ impl Doc for Node<Option<Policy>> {
                             .append(RcDoc::line())
                             .append(add_comment(
                                 RcDoc::text("("),
-                                get_comment_after_end(policy.effect.loc.span, &mut context.tokens)?,
+                                get_comment_after_end(
+                                    policy.effect.loc.as_ref().map(|loc| loc.span),
+                                    &mut context.tokens,
+                                )?,
                                 RcDoc::nil(),
                             ))
                             .group(),
@@ -845,7 +942,10 @@ impl Doc for Node<Option<Policy>> {
                 .append(vars_doc)
                 .append(add_comment(
                     RcDoc::text(")"),
-                    get_comment_after_end(vars.get(2)?.loc.span, &mut context.tokens)?,
+                    get_comment_after_end(
+                        vars.get(2)?.loc.as_ref().map(|loc| loc.span),
+                        &mut context.tokens,
+                    )?,
                     if conds.is_empty() {
                         RcDoc::nil()
                     } else {
@@ -855,7 +955,7 @@ impl Doc for Node<Option<Policy>> {
                 .append(cond_doc)
                 .append(add_comment(
                     RcDoc::text(";"),
-                    get_comment_at_end(self.loc.span, &mut context.tokens)?,
+                    get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
                     RcDoc::nil(),
                 )),
         )

--- a/cedar-policy-formatter/src/pprint/doc.rs
+++ b/cedar-policy-formatter/src/pprint/doc.rs
@@ -106,11 +106,16 @@ impl Doc for Node<Option<VariableDef>> {
 impl Doc for Node<Option<Cond>> {
     fn to_doc<'src>(&self, context: &mut Context<'_, 'src>) -> Option<RcDoc<'src>> {
         let cond = self.as_inner()?;
-        let lb_comment =
-            get_comment_after_end(cond.cond.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
-        let rb_comment = get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
-        let cond_comment =
-            get_comment_at_start(cond.cond.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
+        let lb_comment = get_comment_after_end(
+            cond.cond.loc.as_ref().map(|loc| loc.span),
+            &mut context.tokens,
+        )?;
+        let rb_comment =
+            get_comment_at_end(self.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
+        let cond_comment = get_comment_at_start(
+            cond.cond.loc.as_ref().map(|loc| loc.span),
+            &mut context.tokens,
+        )?;
 
         let rb_doc = add_comment(RcDoc::text("}"), rb_comment, RcDoc::nil());
         let cond_doc = cond.cond.to_doc(context)?;
@@ -227,7 +232,8 @@ impl Doc for Node<Option<Or>> {
         let es: Vec<_> = std::iter::once(initial).chain(extended.iter()).collect();
         let mut d: RcDoc<'_> = RcDoc::nil();
         for e in es.iter().take(es.len() - 1) {
-            let op_comment = get_comment_after_end(e.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
+            let op_comment =
+                get_comment_after_end(e.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
             d = d
                 .append(e.to_doc(context))
                 .append(RcDoc::space())
@@ -247,7 +253,8 @@ impl Doc for Node<Option<And>> {
         let es: Vec<_> = std::iter::once(initial).chain(extended.iter()).collect();
         let mut d: RcDoc<'_> = RcDoc::nil();
         for e in es.iter().take(es.len() - 1) {
-            let op_comment = get_comment_after_end(e.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
+            let op_comment =
+                get_comment_after_end(e.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?;
             d = d
                 .append(e.to_doc(context))
                 .append(RcDoc::space())
@@ -292,7 +299,10 @@ impl Doc for Node<Option<Relation>> {
                     .append(RcDoc::line())
                     .append(add_comment(
                         RcDoc::text("has"),
-                        get_comment_after_end(target.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
+                        get_comment_after_end(
+                            target.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     ))
                     .append(RcDoc::line())
@@ -305,7 +315,10 @@ impl Doc for Node<Option<Relation>> {
                     .append(RcDoc::line())
                     .append(add_comment(
                         RcDoc::text("like"),
-                        get_comment_after_end(target.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
+                        get_comment_after_end(
+                            target.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     ))
                     .append(RcDoc::line())
@@ -322,7 +335,10 @@ impl Doc for Node<Option<Relation>> {
                     .append(RcDoc::space())
                     .append(add_comment(
                         RcDoc::text("is"),
-                        get_comment_after_end(target.loc.as_ref().map(|loc| loc.span), &mut context.tokens)?,
+                        get_comment_after_end(
+                            target.loc.as_ref().map(|loc| loc.span),
+                            &mut context.tokens,
+                        )?,
                         RcDoc::nil(),
                     ))
                     .append(RcDoc::space())

--- a/cedar-policy-formatter/src/pprint/utils.rs
+++ b/cedar-policy-formatter/src/pprint/utils.rs
@@ -64,9 +64,10 @@ pub fn get_trailing_comment_doc_from_str<'src>(
 }
 
 fn get_token_at_start<'a, 'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &'a mut [WrappedToken<'src>],
 ) -> Option<&'a mut WrappedToken<'src>> {
+    let span = span?;
     tokens
         .as_mut()
         .iter_mut()
@@ -74,59 +75,64 @@ fn get_token_at_start<'a, 'src>(
 }
 
 pub fn get_comment_at_start<'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &mut [WrappedToken<'src>],
 ) -> Option<Comment<'src>> {
     Some(get_token_at_start(span, tokens)?.consume_comment())
 }
 
 pub fn get_leading_comment_at_start<'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &mut [WrappedToken<'src>],
 ) -> Option<Vec<&'src str>> {
     Some(get_token_at_start(span, tokens)?.consume_leading_comment())
 }
 
 fn get_token_after_end<'a, 'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &'a mut [WrappedToken<'src>],
 ) -> Option<&'a mut WrappedToken<'src>> {
+    let span = span?;
     let end = span.offset() + span.len();
     tokens.iter_mut().find_or_first(|t| t.span.start >= end)
 }
 
 fn get_token_at_end<'a, 'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &'a mut [WrappedToken<'src>],
 ) -> Option<&'a mut WrappedToken<'src>> {
+    let span = span?;
     let end = span.offset() + span.len();
     tokens.iter_mut().find(|t| t.span.end == end)
 }
 
 pub fn get_comment_at_end<'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &mut [WrappedToken<'src>],
 ) -> Option<Comment<'src>> {
     Some(get_token_at_end(span, tokens)?.consume_comment())
 }
 
 pub fn get_comment_after_end<'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &mut [WrappedToken<'src>],
 ) -> Option<Comment<'src>> {
     Some(get_token_after_end(span, tokens)?.consume_comment())
 }
 
 pub fn get_comment_in_range<'src>(
-    span: miette::SourceSpan,
+    span: Option<miette::SourceSpan>,
     tokens: &mut [WrappedToken<'src>],
-) -> Vec<Comment<'src>> {
-    tokens
-        .iter_mut()
-        .skip_while(|t| t.span.start < span.offset())
-        .take_while(|t| t.span.end <= span.offset() + span.len())
-        .map(|t| t.consume_comment())
-        .collect()
+) -> Option<Vec<Comment<'src>>> {
+    let span = span?;
+    Some(
+        tokens
+            .iter_mut()
+            .skip_while(|t| t.span.start < span.offset())
+            .take_while(|t| t.span.end <= span.offset() + span.len())
+            .map(|t| t.consume_comment())
+            .collect(),
+    )
 }
 
 /// Wrap an `RcDoc` with comments. If there is a leading comment, then this

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -718,7 +718,7 @@ impl Diagnostic for NoPrincipalOrResource {
                 });
                 let spans: Vec<_> = [action_name, decl]
                     .into_iter()
-                    .filter_map(|span| span)
+                    .flatten()
                     .collect();
 
                 if spans.is_empty() {

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -24,8 +24,7 @@ use std::{
 
 use cedar_policy_core::{
     ast::AnyId,
-    impl_diagnostic_from_source_loc_opt_field, impl_diagnostic_from_two_source_loc_fields,
-    impl_diagnostic_from_two_source_loc_opt_fields,
+    impl_diagnostic_from_source_loc_opt_field, impl_diagnostic_from_two_source_loc_opt_fields,
     parser::{
         err::{expected_to_string, ExpectedTokenConfig},
         unescape::UnescapeError,
@@ -632,7 +631,7 @@ pub struct DuplicatePrincipalOrResource {
 }
 
 impl Diagnostic for DuplicatePrincipalOrResource {
-    impl_diagnostic_from_two_source_loc_fields!(loc1, loc2);
+    impl_diagnostic_from_two_source_loc_opt_fields!(loc1, loc2);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         let msg = format!("Actions may only have a single {kind} declaration, but a {kind} declaration may specify a list of entity types like `{kind}: [X, Y, Z]`", kind=self.kind);
@@ -649,7 +648,7 @@ pub struct DuplicateContext {
 }
 
 impl Diagnostic for DuplicateContext {
-    impl_diagnostic_from_two_source_loc_fields!(loc1, loc2);
+    impl_diagnostic_from_two_source_loc_opt_fields!(loc1, loc2);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(
@@ -666,7 +665,7 @@ pub struct DuplicateDeclarations {
 }
 
 impl Diagnostic for DuplicateDeclarations {
-    impl_diagnostic_from_two_source_loc_fields!(loc1, loc2);
+    impl_diagnostic_from_two_source_loc_opt_fields!(loc1, loc2);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -23,14 +23,11 @@ use std::{
 };
 
 use cedar_policy_core::{
-    ast::AnyId,
-    impl_diagnostic_from_source_loc_field, impl_diagnostic_from_two_source_loc_fields,
-    impl_diagnostic_from_two_source_loc_opt_fields,
-    parser::{
+    ast::AnyId, impl_diagnostic_from_source_loc_opt_field, impl_diagnostic_from_two_source_loc_fields, impl_diagnostic_from_two_source_loc_opt_fields, parser::{
         err::{expected_to_string, ExpectedTokenConfig},
         unescape::UnescapeError,
         Loc, Node,
-    },
+    }
 };
 use lalrpop_util as lalr;
 use lazy_static::lazy_static;
@@ -579,7 +576,7 @@ pub struct ReservedSchemaKeyword {
 }
 
 impl Diagnostic for ReservedSchemaKeyword {
-    impl_diagnostic_from_source_loc_field!(loc);
+    impl_diagnostic_from_source_loc_opt_field!(loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new("Keywords such as `entity`, `extension`, `set` and `record` cannot be used as common type names"))
@@ -594,7 +591,7 @@ pub struct ReservedName {
 }
 
 impl Diagnostic for ReservedName {
-    impl_diagnostic_from_source_loc_field!(loc);
+    impl_diagnostic_from_source_loc_opt_field!(loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         Some(Box::new(
@@ -611,7 +608,7 @@ pub struct UnknownTypeName {
 }
 
 impl Diagnostic for UnknownTypeName {
-    impl_diagnostic_from_source_loc_field!(loc);
+    impl_diagnostic_from_source_loc_opt_field!(loc);
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
         let msg = format!(
@@ -747,7 +744,7 @@ impl Diagnostic for DuplicateNamespace {
 
 /// Error subtypes for [`SchemaWarning`]
 pub mod schema_warnings {
-    use cedar_policy_core::{impl_diagnostic_from_source_loc_field, parser::Loc};
+    use cedar_policy_core::{impl_diagnostic_from_source_loc_opt_field, parser::Loc};
     use miette::Diagnostic;
     use smol_str::SmolStr;
     use thiserror::Error;
@@ -765,7 +762,7 @@ pub mod schema_warnings {
     }
 
     impl Diagnostic for ShadowsBuiltinWarning {
-        impl_diagnostic_from_source_loc_field!(loc);
+        impl_diagnostic_from_source_loc_opt_field!(loc);
 
         fn severity(&self) -> Option<miette::Severity> {
             Some(miette::Severity::Warning)

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -716,10 +716,7 @@ impl Diagnostic for NoPrincipalOrResource {
                 let decl = loc.as_ref().map(|loc| {
                     miette::LabeledSpan::new_with_span(Some("must not be `[]`".into()), loc.span)
                 });
-                let spans: Vec<_> = [action_name, decl]
-                    .into_iter()
-                    .flatten()
-                    .collect();
+                let spans: Vec<_> = [action_name, decl].into_iter().flatten().collect();
 
                 if spans.is_empty() {
                     None

--- a/cedar-policy-validator/src/cedar_schema/err.rs
+++ b/cedar-policy-validator/src/cedar_schema/err.rs
@@ -23,11 +23,14 @@ use std::{
 };
 
 use cedar_policy_core::{
-    ast::AnyId, impl_diagnostic_from_source_loc_opt_field, impl_diagnostic_from_two_source_loc_fields, impl_diagnostic_from_two_source_loc_opt_fields, parser::{
+    ast::AnyId,
+    impl_diagnostic_from_source_loc_opt_field, impl_diagnostic_from_two_source_loc_fields,
+    impl_diagnostic_from_two_source_loc_opt_fields,
+    parser::{
         err::{expected_to_string, ExpectedTokenConfig},
         unescape::UnescapeError,
         Loc, Node,
-    }
+    },
 };
 use lalrpop_util as lalr;
 use lazy_static::lazy_static;

--- a/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
+++ b/cedar-policy-validator/src/cedar_schema/grammar.lalrpop
@@ -203,7 +203,7 @@ AppDecls: Node<NonEmpty<Node<AppDecl>>> = {
 // Type := PRIMTYPE | Path | SetType | RecType
 pub Type: Node<SType> = {
     <p:Path>
-        => { let loc = p.loc().clone(); Node::with_source_loc(SType::Ident(p), loc) },
+        => { let loc = p.loc().cloned(); Node::with_maybe_source_loc(SType::Ident(p), loc) },
     <l:@L> SET "<" <t:Type> ">" <r:@R>
         => Node::with_source_loc(SType::Set(Box::new(t)), Loc::new(l..r, Arc::clone(src))),
     <l:@L> "{" <ds:AttrDecls?> "}" <r:@R>
@@ -228,8 +228,8 @@ Comma<E>: Vec<E> = {
 
 // IDENT := ['_''a'-'z''A'-'Z']['_''a'-'z''A'-'Z''0'-'9']* - RESERVED
 Ident: Node<Id> = {
-    <id: AnyIdent> =>? Id::from_str(id.node.as_ref()).map(|i| Node::with_source_loc(i, id.loc.clone())).map_err(|err : cedar_policy_core::parser::err::ParseErrors| ParseError::User {
-        error: UserError::ReservedIdentifierUsed(Node::with_source_loc(id.node.to_smolstr(), id.loc.clone()))
+    <id: AnyIdent> =>? Id::from_str(id.node.as_ref()).map(|i| Node::with_maybe_source_loc(i, id.loc.clone())).map_err(|err : cedar_policy_core::parser::err::ParseErrors| ParseError::User {
+        error: UserError::ReservedIdentifierUsed(Node::with_maybe_source_loc(id.node.to_smolstr(), id.loc.clone()))
     }),
 }
 

--- a/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-validator/src/cedar_schema/to_json_schema.rs
@@ -248,7 +248,7 @@ fn convert_action_decl(
             annotations: a.annotations.clone().into(),
             loc: a.data.loc.clone(),
             #[cfg(feature = "extended-schema")]
-            defn_loc: Some(name.loc),
+            defn_loc: name.loc,
         };
         (name.node, ty)
     }))
@@ -460,7 +460,7 @@ fn convert_attr_decl(
             required: attr.node.data.required,
             annotations: attr.node.annotations.into(),
             #[cfg(feature = "extended-schema")]
-            loc: Some(attr.loc),
+            loc: attr.loc,
         },
     )
 }


### PR DESCRIPTION
## Description of changes

Makes location information optional throughout most of the code base. Note that location information was already optional in some places. This change mainly focuses on the CST's `Loc`, but requires propagating the change to other structures and function/method calls like those where we expected a `miette::SourceSpan`. Whenever we can, we make our best to compute spans like we do in other parts of the code base.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
