### PR TITLE
Create policy set splitting functionality

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,9 +22,8 @@ Cedar Language Version: TBD
   format. The new functions are deprecated and placed behind the `deprecated-schema-compat` feature. (#1600)
 - `Expression::new_duration`, `Expression::new_datetime`, `RestrictedExpression::new_duration`,
    and `RestrictedExpression::new_datetime` (#1614)
-- Added a function to be able to split a policy set parsed from a large file into its component static policies
-  and templates. The relevant functions are `policy_set_text_to_parts` which can be used from wasm, and 
-  `PolicySet::to_string_representations` in `api.rs`, which returns a `StringifiedPolicySet`.
+- Added a function to be able to split a policy set parsed from a single string into its component static 
+  policies and templates. The relevant function is `policy_set_text_to_parts` in the `ffi` module.
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,9 @@ Cedar Language Version: TBD
   format. The new functions are deprecated and placed behind the `deprecated-schema-compat` feature. (#1600)
 - `Expression::new_duration`, `Expression::new_datetime`, `RestrictedExpression::new_duration`,
    and `RestrictedExpression::new_datetime` (#1614)
+- Added a function to be able to split a policy set parsed from a large file into its component static policies
+  and templates. The relevant functions are `policy_set_text_to_parts` which can be used from wasm, and 
+  `PolicySet::to_string_representations` in `api.rs`, which returns a `StringifiedPolicySet`.
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2196,8 +2196,8 @@ impl std::fmt::Display for EntityNamespace {
 }
 
 #[derive(Debug, Clone, Default)]
-/// A struct representing a PolicySet as a series of strings for ser/de.
-/// A PolicySet that contains template-linked policies cannot be
+/// A struct representing a `PolicySet` as a series of strings for ser/de.
+/// A `PolicySet` that contains template-linked policies cannot be
 /// represented as this struct.
 pub struct StringifiedPolicySet {
     /// The static policies in the set

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2199,7 +2199,7 @@ impl std::fmt::Display for EntityNamespace {
 /// A struct representing a `PolicySet` as a series of strings for ser/de.
 /// A `PolicySet` that contains template-linked policies cannot be
 /// represented as this struct.
-pub struct StringifiedPolicySet {
+pub(crate) struct StringifiedPolicySet {
     /// The static policies in the set
     pub policies: Vec<String>,
     /// The policy templates in the set
@@ -2384,7 +2384,7 @@ impl PolicySet {
     /// rules.  Policy formatting can be done through the Cedar policy CLI or
     /// the `cedar-policy-formatter` crate.
     pub fn to_cedar(&self) -> Option<String> {
-        match self.to_string_representations() {
+        match self.stringify() {
             Some(StringifiedPolicySet {
                 policies,
                 policy_templates,
@@ -2409,13 +2409,13 @@ impl PolicySet {
     /// syntax. The policies may be reordered, so parsing the resulting string
     /// with [`PolicySet::from_str`] is likely to yield different policy id
     /// assignments. For these reasons you should prefer serializing as JSON (or protobuf) and
-    /// only using this function to obtain a representation to display to human
-    /// users.
+    /// only using this function to obtain a compact cedar representation,
+    /// perhaps for storage purposes.
     ///
     /// This function does not format the policy according to any particular
     /// rules.  Policy formatting can be done through the Cedar policy CLI or
     /// the `cedar-policy-formatter` crate.
-    pub fn to_string_representations(&self) -> Option<StringifiedPolicySet> {
+    pub(crate) fn stringify(&self) -> Option<StringifiedPolicySet> {
         let policies = self
             .policies
             .values()

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2384,18 +2384,16 @@ impl PolicySet {
     /// rules.  Policy formatting can be done through the Cedar policy CLI or
     /// the `cedar-policy-formatter` crate.
     pub fn to_cedar(&self) -> Option<String> {
-        if let Some(StringifiedPolicySet {
-            policies,
-            policy_templates,
-        }) = self.to_string_representations()
-        {
-            let policies_as_vec = policies
-                .into_iter()
-                .chain(policy_templates)
-                .collect::<Vec<_>>();
-            return Some(policies_as_vec.join("\n\n"));
-        };
-        None
+        match self.to_string_representations() {
+            Some(StringifiedPolicySet { policies, policy_templates }) => {
+                let policies_as_vec = policies
+                    .into_iter()
+                    .chain(policy_templates)
+                    .collect::<Vec<_>>();
+                Some(policies_as_vec.join("\n\n"))
+            }
+            None => None,
+        }
     }
 
     /// Get the human-readable Cedar syntax representation of this policy set,

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2385,7 +2385,10 @@ impl PolicySet {
     /// the `cedar-policy-formatter` crate.
     pub fn to_cedar(&self) -> Option<String> {
         match self.to_string_representations() {
-            Some(StringifiedPolicySet { policies, policy_templates }) => {
+            Some(StringifiedPolicySet {
+                policies,
+                policy_templates,
+            }) => {
                 let policies_as_vec = policies
                     .into_iter()
                     .chain(policy_templates)

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2195,6 +2195,17 @@ impl std::fmt::Display for EntityNamespace {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+/// A struct representing a PolicySet as a series of strings for ser/de.
+/// A PolicySet that contains template-linked policies cannot be
+/// represented as this struct.
+pub struct StringifiedPolicySet {
+    /// The static policies in the set
+    pub policies: Vec<String>,
+    /// The policy templates in the set
+    pub policy_templates: Vec<String>,
+}
+
 /// Represents a set of `Policy`s
 #[derive(Debug, Clone, Default)]
 pub struct PolicySet {
@@ -2373,6 +2384,37 @@ impl PolicySet {
     /// rules.  Policy formatting can be done through the Cedar policy CLI or
     /// the `cedar-policy-formatter` crate.
     pub fn to_cedar(&self) -> Option<String> {
+        if let Some(StringifiedPolicySet {
+            policies,
+            policy_templates,
+        }) = self.to_string_representations()
+        {
+            let policies_as_vec = policies
+                .into_iter()
+                .chain(policy_templates)
+                .collect::<Vec<_>>();
+            return Some(policies_as_vec.join("\n\n"));
+        };
+        None
+    }
+
+    /// Get the human-readable Cedar syntax representation of this policy set,
+    /// as a vec of strings. This function is useful to break up a large cedar
+    /// file containing many policies into individual policies.
+    ///
+    /// This will return `None` if there are any linked policies in the policy
+    /// set because they cannot be directly rendered in Cedar syntax. It also
+    /// cannot record policy ids because these cannot be specified in the Cedar
+    /// syntax. The policies may be reordered, so parsing the resulting string
+    /// with [`PolicySet::from_str`] is likely to yield different policy id
+    /// assignments. For these reasons you should prefer serializing as JSON (or protobuf) and
+    /// only using this function to obtain a representation to display to human
+    /// users.
+    ///
+    /// This function does not format the policy according to any particular
+    /// rules.  Policy formatting can be done through the Cedar policy CLI or
+    /// the `cedar-policy-formatter` crate.
+    pub fn to_string_representations(&self) -> Option<StringifiedPolicySet> {
         let policies = self
             .policies
             .values()
@@ -2382,13 +2424,17 @@ impl PolicySet {
             .sorted_by_key(|p| AsRef::<str>::as_ref(p.id()))
             .map(Policy::to_cedar)
             .collect::<Option<Vec<_>>>()?;
-        let templates = self
+        let policy_templates = self
             .templates
             .values()
             .sorted_by_key(|t| AsRef::<str>::as_ref(t.id()))
-            .map(Template::to_cedar);
+            .map(Template::to_cedar)
+            .collect_vec();
 
-        Some(policies.into_iter().chain(templates).join("\n\n"))
+        Some(StringifiedPolicySet {
+            policies,
+            policy_templates,
+        })
     }
 
     /// Create a fresh empty `PolicySet`

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -29,17 +29,17 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
-/// Takes a large PolicySet represented as string and return the policies
+/// Takes a PolicySet represented as string and return the policies
 /// and templates split into vecs and sorted by id.
 #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policySetTextToParts"))]
-pub fn policy_set_text_to_parts(policy_set_str: &str) -> PolicySetTextToPartsAnswer {
-    let parsed_ps: Result<PolicySet, _> = PolicySet::from_str(policy_set_str);
+pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnswer {
+    let parsed_ps: Result<PolicySet, _> = PolicySet::from_str(policyset_str);
     match parsed_ps {
         Ok(policy_set) => {
             if let Some(StringifiedPolicySet {
                 policies,
                 policy_templates,
-            }) = policy_set.to_string_representations()
+            }) = policy_set.stringify()
             {
                 PolicySetTextToPartsAnswer::Success {
                     policies,
@@ -586,20 +586,16 @@ action "sendMessage" appliesTo {
 
     #[test]
     fn test_policy_set_text_to_parts_parse_failure() {
-        // Arrange
         let invalid_input = "This is not a valid PolicySet string";
 
-        // Act
         let result = policy_set_text_to_parts(invalid_input);
 
-        // Assert
-        match result {
-            PolicySetTextToPartsAnswer::Failure { errors } => {
-                assert_eq!(errors.len(), 1);
-                // You might want to check more specifics about the error here,
-                // depending on what your FromStr implementation returns
-            }
-            _ => panic!("Expected Failure, but got Success"),
-        }
+        assert_matches!(result, PolicySetTextToPartsAnswer::Failure { errors } => {
+            assert_exactly_one_error(
+                &errors,
+                "unexpected token `is`",
+                None,
+            );
+        });
     }
 }

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -49,17 +49,10 @@ pub fn policy_set_text_to_parts(policy_set_str: &str) -> PolicySetTextToPartsAns
                 // This should never happen due to the nature of the input but we cover it
                 // just in case, to future-proof the interface
                 PolicySetTextToPartsAnswer::Failure {
-                    errors: vec![DetailedError {
-                        message: String::from(
-                            "Policy set input contained template linked policies",
-                        ),
-                        help: None,
-                        code: None,
-                        url: None,
-                        severity: None,
-                        source_locations: vec![],
-                        related: vec![],
-                    }],
+                    errors: vec![DetailedError::from_str(
+                        "Policy set input contained template linked policies",
+                    )
+                    .unwrap_or_default()],
                 }
             }
         }
@@ -589,5 +582,24 @@ action "sendMessage" appliesTo {
             assert_eq!(policies.len(), 2);
             assert_eq!(policy_templates.len(), 1);
         });
+    }
+
+    #[test]
+    fn test_policy_set_text_to_parts_parse_failure() {
+        // Arrange
+        let invalid_input = "This is not a valid PolicySet string";
+
+        // Act
+        let result = policy_set_text_to_parts(invalid_input);
+
+        // Assert
+        match result {
+            PolicySetTextToPartsAnswer::Failure { errors } => {
+                assert_eq!(errors.len(), 1);
+                // You might want to check more specifics about the error here,
+                // depending on what your FromStr implementation returns
+            }
+            _ => panic!("Expected Failure, but got Success"),
+        }
     }
 }

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -31,7 +31,7 @@ pub use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 extern crate tsify;
 
 /// Structure of the JSON output representing one `miette` error
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize, Default)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +54,22 @@ pub struct DetailedError {
     /// Related errors
     #[serde(default)]
     pub related: Vec<DetailedError>,
+}
+
+impl FromStr for DetailedError {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(DetailedError {
+            message: s.to_string(),
+            help: None,
+            code: None,
+            url: None,
+            severity: None,
+            source_locations: Vec::new(),
+            related: Vec::new(),
+        })
+    }
 }
 
 /// Exactly like `miette::Severity` but implements `Hash`
@@ -1208,5 +1224,11 @@ mod test {
                 .source("error parsing schema: unexpected token `permit`")
                 .build(),
         );
+    }
+
+    #[test]
+    fn test_detailed_err_from_str() {
+        let detailed_err = DetailedError::from_str("xxx");
+        assert_eq!(detailed_err.unwrap().message, "xxx");
     }
 }


### PR DESCRIPTION
## Description of changes

There is a use case where customers want to specify all policies in a single file. They want this for devex purposes, since it's a nicer experience than having 10+ tiny files. But if they do this, they currently have no way of splitting them up other than sentinel characters in comments and regex parsing, both of which are bug-prone. Splitting them up is important in order for them to be able to store them individually wherever their policy storage may be.

## Issue #, if available

n/a

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).


I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.


I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.

