### PR TITLE
Reverted downgrade of grcov

### DIFF
--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -24,7 +24,7 @@ runs:
       run: rustup component add llvm-tools-preview
     - name: Install grcov
       shell: bash
-      run: cargo install grcov --version 0.8.20
+      run: cargo install grcov
     - name: Collect coverage profiles
       shell: bash
       run: zip -0 raw_cov.zip $(find . -name "*.profraw") -q


### PR DESCRIPTION
## Description of changes
Unpinned grcov version in GitHub action workflow now that grcov has released a fix for the yanked zip dependency issue (See https://github.com/mozilla/grcov/issues/1351).

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
