### PR TITLE
Take `id` as ref for EST `try_into_est`

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -283,7 +283,7 @@ impl Policy {
         let mut conditions_iter = self
             .conditions
             .into_iter()
-            .map(|cond| cond.try_into_ast(id.clone()));
+            .map(|cond| cond.try_into_ast(&id));
         let conditions = match conditions_iter.next() {
             None => ast::Expr::val(true),
             Some(first) => ast::ExprBuilder::with_data(())
@@ -325,7 +325,7 @@ impl Clause {
         }
     }
     /// `id` is the ID of the policy the clause belongs to, used only for reporting errors
-    fn try_into_ast(self, id: ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
+    fn try_into_ast(self, id: &ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
         match self {
             Clause::When(expr) => Self::filter_slots(expr.try_into_ast(id)?, true),
             Clause::Unless(expr) => {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -883,7 +883,7 @@ impl Expr {
     /// Attempt to convert this `est::Expr` into an `ast::Expr`
     ///
     /// `id`: the ID of the policy this `Expr` belongs to, used only for reporting errors
-    pub fn try_into_ast(self, id: ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
+    pub fn try_into_ast(self, id: &ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
         match self {
             Expr::ExprNoExt(ExprNoExt::Value(jsonvalue)) => jsonvalue
                 .into_expr(|| JsonDeserializationErrorContext::Policy { id: id.clone() })
@@ -898,74 +898,74 @@ impl Expr {
                 Ok(ast::Expr::neg(Arc::unwrap_or_clone(arg).try_into_ast(id)?))
             }
             Expr::ExprNoExt(ExprNoExt::Eq { left, right }) => Ok(ast::Expr::is_eq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::NotEq { left, right }) => Ok(ast::Expr::noteq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::In { left, right }) => Ok(ast::Expr::is_in(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Less { left, right }) => Ok(ast::Expr::less(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::LessEq { left, right }) => Ok(ast::Expr::lesseq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Greater { left, right }) => Ok(ast::Expr::greater(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GreaterEq { left, right }) => Ok(ast::Expr::greatereq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::And { left, right }) => Ok(ast::Expr::and(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Or { left, right }) => Ok(ast::Expr::or(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Add { left, right }) => Ok(ast::Expr::add(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Sub { left, right }) => Ok(ast::Expr::sub(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Mul { left, right }) => Ok(ast::Expr::mul(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Contains { left, right }) => Ok(ast::Expr::contains(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::ContainsAll { left, right }) => Ok(ast::Expr::contains_all(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::ContainsAny { left, right }) => Ok(ast::Expr::contains_any(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::IsEmpty { arg }) => Ok(ast::Expr::is_empty(
                 Arc::unwrap_or_clone(arg).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GetTag { left, right }) => Ok(ast::Expr::get_tag(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::HasTag { left, right }) => Ok(ast::Expr::has_tag(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GetAttr { left, attr }) => Ok(ast::Expr::get_attr(
@@ -987,7 +987,7 @@ impl Expr {
             }) => ast::EntityType::from_normalized_str(entity_type.as_str())
                 .map_err(FromJsonError::InvalidEntityType)
                 .and_then(|entity_type_name| {
-                    let left: ast::Expr = Arc::unwrap_or_clone(left).try_into_ast(id.clone())?;
+                    let left: ast::Expr = Arc::unwrap_or_clone(left).try_into_ast(id)?;
                     let is_expr = ast::Expr::is_entity_type(left.clone(), entity_type_name);
                     match in_expr {
                         // The AST doesn't have an `... is ... in ..` node, so
@@ -1004,14 +1004,14 @@ impl Expr {
                 then_expr,
                 else_expr,
             }) => Ok(ast::Expr::ite(
-                Arc::unwrap_or_clone(cond_expr).try_into_ast(id.clone())?,
-                Arc::unwrap_or_clone(then_expr).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(cond_expr).try_into_ast(id)?,
+                Arc::unwrap_or_clone(then_expr).try_into_ast(id)?,
                 Arc::unwrap_or_clone(else_expr).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Set(elements)) => Ok(ast::Expr::set(
                 elements
                     .into_iter()
-                    .map(|el| el.try_into_ast(id.clone()))
+                    .map(|el| el.try_into_ast(id))
                     .collect::<Result<Vec<_>, FromJsonError>>()?,
             )),
             Expr::ExprNoExt(ExprNoExt::Record(map)) => {
@@ -1019,7 +1019,7 @@ impl Expr {
                 #[allow(clippy::expect_used)]
                 Ok(ast::Expr::record(
                     map.into_iter()
-                        .map(|(k, v)| Ok((k, v.try_into_ast(id.clone())?)))
+                        .map(|(k, v)| Ok((k, v.try_into_ast(id)?)))
                         .collect::<Result<HashMap<SmolStr, _>, FromJsonError>>()?,
                 )
                 .expect("can't have duplicate keys here because the input was already a HashMap"))
@@ -1047,7 +1047,7 @@ impl Expr {
                         Ok(ast::Expr::call_extension_fn(
                             fn_name,
                             args.into_iter()
-                                .map(|arg| arg.try_into_ast(id.clone()))
+                                .map(|arg| arg.try_into_ast(id))
                                 .collect::<Result<_, _>>()?,
                         ))
                     }


### PR DESCRIPTION
## Description of changes

Makes the `PolicyId` parameter to `try_into_ast` passed by reference. This parameter is only used for error reporting in one place but was being cloned for every recursive call in this function. `PolicyId` is just a wrapper around `SmolStr`, but still better to avoid these useless clones. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
