### PR TITLE
4.4.1 Changelog Updates

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -5,6 +5,8 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ## Unreleased
 
+## 4.4.1
+
 ## 4.4.0
 
 ### Added
@@ -42,6 +44,7 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
   file is formatted with `--check` will require a trailing newline. (resolving #1217)
 
 ### Added
+
 - Add a command `language-version` to print the Cedar language version (#1219)
 
 ## 4.0.0

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,8 +22,8 @@ Cedar Language Version: TBD
   format. The new functions are deprecated and placed behind the `deprecated-schema-compat` feature. (#1600)
 - `Expression::new_duration`, `Expression::new_datetime`, `RestrictedExpression::new_duration`,
    and `RestrictedExpression::new_datetime` (#1614)
-- Added a function to be able to split a policy set parsed from a single string into its component static 
-  policies and templates. The relevant function is `policy_set_text_to_parts` in the `ffi` module.
+- Added a function to be able to split a policy set parsed from a single string into its component static
+  policies and templates. The relevant function is `policy_set_text_to_parts` in the `ffi` module (#1629).
 
 ### Changed
 
@@ -33,7 +33,12 @@ Cedar Language Version: TBD
   schema can be retrieved using `Validator::schema`. (#1584)
 - Bumped MSRV to 1.82 (#1611)
 
+## [4.4.1] - Coming soon
+
+Cedar Language Version: 4.3
+
 ### Fixed
+
 - Apply entity conformance checking to tags (#1604)
 
 ## [4.4.0] - 2025-04-23

--- a/cedar-wasm/CHANGELOG.md
+++ b/cedar-wasm/CHANGELOG.md
@@ -2,11 +2,29 @@
 
 ## Unreleased
 
+## 4.4.1
+
+## 4.4.0
+
+## 4.3.3
+
+## 4.3.2
+
+## 4.3.1
+
+## 4.3.0
+
+## 4.2.2
+
+## 4.2.1
+
 ## 4.2.0
 
 ### Fixed
 - Fixed import logic (https://github.com/cedar-policy/cedar/issues/1227
   and https://github.com/cedar-policy/cedar/issues/1226)
+
+## 4.1.0
 
 ## 4.0.0
 


### PR DESCRIPTION
* Added entries for version 4.4.1 to changelogs
* Added missing release entries to cedar-wasm changelogs

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
