### PR TITLE
Optimize and inline `flatten_tuple_2`

### DIFF
--- a/cedar-policy-core/src/parser/util.rs
+++ b/cedar-policy-core/src/parser/util.rs
@@ -23,6 +23,8 @@ type Result<T> = std::result::Result<T, ParseErrors>;
 /// Combine two `Result`s into a single `Result`
 #[inline]
 pub fn flatten_tuple_2<T1, T2>(res1: Result<T1>, res2: Result<T2>) -> Result<(T1, T2)> {
+    // WARNING: Do not refactor without considering performance. See
+    // https://github.com/cedar-policy/cedar/pull/1649 for more details.
     match res1 {
         Ok(v1) => match res2 {
             Ok(v2) => Ok((v1, v2)),


### PR DESCRIPTION
## Description of changes

The function `flatten_tuple_2` is called in many of our conversion methods after `ParseErrors::transpose`. This PR modifies `flatten_tuple_2` in two ways:
 1. Unfolds the match statement with two arguments into nested match statements. This avoids creating and matching intermediate tuple values.
 2. Applies the `#[inline]` attribute to the function.

These two changes seem to have a positive performance impact. For more details, see the tables below where `cedar_from_str` uses `PolicySet::from_str` (standard parsing) and `cedar_parse_raw` uses `PolicySet::parse_raw` (enabled with `raw-parsing`).

### Baseline
```
example            fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_from_str                │               │               │               │         │
   ├─ 1            24.95 µs      │ 1.196 ms      │ 27.95 µs      │ 29.53 µs      │ 1000    │ 1000
   ├─ 100          227.2 µs      │ 274.6 µs      │ 231 µs        │ 234.4 µs      │ 1000    │ 1000
   ├─ 1000         2.06 ms       │ 2.475 ms      │ 2.092 ms      │ 2.097 ms      │ 1000    │ 1000
   ├─ 5000         11.79 ms      │ 24.86 ms      │ 12.02 ms      │ 12.08 ms      │ 1000    │ 1000
   ├─ 10000        25.37 ms      │ 29.14 ms      │ 26.08 ms      │ 26.25 ms      │ 1000    │ 1000
   ╰─ 20000        51.24 ms      │ 68.83 ms      │ 53.63 ms      │ 53.97 ms      │ 1000    │ 1000

example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_parse_raw                │               │               │               │         │
   ├─ 1             24.2 µs       │ 1.434 ms      │ 26.62 µs      │ 28.41 µs      │ 1000    │ 1000
   ├─ 100           187.9 µs      │ 249.8 µs      │ 190.4 µs      │ 192.7 µs      │ 1000    │ 1000
   ├─ 1000          1.646 ms      │ 1.955 ms      │ 1.682 ms      │ 1.689 ms      │ 1000    │ 1000
   ├─ 5000          8.848 ms      │ 9.873 ms      │ 9.063 ms      │ 9.084 ms      │ 1000    │ 1000
   ├─ 10000         18.77 ms      │ 29.23 ms      │ 19.19 ms      │ 19.27 ms      │ 1000    │ 1000
   ╰─ 20000         38.26 ms      │ 56.02 ms      │ 39.32 ms      │ 39.55 ms      │ 1000    │ 1000
```

### This PR

```
example            fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_from_str                │               │               │               │         │
   ├─ 1            24.83 µs      │ 1.083 ms      │ 27.74 µs      │ 29.35 µs      │ 1000    │ 1000
   ├─ 100          218.3 µs      │ 259.3 µs      │ 221.1 µs      │ 223.2 µs      │ 1000    │ 1000
   ├─ 1000         2.007 ms      │ 2.396 ms      │ 2.045 ms      │ 2.05 ms       │ 1000    │ 1000
   ├─ 5000         11.16 ms      │ 13.93 ms      │ 11.35 ms      │ 11.52 ms      │ 1000    │ 1000
   ├─ 10000        23.7 ms       │ 41.39 ms      │ 24.09 ms      │ 24.27 ms      │ 1000    │ 1000
   ╰─ 20000        49.88 ms      │ 75.77 ms      │ 50.71 ms      │ 51 ms         │ 1000    │ 1000

example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_parse_raw                │               │               │               │         │
   ├─ 1             22.49 µs      │ 337.7 µs      │ 25.85 µs      │ 26.27 µs      │ 1000    │ 1000
   ├─ 100           185.3 µs      │ 282.2 µs      │ 189.7 µs      │ 198.9 µs      │ 1000    │ 1000
   ├─ 1000          1.608 ms      │ 2.093 ms      │ 1.64 ms       │ 1.663 ms      │ 1000    │ 1000
   ├─ 5000          8.699 ms      │ 10.31 ms      │ 8.839 ms      │ 8.849 ms      │ 1000    │ 1000
   ├─ 10000         18.11 ms      │ 27.93 ms      │ 18.67 ms      │ 18.72 ms      │ 1000    │ 1000
   ╰─ 20000         37.06 ms      │ 42.77 ms      │ 38.29 ms      │ 38.44 ms      │ 1000    │ 1000
```

Note that this data is biased because each one of the operations in this benchmark uses `flatten_tuple_2` at least once. Therefore, it's possible that this improvement isn't reflected for overall parsing, but it's evidence that the function's performance is being improved nonetheless.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
