### PR TITLE
Pass dummy `Arc` to raw parser

### DIFF
--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -50,7 +50,11 @@ fn parse_collect_errors<'a, P, T>(
     text: &'a str,
 ) -> Result<T, err::ParseErrors> {
     // We don't need to copy the source if we won't keep it
-    let shared_src = if keep_src { Arc::from(text) } else { Arc::from("") };
+    let shared_src = if keep_src {
+        Arc::from(text)
+    } else {
+        Arc::from("")
+    };
     let mut errs = Vec::new();
     let result = parse(parser, &mut errs, &shared_src, keep_src, text);
 

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -49,18 +49,20 @@ fn parse_collect_errors<'a, P, T>(
     keep_src: bool,
     text: &'a str,
 ) -> Result<T, err::ParseErrors> {
+    // We don't need to copy the source if we won't keep it
+    let shared_src = if keep_src { Arc::from(text) } else { Arc::from("") };
     let mut errs = Vec::new();
-    let result = parse(parser, &mut errs, &Arc::from(text), keep_src, text);
+    let result = parse(parser, &mut errs, &shared_src, keep_src, text);
 
     let errors = errs
         .into_iter()
-        .map(|rc| err::ToCSTError::from_raw_err_recovery(rc, Arc::from(text)))
+        .map(|rc| err::ToCSTError::from_raw_err_recovery(rc, Arc::clone(&shared_src)))
         .map(Into::into);
     let parsed = match result {
         Ok(parsed) => parsed,
         Err(e) => {
             return Err(err::ParseErrors::new(
-                err::ToCSTError::from_raw_parse_err(e, Arc::from(text)).into(),
+                err::ToCSTError::from_raw_parse_err(e, Arc::clone(&shared_src)).into(),
                 errors,
             ));
         }


### PR DESCRIPTION
## Description of changes

Use the dummy `Arc::from("")` instead of `Arc::from(text)` when we don't plan on keeping source information. Also replace the other `Arc::from` in this function by `Arc::clone`. Represents a slight performance improvement in raw parsing.

```
example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_parse_raw                │               │               │               │         │
   ├─ 1             22.99 µs      │ 1.079 ms      │ 25.66 µs      │ 26.96 µs      │ 1000    │ 1000
   ├─ 100           186.7 µs      │ 240.8 µs      │ 188.8 µs      │ 190.3 µs      │ 1000    │ 1000
   ├─ 1000          1.641 ms      │ 1.952 ms      │ 1.704 ms      │ 1.704 ms      │ 1000    │ 1000
   ├─ 5000          8.756 ms      │ 18.52 ms      │ 9.006 ms      │ 9.085 ms      │ 1000    │ 1000
   ├─ 10000         18.5 ms       │ 39.69 ms      │ 19.04 ms      │ 19.2 ms       │ 1000    │ 1000
   ╰─ 20000         37.82 ms      │ 62.66 ms      │ 38.91 ms      │ 39.08 ms      │ 1000    │ 1000

example             fastest       │ slowest       │ median        │ mean          │ samples │ iters
╰─ cedar_parse_raw                │               │               │               │         │
   ├─ 1             23.12 µs      │ 1.229 ms      │ 25.79 µs      │ 27.38 µs      │ 1000    │ 1000
   ├─ 100           184.4 µs      │ 275.3 µs      │ 187 µs        │ 189.4 µs      │ 1000    │ 1000
   ├─ 1000          1.635 ms      │ 2.049 ms      │ 1.681 ms      │ 1.692 ms      │ 1000    │ 1000
   ├─ 5000          8.635 ms      │ 11.53 ms      │ 8.982 ms      │ 9.117 ms      │ 1000    │ 1000
   ├─ 10000         18.37 ms      │ 31.8 ms       │ 18.87 ms      │ 19 ms         │ 1000    │ 1000
   ╰─ 20000         37.69 ms      │ 59.94 ms      │ 38.71 ms      │ 38.85 ms      │ 1000    │ 1000
```

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
