### PR TITLE
allow entity attributes and tags to contain Action-typed entities

### DIFF
--- a/cedar-policy-core/src/entities/conformance/err.rs
+++ b/cedar-policy-core/src/entities/conformance/err.rs
@@ -60,7 +60,7 @@ pub enum EntitySchemaConformanceError {
     /// Encountered an action which was not declared in the schema
     #[error(transparent)]
     #[diagnostic(transparent)]
-    UndeclaredAction(UndeclaredAction),
+    UndeclaredAction(#[from] UndeclaredAction),
     /// Encountered an action whose definition doesn't precisely match the
     /// schema's declaration of that action
     #[error(transparent)]
@@ -190,7 +190,7 @@ pub struct ActionDeclarationMismatch {
 #[error("found action entity `{uid}`, but it was not declared as an action in the schema")]
 pub struct UndeclaredAction {
     /// Action which was not declared in the schema
-    uid: EntityUID,
+    pub(crate) uid: EntityUID,
 }
 
 /// Found an ancestor of a type that's not allowed for that entity

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -33,6 +33,8 @@ Cedar Language Version: TBD
 
 ### Changed
 
+- Allow entity attributes and tags to contain Action-typed entities, and pass
+  policy/entity/request validation (#1652)
 - Changed experimental `entity-manifest` function `compute_entity_manifest` to
   accept an `&Validator` instead of `&Schema`. Callers can construct a `Validator`
   from a schema with `Validator::new` afterwhich a reference to the original


### PR DESCRIPTION
## Description of changes

Allow entity attributes and tags to contain Action-typed entities.  This was always supported in the evaluator, but is now also supported in policy validation, entity validation, and request validation.  Any action UID literals that appear in attribute values or tag values must refer to actions that actually exist in the schema.

## Issue #, if available

Fixes #304 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
