### PR TITLE
Changed coverage report action to use a directory instead of a zip to avoid file duplication

### DIFF
--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -27,14 +27,16 @@ runs:
       run: cargo install grcov
     - name: Collect coverage profiles
       shell: bash
-      run: zip -0 raw_cov.zip $(find . -name "*.profraw") -q
+      run: |
+        mkdir -p ./target/raw_coverage
+        find . -name "*.profraw" -type f -exec mv "{}" ./target/raw_coverage  \;
     # Note: source-based branch coverage is not supported for Rust
     # (see http://github.com/rust-lang/rust/issues/79649)
     - name: Build coverage report
       shell: bash
       run: |
         mkdir -p ./target/coverage
-        grcov raw_cov.zip \
+        grcov ./target/raw_coverage \
             --source-dir . \
             --binary-path ./target/debug/ \
             -t html,cobertura \


### PR DESCRIPTION
## Description of changes
Changed coverage report action to use a directory instead of a zip to avoid file duplication. See PR #1654. For more information on why this is necessary. I am not confident this will address the issue because the documentation for grcov is not clear but it should otherwise be harmless.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
