### PR TITLE
Free disk space in github workflow

### DIFF
--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -19,6 +19,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check disk space
+      shell: bash
+      run: df -h
     - name: Install LLVM tools
       shell: bash
       run: rustup component add llvm-tools-preview

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,6 +29,18 @@ jobs:
       RUSTFLAGS: '-D warnings -F unsafe-code'
 
     steps:
+      - name: Check initialize disk space
+        shell: bash
+        run: df -h
+      # Based on https://github.com/easimon/maximize-build-space
+      - name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+      - name: Check final disk space
+        shell: bash
+        run: df -h
       - name: Set environment variables for coverage collection
         if: ${{ inputs.collect_coverage }} && ${{ matrix.toolchain }} == 'stable'
         shell: bash


### PR DESCRIPTION
## Description of changes
Removes pre-installed software from the GHA runner to free disk space for the "build and test" GitHub workflow.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
