### PR TITLE
add missing Protobuf conversions for `api::ValidationMode`

### DIFF
--- a/cedar-policy/protobuf_schema/validator.proto
+++ b/cedar-policy/protobuf_schema/validator.proto
@@ -79,4 +79,5 @@ message AttributeType {
 enum ValidationMode {
     Strict = 0;
     Permissive = 1;
+    Partial = 2;
 }

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -93,6 +93,36 @@ impl TryFrom<&models::PolicySet> for api::PolicySet {
     }
 }
 
+#[allow(clippy::use_self)]
+impl From<&api::ValidationMode> for models::ValidationMode {
+    fn from(v: &api::ValidationMode) -> Self {
+        match v {
+            api::ValidationMode::Strict => models::ValidationMode::Strict,
+            #[cfg(feature = "permissive-validate")]
+            api::ValidationMode::Permissive => models::ValidationMode::Permissive,
+            #[cfg(feature = "partial-validate")]
+            api::ValidationMode::Partial => models::ValidationMode::Partial,
+        }
+    }
+}
+
+#[allow(clippy::use_self)]
+impl From<&models::ValidationMode> for api::ValidationMode {
+    fn from(v: &models::ValidationMode) -> Self {
+        match v {
+            models::ValidationMode::Strict => api::ValidationMode::Strict,
+            #[cfg(feature = "permissive-validate")]
+            models::ValidationMode::Permissive => api::ValidationMode::Permissive,
+            #[cfg(not(feature = "permissive-validate"))]
+            models::ValidationMode::Permissive => panic!("Protobuf specifies permissive validation, but `permissive-validate` feature not enabled in this build"),
+            #[cfg(feature = "partial-validate")]
+            models::ValidationMode::Partial => api::ValidationMode::Partial,
+            #[cfg(not(feature = "partial-validate"))]
+            models::ValidationMode::Partial => panic!("Protobuf specifies partial validation, but `partial-validate` feature not enabled in this build"),
+        }
+    }
+}
+
 /// Macro that implements `traits::Protobuf` for cases where From<> conversions
 /// exist both ways between the api type `$api` and the protobuf model type `$model`
 macro_rules! standard_protobuf_impl {

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -57,7 +57,7 @@ impl From<&cedar_policy_core::validator::ValidationMode> for models::ValidationM
                 models::ValidationMode::Permissive
             }
             #[cfg(feature = "partial-validate")]
-            cedar_policy_core::validator::ValidationMode::Partial => unimplemented!(),
+            cedar_policy_core::validator::ValidationMode::Partial => models::ValidationMode::Partial,
         }
     }
 }
@@ -69,8 +69,13 @@ impl From<&models::ValidationMode> for cedar_policy_core::validator::ValidationM
             models::ValidationMode::Permissive => {
                 cedar_policy_core::validator::ValidationMode::Permissive
             }
+            #[cfg(feature = "partial-validate")]
             models::ValidationMode::Partial => {
                 cedar_policy_core::validator::ValidationMode::Partial
+            }
+            #[cfg(not(feature = "partial-validate"))]
+            models::ValidationMode::Partial => {
+                panic!("Protobuf specifies partial validation, but `partial-validate` feature not enabled in this build")
             }
         }
     }

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -69,6 +69,9 @@ impl From<&models::ValidationMode> for cedar_policy_core::validator::ValidationM
             models::ValidationMode::Permissive => {
                 cedar_policy_core::validator::ValidationMode::Permissive
             }
+            models::ValidationMode::Partial => {
+                cedar_policy_core::validator::ValidationMode::Partial
+            }
         }
     }
 }

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -57,7 +57,9 @@ impl From<&cedar_policy_core::validator::ValidationMode> for models::ValidationM
                 models::ValidationMode::Permissive
             }
             #[cfg(feature = "partial-validate")]
-            cedar_policy_core::validator::ValidationMode::Partial => models::ValidationMode::Partial,
+            cedar_policy_core::validator::ValidationMode::Partial => {
+                models::ValidationMode::Partial
+            }
         }
     }
 }


### PR DESCRIPTION
Also reserves `2` to represent the `Partial` variant in Protobuf
