### PR TITLE
Cherrypick a bunch of PRs to `release/4.5.x`

### DIFF
--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -24,7 +24,7 @@ runs:
       run: rustup component add llvm-tools-preview
     - name: Install grcov
       shell: bash
-      run: cargo install grcov --version 0.8.20
+      run: cargo install grcov
     - name: Collect coverage profiles
       shell: bash
       run: zip -0 raw_cov.zip $(find . -name "*.profraw") -q

--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -19,6 +19,9 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Check disk space
+      shell: bash
+      run: df -h
     - name: Install LLVM tools
       shell: bash
       run: rustup component add llvm-tools-preview

--- a/.github/actions/create_coverage_reports/action.yml
+++ b/.github/actions/create_coverage_reports/action.yml
@@ -27,14 +27,16 @@ runs:
       run: cargo install grcov
     - name: Collect coverage profiles
       shell: bash
-      run: zip -0 raw_cov.zip $(find . -name "*.profraw") -q
+      run: |
+        mkdir -p ./target/raw_coverage
+        find . -path ./target/raw_coverage -prune -o -name "*.profraw" -type f -exec mv "{}" ./target/raw_coverage  \;
     # Note: source-based branch coverage is not supported for Rust
     # (see http://github.com/rust-lang/rust/issues/79649)
     - name: Build coverage report
       shell: bash
       run: |
         mkdir -p ./target/coverage
-        grcov raw_cov.zip \
+        grcov ./target/raw_coverage \
             --source-dir . \
             --binary-path ./target/debug/ \
             -t html,cobertura \

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,6 +29,18 @@ jobs:
       RUSTFLAGS: '-D warnings -F unsafe-code'
 
     steps:
+      - name: Check initialize disk space
+        shell: bash
+        run: df -h
+      # Based on https://github.com/easimon/maximize-build-space
+      - name: Free disk space
+        shell: bash
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+      - name: Check final disk space
+        shell: bash
+        run: df -h
       - name: Set environment variables for coverage collection
         if: ${{ inputs.collect_coverage }} && ${{ matrix.toolchain }} == 'stable'
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,12 +88,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -255,9 +255,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "shlex",
 ]
@@ -1174,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7047a26de42016abf8f181b46b398aef0b77ad46711df41847f6ed869a2a1d5b"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d05b3fe34b8bd562c338db725dfa9beb9451a48f65f129ccb9538b48d2c93b"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
  "regex-automata",
  "rustversion",
@@ -1390,6 +1390,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -1926,9 +1932,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rusty-fork"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.22"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "shlex",
 ]
@@ -565,25 +565,22 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -1004,12 +1001,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1118,17 +1109,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "is_ci"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1125,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1410,9 +1399,9 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
@@ -2637,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2678,18 +2667,18 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,7 +502,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -658,7 +658,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -669,7 +669,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -690,7 +690,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -761,7 +761,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -802,7 +802,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -862,7 +862,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -914,9 +914,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -996,9 +996,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
 
 [[package]]
 name = "heck"
@@ -1075,7 +1075,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.4",
  "serde",
 ]
 
@@ -1266,7 +1266,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1312,7 +1312,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1469,7 +1469,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1616,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1659,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe28332295ca4451b7d779aff2749b144cabe5e6e05fe86f31337831d7df232"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1669,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.14.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8189daf915866b24b097b7775fbdd5a105cc3a44da13637d4b0961be73e8bc2d"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -1683,28 +1683,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.101",
+ "syn 2.0.103",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.14.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ac3e3c6b0e1c219e61ceda600eaad26d7195ecc9b5c027925c904091374ab5"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.14.0"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bfff0dbd11dbadf180fea466aa146cdf20aed230e1c42b8bae192df8f0469a"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
  "prost",
 ]
@@ -1735,9 +1735,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1795,7 +1795,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -1853,7 +1853,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1917,7 +1917,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.101",
+ "syn 2.0.103",
  "unicode-ident",
 ]
 
@@ -2049,7 +2049,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2060,7 +2060,7 @@ checksum = "e578a843d40b4189a4d66bba51d7684f57da5bd7c304c64e14bd63efbef49509"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2104,7 +2104,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2247,9 +2247,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.101"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2263,7 +2263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2302,7 +2302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
  "unicode-linebreak",
- "unicode-width 0.2.0",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -2322,7 +2322,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2426,7 +2426,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2504,9 +2504,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -2582,7 +2582,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -2617,7 +2617,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2652,7 +2652,7 @@ checksum = "17d5042cc5fa009658f9a7333ef24291b1291a25b6382dd68862a7f3b969f69b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2695,7 +2695,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2706,7 +2706,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2841,5 +2841,5 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.101",
+ "syn 2.0.103",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -255,9 +255,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "shlex",
 ]
@@ -421,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+checksum = "40b6887a1d8685cebccf115538db5c0efe625ccac9696ad45c409d96566e910f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.39"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+checksum = "e0c66c08ce9f0c698cbce5c0279d0bb6ac936d8674174fe48f736533b964f59e"
 dependencies = [
  "anstream",
  "anstyle",
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.32"
+version = "4.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+checksum = "d2c7947ae4cc3d851207c1adb5b5e260ff0cca11446b1d6d1423788e442257ce"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -507,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
@@ -747,6 +747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cfcded997a93eb31edd639361fa33fd229a8784e953b37d71035fe3890b7b"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "educe"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,7 +909,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1212,9 +1218,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1274,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miette"
@@ -1321,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
 ]
@@ -1434,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror",
@@ -1445,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1455,9 +1461,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1468,11 +1474,10 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -1606,9 +1611,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -1654,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "bbe28332295ca4451b7d779aff2749b144cabe5e6e05fe86f31337831d7df232"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1664,9 +1669,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "8189daf915866b24b097b7775fbdd5a105cc3a44da13637d4b0961be73e8bc2d"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -1684,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "26ac3e3c6b0e1c219e61ceda600eaad26d7195ecc9b5c027925c904091374ab5"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -1697,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "f2bfff0dbd11dbadf180fea466aa146cdf20aed230e1c42b8bae192df8f0469a"
 dependencies = [
  "prost",
 ]
@@ -1824,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags",
 ]
@@ -1918,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "rustc-hash"
@@ -1993,6 +1998,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2061,15 +2078,16 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
+ "schemars",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2079,9 +2097,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2144,12 +2162,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "smallvec"
@@ -2532,9 +2547,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -2696,9 +2711,9 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -2793,9 +2808,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.10"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -64,33 +64,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -237,9 +237,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "bytes"
@@ -255,9 +255,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.25"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "shlex",
 ]
@@ -513,9 +513,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "graphviz-rust"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f971272959ba59e353181bbc69f29032ffc323a164e4975ff9bed15b1b3aaf56"
+checksum = "844f6cc740402218a8b4c450d4569f368c754d01e41a1917751c4fa3750a942e"
 dependencies = [
  "dot-generator",
  "dot-structures",
@@ -968,7 +968,7 @@ dependencies = [
  "into-attr-derive",
  "pest",
  "pest_derive",
- "rand",
+ "rand 0.8.5",
  "tempfile",
 ]
 
@@ -1634,17 +1634,17 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
+checksum = "6fcdab19deb5195a31cf7726a210015ff1496ba1464fd42cb4f537b8b01b471f"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.1",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1741,8 +1741,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1752,7 +1762,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1765,12 +1785,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xorshift"
-version = "0.3.0"
+name = "rand_core"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "rand_core",
+ "getrandom 0.3.2",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -2124,9 +2153,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smol_str"
@@ -2345,15 +2374,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.9"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.26"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.9.0",
  "toml_datetime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.24"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -483,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1224,9 +1224,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1411,9 +1411,9 @@ checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1421,9 +1421,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1606,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -33,7 +33,7 @@ tempfile = "3"
 glob = "0.3.2"
 predicates = "3.1.3"
 rstest = "0.25.0"
-graphviz-rust = {version = "0.9.4",  default-features = false }
+graphviz-rust = {version = "0.9.5",  default-features = false }
 
 # We override the name of the binary for src/main.rs, which otherwise would be
 # cedar-policy-cli (matching the crate name).

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_with = { version = "3.12", features = ["json"] }
 serde_json = "1.0"
-lalrpop-util = { version = "0.22.1", features = ["lexer"] }
+lalrpop-util = { version = "0.22.2", features = ["lexer"] }
 lazy_static = "1.4"
 either = "1.15"
 itertools = "0.14"
@@ -60,7 +60,7 @@ tolerant-ast = []
 wasm = ["serde-wasm-bindgen", "tsify", "wasm-bindgen"]
 
 [build-dependencies]
-lalrpop = "0.22.1"
+lalrpop = "0.22.2"
 
 [dev-dependencies]
 cool_asserts = "2.0"

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 
 [dependencies]
 serde = { version = "1.0", features = ["derive", "rc"] }
-serde_with = { version = "3.12", features = ["json"] }
+serde_with = { version = "3.13", features = ["json"] }
 serde_json = "1.0"
 lalrpop-util = { version = "0.22.2", features = ["lexer"] }
 lazy_static = "1.4"

--- a/cedar-policy-core/src/ast/request.rs
+++ b/cedar-policy-core/src/ast/request.rs
@@ -612,6 +612,14 @@ pub trait RequestSchema {
         request: &Request,
         extensions: &Extensions<'_>,
     ) -> Result<(), Self::Error>;
+
+    /// Validate the given `context`, returning `Err` if it fails validation
+    fn validate_context<'a>(
+        &self,
+        context: &Context,
+        action: &EntityUID,
+        extensions: &Extensions<'a>,
+    ) -> std::result::Result<(), Self::Error>;
 }
 
 /// A `RequestSchema` that does no validation and always reports a passing result
@@ -624,6 +632,15 @@ impl RequestSchema for RequestSchemaAllPass {
         _request: &Request,
         _extensions: &Extensions<'_>,
     ) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn validate_context<'a>(
+        &self,
+        _context: &Context,
+        _action: &EntityUID,
+        _extensions: &Extensions<'a>,
+    ) -> std::result::Result<(), Self::Error> {
         Ok(())
     }
 }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -283,7 +283,7 @@ impl Policy {
         let mut conditions_iter = self
             .conditions
             .into_iter()
-            .map(|cond| cond.try_into_ast(id.clone()));
+            .map(|cond| cond.try_into_ast(&id));
         let conditions = match conditions_iter.next() {
             None => ast::Expr::val(true),
             Some(first) => ast::ExprBuilder::with_data(())
@@ -325,7 +325,7 @@ impl Clause {
         }
     }
     /// `id` is the ID of the policy the clause belongs to, used only for reporting errors
-    fn try_into_ast(self, id: ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
+    fn try_into_ast(self, id: &ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
         match self {
             Clause::When(expr) => Self::filter_slots(expr.try_into_ast(id)?, true),
             Clause::Unless(expr) => {

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -714,13 +714,13 @@ impl Expr {
         self,
         mapping: &BTreeMap<EntityUID, EntityUID>,
     ) -> Result<Self, JsonDeserializationError> {
-        match self.clone() {
+        match self {
             Expr::ExprNoExt(e) => match e {
                 ExprNoExt::Value(v) => Ok(Expr::ExprNoExt(ExprNoExt::Value(
                     v.sub_entity_literals(mapping)?,
                 ))),
-                ExprNoExt::Var(_) => Ok(self),
-                ExprNoExt::Slot(_) => Ok(self),
+                v @ ExprNoExt::Var(_) => Ok(Expr::ExprNoExt(v)),
+                s @ ExprNoExt::Slot(_) => Ok(Expr::ExprNoExt(s)),
                 ExprNoExt::Not { arg } => Ok(Expr::ExprNoExt(ExprNoExt::Not {
                     arg: Arc::new(Arc::unwrap_or_clone(arg).sub_entity_literals(mapping)?),
                 })),

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -883,7 +883,7 @@ impl Expr {
     /// Attempt to convert this `est::Expr` into an `ast::Expr`
     ///
     /// `id`: the ID of the policy this `Expr` belongs to, used only for reporting errors
-    pub fn try_into_ast(self, id: ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
+    pub fn try_into_ast(self, id: &ast::PolicyID) -> Result<ast::Expr, FromJsonError> {
         match self {
             Expr::ExprNoExt(ExprNoExt::Value(jsonvalue)) => jsonvalue
                 .into_expr(|| JsonDeserializationErrorContext::Policy { id: id.clone() })
@@ -898,74 +898,74 @@ impl Expr {
                 Ok(ast::Expr::neg(Arc::unwrap_or_clone(arg).try_into_ast(id)?))
             }
             Expr::ExprNoExt(ExprNoExt::Eq { left, right }) => Ok(ast::Expr::is_eq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::NotEq { left, right }) => Ok(ast::Expr::noteq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::In { left, right }) => Ok(ast::Expr::is_in(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Less { left, right }) => Ok(ast::Expr::less(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::LessEq { left, right }) => Ok(ast::Expr::lesseq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Greater { left, right }) => Ok(ast::Expr::greater(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GreaterEq { left, right }) => Ok(ast::Expr::greatereq(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::And { left, right }) => Ok(ast::Expr::and(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Or { left, right }) => Ok(ast::Expr::or(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Add { left, right }) => Ok(ast::Expr::add(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Sub { left, right }) => Ok(ast::Expr::sub(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Mul { left, right }) => Ok(ast::Expr::mul(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Contains { left, right }) => Ok(ast::Expr::contains(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::ContainsAll { left, right }) => Ok(ast::Expr::contains_all(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::ContainsAny { left, right }) => Ok(ast::Expr::contains_any(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::IsEmpty { arg }) => Ok(ast::Expr::is_empty(
                 Arc::unwrap_or_clone(arg).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GetTag { left, right }) => Ok(ast::Expr::get_tag(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::HasTag { left, right }) => Ok(ast::Expr::has_tag(
-                Arc::unwrap_or_clone(left).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(left).try_into_ast(id)?,
                 Arc::unwrap_or_clone(right).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::GetAttr { left, attr }) => Ok(ast::Expr::get_attr(
@@ -987,7 +987,7 @@ impl Expr {
             }) => ast::EntityType::from_normalized_str(entity_type.as_str())
                 .map_err(FromJsonError::InvalidEntityType)
                 .and_then(|entity_type_name| {
-                    let left: ast::Expr = Arc::unwrap_or_clone(left).try_into_ast(id.clone())?;
+                    let left: ast::Expr = Arc::unwrap_or_clone(left).try_into_ast(id)?;
                     let is_expr = ast::Expr::is_entity_type(left.clone(), entity_type_name);
                     match in_expr {
                         // The AST doesn't have an `... is ... in ..` node, so
@@ -1004,14 +1004,14 @@ impl Expr {
                 then_expr,
                 else_expr,
             }) => Ok(ast::Expr::ite(
-                Arc::unwrap_or_clone(cond_expr).try_into_ast(id.clone())?,
-                Arc::unwrap_or_clone(then_expr).try_into_ast(id.clone())?,
+                Arc::unwrap_or_clone(cond_expr).try_into_ast(id)?,
+                Arc::unwrap_or_clone(then_expr).try_into_ast(id)?,
                 Arc::unwrap_or_clone(else_expr).try_into_ast(id)?,
             )),
             Expr::ExprNoExt(ExprNoExt::Set(elements)) => Ok(ast::Expr::set(
                 elements
                     .into_iter()
-                    .map(|el| el.try_into_ast(id.clone()))
+                    .map(|el| el.try_into_ast(id))
                     .collect::<Result<Vec<_>, FromJsonError>>()?,
             )),
             Expr::ExprNoExt(ExprNoExt::Record(map)) => {
@@ -1019,7 +1019,7 @@ impl Expr {
                 #[allow(clippy::expect_used)]
                 Ok(ast::Expr::record(
                     map.into_iter()
-                        .map(|(k, v)| Ok((k, v.try_into_ast(id.clone())?)))
+                        .map(|(k, v)| Ok((k, v.try_into_ast(id)?)))
                         .collect::<Result<HashMap<SmolStr, _>, FromJsonError>>()?,
                 )
                 .expect("can't have duplicate keys here because the input was already a HashMap"))
@@ -1047,7 +1047,7 @@ impl Expr {
                         Ok(ast::Expr::call_extension_fn(
                             fn_name,
                             args.into_iter()
-                                .map(|arg| arg.try_into_ast(id.clone()))
+                                .map(|arg| arg.try_into_ast(id))
                                 .collect::<Result<_, _>>()?,
                         ))
                     }

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -1139,20 +1139,20 @@ mod tests {
             "permit(principal,",
             "unexpected end of input",
             "",
-            "expected identifier",
+            "expected `)` or identifier",
         );
         assert_labeled_span(
             "permit(principal,action,",
             "unexpected end of input",
             "",
-            "expected identifier",
+            "expected `)` or identifier",
         );
         // Nothing will actually convert to an AST here.
         assert_labeled_span(
             "permit(principal,action,resource,",
             "unexpected end of input",
             "",
-            "expected identifier",
+            "expected `)` or identifier",
         );
         // We still list out `if` as an expected token because it doesn't get
         // parsed as an ident in this position.

--- a/cedar-policy-core/src/parser/grammar.lalrpop
+++ b/cedar-policy-core/src/parser/grammar.lalrpop
@@ -84,11 +84,13 @@ match {
 }
 
 Comma<E>: Vec<E> = {
-    <e:E?> => e.into_iter().collect(),
-    <mut es:(<E> ",")+> <e:E> => {
-        es.push(e);
-        es
-    },
+    <mut es:(<E> ",")*> <e:E?> => match e {
+        None => es,
+        Some(e) => {
+            es.push(e);
+            es
+        }
+    }
 }
 
 // Policies := {Policy}

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -1229,7 +1229,7 @@ mod tests {
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `!`")
-                .exactly_one_underline_with_label("!", "expected identifier")
+                .exactly_one_underline_with_label("!", "expected `)` or identifier")
                 .build(),
         );
 
@@ -1243,14 +1243,14 @@ mod tests {
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `!`")
-                .exactly_one_underline_with_label("!", "expected identifier")
+                .exactly_one_underline_with_label("!", "expected `)` or identifier")
                 .build(),
         );
         expect_some_error_matches(
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `+`")
-                .exactly_one_underline_with_label("+", "expected identifier")
+                .exactly_one_underline_with_label("+", "expected `)` or identifier")
                 .build(),
         );
         expect_n_errors(src, &errs, 2);
@@ -1264,7 +1264,7 @@ mod tests {
             src,
             &errs,
             &ExpectedErrorMessageBuilder::error("unexpected token `!`")
-                .exactly_one_underline_with_label("!", "expected identifier")
+                .exactly_one_underline_with_label("!", "expected `)` or identifier")
                 .build(),
         );
     }
@@ -1419,6 +1419,20 @@ mod tests {
         };
         "#,
         );
+    }
+
+    #[test]
+    fn trailing_comma() {
+        assert_parse_succeeds(
+            parse_policy,
+            r#"
+        permit(principal, action, resource,);
+        "#,
+        );
+        assert_parse_succeeds(parse_expr, r#"foo(a, b, c,)"#);
+        assert_parse_succeeds(parse_expr, r#"[A, B, C,]"#);
+        assert_parse_succeeds(parse_expr, r#"{ A: B, C: D, }"#);
+        assert_parse_succeeds(parse_ref, r#"Principal::{uid: "123", role: "admin",}"#);
     }
 
     #[test]

--- a/cedar-policy-core/src/parser/util.rs
+++ b/cedar-policy-core/src/parser/util.rs
@@ -21,15 +21,22 @@ use super::err::ParseErrors;
 type Result<T> = std::result::Result<T, ParseErrors>;
 
 /// Combine two `Result`s into a single `Result`
+#[inline]
 pub fn flatten_tuple_2<T1, T2>(res1: Result<T1>, res2: Result<T2>) -> Result<(T1, T2)> {
-    match (res1, res2) {
-        (Ok(v1), Ok(v2)) => Ok((v1, v2)),
-        (Err(errs1), Ok(_)) => Err(errs1),
-        (Ok(_), Err(errs2)) => Err(errs2),
-        (Err(mut errs1), Err(errs2)) => {
-            errs1.extend(errs2);
-            Err(errs1)
-        }
+    // WARNING: Do not refactor without considering performance. See
+    // https://github.com/cedar-policy/cedar/pull/1649 for more details.
+    match res1 {
+        Ok(v1) => match res2 {
+            Ok(v2) => Ok((v1, v2)),
+            Err(errs2) => Err(errs2),
+        },
+        Err(mut errs1) => match res2 {
+            Ok(_) => Err(errs1),
+            Err(errs2) => {
+                errs1.extend(errs2);
+                Err(errs1)
+            }
+        },
     }
 }
 

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -23,7 +23,7 @@ unicode-security = "0.1.0"
 smol_str = { version = "0.3", features = ["serde"] }
 stacker = "0.1.21"
 arbitrary = { version = "1", features = ["derive"], optional = true }
-lalrpop-util = { version = "0.22.1", features = ["lexer", "unicode"] }
+lalrpop-util = { version = "0.22.2", features = ["lexer", "unicode"] }
 lazy_static = "1.4.0"
 nonempty = "0.10.0"
 educe = "0.6.0"
@@ -60,7 +60,7 @@ cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core", feature
 miette = { version = "7.6.0", features = ["fancy"] }
 
 [build-dependencies]
-lalrpop = "0.22.1"
+lalrpop = "0.22.2"
 
 [lints]
 workspace = true

--- a/cedar-policy-validator/Cargo.toml
+++ b/cedar-policy-validator/Cargo.toml
@@ -14,7 +14,7 @@ repository.workspace = true
 cedar-policy-core = { version = "=4.4.0", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-serde_with = "3.12"
+serde_with = "3.13"
 miette = "7.6.0"
 thiserror = "2.0"
 itertools = "0.14"

--- a/cedar-policy-validator/src/coreschema.rs
+++ b/cedar-policy-validator/src/coreschema.rs
@@ -231,22 +231,8 @@ impl ast::RequestSchema for ValidatorSchema {
                     validator_action_id.check_resource_type(principal_type, action)?;
                 }
                 if let Some(context) = request.context() {
-                    validate_euids_in_partial_value(
-                        &CoreSchema::new(self),
-                        &context.clone().into(),
-                    )
-                    .map_err(RequestValidationError::InvalidEnumEntity)?;
-                    let expected_context_ty = validator_action_id.context_type();
-                    if !expected_context_ty
-                        .typecheck_partial_value(&context.clone().into(), extensions)
-                        .map_err(RequestValidationError::TypeOfContext)?
-                    {
-                        return Err(request_validation_errors::InvalidContextError {
-                            context: context.clone(),
-                            action: Arc::clone(action),
-                        }
-                        .into());
-                    }
+                    self.validate_context(context, action, extensions)
+                        .map_err(RequestValidationError::from)?;
                 }
             }
             EntityUIDEntry::Unknown { .. } => {
@@ -257,6 +243,39 @@ impl ast::RequestSchema for ValidatorSchema {
                 // resource are of types that at least _exist_ in the schema)
                 // suffice.
             }
+        }
+        Ok(())
+    }
+
+    /// Validate a context against a schema for a specific action
+    fn validate_context<'a>(
+        &self,
+        context: &ast::Context,
+        action: &ast::EntityUID,
+        extensions: &Extensions<'a>,
+    ) -> std::result::Result<(), RequestValidationError> {
+        // Get the action ID
+        let validator_action_id = self.get_action_id(action).ok_or_else(|| {
+            request_validation_errors::UndeclaredActionError {
+                action: Arc::new(action.clone()),
+            }
+        })?;
+
+        // Validate entity UIDs in the context
+        validate_euids_in_partial_value(&CoreSchema::new(&self), &context.clone().into())
+            .map_err(RequestValidationError::InvalidEnumEntity)?;
+
+        // Typecheck the context against the expected context type
+        let expected_context_ty = validator_action_id.context_type();
+        if !expected_context_ty
+            .typecheck_partial_value(&context.clone().into(), extensions)
+            .map_err(RequestValidationError::TypeOfContext)?
+        {
+            return Err(request_validation_errors::InvalidContextError {
+                context: context.clone(),
+                action: Arc::new(action.clone()),
+            }
+            .into());
         }
         Ok(())
     }
@@ -304,6 +323,16 @@ impl ast::RequestSchema for CoreSchema<'_> {
         extensions: &Extensions<'_>,
     ) -> Result<(), Self::Error> {
         self.schema.validate_request(request, extensions)
+    }
+
+    /// Validate the given `context`, returning `Err` if it fails validation
+    fn validate_context<'a>(
+        &self,
+        context: &ast::Context,
+        action: &EntityUID,
+        extensions: &Extensions<'a>,
+    ) -> std::result::Result<(), Self::Error> {
+        self.schema.validate_context(context, action, extensions)
     }
 }
 

--- a/cedar-policy-validator/src/level_validate.rs
+++ b/cedar-policy-validator/src/level_validate.rs
@@ -974,4 +974,62 @@ mod levels_validation_tests {
             6,
         );
     }
+
+    #[test]
+    fn short_circuiting_checks_evaluated_expr() {
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { (principal.bool || true) || true};"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { (principal.bool && false) && false};"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if (principal.bool && false) then true else false };"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if (principal.bool && false) then true else false };"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if true then principal.bool else false };"#,
+            ["principal.bool"],
+            1,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if false then true else principal.bool };"#,
+            ["principal.bool"],
+            1,
+        );
+    }
+
+    #[test]
+    fn short_circuiting_skips_unevaluated_expr() {
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { true || principal.bool};"#,
+            [],
+            0,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { false && principal.bool};"#,
+            [],
+            0,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if false then principal.bool else false };"#,
+            [],
+            0,
+        );
+        assert_requires_level(
+            r#"permit(principal, action, resource) when { if true then true else principal.bool };"#,
+            [],
+            0,
+        );
+    }
 }

--- a/cedar-policy-validator/src/typecheck.rs
+++ b/cedar-policy-validator/src/typecheck.rs
@@ -577,14 +577,10 @@ impl<'a> SingleEnvTypechecker<'a> {
                 );
                 ans_left.then_typecheck(|typ_left, capability_left| {
                     match typ_left.data() {
-                        // LHS argument is false, so short circuit the `&&` to `False` _without_
-                        // typechecking the RHS.  We still need to build an annotated `&&` with
-                        // some RHS, so we use a literal `true`. The `&&` expression typechecks
-                        // with an empty capability rather than the capability of the lhs.
+                        // LHS argument is false, so short circuit the `&&` to
+                        // `False` _without_ typechecking the RHS.
                         Some(Type::False) => TypecheckAnswer::success(
-                            ExprBuilder::with_data(Some(Type::False))
-                                .with_same_source_loc(e)
-                                .and(typ_left, ExprBuilder::new().val(true)),
+                            typ_left.with_maybe_source_loc(e.source_loc().cloned()),
                         ),
                         _ => {
                             // Similar to the `then` branch of an `if`
@@ -672,16 +668,11 @@ impl<'a> SingleEnvTypechecker<'a> {
                     |_| None,
                 );
                 ans_left.then_typecheck(|ty_expr_left, capability_left| match ty_expr_left.data() {
-                    // LHS argument is true, so short circuit the `|| to `True` _without_
-                    // typechecking the RHS. We still need to build an annotated `||` with
-                    // some RHS, so we use a literal `true`.  Contrary to `&&`, we keep a
-                    // capability  when short circuiting `||`. The left operand is `true`,
-                    // so its capability is maintained. The right operand is not evaluated,
-                    // so its capability is not considered.
+                    // LHS argument is true, so short circuit the `|| to `True`
+                    // _without_ typechecking the RHS. Contrary to `&&`, we
+                    // keep a capability  when short circuiting `||`.
                     Some(Type::True) => TypecheckAnswer::success_with_capability(
-                        ExprBuilder::with_data(Some(Type::True))
-                            .with_same_source_loc(e)
-                            .or(ty_expr_left, ExprBuilder::new().val(true)),
+                        ty_expr_left.with_maybe_source_loc(e.source_loc().cloned()),
                         capability_left,
                     ),
                     _ => {

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,8 @@ Cedar Language Version: TBD
   format. The new functions are deprecated and placed behind the `deprecated-schema-compat` feature. (#1600)
 - `Expression::new_duration`, `Expression::new_datetime`, `RestrictedExpression::new_duration`,
    and `RestrictedExpression::new_datetime` (#1614)
+- Added a function to be able to split a policy set parsed from a single string into its component static 
+  policies and templates. The relevant function is `policy_set_text_to_parts` in the `ffi` module.
 
 ### Changed
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,8 +22,10 @@ Cedar Language Version: TBD
   format. The new functions are deprecated and placed behind the `deprecated-schema-compat` feature. (#1600)
 - `Expression::new_duration`, `Expression::new_datetime`, `RestrictedExpression::new_duration`,
    and `RestrictedExpression::new_datetime` (#1614)
-- Added a function to be able to split a policy set parsed from a single string into its component static 
-  policies and templates. The relevant function is `policy_set_text_to_parts` in the `ffi` module.
+- Added a function to be able to split a policy set parsed from a single string into its component static
+  policies and templates. The relevant function is `policy_set_text_to_parts` in the `ffi` module (#1629).
+- Implemented [RFC 71 (trailing commas)](https://github.com/cedar-policy/rfcs/blob/main/text/0071-trailing-commas.md)
+  for Cedar policy files. (#1606)
 
 ### Changed
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -25,7 +25,7 @@ smol_str = { version = "0.3", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true }
 serde_with = "3.13.0"
 nonempty = "0.10"
-prost = { version = "0.14", optional = true }
+prost = { version = "0.13", optional = true }
 
 # wasm dependencies
 serde-wasm-bindgen = { version = "0.6", optional = true }
@@ -35,7 +35,7 @@ semver = "1.0.26"
 lazy_static = "1.5.0"
 
 [build-dependencies]
-prost-build = { version = "0.14", optional = true }
+prost-build = { version = "0.13", optional = true }
 
 [features]
 # by default, enable all Cedar extensions, but not other crate features

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -23,9 +23,9 @@ miette = "7.6.0"
 thiserror = "2.0"
 smol_str = { version = "0.3", features = ["serde"] }
 dhat = { version = "0.3.2", optional = true }
-serde_with = "3.12.0"
+serde_with = "3.13.0"
 nonempty = "0.10"
-prost = { version = "0.13", optional = true }
+prost = { version = "0.14", optional = true }
 
 # wasm dependencies
 serde-wasm-bindgen = { version = "0.6", optional = true }
@@ -35,7 +35,7 @@ semver = "1.0.26"
 lazy_static = "1.5.0"
 
 [build-dependencies]
-prost-build = { version = "0.13", optional = true }
+prost-build = { version = "0.14", optional = true }
 
 [features]
 # by default, enable all Cedar extensions, but not other crate features

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -17,7 +17,7 @@ cedar-policy-formatter = { version = "=4.4.0", path = "../cedar-policy-formatter
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-lalrpop-util = { version = "0.22.1", features = ["lexer"] }
+lalrpop-util = { version = "0.22.2", features = ["lexer"] }
 itertools = "0.14"
 miette = "7.6.0"
 thiserror = "2.0"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -81,7 +81,7 @@ cedar-policy-core = { version = "=4.4.0", features = [
 # NON-CRYPTOGRAPHIC random number generators
 oorandom = "11.1"
 
-proptest = "1.6.0"
+proptest = "1.7.0"
 
 [[bench]]
 name = "cedar_benchmarks"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -73,7 +73,7 @@ crate-type = ["rlib", "cdylib"]
 [dev-dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }
 cool_asserts = "2.0"
-criterion = "0.5"
+criterion = "0.6"
 globset = "0.4"
 cedar-policy-core = { version = "=4.4.0", features = [
     "test-util",

--- a/cedar-policy/benches/attr_errors.rs
+++ b/cedar-policy/benches/attr_errors.rs
@@ -17,7 +17,8 @@
 #![allow(clippy::unwrap_used)]
 use cedar_policy::EntityUid;
 use cedar_policy::{Authorizer, Context, Entities, PolicySet, Request, RestrictedExpression};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 use std::str::FromStr;
 
 const LARGE_SIZE: usize = 100_000;

--- a/cedar-policy/benches/cedar_benchmarks.rs
+++ b/cedar-policy/benches/cedar_benchmarks.rs
@@ -18,14 +18,14 @@
 // PANIC SAFETY benchmarking
 #![allow(clippy::expect_used)]
 
-use std::str::FromStr;
+use std::{hint::black_box, str::FromStr};
 
 use cedar_policy::{
     Authorizer, Context, Entities, EntityId, EntityTypeName, EntityUid, Policy, PolicySet, Request,
     RestrictedExpression,
 };
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let auth = Authorizer::new();

--- a/cedar-policy/benches/deeply_nested_est.rs
+++ b/cedar-policy/benches/deeply_nested_est.rs
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+use std::hint::black_box;
+
 use cedar_policy::Policy;
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 // PANIC SAFETY: benchmarking
 #[allow(clippy::unwrap_used)]

--- a/cedar-policy/benches/entity_attr_errors.rs
+++ b/cedar-policy/benches/entity_attr_errors.rs
@@ -21,9 +21,10 @@
 use cedar_policy::{
     Authorizer, Context, Entities, Entity, EntityUid, PolicySet, Request, RestrictedExpression,
 };
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use std::{
     collections::{HashMap, HashSet},
+    hint::black_box,
     str::FromStr,
 };
 

--- a/cedar-policy/benches/entity_parsing.rs
+++ b/cedar-policy/benches/entity_parsing.rs
@@ -1,11 +1,11 @@
 // PANIC SAFETY: it's ok for benchmarking code to panic
 #![allow(clippy::unwrap_used)]
 
-use std::str::FromStr;
+use std::{hint::black_box, str::FromStr};
 
 use cedar_policy::EntityTypeName;
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 
 fn entity_type_name_parsing(c: &mut Criterion) {
     let mut group = c.benchmark_group("EntityTypeName parsing");

--- a/cedar-policy/benches/extension_fn_validation.rs
+++ b/cedar-policy/benches/extension_fn_validation.rs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-use std::str::FromStr;
+use std::{hint::black_box, str::FromStr};
 
 use cedar_policy::{Policy, PolicySet, Schema, Validator};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 
 // PANIC SAFETY: benchmarking
 #[allow(clippy::unwrap_used)]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -44,7 +44,7 @@ pub use ast::Effect;
 pub use authorizer::Decision;
 #[cfg(feature = "partial-eval")]
 use cedar_policy_core::ast::BorrowedRestrictedExpr;
-use cedar_policy_core::ast::{self, RestrictedExpr};
+use cedar_policy_core::ast::{self, RequestSchema, RestrictedExpr};
 use cedar_policy_core::authorizer;
 use cedar_policy_core::entities::{ContextSchema, Dereference};
 use cedar_policy_core::est::{self, TemplateLink};
@@ -4560,6 +4560,26 @@ impl Context {
         other_context: impl IntoIterator<Item = (String, RestrictedExpression)>,
     ) -> Result<Self, ContextCreationError> {
         Self::from_pairs(self.into_iter().chain(other_context))
+    }
+
+    /// Validates this context against the provided schema
+    ///
+    /// Returns Ok(()) if the context is valid according to the schema, or an error otherwise
+    ///
+    /// This validation is already handled by `Request::new`, so there is no need to separately call
+    /// if you are validating the whole request
+    pub fn validate(
+        &self,
+        schema: &crate::Schema,
+        action: &EntityUid,
+    ) -> std::result::Result<(), RequestValidationError> {
+        // Call the validate_context function from coreschema.rs
+        Ok(RequestSchema::validate_context(
+            &schema.0,
+            &self.0,
+            action.as_ref(),
+            Extensions::all_available(),
+        )?)
     }
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -101,6 +101,13 @@ impl AsRef<ast::Entity> for Entity {
     }
 }
 
+#[doc(hidden)]
+impl From<ast::Entity> for Entity {
+    fn from(entity: ast::Entity) -> Self {
+        Self(entity)
+    }
+}
+
 impl Entity {
     /// Create a new `Entity` with this Uid, attributes, and parents (and no tags).
     ///
@@ -362,6 +369,13 @@ pub struct Entities(pub(crate) cedar_policy_core::entities::Entities);
 impl AsRef<cedar_policy_core::entities::Entities> for Entities {
     fn as_ref(&self) -> &cedar_policy_core::entities::Entities {
         &self.0
+    }
+}
+
+#[doc(hidden)]
+impl From<cedar_policy_core::entities::Entities> for Entities {
+    fn from(entities: cedar_policy_core::entities::Entities) -> Self {
+        Self(entities)
     }
 }
 
@@ -1780,6 +1794,13 @@ impl AsRef<cedar_policy_validator::ValidatorSchema> for Schema {
     }
 }
 
+#[doc(hidden)]
+impl From<cedar_policy_core::validator::ValidatorSchema> for Schema {
+    fn from(schema: cedar_policy_core::validator::ValidatorSchema) -> Self {
+        Self(schema)
+    }
+}
+
 impl FromStr for Schema {
     type Err = CedarSchemaError;
 
@@ -2230,6 +2251,14 @@ impl Eq for PolicySet {}
 impl AsRef<ast::PolicySet> for PolicySet {
     fn as_ref(&self) -> &ast::PolicySet {
         &self.ast
+    }
+}
+
+#[doc(hidden)]
+impl TryFrom<ast::PolicySet> for PolicySet {
+    type Error = PolicySetError;
+    fn try_from(pset: ast::PolicySet) -> Result<Self, Self::Error> {
+        Self::from_ast(pset)
     }
 }
 
@@ -2962,6 +2991,13 @@ impl AsRef<ast::Template> for Template {
     }
 }
 
+#[doc(hidden)]
+impl From<ast::Template> for Template {
+    fn from(template: ast::Template) -> Self {
+        Self::from_ast(template)
+    }
+}
+
 impl Template {
     /// Attempt to parse a [`Template`] from source.
     /// Returns an error if the input is a static policy (i.e., has no slots).
@@ -3301,6 +3337,20 @@ impl Eq for Policy {}
 impl AsRef<ast::Policy> for Policy {
     fn as_ref(&self) -> &ast::Policy {
         &self.ast
+    }
+}
+
+#[doc(hidden)]
+impl From<ast::Policy> for Policy {
+    fn from(policy: ast::Policy) -> Self {
+        Self::from_ast(policy)
+    }
+}
+
+#[doc(hidden)]
+impl From<ast::StaticPolicy> for Policy {
+    fn from(policy: ast::StaticPolicy) -> Self {
+        ast::Policy::from(policy).into()
     }
 }
 
@@ -3820,6 +3870,13 @@ impl AsRef<ast::Expr> for Expression {
     }
 }
 
+#[doc(hidden)]
+impl From<ast::Expr> for Expression {
+    fn from(expr: ast::Expr) -> Self {
+        Self(expr)
+    }
+}
+
 impl Expression {
     /// Create an expression representing a literal string.
     pub fn new_string(value: String) -> Self {
@@ -4238,6 +4295,13 @@ pub struct Request(pub(crate) ast::Request);
 impl AsRef<ast::Request> for Request {
     fn as_ref(&self) -> &ast::Request {
         &self.0
+    }
+}
+
+#[doc(hidden)]
+impl From<ast::Request> for Request {
+    fn from(req: ast::Request) -> Self {
+        Self(req)
     }
 }
 

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -20,12 +20,47 @@
 
 use super::utils::JsonValueWithNoDuplicateKeys;
 use super::{DetailedError, Policy, Schema, Template};
+use crate::api::{PolicySet, StringifiedPolicySet};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::wasm_bindgen;
 
 #[cfg(feature = "wasm")]
 extern crate tsify;
+
+/// Takes a PolicySet represented as string and return the policies
+/// and templates split into vecs and sorted by id.
+#[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policySetTextToParts"))]
+pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnswer {
+    let parsed_ps: Result<PolicySet, _> = PolicySet::from_str(policyset_str);
+    match parsed_ps {
+        Ok(policy_set) => {
+            if let Some(StringifiedPolicySet {
+                policies,
+                policy_templates,
+            }) = policy_set.stringify()
+            {
+                PolicySetTextToPartsAnswer::Success {
+                    policies,
+                    policy_templates,
+                }
+            } else {
+                // This should never happen due to the nature of the input but we cover it
+                // just in case, to future-proof the interface
+                PolicySetTextToPartsAnswer::Failure {
+                    errors: vec![DetailedError::from_str(
+                        "Policy set input contained template linked policies",
+                    )
+                    .unwrap_or_default()],
+                }
+            }
+        }
+        Err(e) => PolicySetTextToPartsAnswer::Failure {
+            errors: vec![(&e).into()],
+        },
+    }
+}
 
 /// Return the Cedar (textual) representation of a policy.
 #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policyToText"))]
@@ -154,6 +189,28 @@ pub enum PolicyToTextAnswer {
     Success {
         /// Cedar format policy
         text: String,
+    },
+    /// Represents a failed call (e.g., because the input is ill-formed)
+    Failure {
+        /// Errors
+        errors: Vec<DetailedError>,
+    },
+}
+
+/// Result of converting a policyset as a string into its Cedar
+/// format components
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type")]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
+#[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
+pub enum PolicySetTextToPartsAnswer {
+    /// Represents a successful call
+    Success {
+        /// Cedar format policies
+        policies: Vec<String>,
+        /// Cedar format policy templates
+        policy_templates: Vec<String>,
     },
     /// Represents a failed call (e.g., because the input is ill-formed)
     Failure {
@@ -505,6 +562,39 @@ action "sendMessage" appliesTo {
   context: {}
 };
 "#
+            );
+        });
+    }
+
+    #[test]
+    fn policy_set_to_text_to_parts() {
+        let policy_set_str = r#"
+            permit(principal, action, resource)
+            when { principal has "Email" && principal.Email == "a@a.com" };
+            
+            permit(principal in UserGroup::"DeathRowRecords", action == Action::"pop", resource);
+
+            permit(principal in ?principal, action, resource);
+        "#;
+
+        let result = policy_set_text_to_parts(policy_set_str);
+        assert_matches!(result, PolicySetTextToPartsAnswer::Success { policies, policy_templates } => {
+            assert_eq!(policies.len(), 2);
+            assert_eq!(policy_templates.len(), 1);
+        });
+    }
+
+    #[test]
+    fn test_policy_set_text_to_parts_parse_failure() {
+        let invalid_input = "This is not a valid PolicySet string";
+
+        let result = policy_set_text_to_parts(invalid_input);
+
+        assert_matches!(result, PolicySetTextToPartsAnswer::Failure { errors } => {
+            assert_exactly_one_error(
+                &errors,
+                "unexpected token `is`",
+                None,
             );
         });
     }

--- a/cedar-policy/src/ffi/utils.rs
+++ b/cedar-policy/src/ffi/utils.rs
@@ -31,7 +31,7 @@ pub use cedar_policy_core::jsonvalue::JsonValueWithNoDuplicateKeys;
 extern crate tsify;
 
 /// Structure of the JSON output representing one `miette` error
-#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Deserialize, Serialize, Default)]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 #[serde(rename_all = "camelCase")]
@@ -54,6 +54,22 @@ pub struct DetailedError {
     /// Related errors
     #[serde(default)]
     pub related: Vec<DetailedError>,
+}
+
+impl FromStr for DetailedError {
+    type Err = std::convert::Infallible;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(DetailedError {
+            message: s.to_string(),
+            help: None,
+            code: None,
+            url: None,
+            severity: None,
+            source_locations: Vec::new(),
+            related: Vec::new(),
+        })
+    }
 }
 
 /// Exactly like `miette::Severity` but implements `Hash`
@@ -1208,5 +1224,11 @@ mod test {
                 .source("error parsing schema: unexpected token `permit`")
                 .build(),
         );
+    }
+
+    #[test]
+    fn test_detailed_err_from_str() {
+        let detailed_err = DetailedError::from_str("xxx");
+        assert_eq!(detailed_err.unwrap().message, "xxx");
     }
 }

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -485,7 +485,6 @@ mod test {
 
     // We add `PartialOrd` and `Ord` implementations for both `models::Policy` and
     // `models::TemplateBody`, so that these can be sorted for testing purposes
-    impl Eq for models::Policy {}
     impl PartialOrd for models::Policy {
         fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
             Some(self.cmp(other))

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -485,6 +485,7 @@ mod test {
 
     // We add `PartialOrd` and `Ord` implementations for both `models::Policy` and
     // `models::TemplateBody`, so that these can be sorted for testing purposes
+    impl Eq for models::Policy {}
     impl PartialOrd for models::Policy {
         fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
             Some(self.cmp(other))


### PR DESCRIPTION
Cherry-picks the following PRs to `release/4.5.x`:  (note that `release/4.5.x` started at 40be99c4 and thus automatically includes everything that hit `main` prior to #1624)

- #1625 
- #1630 
- #1628 
- #1631 
- #1629 
- #1632 
- #1633 
- #1640 
- #1645 
- #1606 
- #1649 
- #1653 
- #1651 
- #1655 
- #1657 
- #1659 
- #1660 
- #1670 