### PR TITLE
Updates CI to check compatability with with cedar-lean-ffi and cedar-lean-cli in cedar-spec

### DIFF
--- a/.github/workflows/build_downstream_deps.yml
+++ b/.github/workflows/build_downstream_deps.yml
@@ -24,6 +24,21 @@ jobs:
       cedar_policy_ref: ${{ github.ref }}
       cedar_spec_ref: ${{ needs.get-branch-name.outputs.branch_name }}
 
+  build-cedar-lean-ffi:
+    needs: get-branch-name
+    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_ffi_reusable.yml@main
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_spec_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+  
+
+  build-cedar-lean-cli:
+    needs: get-branch-name
+    uses: cedar-policy/cedar-spec/.github/workflows/build_and_test_cli_reusable.yml@main
+    with:
+      cedar_policy_ref: ${{ github.ref }}
+      cedar_spec_ref: ${{ needs.get-branch-name.outputs.branch_name }}
+
   build-cedar-java:
     needs: get-branch-name
     uses: cedar-policy/cedar-java/.github/workflows/run_cedar_java_reusable.yml@main


### PR DESCRIPTION
## Description of changes

Updates CI to check that changes to cedar-policy do not break cedar-lean-ffi and cedar-lean-cli crates within cedar-spec.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
