### PR TITLE
Only compile cedar-policy as rlib by default.

### DIFF
--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -68,10 +68,6 @@ deprecated-schema-compat = []
 # Feature for raw parsing
 raw-parsing = ["cedar-policy-core/raw-parsing"]
 
-[lib]
-# cdylib required for wasm
-crate-type = ["rlib", "cdylib"]
-
 [dev-dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }
 cool_asserts = "2.0"


### PR DESCRIPTION
## Description of changes

Remove flag in `cedar-policy/Cargo.toml` to compile as a `cdylib` crate (i.e., compile as a dynamic library .so file).

It seems that `cdylib` is only required for `cedar-wasm` which has it's own `Cargo.toml` which specifies to compile as `cdylib`.

Addresses request in issue #1684 which points out that we do not need to compile `cdylib`. Removing this compilation target by default improves compiler performance by ~14% in local testing on my development machine.

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
