### PR TITLE
Adds more conversion functions needed for updating DRT to public types

### DIFF
--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -379,13 +379,6 @@ impl From<cedar_policy_core::entities::Entities> for Entities {
     }
 }
 
-#[doc(hidden)]
-impl From<Entities> for cedar_policy_core::entities::Entities {
-    fn from(entities: Entities) -> Self {
-        entities.0
-    }
-}
-
 use entities_errors::EntitiesError;
 
 impl Entities {
@@ -1511,7 +1504,7 @@ impl
     }
 }
 
-#[doc(hidden)] // because this converts to a private/internal type
+#[doc(hidden)] // because this converts from a private/internal type
 impl
     TryFrom<
         cedar_policy_core::validator::json_schema::Fragment<cedar_policy_core::validator::RawName>,


### PR DESCRIPTION
## Description of changes

Adds more conversion functions needed for updating DRT to public types

ast::json_schema::SchemaFragment -> api::SchemaFragment
api::EvalResult -> api::Expression


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

These changes don't impact DRT. But I did make these changes due to (not yet pushed) changes I made to DRT.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
