### PR TITLE
Update CI to use "sudo apt-get update" before each "sudo apt-get install"

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -49,7 +49,7 @@ jobs:
           echo "LLVM_PROFILE_FILE=cedar_%m_%p.profraw" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
-      - run: sudo apt-get install protobuf-compiler
+      - run: sudo apt-get update && sudo apt-get install protobuf-compiler
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo install cargo-audit --locked
       - run: ./panic_safety.sh
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - run: sudo apt-get install protobuf-compiler
+      - run: sudo apt-get update && sudo apt-get install protobuf-compiler
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       # Clippy is configured by `.cargo/config.toml` to deny on lints like
       # `unwrap_used`. They aren't detected by `panic_safety.sh` which only
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: taiki-e/install-action@cargo-hack
-    - run: sudo apt-get install protobuf-compiler
+    - run: sudo apt-get update && sudo apt-get install protobuf-compiler
     - run: cargo hack check --rust-version --workspace --all-targets --ignore-private --all-features
 
   wasm-build:

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -23,7 +23,7 @@ jobs:
         run: rustup update stable && rustup default stable
       - name: Install protobuf (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install protobuf-compiler
+        run: sudo apt-get update && sudo apt-get install protobuf-compiler
       - name: Install protobuf (macOS)
         if: startsWith(matrix.os, 'macos')
         run: brew install protobuf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       # `cargo semver-checks` doesn't understand `rlib` crates.
       - run: >-
           sed -i -E 's/^(crate-type = \["rlib", "cdylib"\]|crate-type = \["rlib"\])$/crate-type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
-      - run: sudo apt-get install protobuf-compiler
+      - run: sudo apt-get update && sudo apt-get install protobuf-compiler
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo install cargo-semver-checks
       - run: cargo semver-checks check-release --package cedar-policy --baseline-root ../base


### PR DESCRIPTION
Updates CI to update apt-get before trying to install. Hopefully fixes CI failures when trying to install protobuf using apt-get.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
