### PR TITLE
Chaluli/cedar symcc datetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -505,6 +505,7 @@ dependencies = [
  "async-recursion",
  "cedar-policy 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cedar-policy-core 4.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono",
  "itertools 0.14.0",
  "log",
  "miette",
@@ -565,8 +566,10 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 

--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -23,6 +23,7 @@ ref-cast = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["io-util", "process"] }
+chrono = "0.4.41"
 
 [dev-dependencies]
 miette = { version = "7.5.0", features = ["fancy"] }

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 use super::type_abbrevs::Nat;
+use super::result::Error;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct BitVec {
@@ -140,6 +141,30 @@ impl BitVec {
                 (lhs.v as u128 / rhs.v as u128) as i128
             },
         }
+    }
+
+    // semantics to match https://leanprover-community.github.io/mathlib4_docs/Init/Data/BitVec/Basic.html#BitVec.srem
+    pub fn srem(_lhs: &Self, _rhs: &Self) -> Self {
+        let unimplemented = Err(Error::UnsupportedError);
+        // PANIC SAFETY (not really panic safe, hack until BitVec refactor)
+        #[allow(clippy::expect_used, reason="TODO, but can't use todo! or unimplemented!")]
+        unimplemented.expect("BitVec::srem not implemented. Waiting for BitVec refactor")
+    }
+
+    // semantics to match https://leanprover-community.github.io/mathlib4_docs/Init/Data/BitVec/Basic.html#BitVec.smod
+    pub fn smod(_lhs: &Self, _rhs: &Self) -> Self {
+        let unimplemented = Err(Error::UnsupportedError);
+        // PANIC SAFETY (not really panic safe, hack until BitVec refactor)
+        #[allow(clippy::expect_used, reason="TODO, but can't use todo! or unimplemented!")]
+        unimplemented.expect("BitVec::smod not implemented. Waiting for BitVec refactor")
+    }
+
+    // semantics to match https://leanprover-community.github.io/mathlib4_docs/Init/Data/BitVec/Basic.html#BitVec.umod
+    pub fn umod(_lhs: &Self, _rhs: &Self) -> Self {
+        let unimplemented = Err(Error::UnsupportedError);
+        // PANIC SAFETY (not really panic safe, hack until BitVec refactor)
+        #[allow(clippy::expect_used, reason="TODO, but can't use todo! or unimplemented!")]
+        unimplemented.expect("BitVec::umod not implemented. Waiting for BitVec refactor")
     }
 
     pub fn shl(lhs: &Self, rhs: &Self) -> Self {

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use super::type_abbrevs::Nat;
 use super::result::Error;
+use super::type_abbrevs::Nat;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct BitVec {
@@ -147,7 +147,10 @@ impl BitVec {
     pub fn srem(_lhs: &Self, _rhs: &Self) -> Self {
         let unimplemented = Err(Error::UnsupportedError);
         // PANIC SAFETY (not really panic safe, hack until BitVec refactor)
-        #[allow(clippy::expect_used, reason="TODO, but can't use todo! or unimplemented!")]
+        #[allow(
+            clippy::expect_used,
+            reason = "TODO, but can't use todo! or unimplemented!"
+        )]
         unimplemented.expect("BitVec::srem not implemented. Waiting for BitVec refactor")
     }
 
@@ -155,7 +158,10 @@ impl BitVec {
     pub fn smod(_lhs: &Self, _rhs: &Self) -> Self {
         let unimplemented = Err(Error::UnsupportedError);
         // PANIC SAFETY (not really panic safe, hack until BitVec refactor)
-        #[allow(clippy::expect_used, reason="TODO, but can't use todo! or unimplemented!")]
+        #[allow(
+            clippy::expect_used,
+            reason = "TODO, but can't use todo! or unimplemented!"
+        )]
         unimplemented.expect("BitVec::smod not implemented. Waiting for BitVec refactor")
     }
 
@@ -163,7 +169,10 @@ impl BitVec {
     pub fn umod(_lhs: &Self, _rhs: &Self) -> Self {
         let unimplemented = Err(Error::UnsupportedError);
         // PANIC SAFETY (not really panic safe, hack until BitVec refactor)
-        #[allow(clippy::expect_used, reason="TODO, but can't use todo! or unimplemented!")]
+        #[allow(
+            clippy::expect_used,
+            reason = "TODO, but can't use todo! or unimplemented!"
+        )]
         unimplemented.expect("BitVec::umod not implemented. Waiting for BitVec refactor")
     }
 

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -576,7 +576,10 @@ fn encode_ext(e: &Ext) -> String {
             let bv_enc = encode_bitvec(&BitVec::of_int(64, i128::from(d.to_milliseconds())));
             format!("(Duration {bv_enc})")
         }
-        Ext::Datetime { .. } => String::new(), // Lean comment "TODO: Provide an actual encoding for datetimes"
+        Ext::Datetime { dt } => {
+            let bv_enc = encode_bitvec(&BitVec::of_int(64, i128::from(dt)));
+            format!("(Datetime {bv_enc})")
+        }
     }
 }
 
@@ -588,7 +591,10 @@ fn encode_ext_op(ext_op: &ExtOp) -> &'static str {
         ExtOp::IpaddrPrefixV4 => "prefixV4",
         ExtOp::IpaddrAddrV6 => "addrV6",
         ExtOp::IpaddrPrefixV6 => "prefixV6",
+        ExtOp::DatetimeVal => "datetimeVal",
+        ExtOp::DatetimeOfBitVec => "Datetime",
         ExtOp::DurationVal => "durationVal",
+        ExtOp::DurationOfBitVec => "Duration",
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/ext.rs
+++ b/cedar-policy-symcc/src/symcc/ext.rs
@@ -36,4 +36,20 @@ impl Ext {
     pub fn parse_decimal(str: String) -> Option<Ext> {
         super::extension_types::decimal::parse(&str).map(|d| Ext::Decimal { d })
     }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "Pass by value expected by consumer"
+    )]
+    pub fn parse_datetime(str: String) -> Option<Ext> {
+        super::extension_types::datetime::Datetime::parse(&str).map(|dt| Ext::Datetime { dt })
+    }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "Pass by value expected by consumer"
+    )]
+    pub fn parse_duration(str: String) -> Option<Ext> {
+        super::extension_types::datetime::Duration::parse(&str).map(|d| Ext::Duration { d })
+    }
 }

--- a/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
@@ -30,6 +30,8 @@
 ///
 /// The datetime type does not provide a way to create a datetime from a Unix timestamp.
 /// One of the readable formats listed above must be used instead.
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Datetime {
     val: i64,
@@ -79,6 +81,135 @@ impl Datetime {
                     val: rem + MILLISECONDS_PER_DAY,
                 })
             }
+        }
+    }
+
+    // Returns true iff s is a datetime str in one of our accepted formats and contains a leap second
+    fn date_contains_leap_seconds(s: &str) -> bool {
+        s.len() >= 20 && s.get(17..19) == Some("60")
+    }
+
+    // Returns true iff s contains the expected delimiters within one of our accepted datetime str formats
+    fn check_component_len(s: &str) -> bool {
+        let check_date_component = |s: &str| -> bool {
+            match s.split('-').collect::<Vec<_>>().as_slice() {
+                [year, month, day] => year.len() == 4 && month.len() == 2 && day.len() == 2,
+                _ => false,
+            }
+        };
+        let check_time_component = |s: &str| -> bool {
+            match s
+                .find(['.', '+', '-', 'Z'])
+                .and_then(|pos| s.split_at_checked(pos))
+            {
+                Some((time, ms_and_tz)) => match time.split(':').collect::<Vec<_>>().as_slice() {
+                    [h, m, s] => {
+                        h.len() == 2 && m.len() == 2 && s.len() == 2 && !ms_and_tz.contains(':')
+                    }
+                    _ => false,
+                },
+                None => false,
+            }
+        };
+
+        match s.split('T').collect::<Vec<_>>().as_slice() {
+            [date] => check_date_component(date),
+            [date, time] => check_date_component(date) && check_time_component(time),
+            _ => false,
+        }
+    }
+
+    fn tz_offset_mins_lt_60(s: &str) -> bool {
+        // Doesn't contain time
+        s.len() <= 10
+            // is UTC
+            || s.ends_with('Z')
+            // Specifies TZ using +xxxx format
+            || s.get((s.len() - 2)..)
+                .and_then(|s| s.parse::<u32>().ok())
+                .is_some_and(|mins_offset| mins_offset < 60)
+    }
+
+    pub fn parse(s: &str) -> Option<Self> {
+        // Validate datetime str
+        if Self::date_contains_leap_seconds(s)
+            || !Self::check_component_len(s)
+            || !Self::tz_offset_mins_lt_60(s)
+        {
+            return None;
+        }
+
+        // Define the format strings
+        const DATE_ONLY: &str = "%Y-%m-%d";
+        const DATE_UTC: &str = "%Y-%m-%dT%H:%M:%SZ";
+        const DATE_UTC_MILLIS: &str = "%Y-%m-%dT%H:%M:%S.%3fZ";
+        // The documentation states that %z accepts TZ specified as +xxxx or -xxxx
+        // but in practice also accepts +xx:xx and -xx::xx. Thus we need to independently
+        // Validate date strings with TZ do not contain ':' in TZ.
+        const DATE_WITH_OFFSET: &str = "%Y-%m-%dT%H:%M:%S%z";
+        const DATE_WITH_OFFSET_MILLIS: &str = "%Y-%m-%dT%H:%M:%S.%3f%z";
+
+        const MAX_OFFSET_SECONDS: i32 = 86400; // 24 hours in seconds
+
+        // Try parsing with each format
+        // PANIC SAFETY
+        #[allow(
+            clippy::unwrap_used,
+            reason = "Should be able to construct a datetime with hour = 0, minute = 0, seconds = 0"
+        )]
+        // Cannot parse a datetime from just date format so use NaiveDate then append time == midnight
+        let datetime = NaiveDate::parse_from_str(s, DATE_ONLY)
+            .map(|date| date.and_hms_opt(0, 0, 0).unwrap())
+            // Datetime expects TZ info to be provided in date string regardless of format str. Use NaiveDatetime for default 'Z' TZ
+            .or_else(|_| NaiveDateTime::parse_from_str(s, DATE_UTC))
+            .or_else(|_| NaiveDateTime::parse_from_str(s, DATE_UTC_MILLIS))
+            // Convert NaiveDatetimes to UTC datetimes
+            .map(|dt| DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc))
+            // Parse date strings that include time zones.
+            .or_else(|_| {
+                DateTime::parse_from_str(s, DATE_WITH_OFFSET).map(|dt| dt.with_timezone(&Utc))
+            })
+            .or_else(|_| {
+                DateTime::parse_from_str(s, DATE_WITH_OFFSET_MILLIS)
+                    .map(|dt| dt.with_timezone(&Utc))
+            })
+            .ok()?;
+
+        // Check if the original timezone offset is within bounds (need to parse again for offset checks)
+        let offset = if let Ok(dt) = DateTime::parse_from_str(s, DATE_WITH_OFFSET) {
+            dt.offset().local_minus_utc()
+        } else if let Ok(dt) = DateTime::parse_from_str(s, DATE_WITH_OFFSET_MILLIS) {
+            dt.offset().local_minus_utc()
+        } else {
+            0 // UTC or local time
+        };
+
+        if offset.abs() < MAX_OFFSET_SECONDS {
+            Some(Self {
+                val: datetime.timestamp_millis(),
+            })
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Datetime> for i128 {
+    fn from(dt: Datetime) -> Self {
+        i128::from(dt.val)
+    }
+}
+
+impl From<&Datetime> for i128 {
+    fn from(dt: &Datetime) -> Self {
+        i128::from(dt.val)
+    }
+}
+
+impl From<i128> for Datetime {
+    fn from(bv_inner: i128) -> Self {
+        Self {
+            val: bv_inner as i64,
         }
     }
 }
@@ -132,6 +263,72 @@ impl Duration {
     pub fn to_days(&self) -> i64 {
         self.to_hours() / 24
     }
+
+    fn parse_unit<'a>(s: &'a str, is_neg: bool, suffix: &str) -> Option<(i64, &'a str)> {
+        match s.strip_suffix(suffix) {
+            Some(prefix) => {
+                let pos = prefix
+                    .rfind(|c: char| !c.is_ascii_digit())
+                    .map_or(0, |i| i + 1);
+                // PANIC SAFETY: by construction pos must be a valid index into prefix
+                let (prefix, digits) = prefix.split_at(pos);
+
+                // Compute the unscaled unit value (# of days/hrs/min/sec/ms)
+                let val = if is_neg && digits == "9223372036854775808" {
+                    // ensure we don't overflow when parsing
+                    i64::MIN
+                } else {
+                    // Parse absolute value. Any remaining overflow / parse errors
+                    let abs_val = digits.parse::<i64>().ok()?;
+                    // negate as necessary
+                    if is_neg {
+                        -abs_val
+                    } else {
+                        abs_val
+                    }
+                };
+                let ms_val = match suffix {
+                    "ms" => val,
+                    "s" => val.checked_mul(1000)?,
+                    "m" => val.checked_mul(60 * 1000)?,
+                    "h" => val.checked_mul(60 * 60 * 1000)?,
+                    "d" => val.checked_mul(24 * 60 * 60 * 1000)?,
+                    _ => return None,
+                };
+                Some((ms_val, prefix))
+            }
+            None => Some((0, s)),
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Duration> {
+        let (is_neg, s) = match s.strip_prefix('-') {
+            Some(s) => (true, s),
+            None => (false, s),
+        };
+
+        if s.is_empty() {
+            return None;
+        }
+
+        let (ms, s) = Self::parse_unit(s, is_neg, "ms")?;
+        let (sec, s) = Self::parse_unit(s, is_neg, "s")?;
+        let (min, s) = Self::parse_unit(s, is_neg, "m")?;
+        let (hr, s) = Self::parse_unit(s, is_neg, "h")?;
+        let (days, s) = Self::parse_unit(s, is_neg, "d")?;
+
+        if !s.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            val: days
+                .checked_add(hr)?
+                .checked_add(min)?
+                .checked_add(sec)?
+                .checked_add(ms)?,
+        })
+    }
 }
 
 #[allow(
@@ -141,5 +338,182 @@ impl Duration {
 impl Default for Duration {
     fn default() -> Self {
         Self { val: 0 }
+    }
+}
+
+impl From<i128> for Duration {
+    fn from(bv_inner: i128) -> Self {
+        Self {
+            val: bv_inner as i64,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::symcc::extension_types::datetime::{Datetime, Duration};
+
+    fn datetime(i: i64) -> Option<Datetime> {
+        Some(Datetime { val: i })
+    }
+
+    fn test_valid_datetime(str: &str, rep: i64) {
+        assert_eq!(Datetime::parse(str), datetime(rep));
+    }
+
+    fn test_invalid_datetime(str: &str, msg: &str) {
+        assert_eq!(Datetime::parse(str), None, "{}", msg);
+    }
+
+    #[test]
+    fn tests_for_valid_datetime_strings() {
+        test_valid_datetime("2022-10-10", 1665360000000);
+        test_valid_datetime("1969-12-31", -86400000);
+        test_valid_datetime("1969-12-31T23:59:59Z", -1000);
+        test_valid_datetime("1969-12-31T23:59:59.001Z", -999);
+        test_valid_datetime("1969-12-31T23:59:59.999Z", -1);
+        test_valid_datetime("2024-10-15", 1728950400000);
+        test_valid_datetime("2024-10-15T11:38:02Z", 1728992282000);
+        test_valid_datetime("2024-10-15T11:38:02.101Z", 1728992282101);
+        test_valid_datetime("2024-10-15T11:38:02.101-1134", 1729033922101);
+        test_valid_datetime("2024-10-15T11:38:02.101+1134", 1728950642101);
+        test_valid_datetime("2024-10-15T11:38:02+1134", 1728950642000);
+        test_valid_datetime("2024-10-15T11:38:02-1134", 1729033922000);
+    }
+
+    #[test]
+    fn tests_for_invalid_datetime_strings() {
+        test_invalid_datetime("", "empty string");
+        test_invalid_datetime("a", "string is letter");
+        test_invalid_datetime("-", "string is character");
+        test_invalid_datetime("-1", "string is integer");
+        test_invalid_datetime(" 2022-10-10", "leading space");
+        test_invalid_datetime("2022-10-10 ", "trailing space");
+        test_invalid_datetime("2022-10- 10", "interior space");
+        test_invalid_datetime("11-12-13", "two digits for year");
+        test_invalid_datetime("011-12-13", "three digits for year");
+        test_invalid_datetime("00011-12-13", "five digits for year");
+        test_invalid_datetime("0001-2-13", "one digit for month");
+        test_invalid_datetime("0001-012-13", "three digits for month");
+        test_invalid_datetime("0001-02-3", "one digit for day");
+        test_invalid_datetime("0001-02-003", "three digits for day");
+        test_invalid_datetime("0001-01-01T1:01:01Z", "one digit for hour");
+        test_invalid_datetime("0001-01-01T001:01:01Z", "three digits for hour");
+        test_invalid_datetime("0001-01-01T01:1:01Z", "one digit for minutes");
+        test_invalid_datetime("0001-01-01T01:001:01Z", "three digits for minutes");
+        test_invalid_datetime("0001-01-01T01:01:1Z", "one digit for seconds");
+        test_invalid_datetime("0001-01-01T01:01:001Z", "three digits for seconds");
+        test_invalid_datetime("0001-01-01T01:01:01.01Z", "two digits for ms");
+        test_invalid_datetime("0001-01-01T01:01:01.0001Z", "four digits for ms");
+        test_invalid_datetime("0001-01-01T01:01:01.001+01", "two digits for offset");
+        test_invalid_datetime("0001-01-01T01:01:01.001+001", "three digits for offset");
+        test_invalid_datetime("0001-01-01T01:01:01.001+000001", "six digits for offset");
+        test_invalid_datetime("0001-01-01T01:01:01.001+00:01", "offset with colon");
+        test_invalid_datetime("0001-01-01T01:01:01.001+00:00:01", "six offset with colon");
+        test_invalid_datetime("-0001-01-01", "negative year");
+        test_invalid_datetime("1111-1x-20", "invalid month");
+        test_invalid_datetime("1111-Jul-20", "abbreviated month");
+        test_invalid_datetime("1111-July-20", "full month");
+        test_invalid_datetime("1111-J-20", "single letter month");
+        test_invalid_datetime("2024-10-15Z", "Zulu code invalid for date");
+        test_invalid_datetime("2024-10-15T11:38:02ZZ", "double Zulu code");
+        test_invalid_datetime("2024-01-01T", "separator not needed");
+        test_invalid_datetime("2024-01-01Ta", "unexpected character 'a'");
+        test_invalid_datetime("2024-01-01T01:", "only hours");
+        test_invalid_datetime("2024-01-01T01:02", "no seconds");
+        test_invalid_datetime("2024-01-01T01:02:0b", "unexpected character 'b'");
+        test_invalid_datetime("2024-01-01T01::02:03", "double colon");
+        test_invalid_datetime("2024-01-01T01::02::03", "double colons");
+        test_invalid_datetime("2024-01-01T31:02:03Z", "invalid hour range");
+        test_invalid_datetime("2024-01-01T01:60:03Z", "invalid minute range");
+        test_invalid_datetime("2016-12-31T23:59:60Z", "leap second");
+        test_invalid_datetime("2016-12-31T23:59:61Z", "invalid second range");
+        test_invalid_datetime("2024-01-01T00:00:00", "timezone not specified");
+        test_invalid_datetime("2024-01-01T00:00:00T", "separator is not timezone");
+        test_invalid_datetime("2024-01-01T00:00:00ZZ", "double Zulu code");
+        test_invalid_datetime("2024-01-01T00:00:00x001Z", "typo in milliseconds separator");
+        test_invalid_datetime("2024-01-01T00:00:00.001ZZ", "double Zulu code w/ millis");
+        test_invalid_datetime("2016-12-31T23:59:60.000Z", "leap second (millis/UTC)");
+        test_invalid_datetime(
+            "2016-12-31T23:59:60.000+0200",
+            "leap second (millis/offset)",
+        );
+        test_invalid_datetime("2024-01-01T00:00:00➕0000", "sign `+` is an emoji");
+        test_invalid_datetime("2024-01-01T00:00:00➖0000", "sign `-` is an emoji");
+        test_invalid_datetime(
+            "2024-01-01T00:00:00.0001Z",
+            "fraction of seconds is 4 digits",
+        );
+        test_invalid_datetime("2024-01-01T00:00:00.001➖0000", "sign `+` is an emoji");
+        test_invalid_datetime("2024-01-01T00:00:00.001➕0000", "sign `-` is an emoji");
+        test_invalid_datetime("2024-01-01T00:00:00.001+00000", "offset is 5 digits");
+        test_invalid_datetime("2024-01-01T00:00:00.001-00000", "offset is 5 digits");
+        test_invalid_datetime("2016-01-01T00:00:00+2400", "invalid offset hour range");
+        test_invalid_datetime("2016-01-01T00:00:00+0060", "invalid offset minute range");
+        test_invalid_datetime(
+            "2016-01-01T00:00:00+9999",
+            "invalid offset hour and minute range",
+        );
+    }
+
+    fn duration(i: i64) -> Option<Duration> {
+        Some(Duration { val: i })
+    }
+
+    fn test_valid_duration(str: &str, rep: i64) {
+        assert_eq!(Duration::parse(str), duration(rep));
+    }
+
+    fn test_invalid_duration(str: &str, msg: &str) {
+        assert_eq!(Duration::parse(str), None, "{}", msg);
+    }
+
+    #[test]
+    fn tests_for_valid_duration_strings() {
+        test_valid_duration("0ms", 0);
+        test_valid_duration("0d0s", 0);
+        test_valid_duration("1ms", 1);
+        test_valid_duration("1s", 1000);
+        test_valid_duration("1m", 60000);
+        test_valid_duration("1h", 3600000);
+        test_valid_duration("1d", 86400000);
+        test_valid_duration("12s340ms", 12340);
+        test_valid_duration("1s234ms", 1234);
+        test_valid_duration("-1ms", -1);
+        test_valid_duration("-1s", -1000);
+        test_valid_duration("-4s200ms", -4200);
+        test_valid_duration("-9s876ms", -9876);
+        test_valid_duration("106751d23h47m16s854ms", 9223372036854);
+        test_valid_duration("-106751d23h47m16s854ms", -9223372036854);
+        test_valid_duration("-9223372036854775808ms", i64::MIN);
+        test_valid_duration("9223372036854775807ms", i64::MAX);
+        test_valid_duration("1d2h3m4s5ms", 93784005);
+        test_valid_duration("2d12h", 216000000);
+        test_valid_duration("3m30s", 210000);
+        test_valid_duration("1h30m45s", 5445000);
+        test_valid_duration("2d5h20m", 192000000);
+        test_valid_duration("-1d12h", -129600000);
+        test_valid_duration("-3h45m", -13500000);
+        test_valid_duration("1d1ms", 86400001);
+        test_valid_duration("59m59s999ms", 3599999);
+        test_valid_duration("23h59m59s999ms", 86399999);
+        test_valid_duration("0d0h0m0s0ms", 0);
+    }
+
+    #[test]
+    fn tests_for_invalid_duration_strings() {
+        test_invalid_duration("", "empty string");
+        test_invalid_duration("d", "unit but no amount");
+        test_invalid_duration("1d-1s", "invalid use of -");
+        test_invalid_duration("1d2h3m4s5ms6", "trailing amount");
+        test_invalid_duration("1x2m3s", "invalid unit");
+        test_invalid_duration("1.23s", "amounts must be integral");
+        test_invalid_duration("1s1d", "invalid order");
+        test_invalid_duration("1s1s", "repeated units");
+        test_invalid_duration("1d2h3m4s5ms ", "trailing space");
+        test_invalid_duration(" 1d2h3m4s5ms", "leading space");
+        test_invalid_duration("1d9223372036854775807ms", "overflow");
+        test_invalid_duration("1d92233720368547758071ms", "overflow ms");
+        test_invalid_duration("9223372036854776s1ms", "overflow s");
     }
 }

--- a/cedar-policy-symcc/src/symcc/interpretation.rs
+++ b/cedar-policy-symcc/src/symcc/interpretation.rs
@@ -291,7 +291,14 @@ impl Term {
                     ExtOp::IpaddrPrefixV4 => factory::ext_ipaddr_prefix_v4(arg.interpret(interp)),
                     ExtOp::IpaddrAddrV6 => factory::ext_ipaddr_addr_v6(arg.interpret(interp)),
                     ExtOp::IpaddrPrefixV6 => factory::ext_ipaddr_prefix_v6(arg.interpret(interp)),
+                    ExtOp::DatetimeVal => factory::ext_datetime_val(arg.interpret(interp)),
+                    ExtOp::DatetimeOfBitVec => {
+                        factory::ext_datetime_of_bitvec(arg.interpret(interp))
+                    }
                     ExtOp::DurationVal => factory::ext_duration_val(arg.interpret(interp)),
+                    ExtOp::DurationOfBitVec => {
+                        factory::ext_duration_of_bitvec(arg.interpret(interp))
+                    }
                 },
 
                 // Otherwise leave the application as it but

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -92,6 +92,12 @@ impl TermType {
                 "decimal" => Ok(TermType::Ext {
                     xty: ExtType::Decimal,
                 }),
+                "datetime" => Ok(TermType::Ext {
+                    xty: ExtType::DateTime,
+                }),
+                "duration" => Ok(TermType::Ext {
+                    xty: ExtType::Duration,
+                }),
                 _ => Err(result::Error::UnsupportedError),
             },
             Type::EntityOrRecord(entity_record_kind) => {


### PR DESCRIPTION
## Description of changes

Adds (most of) the code needed for encoding Datetime and Duration Extension Types and Operators. This code is missing code for 3 `BitVec` operators which are anticipated to be provided by @lianah 's PR for the encoding of the IP extension.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
