### PR TITLE
Add permission query based on TPE

### DIFF
--- a/cedar-policy-core/src/tpe/request.rs
+++ b/cedar-policy-core/src/tpe/request.rs
@@ -291,6 +291,36 @@ impl PartialRequest {
         }
         Ok(())
     }
+
+    /// Get the [`EntityType`] of `principal`
+    pub fn get_principal_type(&self) -> EntityType {
+        self.principal.ty.clone()
+    }
+
+    /// Get the [`EntityType`] of `resource`
+    pub fn get_resource_type(&self) -> EntityType {
+        self.resource.ty.clone()
+    }
+
+    /// Get the `principal`
+    pub fn get_principal(&self) -> PartialEntityUID {
+        self.principal.clone()
+    }
+
+    /// Get the `resource`
+    pub fn get_resource(&self) -> PartialEntityUID {
+        self.resource.clone()
+    }
+
+    /// Get the `action`
+    pub fn get_action(&self) -> EntityUID {
+        self.action.clone()
+    }
+
+    /// Get the `context` attributes
+    pub fn get_context_attrs(&self) -> Option<&BTreeMap<SmolStr, Value>> {
+        self.context.as_ref().map(|attrs| attrs.as_ref())
+    }
 }
 
 /// A request builder based on a [`PartialRequest`]

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -4158,7 +4158,7 @@ impl std::fmt::Display for Expression {
 ///   - if-then-else expressions
 #[repr(transparent)]
 #[derive(Debug, Clone, RefCast)]
-pub struct RestrictedExpression(ast::RestrictedExpr);
+pub struct RestrictedExpression(pub(crate) ast::RestrictedExpr);
 
 #[doc(hidden)] // because this converts to a private/internal type
 impl AsRef<ast::RestrictedExpr> for RestrictedExpression {
@@ -5063,12 +5063,13 @@ mod tpe {
         extensions::Extensions,
         validator::CoreSchema,
     };
+    use itertools::Itertools;
     use ref_cast::RefCast;
 
     use crate::{
         tpe_err, Authorizer, Context, Entities, EntityId, EntityTypeName, EntityUid,
-        PartialRequestCreationError, Policy, PolicySet, Request, Response, Schema,
-        TPEReauthorizationError,
+        PartialRequestCreationError, PermissionQueryError, Policy, PolicySet, Request,
+        RequestValidationError, Response, RestrictedExpression, Schema, TPEReauthorizationError,
     };
 
     /// A partial [`EntityUid`]
@@ -5114,6 +5115,112 @@ mod tpe {
             tpe::request::PartialRequest::new(principal.0, action.0, resource.0, context, &schema.0)
                 .map(Self)
                 .map_err(|e| PartialRequestCreationError::Validation(e.into()))
+        }
+    }
+
+    /// Like [`PartialRequest`] but only `resource` can be unknown
+    #[repr(transparent)]
+    #[derive(Debug, Clone, RefCast)]
+    pub struct ResourceQueryRequest(pub(crate) PartialRequest);
+
+    impl ResourceQueryRequest {
+        /// Construct a valid [`ResourceQueryRequest`] according to a [`Schema`]
+        pub fn new(
+            principal: EntityUid,
+            action: EntityUid,
+            resource: EntityTypeName,
+            context: Context,
+            schema: &Schema,
+        ) -> Result<Self, PartialRequestCreationError> {
+            PartialRequest::new(
+                PartialEntityUid(principal.0.into()),
+                action,
+                PartialEntityUid::new(resource, None),
+                Some(context),
+                schema,
+            )
+            .map(Self)
+        }
+
+        /// Convert [`ResourceQueryRequest`] to a [`Request`] by providing the resource [`EntityId`]
+        pub fn to_request(
+            &self,
+            resource_id: EntityId,
+            schema: Option<&Schema>,
+        ) -> Result<Request, RequestValidationError> {
+            // PANIC SAFETY: various fields are validated through the constructor
+            #[allow(clippy::unwrap_used)]
+            Request::new(
+                EntityUid(self.0 .0.get_principal().try_into().unwrap()),
+                EntityUid(self.0 .0.get_action()),
+                EntityUid::from_type_name_and_id(
+                    EntityTypeName(self.0 .0.get_resource_type()),
+                    resource_id,
+                ),
+                Context::from_pairs(
+                    self.0
+                         .0
+                        .get_context_attrs()
+                        .unwrap()
+                        .into_iter()
+                        .map(|(a, v)| (a.to_string(), RestrictedExpression(v.clone().into()))),
+                )
+                .unwrap(),
+                schema,
+            )
+        }
+    }
+
+    /// Like [`PartialRequest`] but only `principal` can be unknown
+    #[repr(transparent)]
+    #[derive(Debug, Clone, RefCast)]
+    pub struct PrincipalQueryRequest(pub(crate) PartialRequest);
+
+    impl PrincipalQueryRequest {
+        /// Construct a valid [`PrincipalRequest`] according to a [`Schema`]
+        pub fn new(
+            principal: EntityTypeName,
+            action: EntityUid,
+            resource: EntityUid,
+            context: Context,
+            schema: &Schema,
+        ) -> Result<Self, PartialRequestCreationError> {
+            PartialRequest::new(
+                PartialEntityUid::new(principal, None),
+                action,
+                PartialEntityUid(resource.0.into()),
+                Some(context),
+                schema,
+            )
+            .map(Self)
+        }
+
+        /// Convert [`PrincipalQueryRequest`] to a [`Request`] by providing the principal [`EntityId`]
+        pub fn to_request(
+            &self,
+            principal_id: EntityId,
+            schema: Option<&Schema>,
+        ) -> Result<Request, RequestValidationError> {
+            // PANIC SAFETY: various fields are validated through the constructor
+            #[allow(clippy::unwrap_used)]
+            Request::new(
+                EntityUid::from_type_name_and_id(
+                    EntityTypeName(self.0 .0.get_principal_type()),
+                    principal_id,
+                ),
+                EntityUid(self.0 .0.get_action()),
+                EntityUid(self.0 .0.get_resource().try_into().unwrap()),
+                Context::from_pairs(
+                    self.0
+                         .0
+                        .get_context_attrs()
+                        .unwrap()
+                        .into_iter()
+                        .map(|(a, v)| (a.to_string(), RestrictedExpression(v.clone().into()))),
+                )
+                .unwrap(),
+                schema,
+            )
         }
     }
 
@@ -5249,6 +5356,104 @@ mod tpe {
                 entities,
                 schema,
             })
+        }
+
+        /// Perform a permission query on the resource
+        pub fn query_resource(
+            &self,
+            request: &ResourceQueryRequest,
+            entities: &Entities,
+            schema: &Schema,
+        ) -> Result<impl Iterator<Item = EntityUid>, PermissionQueryError> {
+            let partial_entities = PartialEntities(entities.clone().0.try_into()?);
+            let core_schema = CoreSchema::new(&schema.0);
+            let validator =
+                EntitySchemaConformanceChecker::new(&core_schema, Extensions::all_available());
+            // We need to type-check the entities
+            for entity in entities.0.iter() {
+                validator.validate_entity(entity)?;
+            }
+            let residuals = self.tpe(&request.0, &partial_entities, schema)?;
+            let policies = &residuals.ps;
+            match residuals.is_authorized() {
+                Some(Decision::Allow) => Ok(entities
+                    .iter()
+                    .filter(|entity| {
+                        entity.0.uid().entity_type() == &request.0 .0.get_resource_type()
+                    })
+                    .map(|entity| entity.uid().clone())
+                    .collect_vec()
+                    .into_iter()),
+                Some(Decision::Deny) => Ok(vec![].into_iter()),
+                None => Ok(entities
+                    .iter()
+                    .filter(|entity| {
+                        entity.0.uid().entity_type() == &request.0 .0.get_resource_type()
+                    })
+                    .filter(|entity| {
+                        let authorizer = Authorizer::new();
+                        authorizer
+                            .is_authorized(
+                                &request.to_request(entity.uid().id().clone(), None).unwrap(),
+                                policies,
+                                entities,
+                            )
+                            .decision
+                            == Decision::Allow
+                    })
+                    .map(|entity| entity.uid().clone())
+                    .collect_vec()
+                    .into_iter()),
+            }
+        }
+
+        /// Perform a permission query on the principal
+        pub fn query_principal(
+            &self,
+            request: &PrincipalQueryRequest,
+            entities: &Entities,
+            schema: &Schema,
+        ) -> Result<impl Iterator<Item = EntityUid>, PermissionQueryError> {
+            let partial_entities = PartialEntities(entities.clone().0.try_into()?);
+            let core_schema = CoreSchema::new(&schema.0);
+            let validator =
+                EntitySchemaConformanceChecker::new(&core_schema, Extensions::all_available());
+            // We need to type-check the entities
+            for entity in entities.0.iter() {
+                validator.validate_entity(entity)?;
+            }
+            let residuals = self.tpe(&request.0, &partial_entities, schema)?;
+            let policies = &residuals.ps;
+            match residuals.is_authorized() {
+                Some(Decision::Allow) => Ok(entities
+                    .iter()
+                    .filter(|entity| {
+                        entity.0.uid().entity_type() == &request.0 .0.get_resource_type()
+                    })
+                    .map(|entity| entity.uid().clone())
+                    .collect_vec()
+                    .into_iter()),
+                Some(Decision::Deny) => Ok(vec![].into_iter()),
+                None => Ok(entities
+                    .iter()
+                    .filter(|entity| {
+                        entity.0.uid().entity_type() == &request.0 .0.get_principal_type()
+                    })
+                    .filter(|entity| {
+                        let authorizer = Authorizer::new();
+                        authorizer
+                            .is_authorized(
+                                &request.to_request(entity.uid().id().clone(), None).unwrap(),
+                                policies,
+                                entities,
+                            )
+                            .decision
+                            == Decision::Allow
+                    })
+                    .map(|entity| entity.uid().clone())
+                    .collect_vec()
+                    .into_iter()),
+            }
         }
     }
 }

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -1344,3 +1344,18 @@ pub enum TPEReauthorizationError {
     #[error(transparent)]
     InconsistentRequests(#[from] tpe_err::RequestConsistencyError),
 }
+
+#[cfg(feature = "tpe")]
+/// Errors that can be encountered when performing a permission query
+#[derive(Debug, Error)]
+pub enum PermissionQueryError {
+    /// When entities contain unknowns
+    #[error(transparent)]
+    EntitiesContainUnknown(#[from] PartialValueToValueError),
+    /// When TPE fails
+    #[error(transparent)]
+    TPE(#[from] tpe_err::TPEError),
+    /// When concrete entities fail validation
+    #[error(transparent)]
+    EntityValidation(#[from] EntitySchemaConformanceError),
+}


### PR DESCRIPTION
## Description of changes

Add (restricted) permission query APIs for querying principal or resource only.
## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
