### PR TITLE
Add a public `deep_eq` method for `Entities` and `Entity`

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -649,7 +649,7 @@ impl Entity {
     /// attributes, attribute values, and ancestors/parents.
     ///
     /// Does not test that they have the same _direct_ parents, only that they have the same overall ancestor set.
-    pub(crate) fn deep_eq(&self, other: &Self) -> bool {
+    pub fn deep_eq(&self, other: &Self) -> bool {
         self.uid == other.uid
             && self.attrs == other.attrs
             && (self.ancestors().collect::<HashSet<_>>())

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -112,6 +112,24 @@ impl Entities {
         self.entities.values().map(|e| e.as_ref())
     }
 
+    /// Test if two entity hierarchies are structurally equal. The hierarchies
+    /// must contain the same set of entity ids, and the entities with each id
+    /// must be structurally equal (decided [`Entity::deep_eq`]). Ancestor
+    /// equality between entities is always decided by comparing the transitive
+    /// closure of ancestor and not direct parents.
+    pub fn deep_eq(&self, other: &Self) -> bool {
+        if self.mode != other.mode || self.entities.len() != other.entities.len() {
+            return false;
+        }
+
+        self.entities.iter().all(|(id, entity)| {
+            other
+                .entities
+                .get(id)
+                .map_or(false, |other_entity| entity.deep_eq(other_entity))
+        })
+    }
+
     /// Adds the [`crate::ast::Entity`]s in the iterator to this [`Entities`].
     /// Fails if
     ///  - there is a pair of non-identical entities in the passed iterator with the same Entity UID, or
@@ -563,7 +581,9 @@ pub enum TCComputation {
 #[allow(clippy::cognitive_complexity)]
 mod json_parsing_tests {
     use super::*;
-    use crate::{extensions::Extensions, test_utils::*, transitive_closure::TcError};
+    use crate::{
+        assert_deep_eq, extensions::Extensions, test_utils::*, transitive_closure::TcError,
+    };
     use cool_asserts::assert_matches;
     use std::collections::HashSet;
 
@@ -1892,7 +1912,7 @@ mod json_parsing_tests {
     #[test]
     fn json_roundtripping() {
         let empty_entities = Entities::new();
-        assert_eq!(
+        assert_deep_eq!(
             empty_entities,
             roundtrip(&empty_entities).expect("should roundtrip without errors")
         );
@@ -1904,7 +1924,7 @@ mod json_parsing_tests {
             Extensions::none(),
         )
         .expect("Failed to construct entities");
-        assert_eq!(
+        assert_deep_eq!(
             entities,
             roundtrip(&entities).expect("should roundtrip without errors")
         );
@@ -1979,7 +1999,7 @@ mod json_parsing_tests {
             Extensions::all_available(),
         )
         .expect("Failed to construct entities");
-        assert_eq!(
+        assert_deep_eq!(
             entities,
             roundtrip(&entities).expect("should roundtrip without errors")
         );

--- a/cedar-policy-core/src/test_utils.rs
+++ b/cedar-policy-core/src/test_utils.rs
@@ -439,3 +439,29 @@ pub fn expect_err<'a>(
     msg.expect_source_matches(src, err);
     msg.expect_underlines_match(err);
 }
+
+/// Assert equality by `Entities` using structural equality with the `deep_eq` method.
+#[macro_export]
+macro_rules! assert_deep_eq {
+    ( $self:expr , $other:expr ) => {
+        assert!(
+            $self.deep_eq(&$other),
+            "expected that {:?} would be structurally equal to {:?}",
+            $self,
+            $other
+        )
+    };
+}
+
+/// Assert equality by `Entities` using structural equality with the `deep_eq` method.
+#[macro_export]
+macro_rules! assert_not_deep_eq {
+    ( $self:expr , $other:expr ) => {
+        assert!(
+            !$self.deep_eq(&$other),
+            "expected that {:?} would not be structurally equal to {:?}",
+            $self,
+            $other
+        )
+    };
+}

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -20,6 +20,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
   APIs, as regular parsing performance is degraded when the `raw-parsing` feature is enabled.
 - Implemented type-aware partial evaluation [RFC 95](https://github.com/cedar-policy/rfcs/pull/95), under the
   experimental flag `tpe`. (#1575)
+- Added `deep_eq` to the `Entity` and `Entities` structs to allow comparing these objects for structural equality. 
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -190,6 +190,18 @@ impl Entity {
         Self(ast::Entity::with_uid(uid.into()))
     }
 
+    /// Test if two entities are structurally equal. That is, not only do they
+    /// have the same UID, but they also have the same attributes and ancestors.
+    ///
+    /// Note that ancestor equality is determined by examining the ancestors
+    /// entities provided when constructing these objects, without computing
+    /// their transitive closure. For accurate comparison, entities should be
+    /// constructed with the transitive closure precomputed or be drawn from an
+    /// [`Entities`] object which will perform this computation.
+    pub fn deep_eq(&self, other: &Self) -> bool {
+        self.0.deep_eq(&other.0)
+    }
+
     /// Get the Uid of this entity
     /// ```
     /// # use cedar_policy::{Entity, EntityId, EntityTypeName, EntityUid};
@@ -412,6 +424,15 @@ impl Entities {
     /// Iterate over the `Entity`'s in the `Entities`
     pub fn iter(&self) -> impl Iterator<Item = &Entity> {
         self.0.iter().map(Entity::ref_cast)
+    }
+
+    /// Test if two entity hierarchies are structurally equal. The hierarchies
+    /// must contain the same set of entity ids, and the entities with each id
+    /// must be structurally equal (decided [`Entity::deep_eq`]). Ancestor
+    /// equality between entities is always decided by comparing the transitive
+    /// closure of ancestor and not direct parents.
+    pub fn deep_eq(&self, other: &Self) -> bool {
+        self.0.deep_eq(&other.0)
     }
 
     /// Create an `Entities` object with the given entities.

--- a/cedar-policy/src/proto/entities.rs
+++ b/cedar-policy/src/proto/entities.rs
@@ -54,6 +54,7 @@ impl From<&entities::Entities> for models::Entities {
 #[cfg(test)]
 mod test {
     use super::*;
+    use cedar_policy_core::assert_deep_eq;
     use smol_str::SmolStr;
     use std::collections::{BTreeMap, HashMap, HashSet};
     use std::sync::Arc;
@@ -62,7 +63,7 @@ mod test {
     fn entities_roundtrip() {
         // Empty Test
         let entities1 = entities::Entities::new();
-        assert_eq!(
+        assert_deep_eq!(
             entities1,
             entities::Entities::from(&models::Entities::from(&entities1))
         );
@@ -91,7 +92,7 @@ mod test {
                 extensions::Extensions::none(),
             )
             .unwrap();
-        assert_eq!(
+        assert_deep_eq!(
             entities2,
             entities::Entities::from(&models::Entities::from(&entities2))
         );
@@ -117,7 +118,7 @@ mod test {
                 extensions::Extensions::none(),
             )
             .unwrap();
-        assert_eq!(
+        assert_deep_eq!(
             entities3,
             entities::Entities::from(&models::Entities::from(&entities3))
         );


### PR DESCRIPTION
Adds a new method to the public API to allow comparing `Entities` and `Entity` objects for structural equality. The `Eq` impl only compares entity ids.

Updates some existing tests to use this method to presumably assert what they originally intended, fortunately not finding any new test failures.

The public API addition is needed to fix cedar-policy/cedar-spec#694 while still using the public API for our fuzz testing.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
