### PR TITLE
Update `Entity::deep_eq` to compare tags

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -652,6 +652,7 @@ impl Entity {
     pub fn deep_eq(&self, other: &Self) -> bool {
         self.uid == other.uid
             && self.attrs == other.attrs
+            && self.tags == other.tags
             && (self.ancestors().collect::<HashSet<_>>())
                 == (other.ancestors().collect::<HashSet<_>>())
     }

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -1036,6 +1036,34 @@ mod json_parsing_tests {
     }
 
     #[test]
+    fn add_inconsistent_duplicate_tags() {
+        let parser: EntityJsonParser<'_, '_> =
+            EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
+
+        let initial = parser.single_from_json_value(serde_json::json!({"uid":{ "type" : "Test", "id" : "jeff" }, "attrs": {}, "tags" : {"t": 1}, "parents" : []})).unwrap();
+        let initial_entities = Entities::from_entities(
+            [initial],
+            None::<&NoEntitiesSchema>,
+            TCComputation::ComputeNow,
+            &Extensions::all_available(),
+        )
+        .unwrap();
+
+        let dup = parser.single_from_json_value(serde_json::json!({"uid":{ "type" : "Test", "id" : "jeff" }, "attrs": {}, "tags" : {}, "parents" : []})).unwrap();
+        let err = initial_entities
+            .add_entities(
+                [Arc::new(dup)],
+                None::<&NoEntitiesSchema>,
+                TCComputation::ComputeNow,
+                Extensions::all_available(),
+            )
+            .err()
+            .unwrap();
+
+        assert_matches!(err, EntitiesError::Duplicate(d) => assert_eq!(d.euid(), &r#"Test::"jeff""#.parse().unwrap()));
+    }
+
+    #[test]
     fn simple_entities_correct() {
         let parser: EntityJsonParser<'_, '_> =
             EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -27,6 +27,15 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Allow multiple argument extension function calls in entity JSON format. (#1697)
 - Bumped MSRV to 1.85 (#1683)
 
+### Fixed
+
+- Fixed multiple functions on `Entities` to correctly consider entity tags when determining whether two entities are identical.
+  These functions will now only consider two entities identical if they have the same identifiers, attributes, ancestors, and tags.
+  Attempting to create an `Entities` object where a duplicated entity identifier maps to two entities with different tags will now
+  result in an error result. Attempting to validate an action entity with any tags will always result in an error result. This change
+  specifically impacts `from_entities`, `add_entities`, `add_entities_from_json_file`, `add_entities_from_json_value`,
+  and `add_entities_from_json_str`.
+
 ## [4.5.0] - 2025-06-30
 Cedar Language Version: 4.4
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -32,7 +32,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Fixed multiple functions on `Entities` to correctly consider entity tags when determining whether two entities are identical.
   These functions will now only consider two entities identical if they have the same identifiers, attributes, ancestors, and tags.
   Attempting to create an `Entities` object where a duplicated entity identifier maps to two entities with different tags will now
-  result in an error result. Attempting to validate an action entity with any tags will always result in an error result. This change
+  result in an error. Attempting to validate an action entity with any tags will always result in an error. This change
   specifically impacts `from_entities`, `add_entities`, `add_entities_from_json_file`, `add_entities_from_json_value`,
   and `add_entities_from_json_str`.
 


### PR DESCRIPTION
This fixes a bug in the new `deep_eq` public function, but the bug also impacts some previously existing parts of the public API that depended on the internal `deep_eq` function.

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
