### PR TITLE
Bug fix to filled_with_slot

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1387,7 +1387,12 @@ impl PrincipalConstraint {
                     EntityReference::EUID(euid),
                 ),
             },
-            _ => self,
+            // enumerated so it is clearer what other variants there are
+            PrincipalOrResourceConstraint::Is(_)
+            | PrincipalOrResourceConstraint::Any
+            | PrincipalOrResourceConstraint::Eq(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::In(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::IsIn(_, EntityReference::EUID(_)) => self,
         }
     }
 }
@@ -1500,7 +1505,12 @@ impl ResourceConstraint {
                     EntityReference::EUID(euid),
                 ),
             },
-            _ => self,
+            // enumerated so it is clearer what other variants there are
+            PrincipalOrResourceConstraint::Is(_)
+            | PrincipalOrResourceConstraint::Any
+            | PrincipalOrResourceConstraint::Eq(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::In(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::IsIn(_, EntityReference::EUID(_)) => self,
         }
     }
 }

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1381,6 +1381,12 @@ impl PrincipalConstraint {
             PrincipalOrResourceConstraint::In(EntityReference::Slot(_)) => Self {
                 constraint: PrincipalOrResourceConstraint::In(EntityReference::EUID(euid)),
             },
+            PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot(_)) => Self {
+                constraint: PrincipalOrResourceConstraint::IsIn(
+                    entity_type,
+                    EntityReference::EUID(euid),
+                ),
+            },
             _ => self,
         }
     }
@@ -1487,6 +1493,12 @@ impl ResourceConstraint {
             },
             PrincipalOrResourceConstraint::In(EntityReference::Slot(_)) => Self {
                 constraint: PrincipalOrResourceConstraint::In(EntityReference::EUID(euid)),
+            },
+            PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot(_)) => Self {
+                constraint: PrincipalOrResourceConstraint::IsIn(
+                    entity_type,
+                    EntityReference::EUID(euid),
+                ),
             },
             _ => self,
         }

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3321,7 +3321,7 @@ mod test {
     }
 
     #[test]
-    fn linked_template_is_in_ast_to_est() {
+    fn ast_to_est_with_linked_template_using_is_in_operator_1() {
         let template = r#"
             permit(
                 principal is XYZCorp::User in ?principal,
@@ -3398,7 +3398,10 @@ mod test {
             serde_json::to_string_pretty(&expected_json).unwrap(),
             serde_json::to_string_pretty(&linked_json).unwrap(),
         );
+    }
 
+    #[test]
+    fn ast_to_est_with_linked_template_using_is_in_operator_2() {
         let template = r#"
             permit(
                 principal is User in ?principal,

--- a/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
@@ -136,9 +136,9 @@ pub struct InvalidActionApplication {
     pub source_loc: MaybeLoc,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
-    /// `true` if changing `==` to `in` wouuld fix the principal clause
+    /// `true` if changing `==` to `in` would fix the principal clause
     pub would_in_fix_principal: bool,
-    /// `true` if changing `==` to `in` wouuld fix the resource clause
+    /// `true` if changing `==` to `in` would fix the resource clause
     pub would_in_fix_resource: bool,
 }
 


### PR DESCRIPTION
## Description of changes
Fixed bug with filled_with_slot and added test case. Previously filled_with_slot did not substitute an entity in when the scope used the `is in` operator.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [X] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
