### PR TITLE
Fix enum support in SymCC

### DIFF
--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -171,7 +171,7 @@ impl<S: Solver> SymCompiler<S> {
             // skip encoding and calling the solver.
             Ok(None)
         } else if asserts.iter().all(|assert| *assert == true.into()) {
-            let interp = Interpretation::default();
+            let interp = Interpretation::default(symenv);
             let exprs = policies.map(|p| p.condition()).collect::<Vec<_>>();
             Ok(Some(symenv.interpret(&interp).concretize(exprs.iter())?))
         } else {
@@ -206,8 +206,8 @@ impl<S: Solver> SymCompiler<S> {
 
                     let model = parse_sexpr(model_str.as_bytes())?;
                     let exprs = policies.map(|p| p.condition()).collect::<Vec<_>>();
-                    let interp = model.decode_model(&id_maps)?;
-                    let interp = interp.repair_as_counterexample(exprs.iter(), symenv);
+                    let interp = model.decode_model(symenv, &id_maps)?;
+                    let interp = interp.repair_as_counterexample(exprs.iter());
 
                     Ok(Some(symenv.interpret(&interp).concretize(exprs.iter())?))
                 }

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -437,7 +437,7 @@ impl TermType {
             TermType::String => Term::Prim(TermPrim::String("".to_string())),
 
             TermType::Entity { ety } => {
-                // If the entity has an enum type, we return the first enum
+                // If the entity is an enum type, we return the first enum
                 let eid = if let Some(SymEntityData {
                     members: Some(eids),
                     ..
@@ -446,7 +446,7 @@ impl TermType {
                     if let Some(eid) = eids.first() {
                         eid
                     } else {
-                        "" // This case should not happen on a valid `SymEnv`
+                        "" // This case should not happen on a well-formed `SymEnv`
                     }
                 } else {
                     ""

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -451,7 +451,6 @@ impl TermType {
                 } else {
                     ""
                 };
-                eprintln!("ety: {}, eid: {}, {:?}", ety, eid, env.entities.get(ety));
                 Term::Prim(TermPrim::Entity(EntityUid::from_type_name_and_id(
                     ety.clone(),
                     EntityId::new(eid),

--- a/cedar-policy-symcc/tests/datetime.rs
+++ b/cedar-policy-symcc/tests/datetime.rs
@@ -17,8 +17,8 @@ use cedar_policy::{Schema, Validator};
 use cedar_policy_symcc::{solver::LocalSolver, CedarSymCompiler};
 
 use crate::utils::{
-    assert_always_allows, assert_does_not_always_allow, assert_does_not_always_deny,
-    assert_does_not_imply, assert_implies, Environments,
+    assert_always_allows, assert_does_not_always_allow, assert_does_not_imply, assert_implies,
+    Environments,
 };
 mod utils;
 

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -1881,3 +1881,26 @@ async fn cex_test_simple_model_trivial() {
 
     assert_does_not_always_deny(&mut compiler, &pset, &envs).await;
 }
+
+/// Tests enum support
+#[tokio::test]
+async fn cex_enum() {
+    let schema = utils::schema_from_cedarstr(
+        r#"
+        entity User enum [ "Alice", "Bob" ];
+        entity Document;
+        action view appliesTo {
+            principal: [User],
+            resource: [Document]
+        };
+        "#,
+    );
+    let validator = Validator::new(schema.clone());
+
+    let pset = utils::pset_from_text(r#"permit(principal, action, resource);"#, &validator);
+
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let envs = Environments::new(validator.schema(), "User", "Action::\"view\"", "Document");
+
+    assert_does_not_always_deny(&mut compiler, &pset, &envs).await;
+}

--- a/cedar-policy-symcc/tests/utils/mod.rs
+++ b/cedar-policy-symcc/tests/utils/mod.rs
@@ -23,9 +23,10 @@
 use std::str::FromStr;
 
 use cedar_policy::{
-    Authorizer, Decision, Policy, PolicyId, PolicySet, RequestEnv, Schema, ValidationMode,
-    Validator,
+    Authorizer, Decision, Entities, Policy, PolicyId, PolicySet, RequestEnv, Schema,
+    ValidationMode, Validator,
 };
+use cedar_policy_core::{ast::RequestSchema, extensions::Extensions};
 use cedar_policy_symcc::{
     solver::Solver, CedarSymCompiler, Env, SymEnv, WellTypedPolicies, WellTypedPolicy,
 };
@@ -151,6 +152,9 @@ pub async fn assert_does_not_always_allow<S: Solver>(
     }
     match compiler.check_always_allows_with_counterexample(&typed_pset, &envs.symenv).await.unwrap() {
         Some(Env { request, entities }) => {
+            // Check that the request/entities pass validation
+            envs.schema.as_ref().validate_request(request.as_ref(), Extensions::all_available()).unwrap();
+            Entities::from_entities(entities.clone(), Some(envs.schema)).unwrap();
             // Check that the counterexample is correct
             let resp1 = Authorizer::new().is_authorized(&request, pset, &entities);
             assert!(resp1.decision() == Decision::Deny,
@@ -193,6 +197,9 @@ pub async fn assert_does_not_always_deny<S: Solver>(
     }
     match compiler.check_always_denies_with_counterexample(&typed_pset, &envs.symenv).await.unwrap() {
         Some(Env { request, entities }) => {
+            // Check that the request/entities pass validation
+            envs.schema.as_ref().validate_request(request.as_ref(), Extensions::all_available()).unwrap();
+            Entities::from_entities(entities.clone(), Some(envs.schema)).unwrap();
             // Check that the counterexample is correct
             let resp1 = Authorizer::new().is_authorized(&request, pset, &entities);
             assert!(resp1.decision() == Decision::Allow,
@@ -242,6 +249,9 @@ pub async fn assert_not_equivalent<S: Solver>(
     }
     match compiler.check_equivalent_with_counterexample(&typed_pset1, &typed_pset2, &envs.symenv).await.unwrap() {
         Some(Env { request, entities }) => {
+            // Check that the request/entities pass validation
+            envs.schema.as_ref().validate_request(request.as_ref(), Extensions::all_available()).unwrap();
+            Entities::from_entities(entities.clone(), Some(envs.schema)).unwrap();
             // Check that the counterexample is correct
             let resp1 = Authorizer::new().is_authorized(&request, pset1, &entities);
             let resp2 = Authorizer::new().is_authorized(&request, pset2, &entities);
@@ -293,6 +303,9 @@ pub async fn assert_does_not_imply<S: Solver>(
     }
     match compiler.check_implies_with_counterexample(&typed_pset1, &typed_pset2, &envs.symenv).await.unwrap() {
         Some(Env { request, entities }) => {
+            // Check that the request/entities pass validation
+            envs.schema.as_ref().validate_request(request.as_ref(), Extensions::all_available()).unwrap();
+            Entities::from_entities(entities.clone(), Some(envs.schema)).unwrap();
             // Check that the counterexample is correct
             let resp1 = Authorizer::new().is_authorized(&request, pset1, &entities);
             let resp2 = Authorizer::new().is_authorized(&request, pset2, &entities);
@@ -344,6 +357,9 @@ pub async fn assert_not_disjoint<S: Solver>(
     }
     match compiler.check_disjoint_with_counterexample(&typed_pset1, &typed_pset2, &envs.symenv).await.unwrap() {
         Some(Env { request, entities }) => {
+            // Check that the request/entities pass validation
+            envs.schema.as_ref().validate_request(request.as_ref(), Extensions::all_available()).unwrap();
+            Entities::from_entities(entities.clone(), Some(envs.schema)).unwrap();
             // Check that the counterexample is correct
             let resp1 = Authorizer::new().is_authorized(&request, pset1, &entities);
             let resp2 = Authorizer::new().is_authorized(&request, pset2, &entities);


### PR DESCRIPTION
## Description of changes

This PR fixes enum support in SymCC, including cex generation.

Previously, the new test `cex_enum` added in this PR would 1) produce an incorrect SMT encoding of the User enum entity; 2) generate an incorrect counterexample with an invalid entity `User::""`.

In addition to fixing the enum support, this PR also strengthens integeration tests by additionally checking that the counterexample passes request/entity validation.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
