### PR TITLE
Fix ipaddr support in SymCC

### DIFF
--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -1273,4 +1273,26 @@ mod datetime_tests {
         test_valid_bool_simpl_expr(r#"duration("-1ms") < duration("-2ms")"#, false);
         test_valid_bool_simpl_expr(r#"duration("8d") <= duration("80109s")"#, false);
     }
+
+    #[test]
+    fn test_ipaddr_simpl_comp_expr() {
+        test_valid_bool_simpl_expr(r#"ip("192.168.0.1").isInRange(ip("192.168.0.1/24"))"#, true);
+        test_valid_bool_simpl_expr(r#"ip("192.168.0.1").isInRange(ip("192.168.0.1/28"))"#, true);
+        test_valid_bool_simpl_expr(r#"ip("192.168.0.75").isInRange(ip("192.168.0.1/24"))"#, true);
+        test_valid_bool_simpl_expr(r#"ip("192.168.0.75").isInRange(ip("192.168.0.1/28"))"#, false);
+        test_valid_bool_simpl_expr(r#"ip("1:2:3:4::").isInRange(ip("1:2:3:4::/48"))"#, true);
+        test_valid_bool_simpl_expr(r#"ip("192.168.0.1").isInRange(ip("1:2:3:4::"))"#, false);
+        test_valid_bool_simpl_expr(r#"ip("192.168.1.1").isInRange(ip("192.168.0.1/24"))"#, false);
+        test_valid_bool_simpl_expr(r#"ip("127.0.0.1").isMulticast()"#, false);
+        test_valid_bool_simpl_expr(r#"ip("ff00::2").isMulticast()"#, true);
+        test_valid_bool_simpl_expr(r#"ip("127.0.0.2").isLoopback()"#, true);
+        test_valid_bool_simpl_expr(r#"ip("::1").isLoopback()"#, true);
+        test_valid_bool_simpl_expr(r#"ip("::2").isLoopback()"#, false);
+        test_valid_bool_simpl_expr(r#"ip("127.0.0.1/24").isIpv6()"#, false);
+        test_valid_bool_simpl_expr(r#"ip("ffee::/64").isIpv6()"#, true);
+        test_valid_bool_simpl_expr(r#"ip("::1").isIpv6()"#, true);
+        test_valid_bool_simpl_expr(r#"ip("127.0.0.1").isIpv4()"#, true);
+        test_valid_bool_simpl_expr(r#"ip("::1").isIpv4()"#, false);
+        test_valid_bool_simpl_expr(r#"ip("127.0.0.1/24").isIpv4()"#, true);
+    }
 }

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -1278,11 +1278,20 @@ mod datetime_tests {
     fn test_ipaddr_simpl_comp_expr() {
         test_valid_bool_simpl_expr(r#"ip("192.168.0.1").isInRange(ip("192.168.0.1/24"))"#, true);
         test_valid_bool_simpl_expr(r#"ip("192.168.0.1").isInRange(ip("192.168.0.1/28"))"#, true);
-        test_valid_bool_simpl_expr(r#"ip("192.168.0.75").isInRange(ip("192.168.0.1/24"))"#, true);
-        test_valid_bool_simpl_expr(r#"ip("192.168.0.75").isInRange(ip("192.168.0.1/28"))"#, false);
+        test_valid_bool_simpl_expr(
+            r#"ip("192.168.0.75").isInRange(ip("192.168.0.1/24"))"#,
+            true,
+        );
+        test_valid_bool_simpl_expr(
+            r#"ip("192.168.0.75").isInRange(ip("192.168.0.1/28"))"#,
+            false,
+        );
         test_valid_bool_simpl_expr(r#"ip("1:2:3:4::").isInRange(ip("1:2:3:4::/48"))"#, true);
         test_valid_bool_simpl_expr(r#"ip("192.168.0.1").isInRange(ip("1:2:3:4::"))"#, false);
-        test_valid_bool_simpl_expr(r#"ip("192.168.1.1").isInRange(ip("192.168.0.1/24"))"#, false);
+        test_valid_bool_simpl_expr(
+            r#"ip("192.168.1.1").isInRange(ip("192.168.0.1/24"))"#,
+            false,
+        );
         test_valid_bool_simpl_expr(r#"ip("127.0.0.1").isMulticast()"#, false);
         test_valid_bool_simpl_expr(r#"ip("ff00::2").isMulticast()"#, true);
         test_valid_bool_simpl_expr(r#"ip("127.0.0.2").isLoopback()"#, true);

--- a/cedar-policy-symcc/src/symcc/extfun.rs
+++ b/cedar-policy-symcc/src/symcc/extfun.rs
@@ -78,7 +78,11 @@ pub fn subnet_width(w: Width, prefix: Term) -> Term {
     let n = 2_u32.pow(w);
     ite(
         is_none(prefix.clone()),
-        0.into(),
+        #[allow(
+            clippy::unwrap_used,
+            reason = "Cannot panic because bitwidth is guaranteed to be non-zero."
+        )]
+        BitVec::of_nat(n, nat(0)).unwrap().into(),
         bvsub(
             #[allow(
                 clippy::unwrap_used,
@@ -91,9 +95,15 @@ pub fn subnet_width(w: Width, prefix: Term) -> Term {
 }
 
 pub fn range(w: Width, ip_addr: Term, prefix: Term) -> (Term, Term) {
+    let n = 2_u32.pow(w);
     let width = subnet_width(w, prefix);
+    #[allow(
+        clippy::unwrap_used,
+        reason = "Cannot panic because bitwidth is guaranteed to be non-zero."
+    )]
+    let one: Term = BitVec::of_nat(n, nat(1)).unwrap().into();
     let lo = bvshl(bvlshr(ip_addr, width.clone()), width.clone());
-    let hi = bvsub(bvadd(lo.clone(), bvshl(1.into(), width)), 1.into());
+    let hi = bvsub(bvadd(lo.clone(), bvshl(one.clone(), width)), one);
     (lo, hi)
 }
 

--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -595,7 +595,6 @@ pub fn ext_ipaddr_is_v4(t: Term) -> Term {
 pub fn ext_ipaddr_addr_v4(t: Term) -> Term {
     match t {
         Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip: IPNet::V4(v4) })) => v4.addr.val.into(),
-        // Ext::Ipaddr { ip }.into(),
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrAddrV4),
             args: vec![t],

--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -594,7 +594,8 @@ pub fn ext_ipaddr_is_v4(t: Term) -> Term {
 
 pub fn ext_ipaddr_addr_v4(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip })) => Ext::Ipaddr { ip }.into(),
+        Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip: IPNet::V4(v4) })) => v4.addr.val.into(),
+        // Ext::Ipaddr { ip }.into(),
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrAddrV4),
             args: vec![t],
@@ -621,7 +622,7 @@ pub fn ext_ipaddr_prefix_v4(t: Term) -> Term {
 
 pub fn ext_ipaddr_addr_v6(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip })) => Ext::Ipaddr { ip }.into(),
+        Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip: IPNet::V6(v6) })) => v6.addr.val.into(),
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrAddrV6),
             args: vec![t],

--- a/cedar-policy-symcc/tests/ipaddr.rs
+++ b/cedar-policy-symcc/tests/ipaddr.rs
@@ -1,0 +1,140 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use cedar_policy::{Schema, Validator};
+use cedar_policy_symcc::{solver::LocalSolver, CedarSymCompiler};
+
+use crate::utils::{
+    assert_always_allows, assert_equivalent, assert_implies, Environments
+};
+mod utils;
+
+fn sample_schema() -> Schema {
+    utils::schema_from_cedarstr(
+        r#"
+        entity User;
+        entity Thing;
+        action View appliesTo {
+          principal: [User],
+          resource: [Thing],
+          context: {
+            x: ipaddr,
+            y: ipaddr,
+            z: ipaddr,
+          }
+        };
+    "#,
+    )
+}
+
+fn env_for_sample_schema<'a>(schema: &'a Schema) -> Environments<'a> {
+    Environments::new(&schema, "User", "Action::\"View\"", "Thing")
+}
+
+#[tokio::test]
+async fn ipaddr_constants() {
+    let validator = Validator::new(sample_schema());
+    let pset = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            ip("192.168.0.1").isInRange(ip("192.168.0.1/24")) == true &&
+            ip("192.168.0.1").isInRange(ip("192.168.0.1/28")) == true &&
+            ip("192.168.0.75").isInRange(ip("192.168.0.1/24")) == true &&
+            ip("192.168.0.75").isInRange(ip("192.168.0.1/28")) == false &&
+            ip("192.168.1.1/16").isInRange(ip("192.168.1.1/24")) == false &&
+            ip("192.168.1.1/25").isInRange(ip("192.168.1.1/24")) == true &&
+            ip("1:2:3:4::").isInRange(ip("1:2:3:4::/48")) == true &&
+            ip("192.168.0.1").isInRange(ip("1:2:3:4::")) == false &&
+            ip("192.168.1.1").isInRange(ip("192.168.0.1/24")) == false &&
+            ip("127.0.0.1").isMulticast() == false &&
+            ip("ff00::2").isMulticast() == true &&
+            ip("127.0.0.2").isLoopback() == true &&
+            ip("::1").isLoopback() == true &&
+            ip("::2").isLoopback() == false &&
+            ip("127.0.0.1/24").isIpv6() == false &&
+            ip("ffee::/64").isIpv6() == true &&
+            ip("::1").isIpv6() == true &&
+            ip("127.0.0.1").isIpv4() == true &&
+            ip("::1").isIpv4() == false &&
+            ip("127.0.0.1/24").isIpv4() == true
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_always_allows(&mut compiler, &pset, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_in_range_transitive() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isInRange(context.y) &&
+            context.y.isInRange(context.z)
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isInRange(context.z)
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_implies(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_in_range_symmetric() {
+    let validator = Validator::new(sample_schema());
+    let pset = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isInRange(context.x)
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_always_allows(&mut compiler, &pset, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_in_range_antisymmetric_modulo_ip_funs() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isInRange(context.y) &&
+            context.y.isInRange(context.x)
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isMulticast() == context.y.isMulticast() &&
+            context.x.isLoopback() == context.y.isLoopback() &&
+            context.x.isIpv4() == context.y.isIpv4() &&
+            context.x.isIpv6() == context.y.isIpv6()
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_implies(&mut compiler, &pset1, &pset2, &envs).await;
+}

--- a/cedar-policy-symcc/tests/ipaddr.rs
+++ b/cedar-policy-symcc/tests/ipaddr.rs
@@ -16,7 +16,9 @@
 use cedar_policy::{Schema, Validator};
 use cedar_policy_symcc::{solver::LocalSolver, CedarSymCompiler};
 
-use crate::utils::{assert_always_allows, assert_implies, Environments};
+use crate::utils::{
+    assert_always_allows, assert_always_denies, assert_does_not_imply, assert_implies, Environments,
+};
 mod utils;
 
 fn sample_schema() -> Schema {
@@ -135,4 +137,162 @@ async fn ipaddr_in_range_antisymmetric_modulo_ip_funs() {
     let schema = sample_schema();
     let envs = env_for_sample_schema(&schema);
     assert_implies(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_in_range_antisymmetric_cex_ipv4() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isInRange(context.y) &&
+            context.y.isInRange(context.x) &&
+            context.x.isIpv4()
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x == context.y
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_does_not_imply(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_in_range_antisymmetric_cex_ipv6() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isInRange(context.y) &&
+            context.y.isInRange(context.x) &&
+            context.x.isIpv6()
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x == context.y
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_does_not_imply(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_cex_multicast_ipv4() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isMulticast() &&
+            context.x.isIpv4()
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when { false };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_does_not_imply(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_cex_multicast_ipv6() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isMulticast() &&
+            context.x.isIpv6()
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when { false };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_does_not_imply(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_cex_loopback_ipv4() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isLoopback() &&
+            context.x.isIpv4()
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when { false };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_does_not_imply(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_cex_loopback_ipv6() {
+    let validator = Validator::new(sample_schema());
+    let pset1 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isLoopback() &&
+            context.x.isIpv6()
+        };"#,
+        &validator,
+    );
+    let pset2 = utils::pset_from_text(
+        r#"permit(principal, action, resource) when { false };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_does_not_imply(&mut compiler, &pset1, &pset2, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_ipv6_ipv4_disjoint() {
+    let validator = Validator::new(sample_schema());
+    let pset = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isIpv4() &&
+            context.x.isIpv6()
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_always_denies(&mut compiler, &pset, &envs).await;
+}
+
+#[tokio::test]
+async fn ipaddr_ipv6_or_ipv4() {
+    let validator = Validator::new(sample_schema());
+    let pset = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            context.x.isIpv4() ||
+            context.x.isIpv6()
+        };"#,
+        &validator,
+    );
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let schema = sample_schema();
+    let envs = env_for_sample_schema(&schema);
+    assert_always_allows(&mut compiler, &pset, &envs).await;
 }

--- a/cedar-policy-symcc/tests/ipaddr.rs
+++ b/cedar-policy-symcc/tests/ipaddr.rs
@@ -16,9 +16,7 @@
 use cedar_policy::{Schema, Validator};
 use cedar_policy_symcc::{solver::LocalSolver, CedarSymCompiler};
 
-use crate::utils::{
-    assert_always_allows, assert_equivalent, assert_implies, Environments
-};
+use crate::utils::{assert_always_allows, assert_implies, Environments};
 mod utils;
 
 fn sample_schema() -> Schema {


### PR DESCRIPTION
## Description of changes

Changes:
- Fix ipaddr encodings in SymCC (there were some typing issues and mismatches with the Lean model)
- Add cex support for ipaddr
- More tests

After this PR, SymCC should have full extension support with cex generation!

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
