### PR TITLE
SymCC: Refactor `Term` and `TermType` to use Arc

### DIFF
--- a/cedar-policy-symcc/src/symcc/concretize.rs
+++ b/cedar-policy-symcc/src/symcc/concretize.rs
@@ -307,7 +307,7 @@ impl Term {
             }
 
             Term::Set { elts, .. } => {
-                for t in elts {
+                for t in elts.iter() {
                     t.get_all_entity_uids(uids);
                 }
             }
@@ -319,7 +319,7 @@ impl Term {
             }
 
             Term::App { args, .. } => {
-                for t in args {
+                for t in args.iter() {
                     t.get_all_entity_uids(uids);
                 }
             }

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -241,7 +241,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                     TermType::Ext { xty } => self.declare_ext_type(xty).await?.into(),
                     TermType::Record { rty } => {
                         let mut record_type = vec![];
-                        for (k, v) in rty {
+                        for (k, v) in rty.iter() {
                             record_type.push((k.clone(), self.encode_type(v).await?));
                         }
                         self.declare_record_type(record_type.iter()).await?
@@ -432,7 +432,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
             }
             Term::Set { elts, .. } => {
                 let mut encoded_terms = vec![];
-                for elt in elts {
+                for elt in elts.iter() {
                     encoded_terms.push(self.encode_term(elt).await?);
                 }
                 self.define_set(&ty_enc, encoded_terms.iter().map(|s| s.as_str()))
@@ -484,10 +484,11 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
             }
             Term::App { op, args, .. } => {
                 let mut encoded_terms = vec![];
-                for arg in args {
+                for arg in args.iter() {
                     encoded_terms.push(self.encode_term(arg).await?);
                 }
-                self.define_app(&ty_enc, op, encoded_terms, args).await?
+                self.define_app(&ty_enc, op, encoded_terms, args.iter())
+                    .await?
             }
         };
         self.terms.insert(t.clone(), enc.clone());

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -40,6 +40,7 @@ use cedar_policy_core::validator::{ValidatorEntityType, ValidatorEntityTypeKind}
 use smol_str::SmolStr;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ops::Deref;
+use std::sync::Arc;
 
 /// A symbolic request is analogous to a concrete request. It binds
 /// request variables to Terms.
@@ -67,7 +68,7 @@ impl SymRequest {
                 id: "resource".to_string(),
                 ty: TermType::Bool,
             }),
-            context: Term::Record(BTreeMap::new()),
+            context: Term::Record(Arc::new(BTreeMap::new())),
         }
     }
 
@@ -228,10 +229,10 @@ impl SymEntityData {
                 let attrs_udf = Udf(function::Udf {
                     arg: entity(ety.clone()),
                     out: TermType::Record {
-                        rty: BTreeMap::new(),
+                        rty: Arc::new(BTreeMap::new()),
                     },
                     table: BTreeMap::new(),
-                    default: Term::Record(BTreeMap::new()),
+                    default: Term::Record(Arc::new(BTreeMap::new())),
                 });
                 Ok(SymEntityData {
                     attrs: attrs_udf,
@@ -252,10 +253,10 @@ impl SymEntityData {
         let attrs_udf = Udf(function::Udf {
             arg: entity(act_ty.clone()),
             out: TermType::Record {
-                rty: BTreeMap::new(),
+                rty: Arc::new(BTreeMap::new()),
             },
             table: BTreeMap::new(),
-            default: Term::Record(BTreeMap::new()),
+            default: Term::Record(Arc::new(BTreeMap::new())),
         });
         let term_of_type = |ety: EntityType, uid: EntityUID| -> Option<Term> {
             if uid.type_name() == &ety {
@@ -266,10 +267,11 @@ impl SymEntityData {
         };
         let ancs_term = |anc_ty: &EntityType, ancs: &BTreeSet<EntityUID>| -> Term {
             Term::Set {
-                elts: ancs
-                    .iter()
-                    .filter_map(|anc| term_of_type(anc_ty.clone(), anc.clone()))
-                    .collect(),
+                elts: Arc::new(
+                    ancs.iter()
+                        .filter_map(|anc| term_of_type(anc_ty.clone(), anc.clone()))
+                        .collect(),
+                ),
                 elts_ty: TermType::set_of(entity(anc_ty.clone())),
             }
         };
@@ -287,7 +289,7 @@ impl SymEntityData {
                     })
                     .collect(),
                 default: Term::Set {
-                    elts: BTreeSet::new(),
+                    elts: Arc::new(BTreeSet::new()),
                     elts_ty: TermType::set_of(entity(anc_ty.clone())),
                 },
             })

--- a/cedar-policy-symcc/src/symcc/op.rs
+++ b/cedar-policy-symcc/src/symcc/op.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use std::sync::Arc;
+
 use super::term_type::TermType;
 use super::type_abbrevs::*;
 
@@ -132,7 +134,7 @@ impl ExtOp {
                 }] =>
             {
                 Some(TermType::Option {
-                    ty: Box::new(TermType::Bitvec { n: 5 }),
+                    ty: Arc::new(TermType::Bitvec { n: 5 }),
                 })
             }
             ExtOp::IpaddrAddrV6
@@ -306,7 +308,7 @@ impl Op {
                 reason = "List of length 1 should not error on first call to next()"
             )]
             Op::OptionGet if l.len() == 1 => match l.into_iter().next().unwrap() {
-                TermType::Option { ty } => Some(*ty),
+                TermType::Option { ty } => Some(Arc::unwrap_or_clone(ty)),
                 _ => None,
             },
             // PANIC SAFETY

--- a/cedar-policy-symcc/src/symcc/term.rs
+++ b/cedar-policy-symcc/src/symcc/term.rs
@@ -34,7 +34,10 @@ use super::ext::Ext;
 use super::op::Op;
 use super::term_type::TermType;
 use super::type_abbrevs::*;
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct TermVar {
@@ -56,15 +59,15 @@ pub enum Term {
     Prim(TermPrim),
     Var(TermVar),
     None(TermType),
-    Some(Box<Term>),
+    Some(Arc<Term>),
     Set {
-        elts: BTreeSet<Term>,
+        elts: Arc<BTreeSet<Term>>,
         elts_ty: TermType,
     },
-    Record(BTreeMap<Attr, Term>),
+    Record(Arc<BTreeMap<Attr, Term>>),
     App {
         op: Op,
-        args: Vec<Term>,
+        args: Arc<Vec<Term>>,
         ret_ty: TermType,
     },
 }
@@ -160,16 +163,16 @@ impl Term {
             Term::Prim(l) => l.type_of(),
             Term::Var(v) => v.ty.clone(),
             Term::None(ty) => TermType::Option {
-                ty: Box::new(ty.clone()),
+                ty: Arc::new(ty.clone()),
             },
             Term::Some(t) => TermType::Option {
-                ty: Box::new(t.type_of()),
+                ty: Arc::new(t.type_of()),
             },
             Term::Set { elts_ty, .. } => TermType::Set {
-                ty: Box::new(elts_ty.clone()),
+                ty: Arc::new(elts_ty.clone()),
             },
             Term::Record(m) => {
-                let rty = m.iter().map(|(k, v)| (k.clone(), v.type_of())).collect();
+                let rty = Arc::new(m.iter().map(|(k, v)| (k.clone(), v.type_of())).collect());
                 TermType::Record { rty }
             }
             Term::App { ret_ty, .. } => ret_ty.clone(),


### PR DESCRIPTION
## Description of changes

This PR changes some parts of `Term` and `TermType` in SymCC to use `Arc`.

In some basic benchmarks, this can reduce the compiler time by 25-100%:
```
cedar_examples/document_cloud
                        time:   [2.2459 ms 2.2500 ms 2.2542 ms]
                        change: [−25.676% −25.268% −24.900%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/gdrive   time:   [321.25 µs 321.45 µs 321.70 µs]
                        change: [−30.300% −29.741% −29.233%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/github   time:   [739.50 µs 752.21 µs 768.34 µs]
                        change: [−36.365% −34.937% −33.487%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/hotel_chains
                        time:   [2.2541 ms 2.2593 ms 2.2648 ms]
                        change: [−64.716% −64.176% −63.635%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/sales_orgs
                        time:   [2.7974 ms 2.8062 ms 2.8165 ms]
                        change: [−42.754% −42.040% −41.546%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/tags_n_roles
                        time:   [1.3845 ms 1.4088 ms 1.4417 ms]
                        change: [−91.851% −91.725% −91.575%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/tax_preparer
                        time:   [47.115 µs 47.536 µs 48.186 µs]
                        change: [−49.820% −49.145% −48.348%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/tinytodo time:   [608.32 µs 609.59 µs 610.86 µs]
                        change: [−33.619% −33.163% −32.700%] (p = 0.00 < 0.05)
                        Performance has improved.
```
This is benchmarking the performance of `verify_always_denies` (i.e. no solver time)
and done with 100 samples for each policy set.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
