### PR TITLE
Fix enum encoding in SymCC

### DIFF
--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -154,7 +154,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                 let mks: Vec<_> = members
                     .iter()
                     .enumerate()
-                    .map(|(i, _)| enum_id(&ety_id, i))
+                    .map(|(i, _)| format!("({})", enum_id(&ety_id, i)))
                     .collect();
                 self.declare_type(&ety_id, mks).await.map(Into::into)
             }


### PR DESCRIPTION
## Description of changes

I bumped into another enum encoding bug.
The PR changes encoder to match the correct behavior of the Lean model: https://github.com/cedar-policy/cedar-spec/blob/d68bbdd5432cbaadabc36ee299167c170b758a63/cedar-lean/Cedar/SymCC/Encoder.lean#L106C51-L106C60

And adds more tests.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
