### PR TITLE
Wrap `Uuf` in `Arc`

### DIFF
--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -206,7 +206,7 @@ pub fn app(f: UnaryFunction, t: Term) -> Term {
         UnaryFunction::Uuf(f) => {
             let ret_ty = f.out.clone();
             Term::App {
-                op: Op::Uuf(f),
+                op: Op::Uuf(Arc::new(f)),
                 args: Arc::new(vec![t]),
                 ret_ty,
             }

--- a/cedar-policy-symcc/src/symcc/op.rs
+++ b/cedar-policy-symcc/src/symcc/op.rs
@@ -50,7 +50,7 @@ pub enum Op {
     Or,
     Eq,
     Ite,
-    Uuf(Uuf),
+    Uuf(Arc<Uuf>),
     //   ---------- SMTLib theory of finite bitvectors (`BV`) ----------
     Bvneg,
     Bvadd,
@@ -212,7 +212,7 @@ impl Op {
             )]
             Op::Uuf(f) if l.len() == 1 => {
                 if f.arg == l[0] {
-                    Some(f.out)
+                    Some(Arc::unwrap_or_clone(f).out)
                 } else {
                     None
                 }


### PR DESCRIPTION
## Description of changes

Another minor performance improvement following #1731.
Turns out that `Uuf` is a bit of a large struct, so wrapping it in `Arc` decreased the size of `Term` from 224 to 120 bytes, which probably helps with cache performance.

Performance improvements of about 6-11% in `verify_always_denies`:
```
cedar_examples/document_cloud
                        time:   [1.4680 ms 1.4690 ms 1.4701 ms]
                        change: [−7.6392% −7.4767% −7.3210%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/gdrive   time:   [220.41 µs 220.45 µs 220.49 µs]
                        change: [−9.4546% −9.3411% −9.2340%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/github   time:   [497.68 µs 498.74 µs 500.07 µs]
                        change: [−8.9989% −8.5099% −8.0301%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/hotel_chains
                        time:   [1.4946 ms 1.4966 ms 1.4994 ms]
                        change: [−11.127% −10.357% −9.6835%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/sales_orgs
                        time:   [1.8993 ms 1.9021 ms 1.9053 ms]
                        change: [−8.5842% −8.3016% −8.0744%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/tags_n_roles
                        time:   [846.44 µs 851.65 µs 857.74 µs]
                        change: [−11.596% −11.208% −10.832%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/tax_preparer
                        time:   [33.457 µs 33.591 µs 33.837 µs]
                        change: [−6.4387% −6.1234% −5.5578%] (p = 0.00 < 0.05)
                        Performance has improved.
cedar_examples/tinytodo time:   [436.25 µs 438.19 µs 440.59 µs]
                        change: [−8.7305% −8.2229% −7.6874%] (p = 0.00 < 0.05)
                        Performance has improved.
```
Although it's probably miniscule compared to solver time.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
