### PR TITLE
Fix SymCC Unicode support

### DIFF
--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -1287,9 +1287,11 @@ mod string_encode_decode_test {
             "\u{ffff}",
             "\u{0}",
             "\u{a01b}",
+            "abc\u{29999}d",
         ];
 
         assert_eq!(encode_string("\u{33333}"), None);
+        assert_eq!(encode_string("abc\u{30000}d"), None);
 
         for s in strs {
             let enc = encode_string(s).unwrap();

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -528,7 +528,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
 
 // `num_codes` in cvc5
 // https://github.com/cvc5/cvc5/blob/b78e7ed23348659db52a32765ad181ae0c26bbd5/src/util/string.h#L53
-pub const SMT_LIB_MAX_CODE_POINT: u32 = 196608;
+pub const SMT_LIB_MAX_CODE_POINT: u32 = 196607;
 
 /// This function needs to encode unicode strings with two levels of
 /// escape sequences:

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -526,8 +526,9 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     }
 }
 
-// `num_codes` in cvc5
-// https://github.com/cvc5/cvc5/blob/b78e7ed23348659db52a32765ad181ae0c26bbd5/src/util/string.h#L53
+/// The maximum Unicode code point supported in SMT-LIB 2.7.
+/// Also see `num_codes` in cvc5:
+/// https://github.com/cvc5/cvc5/blob/b78e7ed23348659db52a32765ad181ae0c26bbd5/src/util/string.h#L53
 pub const SMT_LIB_MAX_CODE_POINT: u32 = 196607;
 
 /// This function needs to encode unicode strings with two levels of

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -2080,3 +2080,61 @@ async fn cex_enum_set() {
 
     assert_implies(&mut compiler, &pset1, &pset2, &envs).await;
 }
+
+/// Tests unicode enum entities
+#[tokio::test]
+async fn entity_unicode_enum() {
+    let schema = utils::schema_from_cedarstr(
+        r#"
+        entity User enum [ "🐼panda🐼", "🐶Leo🐶" ];
+        entity Document { owner: User };
+        action view appliesTo {
+            principal: [User],
+            resource: [Document]
+        };
+        "#,
+    );
+    let validator = Validator::new(schema.clone());
+
+    let pset = utils::pset_from_text(
+        r#"permit(principal, action, resource) when {
+            resource.owner == principal
+        };"#,
+        &validator,
+    );
+
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let envs = Environments::new(validator.schema(), "User", "Action::\"view\"", "Document");
+
+    assert_does_not_always_deny(&mut compiler, &pset, &envs).await;
+    assert_does_not_always_allow(&mut compiler, &pset, &envs).await;
+}
+
+/// Tests unicode entities
+#[tokio::test]
+async fn entity_unicode_uid() {
+    let schema = utils::schema_from_cedarstr(
+        r#"
+        entity User;
+        entity Document { owner: User };
+        action view appliesTo {
+            principal: [User],
+            resource: [Document]
+        };
+        "#,
+    );
+    let validator = Validator::new(schema.clone());
+
+    let pset = utils::pset_from_text(
+        r#"permit(principal == User::"🐼panda🐼", action, resource) when {
+            resource.owner == principal
+        };"#,
+        &validator,
+    );
+
+    let mut compiler = CedarSymCompiler::new(LocalSolver::cvc5().unwrap()).unwrap();
+    let envs = Environments::new(validator.schema(), "User", "Action::\"view\"", "Document");
+
+    assert_does_not_always_deny(&mut compiler, &pset, &envs).await;
+    assert_does_not_always_allow(&mut compiler, &pset, &envs).await;
+}


### PR DESCRIPTION
## Description of changes

SymCC currently fails on policies such as
```
permit(principal == User::"🐼panda🐼", action, resource);
```
This is because the SMT encoding and decoding of strings in SymCC is incorrect when handling unicode characters.

After some digging, it turns out that the encoding and decoding of SMT strings need to support two passes of escape sequences:
- The first pass in the SMT-LIB parser level is as defined in the [SMT-LIB 2.7 standad](https://smt-lib.org/papers/smt-lib-reference-v2.7-r2025-07-07.pdf), where the only escape sequence is `""`, which should be interpreted as one double quote `"`. At this level, string literals can *only* contain whitespace, printable characters (code points in the range [32, 126]), and the escape sequence `""` (i.e., no unicode characters allowed).
- The second type of escape sequences is specified in the [theory of strings](https://smt-lib.org/theories-UnicodeStrings.shtml), where 2 types of escape sequences `\uxxxx` and `\u{xxxx}` are defined. See the note section starting with `The restriction to printable US ASCII characters` for more details.

To make this a bit more complicated:
- The theory of (unicode) strings only supports [code points up to 0x2FFFF](https://smt-lib.org/theories-UnicodeStrings.shtml), so not all Rust strings can be encoded
- Error handling when escape sequences fail to parse is unspecified; [the decoder implementation in cvc5](https://github.com/cvc5/cvc5/blob/b78e7ed23348659db52a32765ad181ae0c26bbd5/src/util/string.cpp#L136) takes a more lenient approach to simply treat invalid unicode escape sequences as their original string (e.g. `\u{0` is interpted as the string itself, but `\u{0}` is interpreted as the NUL character).

To support as much Unicode strings as we can, I modified `encode_string` to encode non-printable characters with `\u` escape sequences; and also added `decode_string` in the decoder to support various patterns of escape sequences, mimicking the [cvc5 implementation](https://github.com/cvc5/cvc5/blob/b78e7ed23348659db52a32765ad181ae0c26bbd5/src/util/string.cpp#L136).

I have not modified the Lean version to do the same. Ideally we should model these string encoding/decoding functions in Lean as well, and prove some roundtrip properties.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
