### PR TITLE
Skip dependabot update for tsify version 0.5.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,12 @@ updates:
     # Update all explicitly defined dependencies
     allow:
       - dependency-type: "all"
+    ignore:
+      # Due to a build error when updating from tsify 0.4.5, we are skipping the
+      # next release (0.5.5). Issue #1744 tracks an eventual upgrade to this
+      # version or a later version.
+      - dependency-name: "tsify"
+        versions: ["0.5.5"]
     # Group all updates into one pull request
     groups:
       rust-dependencies:

--- a/cedar-language-server/Cargo.toml
+++ b/cedar-language-server/Cargo.toml
@@ -34,6 +34,7 @@ dashmap = { version = "6.1.0", optional = true}
 
 # Dependencies needed only for WASM integration
 serde-wasm-bindgen = { version = "0.6", optional = true }
+# Intentionally not updated to 0.5.5, see issue #1744
 tsify = { version = "0.4.5", optional = true }
 wasm-bindgen = { version = "0.2.97", optional = true }
 

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -34,6 +34,7 @@ regex = { version = "1.8", features = ["unicode"]}
 
 # wasm dependencies
 serde-wasm-bindgen = { version = "0.6", optional = true }
+# Intentionally not updated to 0.5.5, see issue #1744
 tsify = { version = "0.4.5", optional = true }
 wasm-bindgen = { version = "0.2.97", optional = true }
 

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -28,6 +28,7 @@ prost = { version = "0.14", optional = true }
 
 # wasm dependencies
 serde-wasm-bindgen = { version = "0.6", optional = true }
+# Intentionally not updated to 0.5.5, see issue #1744
 tsify = { version = "0.4.5", optional = true }
 wasm-bindgen = { version = "0.2.97", optional = true }
 semver = "1.0.26"

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -19,6 +19,7 @@ serde_json = "1.0"
 # wasm support
 wasm-bindgen = { version = "0.2.97" }
 console_error_panic_hook = { version = "0.1.6", optional = true }
+# Intentionally not updated to 0.5.5, see issue #1744
 tsify = "0.4.5"
 
 [features]


### PR DESCRIPTION
## Description of changes

Adds an `ignore` condition to our `dependabot.yml`. This was previously ignored by commenting `@ignore` on a dependabot PR, but I think tracking the ignore condition in the config file is more robust and should help us remember why we did it.

#1744 tracks an eventual upgrade to this version or a later version

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
