### PR TITLE
SymCC: Make `Term`-related interface more difficult to be misused

### DIFF
--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -31,10 +31,6 @@ chrono = "0.4.41"
 miette = { version = "7.5.0", features = ["fancy"] }
 tokio = { version = "1.0", features = ["rt", "macros"] } # for `tokio::test` unit tests
 
-[features]
-term = [] # Exports the internal `Term` interface for more custom queries
-experimental = ["term"]
-
 [lints]
 workspace = true
 

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -143,12 +143,12 @@ pub enum SExpr {
 /// - Theory-level escape sequence for Unicode characters:
 ///   convert any of the following to the corresponding Unicode character
 ///   (see https://smt-lib.org/theories-UnicodeStrings.shtml):
-///     \ud₃d₂d₁d₀  
-///     \u{d₀}
-///     \u{d₁d₀}
-///     \u{d₂d₁d₀}
-///     \u{d₃d₂d₁d₀}
-///     \u{d₄d₃d₂d₁d₀}
+///   \ud₃d₂d₁d₀  
+///   \u{d₀}
+///   \u{d₁d₀}
+///   \u{d₂d₁d₀}
+///   \u{d₃d₂d₁d₀}
+///   \u{d₄d₃d₂d₁d₀}
 ///
 /// See also:
 /// - The (right) inverse: `encode_string`

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -510,7 +510,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     /// constructs an `Encoder` themselves with the `SymEnv`, then calls this.
     pub async fn encode(
         &mut self,
-        ts: impl IntoIterator<Item = Term>,
+        ts: impl IntoIterator<Item = &Term>,
     ) -> Result<(), anyhow::Error> {
         self.script
             .declare_datatype(
@@ -520,7 +520,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
             )
             .await?;
         for t in ts {
-            let id = self.encode_term(&t).await?;
+            let id = self.encode_term(t).await?;
             self.script.assert(&id).await?;
         }
         Ok(())


### PR DESCRIPTION
## Description of changes

As suggested by @chaluli, this PR exports more `Term`-related types and functions, and also introduces a `WellFormedAsserts` type to wrap the results of `CedarSymCompiler::compile_*`, so that it's less likely to be misused (and as a result, I also removed the `term` feature flag):

```
pub struct WellFormedAsserts<'a> {
    asserts: Asserts,
    /// Policies that have been used to generate the asserts.
    footprint: Vec<&'a cedar_policy_core::ast::Policy>,
}
```

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
