### PR TITLE
Allow serializing `Unknown` values as `CedarValueJSON`.

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -2196,6 +2196,28 @@ mod json_parsing_tests {
             });
         });
     }
+
+    #[test]
+    fn serialize_unknown_no_error() {
+        let test = serde_json::json!([{
+            "uid" : { "type" : "A", "id" : "b" },
+            "attrs": {
+                "age":  {
+                    "__extn": {
+                        "fn": "unknown",
+                        "arg": "890.9"
+                    }
+                }
+            },
+            "parents": []
+        }]);
+        let eparser: EntityJsonParser<'_, '_, NoEntitiesSchema> =
+            EntityJsonParser::new(None, Extensions::all_available(), TCComputation::ComputeNow);
+        let x = eparser.from_json_value(test);
+        let y = x.unwrap().to_json_value();
+        // Should not error on reserialization
+        y.unwrap();
+    }
 }
 
 // PANIC SAFETY: Unit Test Code

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -468,6 +468,14 @@ impl CedarValueJson {
                         .collect::<Result<_, JsonSerializationError>>()?,
                 ))
             }
+            // Serialize Unknown as a extension function with a single argument. The name of the unknown.
+            // This matches how Unknown is deserialized from JSON format.
+            ExprKind::Unknown(unknown) => Ok(Self::ExtnEscape {
+                __extn: FnAndArgs::Single {
+                        ext_fn: "unknown".into(),
+                        arg: Box::new(CedarValueJson::String(unknown.name.clone())),
+                },
+            }),
             kind => Err(JsonSerializationError::unexpected_restricted_expr_kind(
                 kind.clone(),
             )),

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -472,8 +472,8 @@ impl CedarValueJson {
             // This matches how Unknown is deserialized from JSON format.
             ExprKind::Unknown(unknown) => Ok(Self::ExtnEscape {
                 __extn: FnAndArgs::Single {
-                        ext_fn: "unknown".into(),
-                        arg: Box::new(CedarValueJson::String(unknown.name.clone())),
+                    ext_fn: "unknown".into(),
+                    arg: Box::new(CedarValueJson::String(unknown.name.clone())),
                 },
             }),
             kind => Err(JsonSerializationError::unexpected_restricted_expr_kind(


### PR DESCRIPTION
Update construction of `CedarValueJson` from `BorrowedRestrictedExpr` to serialize unknown as an extension function with name "unknown" and arg the name of the unknown. This matches the already existing pattern for deserializing an extension function with name "unknown" as an Unknown `RestrictedExpr`.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
