### PR TITLE
Patch Release 4.5.1

### DIFF
--- a/cedar-policy-core/src/ast/entity.rs
+++ b/cedar-policy-core/src/ast/entity.rs
@@ -645,6 +645,7 @@ impl Entity {
     pub(crate) fn deep_eq(&self, other: &Self) -> bool {
         self.uid == other.uid
             && self.attrs == other.attrs
+            && self.tags == other.tags
             && (self.ancestors().collect::<HashSet<_>>())
                 == (other.ancestors().collect::<HashSet<_>>())
     }

--- a/cedar-policy-core/src/ast/extension.rs
+++ b/cedar-policy-core/src/ast/extension.rs
@@ -325,15 +325,16 @@ impl ExtensionFunction {
         &self.arg_types
     }
 
-    /// Returns `true` if this function is considered a "constructor".
+    /// Returns `true` if this function is considered a single argument
+    /// constructor.
     ///
-    /// Currently, the only impact of this is that non-constructors are not
-    /// accessible in the JSON format (entities/json.rs).
-    pub fn is_constructor(&self) -> bool {
+    /// Only functions satisfying this predicate can have their names implicit
+    /// during schema-based entity parsing
+    pub fn is_single_arg_constructor(&self) -> bool {
         // return type is an extension type
         matches!(self.return_type(), Some(SchemaType::Extension { .. }))
-        // no argument is an extension type
-        && !self.arg_types().iter().any(|ty| matches!(ty, SchemaType::Extension { .. }))
+        // the only argument is a string
+        && matches!(self.arg_types(), [SchemaType::String])
     }
 
     /// Call the `ExtensionFunction` with the given args

--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -1381,7 +1381,18 @@ impl PrincipalConstraint {
             PrincipalOrResourceConstraint::In(EntityReference::Slot(_)) => Self {
                 constraint: PrincipalOrResourceConstraint::In(EntityReference::EUID(euid)),
             },
-            _ => self,
+            PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot(_)) => Self {
+                constraint: PrincipalOrResourceConstraint::IsIn(
+                    entity_type,
+                    EntityReference::EUID(euid),
+                ),
+            },
+            // enumerated so it is clearer what other variants there are
+            PrincipalOrResourceConstraint::Is(_)
+            | PrincipalOrResourceConstraint::Any
+            | PrincipalOrResourceConstraint::Eq(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::In(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::IsIn(_, EntityReference::EUID(_)) => self,
         }
     }
 }
@@ -1488,7 +1499,18 @@ impl ResourceConstraint {
             PrincipalOrResourceConstraint::In(EntityReference::Slot(_)) => Self {
                 constraint: PrincipalOrResourceConstraint::In(EntityReference::EUID(euid)),
             },
-            _ => self,
+            PrincipalOrResourceConstraint::IsIn(entity_type, EntityReference::Slot(_)) => Self {
+                constraint: PrincipalOrResourceConstraint::IsIn(
+                    entity_type,
+                    EntityReference::EUID(euid),
+                ),
+            },
+            // enumerated so it is clearer what other variants there are
+            PrincipalOrResourceConstraint::Is(_)
+            | PrincipalOrResourceConstraint::Any
+            | PrincipalOrResourceConstraint::Eq(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::In(EntityReference::EUID(_))
+            | PrincipalOrResourceConstraint::IsIn(_, EntityReference::EUID(_)) => self,
         }
     }
 }

--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -31,8 +31,8 @@ use json::err::JsonSerializationError;
 
 pub use json::{
     AllEntitiesNoAttrsSchema, AttributeType, CedarValueJson, ContextJsonParser, ContextSchema,
-    EntityJson, EntityJsonParser, EntityTypeDescription, EntityUidJson, FnAndArg, NoEntitiesSchema,
-    NoStaticContext, Schema, SchemaType, TypeAndId,
+    EntityJson, EntityJsonParser, EntityTypeDescription, EntityUidJson, FnAndArgs,
+    NoEntitiesSchema, NoStaticContext, Schema, SchemaType, TypeAndId,
 };
 
 use conformance::EntitySchemaConformanceChecker;
@@ -2608,6 +2608,9 @@ mod schema_based_parsing_tests {
                     .collect(),
                     open_attrs: false,
                 }),
+                "start_date" => Some(SchemaType::Extension {
+                    name: Name::parse_unqualified_name("datetime").expect("valid"),
+                }),
                 _ => None,
             }
         }
@@ -2670,7 +2673,11 @@ mod schema_based_parsing_tests {
                         "home_ip": "222.222.222.101",
                         "work_ip": { "fn": "ip", "arg": "2.2.2.0/24" },
                         "trust_score": "5.7",
-                        "tricky": { "type": "Employee", "id": "34FB87" }
+                        "tricky": { "type": "Employee", "id": "34FB87" },
+                        "start_date": { "fn": "offset", "args": [
+                            {"fn": "datetime", "arg": "1970-01-01"},
+                            {"fn": "duration", "arg": "1h"}
+                        ]}
                     },
                     "parents": [],
                     "tags": {

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -419,6 +419,14 @@ impl CedarValueJson {
                         .collect::<Result<_, JsonSerializationError>>()?,
                 ))
             }
+            // Serialize Unknown as a extension function with a single argument. The name of the unknown.
+            // This matches how Unknown is deserialized from JSON format.
+            ExprKind::Unknown(unknown) => Ok(Self::ExtnEscape {
+                __extn: FnAndArgs::Single {
+                    ext_fn: "unknown".into(),
+                    arg: Box::new(CedarValueJson::String(unknown.name.clone())),
+                },
+            }),
             kind => Err(JsonSerializationError::unexpected_restricted_expr_kind(
                 kind.clone(),
             )),

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -422,7 +422,7 @@ impl CedarValueJson {
             // Serialize Unknown as a extension function with a single argument. The name of the unknown.
             // This matches how Unknown is deserialized from JSON format.
             ExprKind::Unknown(unknown) => Ok(Self::ExtnEscape {
-                __extn: FnAndArgs::Single {
+                __extn: FnAndArg {
                     ext_fn: "unknown".into(),
                     arg: Box::new(CedarValueJson::String(unknown.name.clone())),
                 },

--- a/cedar-policy-core/src/entities/json/value.rs
+++ b/cedar-policy-core/src/entities/json/value.rs
@@ -104,7 +104,7 @@ pub enum CedarValueJson {
     // `serde(untagged)`
     ExtnEscape {
         /// JSON object containing the extension-constructor call
-        __extn: FnAndArg,
+        __extn: FnAndArgs,
     },
     /// JSON bool => Cedar bool
     Bool(bool),
@@ -151,9 +151,22 @@ impl From<RawCedarValueJson> for CedarValueJson {
                                 {
                                     if let Some(arg) = r.values.get("arg") {
                                         return Self::ExtnEscape {
-                                            __extn: FnAndArg {
+                                            __extn: FnAndArgs::Single {
                                                 ext_fn: fn_name.clone(),
                                                 arg: Box::new(arg.clone().into()),
+                                            },
+                                        };
+                                    }
+                                    if let Some(RawCedarValueJson::Set(args)) = r.values.get("args")
+                                    {
+                                        return Self::ExtnEscape {
+                                            __extn: FnAndArgs::Multi {
+                                                ext_fn: fn_name.clone(),
+                                                args: args
+                                                    .into_iter()
+                                                    .cloned()
+                                                    .map(Into::into)
+                                                    .collect(),
                                             },
                                         };
                                     }
@@ -318,13 +331,41 @@ impl TryFrom<TypeAndId> for EntityUID {
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "wasm", derive(tsify::Tsify))]
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
-pub struct FnAndArg {
-    /// Extension constructor function
-    #[serde(rename = "fn")]
-    #[cfg_attr(feature = "wasm", tsify(type = "string"))]
-    pub(crate) ext_fn: SmolStr,
-    /// Argument to that constructor
-    pub(crate) arg: Box<CedarValueJson>,
+#[serde(untagged)]
+pub enum FnAndArgs {
+    /// Single-argument function
+    Single {
+        /// Extension constructor function
+        #[serde(rename = "fn")]
+        #[cfg_attr(feature = "wasm", tsify(type = "string"))]
+        ext_fn: SmolStr,
+        /// Argument to that constructor
+        arg: Box<CedarValueJson>,
+    },
+    /// Multi-argument function
+    Multi {
+        /// Extension constructor function
+        #[serde(rename = "fn")]
+        #[cfg_attr(feature = "wasm", tsify(type = "string"))]
+        ext_fn: SmolStr,
+        /// Arguments to that constructor
+        args: Vec<CedarValueJson>,
+    },
+}
+
+impl FnAndArgs {
+    pub(crate) fn fn_str(&self) -> &str {
+        match self {
+            Self::Multi { ext_fn, .. } | Self::Single { ext_fn, .. } => ext_fn,
+        }
+    }
+
+    pub(crate) fn args(&self) -> &[CedarValueJson] {
+        match self {
+            Self::Multi { args, .. } => args,
+            Self::Single { arg, .. } => std::slice::from_ref(arg),
+        }
+    }
 }
 
 impl CedarValueJson {
@@ -376,22 +417,30 @@ impl CedarValueJson {
     pub fn from_expr(expr: BorrowedRestrictedExpr<'_>) -> Result<Self, JsonSerializationError> {
         match expr.as_ref().expr_kind() {
             ExprKind::Lit(lit) => Ok(Self::from_lit(lit.clone())),
-            ExprKind::ExtensionFunctionApp { fn_name, args } => match args.len() {
-                0 => Err(JsonSerializationError::call_0_args(fn_name.clone())),
-                // PANIC SAFETY. We've checked that `args` is of length 1, fine to index at 0
-                #[allow(clippy::indexing_slicing)]
-                1 => Ok(Self::ExtnEscape {
-                    __extn: FnAndArg {
+            ExprKind::ExtensionFunctionApp { fn_name, args } => match args.as_slice() {
+                [] => Err(JsonSerializationError::call_0_args(fn_name.clone())),
+                [arg] => Ok(Self::ExtnEscape {
+                    __extn: FnAndArgs::Single {
                         ext_fn: fn_name.to_smolstr(),
                         arg: Box::new(CedarValueJson::from_expr(
                             // assuming the invariant holds for `expr`, it must also hold here
-                            BorrowedRestrictedExpr::new_unchecked(
-                                &args[0], // checked above that |args| == 1
-                            ),
+                            BorrowedRestrictedExpr::new_unchecked(arg),
                         )?),
                     },
                 }),
-                _ => Err(JsonSerializationError::call_2_or_more_args(fn_name.clone())),
+                args => Ok(Self::ExtnEscape {
+                    __extn: FnAndArgs::Multi {
+                        ext_fn: fn_name.to_smolstr(),
+                        args: args
+                            .into_iter()
+                            .map(|arg| {
+                                CedarValueJson::from_expr(BorrowedRestrictedExpr::new_unchecked(
+                                    arg,
+                                ))
+                            })
+                            .collect::<Result<Vec<_>, _>>()?,
+                    },
+                }),
             },
             ExprKind::Set(exprs) => Ok(Self::Set(
                 exprs
@@ -422,7 +471,7 @@ impl CedarValueJson {
             // Serialize Unknown as a extension function with a single argument. The name of the unknown.
             // This matches how Unknown is deserialized from JSON format.
             ExprKind::Unknown(unknown) => Ok(Self::ExtnEscape {
-                __extn: FnAndArg {
+                __extn: FnAndArgs::Single {
                     ext_fn: "unknown".into(),
                     arg: Box::new(CedarValueJson::String(unknown.name.clone())),
                 },
@@ -473,22 +522,24 @@ impl CedarValueJson {
             }
             ValueKind::ExtensionValue(ev) => {
                 let ext_func = &ev.func;
-                Ok(Self::ExtnEscape {
-                    __extn: FnAndArg {
-                        ext_fn: ext_func.to_smolstr(),
-                        arg: match ev.args.as_slice() {
-                            [ref expr] => Box::new(Self::from_expr(expr.as_borrowed())?),
-                            [] => {
-                                return Err(JsonSerializationError::call_0_args(ext_func.clone()))
-                            }
-                            _ => {
-                                return Err(JsonSerializationError::call_2_or_more_args(
-                                    ext_func.clone(),
-                                ))
-                            }
+                match ev.args.as_slice() {
+                    [] => Err(JsonSerializationError::call_0_args(ext_func.clone())),
+                    [ref expr] => Ok(Self::ExtnEscape {
+                        __extn: FnAndArgs::Single {
+                            ext_fn: ext_func.to_smolstr(),
+                            arg: Box::new(Self::from_expr(expr.as_borrowed())?),
                         },
-                    },
-                })
+                    }),
+                    exprs => Ok(Self::ExtnEscape {
+                        __extn: FnAndArgs::Multi {
+                            ext_fn: ext_func.to_smolstr(),
+                            args: exprs
+                                .into_iter()
+                                .map(|expr| Self::from_expr(expr.as_borrowed()))
+                                .collect::<Result<Vec<_>, _>>()?,
+                        },
+                    }),
+                }
             }
         }
     }
@@ -527,10 +578,23 @@ impl CedarValueJson {
                     Err(_) => Ok(CedarValueJson::EntityEscape { __entity }),
                 }
             }
-            CedarValueJson::ExtnEscape { __extn } => Ok(CedarValueJson::ExtnEscape {
-                __extn: FnAndArg {
-                    ext_fn: __extn.ext_fn,
-                    arg: Box::new((*__extn.arg).sub_entity_literals(mapping)?),
+            CedarValueJson::ExtnEscape {
+                __extn: FnAndArgs::Single { ext_fn, arg },
+            } => Ok(CedarValueJson::ExtnEscape {
+                __extn: FnAndArgs::Single {
+                    ext_fn,
+                    arg: Box::new((*arg).sub_entity_literals(mapping)?),
+                },
+            }),
+            CedarValueJson::ExtnEscape {
+                __extn: FnAndArgs::Multi { ext_fn, args },
+            } => Ok(CedarValueJson::ExtnEscape {
+                __extn: FnAndArgs::Multi {
+                    ext_fn,
+                    args: args
+                        .into_iter()
+                        .map(|arg| arg.sub_entity_literals(mapping))
+                        .collect::<Result<Vec<_>, _>>()?,
                 },
             }),
             v @ CedarValueJson::Bool(_) => Ok(v),
@@ -570,17 +634,21 @@ fn check_for_reserved_keys<'a>(
     }
 }
 
-impl FnAndArg {
+impl FnAndArgs {
     /// Convert this `FnAndArg` into a Cedar "restricted expression" (which will be a call to an extension constructor)
     pub fn into_expr(
         self,
         ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
     ) -> Result<RestrictedExpr, JsonDeserializationError> {
+        let ext_fn = self.fn_str();
+        let args = self.args();
         Ok(RestrictedExpr::call_extension_fn(
-            Name::from_normalized_str(&self.ext_fn).map_err(|errs| {
-                JsonDeserializationError::parse_escape(EscapeKind::Extension, self.ext_fn, errs)
+            Name::from_normalized_str(ext_fn).map_err(|errs| {
+                JsonDeserializationError::parse_escape(EscapeKind::Extension, ext_fn, errs)
             })?,
-            vec![CedarValueJson::into_expr(*self.arg, ctx)?],
+            args.into_iter()
+                .map(|arg| CedarValueJson::into_expr(arg.clone(), ctx.clone()))
+                .collect::<Result<Vec<_>, _>>()?,
         ))
     }
 }
@@ -614,7 +682,7 @@ impl<'e> ValueParser<'e> {
             let extjson: ExtnValueJson = serde_json::from_value(val).ok()?;
             match extjson {
                 ExtnValueJson::ExplicitExtnEscape {
-                    __extn: FnAndArg { ext_fn, arg },
+                    __extn: FnAndArgs::Single { ext_fn, arg },
                 } if ext_fn == "unknown" => {
                     let arg = arg.into_expr(ctx.clone()).ok()?;
                     let name = arg.as_string()?;
@@ -642,7 +710,81 @@ impl<'e> ValueParser<'e> {
             // convert that into an extension-function-call `RestrictedExpr`
             Some(SchemaType::Extension { ref name, .. }) => {
                 let extjson: ExtnValueJson = serde_json::from_value(val)?;
-                self.extn_value_json_into_rexpr(extjson, name.clone(), ctx)
+                match extjson {
+                    ExtnValueJson::ExplicitExprEscape { .. } => {
+                        Err(JsonDeserializationError::ExprTag(Box::new(ctx())))
+                    }
+                    ExtnValueJson::ExplicitExtnEscape { __extn }
+                    | ExtnValueJson::ImplicitExtnEscape(__extn) => {
+                        let func = self.extensions.func(
+                            &Name::from_normalized_str(__extn.fn_str()).map_err(|errs| {
+                                JsonDeserializationError::parse_escape(
+                                    EscapeKind::Extension,
+                                    __extn.fn_str(),
+                                    errs,
+                                )
+                            })?,
+                        )?;
+                        let arg_types = func.arg_types();
+                        let args = __extn.args();
+                        if args.len() != arg_types.len() {
+                            return Err(JsonDeserializationError::incorrect_num_of_arguments(
+                                arg_types.len(),
+                                args.len(),
+                                __extn.fn_str(),
+                            ));
+                        }
+                        Ok(RestrictedExpr::call_extension_fn(
+                            func.name().clone(),
+                            arg_types
+                                .into_iter()
+                                .zip(args.iter())
+                                .map(|(arg_type, arg)| {
+                                    // We need to recur here because there
+                                    // could be arguments of non-primitive
+                                    // types like `datetime`, which could be
+                                    // expressed using `ImplicitExtnEscape` or
+                                    // `ImplicitConstructor`
+                                    self.val_into_restricted_expr(
+                                        // So, we have to serialize
+                                        // `CedarValueJson` here
+                                        serde_json::to_value(arg)?,
+                                        Some(arg_type),
+                                        ctx.clone(),
+                                    )
+                                })
+                                .collect::<Result<Vec<_>, _>>()?,
+                        ))
+                    }
+                    ExtnValueJson::ImplicitConstructor(val) => {
+                        let expected_return_type = SchemaType::Extension { name: name.clone() };
+                        // Unfortunately, we can only allow one argument
+                        // constructor here because it's impossible to
+                        // distinguish two cases where there are
+                        // multiple arguments and where there is one
+                        // argument of a set type
+                        if let Some(constructor) = self
+                            .extensions
+                            .lookup_single_arg_constructor(&expected_return_type)
+                        {
+                            // PANIC SAFETY: we've concluded above that it has one arugment
+                            #[allow(clippy::indexing_slicing)]
+                            Ok(RestrictedExpr::call_extension_fn(
+                                constructor.name().clone(),
+                                std::iter::once(self.val_into_restricted_expr(
+                                    serde_json::to_value(val)?,
+                                    Some(&constructor.arg_types()[0]),
+                                    ctx,
+                                )?),
+                            ))
+                        } else {
+                            Err(JsonDeserializationError::missing_implied_constructor(
+                                ctx(),
+                                expected_return_type,
+                            ))
+                        }
+                    }
+                }
             }
             // The expected type is a set type. No special parsing rules apply, but
             // we need to parse the elements according to the expected element type
@@ -761,55 +903,6 @@ impl<'e> ValueParser<'e> {
                 // `RestrictedExpr` from that.
                 let jvalue: CedarValueJson = serde_json::from_value(val)?;
                 Ok(jvalue.into_expr(ctx)?)
-            }
-        }
-    }
-
-    /// internal function that converts an `ExtnValueJson` into a
-    /// `RestrictedExpr`, which will be an extension constructor call.
-    ///
-    /// `expected_typename`: Specific extension type that is expected.
-    fn extn_value_json_into_rexpr(
-        &self,
-        extnjson: ExtnValueJson,
-        expected_typename: Name,
-        ctx: impl Fn() -> JsonDeserializationErrorContext + Clone,
-    ) -> Result<RestrictedExpr, JsonDeserializationError> {
-        match extnjson {
-            ExtnValueJson::ExplicitExprEscape { __expr } => {
-                Err(JsonDeserializationError::ExprTag(Box::new(ctx())))
-            }
-            ExtnValueJson::ExplicitExtnEscape { __extn }
-            | ExtnValueJson::ImplicitExtnEscape(__extn) => {
-                // reuse the same logic that parses CedarValueJson
-                let jvalue = CedarValueJson::ExtnEscape { __extn };
-                let expr = jvalue.into_expr(ctx.clone())?;
-                match expr.expr_kind() {
-                    ExprKind::ExtensionFunctionApp { .. } => Ok(expr),
-                    _ => Err(JsonDeserializationError::expected_extn_value(
-                        ctx(),
-                        Either::Right(expr.clone().into()),
-                    )),
-                }
-            }
-            ExtnValueJson::ImplicitConstructor(val) => {
-                let expected_return_type = SchemaType::Extension {
-                    name: expected_typename,
-                };
-                let func = self
-                    .extensions
-                    .lookup_single_arg_constructor(&expected_return_type)
-                    .ok_or_else(|| {
-                        JsonDeserializationError::missing_implied_constructor(
-                            ctx(),
-                            expected_return_type,
-                        )
-                    })?;
-                let arg = val.into_expr(ctx.clone())?;
-                Ok(RestrictedExpr::call_extension_fn(
-                    func.name().clone(),
-                    vec![arg],
-                ))
             }
         }
     }
@@ -960,11 +1053,11 @@ pub enum ExtnValueJson {
     /// Explicit `__extn` escape; see notes on `CedarValueJson::ExtnEscape`
     ExplicitExtnEscape {
         /// JSON object containing the extension-constructor call
-        __extn: FnAndArg,
+        __extn: FnAndArgs,
     },
     /// Implicit `__extn` escape, in which case we'll just see the `FnAndArg`
     /// directly
-    ImplicitExtnEscape(FnAndArg),
+    ImplicitExtnEscape(FnAndArgs),
     /// Implicit `__extn` escape and constructor. Constructor is implicitly
     /// selected based on the argument type and the expected type.
     //

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -3321,6 +3321,152 @@ mod test {
     }
 
     #[test]
+    fn ast_to_est_with_linked_template_using_is_in_operator_1() {
+        let template = r#"
+            permit(
+                principal is XYZCorp::User in ?principal,
+                action == Action::"view",
+                resource in ?resource
+            ) when {
+                principal in resource.owners
+            };
+        "#;
+
+        let cst = parser::text_to_cst::parse_policy(template).unwrap();
+        let ast: ast::Template = cst
+            .to_policy_template(ast::PolicyID::from_string("test"))
+            .unwrap();
+
+        let policy = ast::Template::link(
+            std::sync::Arc::new(ast),
+            ast::PolicyID::from_string("test"),
+            HashMap::from_iter([
+                (
+                    ast::SlotId::principal(),
+                    r#"XYZCorp::User::"12UA45""#.parse().unwrap(),
+                ),
+                (ast::SlotId::resource(), r#"Folder::"abc""#.parse().unwrap()),
+            ]),
+        )
+        .unwrap();
+
+        let est: Policy = policy.into();
+
+        let expected_json = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "is",
+                        "entity_type": "XYZCorp::User",
+                        "in": { "entity": { "type": "XYZCorp::User", "id": "12UA45" } },
+                },
+                "action": {
+                    "op": "==",
+                    "entity": { "type": "Action", "id": "view" },
+                },
+                "resource": {
+                    "op": "in",
+                    "entity": { "type": "Folder", "id": "abc" },
+                },
+                "conditions": [
+                    {
+                        "kind": "when",
+                        "body": {
+                            "in": {
+                                "left": {
+                                    "Var": "principal"
+                                },
+                                "right": {
+                                    ".": {
+                                        "left": {
+                                            "Var": "resource"
+                                        },
+                                        "attr": "owners"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ],
+            }
+        );
+        let linked_json = serde_json::to_value(est).unwrap();
+        assert_eq!(
+            linked_json,
+            expected_json,
+            "\nExpected:\n{}\n\nActual:\n{}\n\n",
+            serde_json::to_string_pretty(&expected_json).unwrap(),
+            serde_json::to_string_pretty(&linked_json).unwrap(),
+        );
+    }
+
+    #[test]
+    fn ast_to_est_with_linked_template_using_is_in_operator_2() {
+        let template = r#"
+            permit(
+                principal is User in ?principal,
+                action,
+                resource is Doc in ?resource
+            );
+        "#;
+
+        let cst = parser::text_to_cst::parse_policy(template).unwrap();
+        let ast: ast::Template = cst
+            .to_policy_template(ast::PolicyID::from_string("test"))
+            .unwrap();
+
+        let policy = ast::Template::link(
+            std::sync::Arc::new(ast),
+            ast::PolicyID::from_string("test"),
+            HashMap::from_iter([
+                (
+                    ast::SlotId::principal(),
+                    r#"User::"alice""#.parse().unwrap(),
+                ),
+                (ast::SlotId::resource(), r#"Doc::"abc""#.parse().unwrap()),
+            ]),
+        )
+        .unwrap();
+
+        let est: Policy = policy.into();
+
+        let expected_json = json!(
+            {
+                "effect": "permit",
+                "principal": {
+                    "op": "is",
+                    "entity_type": "User",
+                    "in": { "entity": { "type": "User", "id": "alice" } }
+                },
+                "action": {
+                    "op": "All"
+                },
+                "resource": {
+                    "op": "is",
+                    "entity_type": "Doc",
+                    "in": { "entity": { "type": "Doc", "id": "abc" } }
+                },
+                "conditions": [
+                    {
+                        "kind": "when",
+                        "body": {
+                            "Value": true
+                        }
+                    }
+                ],
+            }
+        );
+        let linked_json = serde_json::to_value(est).unwrap();
+        assert_eq!(
+            linked_json,
+            expected_json,
+            "\nExpected:\n{}\n\nActual:\n{}\n\n",
+            serde_json::to_string_pretty(&expected_json).unwrap(),
+            serde_json::to_string_pretty(&linked_json).unwrap(),
+        );
+    }
+
+    #[test]
     fn eid_with_nulls() {
         let policy = r#"
             permit(

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -22,7 +22,7 @@ use crate::ast::Infallible;
 use crate::ast::{self, BoundedDisplay, EntityUID};
 use crate::entities::json::{
     err::EscapeKind, err::JsonDeserializationError, err::JsonDeserializationErrorContext,
-    CedarValueJson, FnAndArg,
+    CedarValueJson, FnAndArgs,
 };
 use crate::expr_builder::ExprBuilder;
 use crate::extensions::Extensions;
@@ -1125,7 +1125,7 @@ fn display_cedarvaluejson(
         }
         CedarValueJson::ExprEscape { __expr } => write!(f, "({__expr})"),
         CedarValueJson::ExtnEscape {
-            __extn: FnAndArg { ext_fn, arg },
+            __extn: FnAndArgs::Single { ext_fn, arg },
         } => {
             // search for the name and callstyle
             let style = Extensions::all_available().all_funcs().find_map(|f| {
@@ -1144,6 +1144,55 @@ fn display_cedarvaluejson(
                 Some(ast::CallStyle::FunctionStyle) | None => {
                     write!(f, "{ext_fn}(")?;
                     display_cedarvaluejson(f, arg, n)?;
+                    write!(f, ")")?;
+                    Ok(())
+                }
+            }
+        }
+        CedarValueJson::ExtnEscape {
+            __extn: FnAndArgs::Multi { ext_fn, args },
+        } => {
+            // search for the name and callstyle
+            let style = Extensions::all_available().all_funcs().find_map(|f| {
+                if &f.name().to_smolstr() == ext_fn {
+                    Some(f.style())
+                } else {
+                    None
+                }
+            });
+            match style {
+                Some(ast::CallStyle::MethodStyle) => {
+                    // PANIC SAFETY: method-style calls must have more than one argument
+                    #[allow(clippy::indexing_slicing)]
+                    display_cedarvaluejson(f, &args[0], n)?;
+                    write!(f, ".{ext_fn}(")?;
+                    // PANIC SAFETY: method-style calls must have more than one argument
+                    #[allow(clippy::indexing_slicing)]
+                    match &args[1..] {
+                        [] => {}
+                        [args @ .., last] => {
+                            for arg in args {
+                                display_cedarvaluejson(f, arg, n)?;
+                                write!(f, ", ")?;
+                            }
+                            display_cedarvaluejson(f, last, n)?;
+                        }
+                    }
+                    write!(f, ")")?;
+                    Ok(())
+                }
+                Some(ast::CallStyle::FunctionStyle) | None => {
+                    write!(f, "{ext_fn}(")?;
+                    match &args[..] {
+                        [] => {}
+                        [args @ .., last] => {
+                            for arg in args {
+                                display_cedarvaluejson(f, arg, n)?;
+                                write!(f, ", ")?;
+                            }
+                            display_cedarvaluejson(f, last, n)?;
+                        }
+                    }
                     write!(f, ")")?;
                     Ok(())
                 }

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -31,7 +31,7 @@ use std::collections::HashMap;
 use crate::ast::{Extension, ExtensionFunction, Name};
 use crate::entities::SchemaType;
 use crate::extensions::extension_initialization_errors::MultipleConstructorsSameSignatureError;
-use crate::parser::{AsLocRef, IntoMaybeLoc, Loc, MaybeLoc};
+use crate::parser::Loc;
 use miette::Diagnostic;
 use thiserror::Error;
 

--- a/cedar-policy-core/src/extensions.rs
+++ b/cedar-policy-core/src/extensions.rs
@@ -30,14 +30,13 @@ use std::collections::HashMap;
 
 use crate::ast::{Extension, ExtensionFunction, Name};
 use crate::entities::SchemaType;
-use crate::parser::Loc;
+use crate::extensions::extension_initialization_errors::MultipleConstructorsSameSignatureError;
+use crate::parser::{AsLocRef, IntoMaybeLoc, Loc, MaybeLoc};
 use miette::Diagnostic;
 use thiserror::Error;
 
 use self::extension_function_lookup_errors::FuncDoesNotExistError;
-use self::extension_initialization_errors::{
-    FuncMultiplyDefinedError, MultipleConstructorsSameSignatureError,
-};
+use self::extension_initialization_errors::FuncMultiplyDefinedError;
 
 lazy_static::lazy_static! {
     static ref ALL_AVAILABLE_EXTENSION_OBJECTS: Vec<Extension> = vec![
@@ -124,7 +123,7 @@ impl<'a> Extensions<'a> {
             extensions
                 .iter()
                 .flat_map(|e| e.funcs())
-                .filter(|f| f.is_constructor() && f.arg_types().len() == 1)
+                .filter(|f| f.is_single_arg_constructor())
                 .filter_map(|f| f.return_type().map(|return_type| (return_type, f))),
         )
         .map_err(|return_type| MultipleConstructorsSameSignatureError {
@@ -174,10 +173,8 @@ impl<'a> Extensions<'a> {
         self.extensions.iter().flat_map(|ext| ext.funcs())
     }
 
-    /// Lookup a single-argument constructor by its return type and argument type.
-    ///
-    /// `None` means no constructor has that signature.
-    pub(crate) fn lookup_single_arg_constructor(
+    /// Lookup a single-argument constructor by its return type
+    pub(crate) fn lookup_single_arg_constructor<'b>(
         &self,
         return_type: &SchemaType,
     ) -> Option<&ExtensionFunction> {

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -359,33 +359,33 @@ mod tests {
                 &Name::parse_unqualified_name("decimal").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("lessThan").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("lessThanOrEqual")
                     .expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("greaterThan").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("greaterThanOrEqual")
                     .expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor(),);
+            .is_single_arg_constructor(),);
     }
 
     #[test]

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -484,37 +484,37 @@ mod tests {
         assert!(ext
             .get_func(&Name::parse_unqualified_name("ip").expect("should be a valid identifier"))
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("isIpv4").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("isIpv6").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("isLoopback").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("isMulticast").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor());
+            .is_single_arg_constructor());
         assert!(!ext
             .get_func(
                 &Name::parse_unqualified_name("isInRange").expect("should be a valid identifier")
             )
             .expect("function should exist")
-            .is_constructor(),);
+            .is_single_arg_constructor(),);
     }
 
     #[test]

--- a/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
@@ -136,9 +136,9 @@ pub struct InvalidActionApplication {
     pub source_loc: Option<Loc>,
     /// Policy ID where the error occurred
     pub policy_id: PolicyID,
-    /// `true` if changing `==` to `in` wouuld fix the principal clause
+    /// `true` if changing `==` to `in` would fix the principal clause
     pub would_in_fix_principal: bool,
-    /// `true` if changing `==` to `in` wouuld fix the resource clause
+    /// `true` if changing `==` to `in` would fix the resource clause
     pub would_in_fix_resource: bool,
 }
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -4829,6 +4829,35 @@ impl From<ast::Value> for EvalResult {
         }
     }
 }
+
+#[doc(hidden)]
+// PANIC SAFETY: see the panic safety comments below
+#[allow(clippy::fallible_impl_from)]
+impl From<EvalResult> for Expression {
+    fn from(res: EvalResult) -> Self {
+        match res {
+            EvalResult::Bool(b) => Self::new_bool(b),
+            EvalResult::Long(l) => Self::new_long(l),
+            EvalResult::String(s) => Self::new_string(s),
+            EvalResult::EntityUid(eid) => {
+                Self::from(ast::Expr::from(ast::Value::from(ast::EntityUID::from(eid))))
+            }
+            EvalResult::Set(set) => Self::new_set(set.iter().cloned().map(Self::from)),
+            EvalResult::Record(r) => {
+                // PANIC SAFETY: record originates from EvalResult so should not panic when reconstructing as an Expression
+                #[allow(clippy::unwrap_used)]
+                Self::new_record(r.iter().map(|(k, v)| (k.clone(), Self::from(v.clone())))).unwrap()
+            }
+            EvalResult::ExtensionValue(s) => {
+                // PANIC SAFETY: the string s is constructed using RestrictedExpr::to_string() so should not panic when being parsed back into a RestrictedExpr
+                #[allow(clippy::unwrap_used)]
+                let expr: ast::Expr = ast::RestrictedExpr::from_str(&s).unwrap().into();
+                Self::from(expr)
+            }
+        }
+    }
+}
+
 impl std::fmt::Display for EvalResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/cedar-policy/src/api/err.rs
+++ b/cedar-policy/src/api/err.rs
@@ -54,9 +54,9 @@ pub mod entities_errors {
 pub mod entities_json_errors {
     pub use cedar_policy_core::entities::json::err::{
         ActionParentIsNotAction, DuplicateKey, ExpectedExtnValue, ExpectedLiteralEntityRef,
-        ExtnCall0Arguments, ExtnCall2OrMoreArguments, JsonDeserializationError, JsonError,
-        JsonSerializationError, MissingImpliedConstructor, MissingRequiredRecordAttr, ParseEscape,
-        ReservedKey, Residual, TypeMismatch, UnexpectedRecordAttr, UnexpectedRestrictedExprKind,
+        ExtnCall0Arguments, JsonDeserializationError, JsonError, JsonSerializationError,
+        MissingImpliedConstructor, MissingRequiredRecordAttr, ParseEscape, ReservedKey, Residual,
+        TypeMismatch, UnexpectedRecordAttr, UnexpectedRestrictedExprKind,
     };
 }
 

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -1820,6 +1820,31 @@ mod entity_validate_tests {
         );
     }
 
+    #[test]
+    fn from_entities_action_with_unexpected_tags() {
+        let (schema, _) = Schema::from_cedarschema_str("action Act;").unwrap();
+        let entity = Entity::new_with_tags(
+            EntityUid::from_str(r#"Action::"Act""#).unwrap(),
+            [],
+            [],
+            [("foo".into(), RestrictedExpression::new_bool(false))],
+        )
+        .unwrap();
+        assert_matches!(
+            Entities::from_entities([entity], Some(&schema)),
+            Err(e @ EntitiesError::InvalidEntity(_)) => {
+                expect_err(
+                    "",
+                    &Report::new(e),
+                    &ExpectedErrorMessageBuilder::error("entity does not conform to the schema")
+                        .source(r#"definition of action `Action::"Act"` does not match its schema declaration"#)
+                        .help(r#"to use the schema's definition of `Action::"Act"`, simply omit it from the entities input data"#)
+                        .build()
+                );
+            }
+        );
+    }
+
     /// Record inside entity doesn't conform to schema
     #[test]
     #[cfg(feature = "partial-validate")]


### PR DESCRIPTION
## Description of changes

Cherry-picks:
[Update `Entity::deep_eq` to compare tags](https://github.com/cedar-policy/cedar/commit/72b3310c01266c7106da838ffb3fa6d71236ad79)

[Bug fix to filled_with_slot](https://github.com/cedar-policy/cedar/commit/1bc364953e91110362eaa0fd3465ed6de0a6be9a)

[Allow serializing `Unknown` values as `CedarValueJSON`](https://github.com/cedar-policy/cedar/commit/138f25ca18679793791eb7a152326514653bc1a6)

[Allow multiple extension function arguments in JSON entity format](https://github.com/cedar-policy/cedar/commit/218d048aa44fc1547dc06d6ef3f1fe656fd6cddc)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
