### PR TITLE
SymCC: Fix bvurem encoding typo

### DIFF
--- a/cedar-policy-symcc/src/symcc/op.rs
+++ b/cedar-policy-symcc/src/symcc/op.rs
@@ -342,7 +342,7 @@ impl Op {
             Op::Bvudiv => "bvudiv",
             Op::Bvsrem => "bvsrem",
             Op::Bvsmod => "bvsmod",
-            Op::Bvumod => "Bvurem",
+            Op::Bvumod => "bvurem",
             Op::Bvshl => "bvshl",
             Op::Bvlshr => "bvlshr",
             Op::Bvslt => "bvslt",


### PR DESCRIPTION
## Description of changes

Minor typo. bvurem/bvumod is not actually used right now.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
