### PR TITLE
Bump version to 4.5.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,6 @@ jobs:
           sed -i -E 's/^(crate-type = \["rlib", "cdylib"\]|crate-type = \["rlib"\])$/crate-type = ["lib"]/' {head,base}/cedar-policy/Cargo.toml
       - run: sudo apt-get install protobuf-compiler
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo install cargo-semver-checks
+      - run: cargo install cargo-semver-checks --locked
       - run: cargo semver-checks check-release --package cedar-policy --baseline-root ../base
         working-directory: head

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "cedar-policy-core",
  "cedar-policy-formatter",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-cli"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -315,7 +315,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-core"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "arbitrary",
  "chrono",
@@ -346,7 +346,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-policy-formatter"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "cedar-policy-core",
  "insta",
@@ -361,7 +361,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-testing"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "assert_cmd",
  "cedar-policy",
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "cedar-wasm"
-version = "4.5.0"
+version = "4.5.1"
 dependencies = [
  "cedar-policy",
  "cedar-policy-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ debug = "line-tables-only"  # this adds more debug symbols/info to the binary th
 [workspace.package]
 # Check the minimum supported Rust version with `cargo install cargo-msrv && cargo msrv --min 1.X.0` where `X` is something lower than the version noted here (to confirm that versions lower than the one noted here _don't_ work)
 rust-version = "1.82"
-version = "4.5.0"
+version = "4.5.1"
 homepage = "https://cedarpolicy.com"
 keywords = ["cedar", "authorization", "policy", "security"]
 categories = ["compilers", "config"]

--- a/cedar-policy-cli/Cargo.toml
+++ b/cedar-policy-cli/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy = { version = "=4.5.0", path = "../cedar-policy" }
-cedar-policy-formatter = { version = "=4.5.0", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=4.5.1", path = "../cedar-policy" }
+cedar-policy-formatter = { version = "=4.5.1", path = "../cedar-policy-formatter" }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -11,7 +11,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-cedar-policy-core = { version = "=4.5.0", path = "../cedar-policy-core" }
+cedar-policy-core = { version = "=4.5.1", path = "../cedar-policy-core" }
 pretty = "0.12.4"
 logos = "0.15.0"
 itertools = "0.14"

--- a/cedar-policy/Cargo.toml
+++ b/cedar-policy/Cargo.toml
@@ -11,8 +11,8 @@ homepage.workspace = true
 repository = "https://github.com/cedar-policy/cedar"
 
 [dependencies]
-cedar-policy-core = { version = "=4.5.0", path = "../cedar-policy-core" }
-cedar-policy-formatter = { version = "=4.5.0", path = "../cedar-policy-formatter" }
+cedar-policy-core = { version = "=4.5.1", path = "../cedar-policy-core" }
+cedar-policy-formatter = { version = "=4.5.1", path = "../cedar-policy-formatter" }
 ref-cast = "1.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -74,7 +74,7 @@ miette = { version = "7.6.0", features = ["fancy"] }
 cool_asserts = "2.0"
 criterion = "0.6"
 globset = "0.4"
-cedar-policy-core = { version = "=4.5.0", features = [
+cedar-policy-core = { version = "=4.5.1", features = [
     "test-util",
 ], path = "../cedar-policy-core" }
 # NON-CRYPTOGRAPHIC random number generators

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -7506,7 +7506,7 @@ mod version_tests {
 
     #[test]
     fn test_sdk_version() {
-        assert_eq!(get_sdk_version().to_string(), "4.5.0");
+        assert_eq!(get_sdk_version().to_string(), "4.5.1");
     }
 
     #[test]

--- a/cedar-testing/Cargo.toml
+++ b/cedar-testing/Cargo.toml
@@ -6,8 +6,8 @@ license.workspace = true
 publish = false
 
 [dependencies]
-cedar-policy = { version = "=4.5.0", path = "../cedar-policy" }
-cedar-policy-core = { version = "=4.5.0", path = "../cedar-policy-core" }
+cedar-policy = { version = "=4.5.1", path = "../cedar-policy" }
+cedar-policy-core = { version = "=4.5.1", path = "../cedar-policy-core" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol_str = { version = "0.3", features = ["serde"] }

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -9,9 +9,9 @@ license.workspace = true
 exclude = ['/build']
 
 [dependencies]
-cedar-policy = { version = "=4.5.0", path = "../cedar-policy", features = ["wasm"] }
-cedar-policy-core = { version = "=4.5.0", path = "../cedar-policy-core", features = ["wasm"] }
-cedar-policy-formatter = { version = "=4.5.0", path = "../cedar-policy-formatter" }
+cedar-policy = { version = "=4.5.1", path = "../cedar-policy", features = ["wasm"] }
+cedar-policy-core = { version = "=4.5.1", path = "../cedar-policy-core", features = ["wasm"] }
+cedar-policy-formatter = { version = "=4.5.1", path = "../cedar-policy-formatter" }
 
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-wasm-bindgen = "0.6"


### PR DESCRIPTION
## Description of changes

Bumps version number for new patch 4.5.1

Also cherry-picks [Fix `cargo-semver-checks` installation error](https://github.com/cedar-policy/cedar/commit/d2835f51c5cd4ac59ce1477cdb4de241d72c0eb6) to fix CI failures.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
