### PR TITLE
SymCC: Fix Unicode support in patterns

### DIFF
--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -1299,7 +1299,7 @@ mod string_encode_decode_test {
 
         for s in strs {
             let enc = encode_string(s).unwrap();
-            assert_eq!(decode_string(&enc.as_bytes()[1..enc.len() - 1]).unwrap(), s);
+            assert_eq!(decode_string(&enc.as_bytes()).unwrap(), s);
         }
     }
 }

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -553,7 +553,7 @@ pub const SMT_LIB_MAX_CODE_POINT: u32 = 196607;
 /// so cvc5 will read `\\u{0}` as a two-character string with
 /// characters `\u{5c}` and `\0`.
 pub(super) fn encode_string(s: &str) -> Option<String> {
-    let mut out = String::with_capacity(s.len() + 2);
+    let mut out = String::with_capacity(s.len());
     for c in s.chars() {
         if c == '"' {
             out.push_str("\"\"");

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -334,7 +334,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                 self.define_term(
                     ty_enc,
                     &format!(
-                        "({ty_enc} {})",
+                        "({ty_enc} \"{}\")",
                         encode_string(<EntityID as AsRef<str>>::as_ref(entity.id()))
                             .ok_or_else(|| anyhow!("unable to encode entity id in SMT as it exceeds the max supported code point: {:?}", entity.id()))?
                     ),
@@ -387,8 +387,15 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         match op {
             Op::RecordGet(a) => self.define_record_get(ty_enc, a, &args, &t).await,
             Op::StringLike(p) => {
-                self.define_term(ty_enc, &format!("(str.in_re {args} {})", encode_pattern(p)))
-                    .await
+                self.define_term(
+                    ty_enc,
+                    &format!(
+                        "(str.in_re {args} {})",
+                        encode_pattern(p)
+                            .ok_or_else(|| anyhow!("unable to encode pattern {:?} in SMT", p))?
+                    ),
+                )
+                .await
             }
             Op::Uuf(f) => {
                 let encoded_uuf = self.encode_uuf(f).await?;
@@ -419,8 +426,8 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                     }
                 }
                 TermPrim::Bitvec(bv) => encode_bitvec(bv),
-                TermPrim::String(s) => encode_string(s)
-                    .ok_or_else(|| anyhow!("unable to encode string in SMT as it exceeds the max supported code point: {:?}", s))?,
+                TermPrim::String(s) => format!("\"{}\"", encode_string(s)
+                    .ok_or_else(|| anyhow!("unable to encode string in SMT as it exceeds the max supported code point: {:?}", s))?),
                 TermPrim::Entity(e) => self.define_entity(&ty_enc, e).await?,
                 TermPrim::Ext(x) => self.define_term(&ty_enc, &encode_ext(x)).await?,
             },
@@ -547,7 +554,6 @@ pub const SMT_LIB_MAX_CODE_POINT: u32 = 196607;
 /// characters `\u{5c}` and `\0`.
 pub(super) fn encode_string(s: &str) -> Option<String> {
     let mut out = String::with_capacity(s.len() + 2);
-    out.push('"');
     for c in s.chars() {
         if c == '"' {
             out.push_str("\"\"");
@@ -564,7 +570,6 @@ pub(super) fn encode_string(s: &str) -> Option<String> {
             write!(out, "\\u{{{:x}}}", c as u32).unwrap();
         }
     }
-    out.push('"');
     Some(out)
 }
 
@@ -654,16 +659,16 @@ fn encode_op(op: &Op) -> String {
     }
 }
 
-fn encode_pat_elem(pat_elem: PatternElem) -> String {
-    match pat_elem {
+fn encode_pat_elem(pat_elem: PatternElem) -> Option<String> {
+    Some(match pat_elem {
         PatternElem::Wildcard => "(re.* re.allchar)".to_string(),
-        PatternElem::Char(c) => format!("(str.to_re \"{c}\")"),
-    }
+        PatternElem::Char(c) => format!("(str.to_re \"{}\")", encode_string(&c.to_string())?),
+    })
 }
 
-fn encode_pattern(pattern: &OrdPattern) -> String {
+fn encode_pattern(pattern: &OrdPattern) -> Option<String> {
     if pattern.get_elems().is_empty() {
-        "(str.to_re \"\")".to_string()
+        Some("(str.to_re \"\")".to_string())
     } else if pattern.get_elems().len() == 1 {
         // PANIC SAFETY
         #[allow(
@@ -672,10 +677,16 @@ fn encode_pattern(pattern: &OrdPattern) -> String {
         )]
         encode_pat_elem(pattern.get_elems()[0])
     } else {
-        format!(
+        Some(format!(
             "(re.++ {})",
-            pattern.iter().copied().map(encode_pat_elem).join(" ")
-        )
+            pattern
+                .iter()
+                .copied()
+                .map(encode_pat_elem)
+                .collect::<Option<Vec<_>>>()?
+                .into_iter()
+                .join(" ")
+        ))
     }
 }
 

--- a/cedar-policy-symcc/tests/properties.rs
+++ b/cedar-policy-symcc/tests/properties.rs
@@ -342,3 +342,9 @@ check_prop!(prop_to_days_lower,
 
 check_prop!(prop_str_empty_pattern,
     forall |a : String, b : String| !($a like "" && $b like "") || $a == $b);
+
+check_prop!(prop_str_pattern_unicode,
+    forall |a : String, b : String| !($a like "🫠" && $b like "🫠") || $a == $b);
+
+check_prop!(prop_str_pattern_quote,
+    forall |a : String, b : String| !($a like "\"" && $b like "\"") || $a == $b);


### PR DESCRIPTION
## Description of changes

Unicode is back again 🙃

This PR fixes the SMT encoding of patterns in SymCC, which previously uses an incorrect encoding of strings.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
