### PR TITLE
SymCC: Error type refactoring

### DIFF
--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.0", features = ["io-util", "process"] }
 num-bigint = "0.4"
 num-traits = "0.2"
 chrono = "0.4.41"
+miette = { version = "7.6.0" }
 
 [dev-dependencies]
 miette = { version = "7.5.0", features = ["fancy"] }

--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.0", features = ["io-util", "process"] }
 num-bigint = "0.4"
 num-traits = "0.2"
 chrono = "0.4.41"
-miette = { version = "7.6.0" }
+miette = "7.6.0"
 
 [dev-dependencies]
 miette = { version = "7.5.0", features = ["fancy"] }

--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -17,9 +17,8 @@ use miette::Diagnostic;
  */
 use thiserror::Error;
 
-pub use crate::{
-    solver::SolverError,
-    symcc::{BitVecError, CompileError, ConcretizeError, DecodeError, IPError},
+pub use crate::symcc::{
+    BitVecError, CompileError, ConcretizeError, DecodeError, EncodeError, IPError, SolverError,
 };
 
 /// Top-level errors from the whole `cedar-policy-symcc` crate.
@@ -34,9 +33,9 @@ pub enum Error {
     /// Errors during symbolic compilation.
     #[error("symbolic compilation failed")]
     CompileError(#[from] CompileError),
-    /// Errors in the SMT encoder.
+    /// Errors from the SMT encoder.
     #[error("failed to encode SMT terms")]
-    EncodeError(#[source] anyhow::Error),
+    EncodeError(#[from] EncodeError),
     /// Solver-related errors.
     #[error(transparent)]
     SolverError(#[from] SolverError),

--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -23,9 +23,6 @@ pub use crate::symcc::{
 
 /// Top-level errors from the whole `cedar-policy-symcc` crate.
 #[derive(Debug, Diagnostic, Error)]
-#[diagnostic(
-    help("if you are not using *_unchecked functions, this is likely due to a bug in the symbolic compiler or cvc5")
-)]
 pub enum Error {
     /// Action not found in schema.
     #[error("action not found in schema: {0}")]

--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -17,20 +17,22 @@ use miette::Diagnostic;
  */
 use thiserror::Error;
 
-use crate::{
-    result::CompileError,
+pub use crate::{
     solver::SolverError,
-    symcc::{ConcretizeError, DecodeError},
+    symcc::{BitVecError, CompileError, ConcretizeError, DecodeError, IPError},
 };
 
 /// Top-level errors from the whole `cedar-policy-symcc` crate.
 #[derive(Debug, Diagnostic, Error)]
+#[diagnostic(
+    help("if you are not using *_unchecked functions, this is likely due to a bug in the symbolic compiler or cvc5")
+)]
 pub enum Error {
     /// Action not found in schema.
     #[error("action not found in schema: {0}")]
     ActionNotInSchema(String),
     /// Errors during symbolic compilation.
-    #[error(transparent)]
+    #[error("symbolic compilation failed")]
     CompileError(#[from] CompileError),
     /// Errors in the SMT encoder.
     #[error("failed to encode SMT terms")]
@@ -42,13 +44,13 @@ pub enum Error {
     #[error("solver returned `unknown`")]
     SolverUnknown,
     /// Policy is not well-typed.
-    #[error("input policy (set) is not well typed")]
+    #[error("input policy (set) is not well typed with respect to the schema {errs:?}")]
     PolicyNotWellTyped { errs: Vec<ValidationError> },
     /// Failed to decode the SMT model.
     #[error("failed to decode model")]
     DecodeModel(#[from] DecodeError),
     /// Errors during concretization.
-    #[error("failed to recover a concrete counterexample: {0}")]
+    #[error("failed to recover a concrete counterexample")]
     ConcretizeError(#[from] ConcretizeError),
 }
 

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -53,12 +53,9 @@ pub struct CedarSymCompiler<S: Solver> {
 impl SymEnv {
     /// Construct a new `SymEnv` from the given `schema` and `req_env`
     pub fn new(schema: &Schema, req_env: &RequestEnv) -> Result<Self> {
-        let env = Environment::from_request_env(req_env, schema.as_ref()).ok_or_else(|| {
-            Error::Symcc(symcc::Error::ActionNotInSchema {
-                action: req_env.action().to_string(),
-            })
-        })?;
-        Self::of_env(&env).map_err(|e| Error::Symcc(symcc::Error::SymCC(e)))
+        let env = Environment::from_request_env(req_env, schema.as_ref())
+            .ok_or_else(|| Error::ActionNotInSchema(req_env.action().to_string()))?;
+        Ok(Self::of_env(&env)?)
     }
 }
 use std::fmt;
@@ -82,9 +79,7 @@ impl WellTypedPolicy {
         env: &RequestEnv,
         schema: &Schema,
     ) -> Result<WellTypedPolicy> {
-        well_typed_policy(policy.as_ref(), env, schema)
-            .map(|p| WellTypedPolicy { policy: p })
-            .map_err(Error::Symcc)
+        well_typed_policy(policy.as_ref(), env, schema).map(|p| WellTypedPolicy { policy: p })
     }
 
     /// Convers a [`Policy`] to a [`WellTypedPolicy`] unchecked.
@@ -124,9 +119,7 @@ impl WellTypedPolicies {
         env: &RequestEnv,
         schema: &Schema,
     ) -> Result<WellTypedPolicies> {
-        well_typed_policies(ps.as_ref(), env, schema)
-            .map(|ps| WellTypedPolicies { policies: ps })
-            .map_err(Error::Symcc)
+        well_typed_policies(ps.as_ref(), env, schema).map(|ps| WellTypedPolicies { policies: ps })
     }
 
     /// Converts a [`PolicySet`] to a [`WellTypedPolicies`] unchecked.
@@ -173,10 +166,7 @@ impl<S: Solver> CedarSymCompiler<S> {
         policy: &WellTypedPolicy,
         symenv: &SymEnv,
     ) -> Result<bool> {
-        Ok(self
-            .symcc
-            .check_never_errors(&policy.policy, symenv)
-            .await?)
+        self.symcc.check_never_errors(&policy.policy, symenv).await
     }
 
     /// Similar to [`Self::check_never_errors`], but returns a counterexample
@@ -186,10 +176,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         policy: &WellTypedPolicy,
         symenv: &SymEnv,
     ) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_never_errors_with_counterexample(&policy.policy, symenv)
-            .await?)
+            .await
     }
 
     /// Returns true iff the authorization decision of `pset1` implies that of
@@ -205,10 +194,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset2: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<bool> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_implies(&pset1.policies, &pset2.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Similar to [`Self::check_implies`], but returns a counterexample
@@ -219,10 +207,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset2: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_implies_with_counterexample(&pset1.policies, &pset2.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Returns true iff `pset` allows all well-formed inputs in the `symenv`.
@@ -234,10 +221,7 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<bool> {
-        Ok(self
-            .symcc
-            .check_always_allows(&pset.policies, symenv)
-            .await?)
+        self.symcc.check_always_allows(&pset.policies, symenv).await
     }
 
     /// Similar to [`Self::check_always_allows`], but returns a counterexample
@@ -247,10 +231,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_always_allows_with_counterexample(&pset.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Returns true iff `pset` denies all well-formed inputs in the `symenv`.
@@ -262,10 +245,7 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<bool> {
-        Ok(self
-            .symcc
-            .check_always_denies(&pset.policies, symenv)
-            .await?)
+        self.symcc.check_always_denies(&pset.policies, symenv).await
     }
 
     /// Similar to [`Self::check_always_denies`], but returns a counterexample
@@ -275,10 +255,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_always_denies_with_counterexample(&pset.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Returns true iff `pset1` and `pset2` produce the same authorization
@@ -292,10 +271,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset2: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<bool> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_equivalent(&pset1.policies, &pset2.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Similar to [`Self::check_equivalent`], but returns a counterexample
@@ -306,10 +284,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset2: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_equivalent_with_counterexample(&pset1.policies, &pset2.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Returns true iff there is no well-formed input in the `symenv` that is
@@ -325,10 +302,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset2: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<bool> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_disjoint(&pset1.policies, &pset2.policies, symenv)
-            .await?)
+            .await
     }
 
     /// Similar to [`Self::check_disjoint`], but returns a counterexample
@@ -339,10 +315,9 @@ impl<S: Solver> CedarSymCompiler<S> {
         pset2: &WellTypedPolicies,
         symenv: &SymEnv,
     ) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_disjoint_with_counterexample(&pset1.policies, &pset2.policies, symenv)
-            .await?)
+            .await
     }
 }
 
@@ -403,10 +378,9 @@ impl<S: Solver> CedarSymCompiler<S> {
     ///
     /// NOTE: This is an experimental feature that may break or change in the future.
     pub async fn check_unsat(&mut self, asserts: &WellFormedAsserts<'_>) -> Result<bool> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_unsat(|_| Ok(asserts.asserts().clone()), asserts.symenv())
-            .await?)
+            .await
     }
 
     /// Calls the underlying solver to check if the given `asserts` are unsatisfiable.
@@ -414,14 +388,13 @@ impl<S: Solver> CedarSymCompiler<S> {
     ///
     /// NOTE: This is an experimental feature that may break or change in the future.
     pub async fn check_sat(&mut self, asserts: &WellFormedAsserts<'_>) -> Result<Option<Env>> {
-        Ok(self
-            .symcc
+        self.symcc
             .check_sat(
                 |_| Ok(asserts.asserts().clone()),
                 asserts.symenv(),
                 asserts.footprint.iter(),
             )
-            .await?)
+            .await
     }
 }
 

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -15,7 +15,6 @@
  */
 mod err;
 
-pub use err::{Error, Result};
 mod symcc;
 use solver::Solver;
 use symcc::SymCompiler;
@@ -31,7 +30,6 @@ pub use symcc::{
     ext::Ext,
     extension_types,
     op::{ExtOp, Op, Uuf},
-    result,
     term::Term,
     term::TermPrim,
     term::TermVar,
@@ -42,6 +40,9 @@ pub use symcc::{
 };
 
 use cedar_policy::{Policy, PolicySet, RequestEnv, Schema};
+
+/// Export various error types.
+pub use err::*;
 
 /// Cedar Symbolic Compiler paramatized by a solver `S`.
 #[derive(Clone, Debug)]

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -58,11 +58,13 @@ pub use bitvec::BitVecError;
 pub use concretize::ConcretizeError;
 pub use concretize::Env;
 pub use decoder::DecodeError;
+pub use encoder::EncodeError;
 pub use env::{Environment, SymEnv};
 pub use extension_types::ipaddr::IPError;
 pub use interpretation::Interpretation;
 pub use result::CompileError;
 pub use smtlib_script::SmtLibScript;
+pub use solver::SolverError;
 pub use verifier::{
     verify_always_allows, verify_always_denies, verify_disjoint, verify_equivalent, verify_implies,
     verify_never_errors,
@@ -119,12 +121,8 @@ impl<S: Solver> SymCompiler<S> {
                 .set_logic("ALL")
                 .await
                 .map_err(|err| Error::EncodeError(err.into()))?;
-            let mut encoder =
-                Encoder::new(symenv, self.solver.smtlib_input()).map_err(Error::EncodeError)?;
-            encoder
-                .encode(asserts.iter())
-                .await
-                .map_err(Error::EncodeError)?;
+            let mut encoder = Encoder::new(symenv, self.solver.smtlib_input())?;
+            encoder.encode(asserts.iter()).await?;
             match self.solver.check_sat().await? {
                 Decision::Unsat => Ok(true),
                 Decision::Sat => Ok(false),

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -33,7 +33,7 @@ pub mod factory;
 mod function;
 mod interpretation;
 pub mod op;
-pub mod result;
+mod result;
 mod smtlib_script;
 pub mod solver;
 mod tags;
@@ -52,21 +52,21 @@ use encoder::Encoder;
 use solver::{Decision, Solver};
 use verifier::Asserts;
 
-use crate::err::Error;
-use crate::result::CompileError;
+use crate::err::{Error, Result};
 
+pub use bitvec::BitVecError;
 pub use concretize::ConcretizeError;
 pub use concretize::Env;
 pub use decoder::DecodeError;
 pub use env::{Environment, SymEnv};
+pub use extension_types::ipaddr::IPError;
 pub use interpretation::Interpretation;
+pub use result::CompileError;
 pub use smtlib_script::SmtLibScript;
 pub use verifier::{
     verify_always_allows, verify_always_denies, verify_disjoint, verify_equivalent, verify_implies,
     verify_never_errors,
 };
-
-pub type Result<T> = std::result::Result<T, Error>;
 
 /// Corresponds to the `SolverM` monad in Lean
 #[derive(Debug, Clone)]

--- a/cedar-policy-symcc/src/symcc/authorizer.rs
+++ b/cedar-policy-symcc/src/symcc/authorizer.rs
@@ -20,7 +20,7 @@ use crate::symcc::{
     compiler::compile,
     env::SymEnv,
     factory::{and, eq, not, or, some_of},
-    result,
+    result::CompileError,
     term::Term,
 };
 
@@ -28,7 +28,7 @@ pub fn satisfied_with_effect(
     effect: Effect,
     policy: &Policy,
     env: &SymEnv,
-) -> Result<Option<Term>, result::Error> {
+) -> Result<Option<Term>, CompileError> {
     if policy.effect() == effect {
         Ok(Some(compile(&policy.condition(), env)?))
     } else {
@@ -45,16 +45,16 @@ pub fn satisfied_policies(
     effect: Effect,
     policies: &PolicySet,
     env: &SymEnv,
-) -> Result<Term, result::Error> {
+) -> Result<Term, CompileError> {
     let terms = policies
         .policies()
         .filter_map(|p| satisfied_with_effect(effect, p, env).transpose())
-        .collect::<Result<Vec<Term>, result::Error>>()?
+        .collect::<Result<Vec<Term>, CompileError>>()?
         .into_iter();
     Ok(any_satisfied(terms))
 }
 
-pub fn is_authorized(policies: &PolicySet, env: &SymEnv) -> Result<Term, result::Error> {
+pub fn is_authorized(policies: &PolicySet, env: &SymEnv) -> Result<Term, CompileError> {
     let forbids = satisfied_policies(Effect::Forbid, policies, env)?;
     let permits = satisfied_policies(Effect::Permit, policies, env)?;
     Ok(and(permits, not(forbids)))

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -45,8 +45,8 @@ pub enum BitVecError {
     /// Mismatched bit-vector widths in various operations
     #[error("mismatched bit-vector widths in {0}")]
     MismatchedWidths(String),
-    /// Shifting by a value greater than the bit-width
-    #[error("shifting by a value greater than the bit-width")]
+    /// Shifting value would not fit in the bit-width
+    #[error("shifted value would not fit in the bit-width")]
     ShiftAmountTooLarge,
 }
 

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -45,8 +45,8 @@ pub enum BitVecError {
     /// Mismatched bit-vector widths in various operations
     #[error("mismatched bit-vector widths in {0}")]
     MismatchedWidths(String),
-    /// Shifting value would not fit in the bit-width
-    #[error("shifted value would not fit in the bit-width")]
+    /// Shift amount too large to fit in u32
+    #[error("shift amount too large to fit in u32")]
     ShiftAmountTooLarge,
 }
 

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -34,7 +34,7 @@ pub struct BitVec {
 pub static TWO: LazyLock<BigUint> = LazyLock::new(|| BigUint::from(2u128));
 
 /// Errors in [`BitVec`] operations.
-#[derive(Clone, Diagnostic, Debug, PartialEq, Eq, Error)]
+#[derive(Debug, Diagnostic, Error)]
 pub enum BitVecError {
     /// Extract out of bounds
     #[error("extract out of bounds")]

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -37,14 +37,13 @@ use super::factory::{
     self, if_all_some, if_some, is_some, ite, option_get, record_get, record_of, some_of,
 };
 use super::function::UnaryFunction;
-use super::result::Error;
+use super::result::CompileError;
 use super::tags::SymTags;
 use super::term::{Term, TermPrim};
 use super::term_type::TermType;
 use super::type_abbrevs::*;
 
-//Utilities
-type Result<T> = std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, CompileError>;
 
 fn compile_prim(p: &Prim, es: &SymEntities) -> Result<Term> {
     match p {
@@ -56,7 +55,7 @@ fn compile_prim(p: &Prim, es: &SymEntities) -> Result<Term> {
             if es.is_valid_entity_uid(uid) {
                 Ok(some_of(uid.clone().into()))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
     }
@@ -68,28 +67,28 @@ fn compile_var(v: Var, req: &SymRequest) -> Result<Term> {
             if req.principal.type_of().is_entity_type() {
                 Ok(some_of(req.principal.clone()))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
         Var::Action => {
             if req.action.type_of().is_entity_type() {
                 Ok(some_of(req.action.clone()))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
         Var::Resource => {
             if req.resource.type_of().is_entity_type() {
                 Ok(some_of(req.resource.clone()))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
         Var::Context => {
             if req.context.type_of().is_record_type() {
                 Ok(some_of(req.context.clone()))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
     }
@@ -106,7 +105,7 @@ fn compile_app1(op1: UnaryOp, t: Term) -> Result<Term> {
         // No `like` or `is` cases here, because in Rust those are not
         // `UnaryOp`s, so we can't fully match the Lean.
         // In Rust we handle those in `compile_like()` and `compile_is()`.
-        (_, _) => Err(Error::TypeError),
+        (_, _) => Err(CompileError::TypeError),
     }
 }
 
@@ -115,7 +114,7 @@ fn compile_app1(op1: UnaryOp, t: Term) -> Result<Term> {
 fn compile_like(t: Term, pat: OrdPattern) -> Result<Term> {
     match t.type_of() {
         TermType::String => Ok(some_of(factory::string_like(t, pat))),
-        _ => Err(Error::TypeError),
+        _ => Err(CompileError::TypeError),
     }
 }
 
@@ -124,7 +123,7 @@ fn compile_like(t: Term, pat: OrdPattern) -> Result<Term> {
 fn compile_is(t: &Term, ety1: &EntityType) -> Result<Term> {
     match t.type_of() {
         TermType::Entity { ety: ety2 } => Ok(some_of((ety1 == &ety2).into())),
-        _ => Err(Error::TypeError),
+        _ => Err(CompileError::TypeError),
     }
 }
 
@@ -143,7 +142,7 @@ fn reducible_eq(ty1: &TermType, ty2: &TermType) -> Result<bool> {
     } else if ty1.is_prim_type() && ty2.is_prim_type() {
         Ok(false)
     } else {
-        Err(Error::TypeError)
+        Err(CompileError::TypeError)
     }
 }
 
@@ -176,18 +175,28 @@ pub fn compile_in_set(t: Term, ts: Term, ancs: Option<UnaryFunction>) -> Term {
     factory::or(is_in1, is_in2)
 }
 
-pub fn compile_has_tag(entity: Term, tag: Term, tags: Option<&Option<SymTags>>) -> Result<Term> {
+pub fn compile_has_tag(
+    entity: Term,
+    tag: Term,
+    tags: Option<&Option<SymTags>>,
+    ety: &EntityType,
+) -> Result<Term> {
     match tags {
-        None => Err(Error::NoSuchEntityType),
+        None => Err(CompileError::NoSuchEntityType(ety.clone())),
         Some(None) => Ok(some_of(false.into())),
         Some(Some(tags)) => Ok(some_of(tags.has_tag(entity, tag))),
     }
 }
 
-pub fn compile_get_tag(entity: Term, tag: Term, tags: Option<&Option<SymTags>>) -> Result<Term> {
+pub fn compile_get_tag(
+    entity: Term,
+    tag: Term,
+    tags: Option<&Option<SymTags>>,
+    ety: &EntityType,
+) -> Result<Term> {
     match tags {
-        None => Err(Error::NoSuchEntityType),
-        Some(None) => Err(Error::TypeError), // no tags declared
+        None => Err(CompileError::NoSuchEntityType(ety.clone())),
+        Some(None) => Err(CompileError::TypeError), // no tags declared
         Some(Some(tags)) => Ok(tags.get_tag(entity, tag)),
     }
 }
@@ -238,21 +247,21 @@ pub fn compile_app2(op2: BinaryOp, t1: Term, t2: Term, es: &SymEntities) -> Resu
             if *ty1 == ty2 {
                 Ok(some_of(factory::set_member(t2, t1)))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
         (ContainsAll, Set { ty: ty1 }, Set { ty: ty2 }) => {
             if *ty1 == *ty2 {
                 Ok(some_of(factory::set_subset(t2, t1)))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
         (ContainsAny, Set { ty: ty1 }, Set { ty: ty2 }) => {
             if *ty1 == *ty2 {
                 Ok(some_of(factory::set_intersects(t1, t2)))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
         (In, Entity { ety: ety1 }, Entity { ety: ety2 }) => Ok(some_of(compile_in_ent(
@@ -275,9 +284,9 @@ pub fn compile_app2(op2: BinaryOp, t1: Term, t2: Term, es: &SymEntities) -> Resu
                 _ => unreachable!("We just matched with entity type above"),
             }
         }
-        (HasTag, Entity { ety }, String) => compile_has_tag(t1, t2, es.tags(&ety)),
-        (GetTag, Entity { ety }, String) => compile_get_tag(t1, t2, es.tags(&ety)),
-        (_, _, _) => Err(Error::TypeError),
+        (HasTag, Entity { ety }, String) => compile_has_tag(t1, t2, es.tags(&ety), &ety),
+        (GetTag, Entity { ety }, String) => compile_get_tag(t1, t2, es.tags(&ety), &ety),
+        (_, _, _) => Err(CompileError::TypeError),
     }
 }
 
@@ -285,10 +294,10 @@ pub fn compile_attrs_of(t: Term, es: &SymEntities) -> Result<Term> {
     match t.type_of() {
         TermType::Entity { ety } => match es.attrs(&ety) {
             Some(attrs) => Ok(factory::app(attrs.clone(), t)),
-            None => Err(Error::NoSuchEntityType),
+            None => Err(CompileError::NoSuchEntityType(ety)),
         },
         TermType::Record { .. } => Ok(t),
-        _ => Err(Error::TypeError),
+        _ => Err(CompileError::TypeError),
     }
 }
 
@@ -300,7 +309,7 @@ pub fn compile_has_attr(t: Term, a: &Attr, es: &SymEntities) -> Result<Term> {
             Some(_) => Ok(true.into()),
             None => Ok(false.into()),
         },
-        _ => Err(Error::TypeError),
+        _ => Err(CompileError::TypeError),
     }
 }
 
@@ -310,9 +319,9 @@ pub fn compile_get_attr(t: Term, a: &Attr, es: &SymEntities) -> Result<Term> {
         TermType::Record { rty } => match rty.get(a) {
             Some(ty) if ty.is_option_type() => Ok(record_get(attrs, a)),
             Some(_) => Ok(some_of(record_get(attrs, a))),
-            None => Err(Error::NoSuchAttribute),
+            None => Err(CompileError::NoSuchAttribute),
         },
-        _ => Err(Error::TypeError),
+        _ => Err(CompileError::TypeError),
     }
 }
 
@@ -329,10 +338,10 @@ pub fn compile_if(t1: Term, r2: Result<Term>, r3: Result<Term>) -> Result<Term> 
                     factory::ite(factory::option_get(t1), t2, t3),
                 ))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
-        (_, _) => Err(Error::TypeError),
+        (_, _) => Err(CompileError::TypeError),
     }
 }
 
@@ -347,10 +356,10 @@ pub fn compile_and(t1: Term, r2: Result<Term>) -> Result<Term> {
                     ite(option_get(t1), t2, some_of(false.into())),
                 ))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
-        (_, _) => Err(Error::TypeError),
+        (_, _) => Err(CompileError::TypeError),
     }
 }
 
@@ -365,16 +374,18 @@ pub fn compile_or(t1: Term, r2: Result<Term>) -> Result<Term> {
                     ite(option_get(t1), some_of(true.into()), t2),
                 ))
             } else {
-                Err(Error::TypeError)
+                Err(CompileError::TypeError)
             }
         }
-        (_, _) => Err(Error::TypeError),
+        (_, _) => Err(CompileError::TypeError),
     }
 }
 
 pub fn compile_set(ts: Vec<Term>) -> Result<Term> {
     if ts.is_empty() {
-        Err(Error::UnsupportedError) // Reject empty set literals
+        Err(CompileError::UnsupportedFeature(
+            "empty set literals are not supported".to_string(),
+        )) // Reject empty set literals
     } else {
         // PANIC SAFETY
         #[allow(
@@ -392,10 +403,10 @@ pub fn compile_set(ts: Vec<Term>) -> Result<Term> {
                         )),
                     ))
                 } else {
-                    Err(Error::TypeError)
+                    Err(CompileError::TypeError)
                 }
             }
-            _ => Err(Error::TypeError),
+            _ => Err(CompileError::TypeError),
         }
     }
 }
@@ -416,11 +427,11 @@ pub fn compile_call0(mk: impl Fn(String) -> Option<Ext>, arg: Term) -> Result<Te
         Term::Some(t) => match Arc::unwrap_or_clone(t) {
             Term::Prim(TermPrim::String(s)) => match mk(s) {
                 Some(v) => Ok(some_of(v.into())),
-                None => Err(Error::TypeError),
+                None => Err(CompileError::TypeError),
             },
-            _ => Err(Error::TypeError),
+            _ => Err(CompileError::TypeError),
         },
-        _ => Err(Error::TypeError),
+        _ => Err(CompileError::TypeError),
     }
 }
 
@@ -432,7 +443,7 @@ pub fn compile_call1_error(xty: ExtType, enc: impl Fn(Term) -> Term, t1: Term) -
     if t1.type_of() == ty {
         Ok(if_some(t1.clone(), enc(option_get(t1))))
     } else {
-        Err(Error::TypeError)
+        Err(CompileError::TypeError)
     }
 }
 
@@ -462,7 +473,7 @@ pub fn compile_call2_error(
             if_some(t2.clone(), enc(option_get(t1), option_get(t2))),
         ))
     } else {
-        Err(Error::TypeError)
+        Err(CompileError::TypeError)
     }
 }
 
@@ -596,7 +607,7 @@ pub fn compile_call(xfn: &cedar_policy_core::ast::Name, ts: Vec<Term>) -> Result
             let t1 = extract_first(ts);
             compile_call1(ExtType::Duration, extfun::to_days, t1)
         }
-        (_, _) => Err(Error::TypeError),
+        (_, _) => Err(CompileError::TypeError),
     }
 }
 
@@ -607,8 +618,12 @@ pub fn compile(x: &Expr, env: &SymEnv) -> Result<Term> {
     match x.expr_kind() {
         ExprKind::Lit(l) => compile_prim(l, &env.entities),
         ExprKind::Var(v) => compile_var(*v, &env.request),
-        ExprKind::Slot(_) => Err(Error::UnsupportedError), // analyzing templates is not supported
-        ExprKind::Unknown(_) => Err(Error::UnsupportedError), // analyzing partial expressions is not supported
+        ExprKind::Slot(_) => Err(CompileError::UnsupportedFeature(
+            "templates/slots are not supported".to_string(),
+        )),
+        ExprKind::Unknown(_) => Err(CompileError::UnsupportedFeature(
+            "partial evaluation is not supported".to_string(),
+        )),
         ExprKind::If {
             test_expr: x1,
             then_expr: x2,
@@ -699,7 +714,7 @@ mod decimal_tests {
 
     use cedar_policy::{RequestEnv, Schema};
 
-    use crate::symcc::{extension_types::decimal::Decimal, result::Error};
+    use crate::symcc::{extension_types::decimal::Decimal, result::CompileError};
 
     use std::str::FromStr;
 
@@ -770,7 +785,7 @@ mod decimal_tests {
         let sym_env = SymEnv::new(&decimal_schema(), &request_env()).expect("Malformed sym env.");
         assert_eq!(
             compile(&dec_lit(str), &sym_env),
-            Err(Error::TypeError),
+            Err(CompileError::TypeError),
             "{msg}"
         );
     }
@@ -810,7 +825,7 @@ mod decimal_tests {
         let s = Expr::get_attr(Expr::var(Var::Context), "s".into());
         assert_eq!(
             compile(&dec_expr(s), &sym_env()),
-            Err(Error::TypeError),
+            Err(CompileError::TypeError),
             "Error: applying decimal constructor to a non-literal"
         );
     }
@@ -843,7 +858,7 @@ mod datetime_tests {
 
     use crate::symcc::{
         extension_types::datetime::{Datetime, Duration},
-        result::Error,
+        result::CompileError,
     };
 
     use super::*;
@@ -945,7 +960,7 @@ mod datetime_tests {
         let sym_env = SymEnv::new(&datetime_schema(), &request_env()).expect("Malformed sym env.");
         assert_eq!(
             compile(&datetime_lit(str), &sym_env),
-            Err(Error::TypeError),
+            Err(CompileError::TypeError),
             "{msg}"
         );
     }
@@ -968,7 +983,7 @@ mod datetime_tests {
         let sym_env = SymEnv::new(&duration_schema(), &request_env()).expect("Malformed sym env.");
         assert_eq!(
             compile(&duration_lit(str), &sym_env),
-            Err(Error::TypeError),
+            Err(CompileError::TypeError),
             "{msg}"
         );
     }

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -385,7 +385,7 @@ pub fn compile_set(ts: Vec<Term>) -> Result<Term> {
     if ts.is_empty() {
         Err(CompileError::UnsupportedFeature(
             "empty set literals are not supported".to_string(),
-        )) // Reject empty set literals
+        ))
     } else {
         // PANIC SAFETY
         #[allow(

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -19,22 +19,23 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Display;
-use std::io;
 use std::sync::Arc;
 
 use cedar_policy::{EntityId, EntityUid};
 use itertools::Itertools;
+use miette::Diagnostic;
 use num_bigint::BigUint;
 
 use thiserror::Error;
 
+use crate::symcc::bitvec::BitVecError;
 use crate::symcc::encoder::SMT_LIB_MAX_CODE_POINT;
 use crate::symcc::env::SymEntityData;
 use crate::symcc::extension_types::ipaddr::{
     CIDRv4, CIDRv6, IPv4Addr, IPv4Prefix, IPv6Addr, IPv6Prefix,
 };
 use crate::symcc::type_abbrevs::{ExtType, Width};
-use crate::{symcc, SymEnv};
+use crate::SymEnv;
 
 use super::bitvec::BitVec;
 use super::encoder::Encoder;
@@ -49,71 +50,68 @@ use super::op::Uuf;
 use super::term::{Term, TermPrim, TermVar};
 use super::term_type::TermType;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Clone, Diagnostic, Error)]
 pub enum DecodeError {
-    /// IO error
-    #[error("IO error during decoding: {0}")]
-    Io(#[from] io::Error),
-
+    /// Unexpected end of input.
     #[error("Unexpected end of input")]
     UnexpectedEnd,
-
+    /// UTF-8 decoding error.
     #[error("Invalid UTF-8 sequence: {0}")]
-    UTF8Error(#[from] std::string::FromUtf8Error),
-
+    Utf8Error(#[from] std::string::FromUtf8Error),
+    /// Failed to parse an SMT string.
     #[error("Failed to parse string: {0:?}")]
     StringParseError(Vec<u8>),
-
+    /// Failed to parse an SMT numeral.
     #[error("Invalid numeric token: {0}")]
     ParseIntError(#[from] std::num::ParseIntError),
-
-    #[error("Right parenthesis without left parenthesis")]
-    RightParenWithoutLeftParen,
-
+    /// Unclosed S-expression.
+    #[error("Unclosed S-expression")]
+    UnclosedSExpr,
+    /// Trailing unparsed tokens.
     #[error("Trailing tokens")]
     TrailingTokens,
-
+    /// Integer overflow.
     #[error("Integer overflow")]
     IntegerOverflow,
-
-    #[error("Model of unexpected form returned by the solver")]
+    /// Model of an unexpected form returned by the solver.
+    #[error("Model of an unexpected form returned by the solver")]
     UnexpectedModel,
-
-    #[error("Unknown type: {0}")]
+    /// Unknown SMT type.
+    #[error("Unknown SMT type: {0}")]
     UnknownType(SExpr),
-
-    #[error("Unknown literal: {0}")]
+    /// Unknown SMT literal.
+    #[error("Unknown SMT literal: {0}")]
     UnknownLiteral(SExpr),
-
+    /// Unmatched types.
     #[error("Unmatched type: expected {0:?}, found {1:?}")]
     UnmatchedType(TermType, TermType),
-
+    /// Unmatched field type.
     #[error("Unmatched field type: expected {0:?}, found {1:?}")]
     UnmatchedFieldType(TermType, TermType),
-
+    /// Invalid set type.
     #[error("Invalid set type: {0}")]
     InvalidSetType(SExpr),
-
+    /// Invalid option type.
     #[error("Invalid option type: {0}")]
     InvalidOptionType(SExpr),
-
+    /// `set.union` applied to non-literals.
     #[error("set.union applied to non-literals {0:?} and {1:?}")]
     SetUnionNonLiterals(Term, Term),
-
+    /// Unmatched record type fields.
     #[error("Unmatched record type fields")]
     UnmatchedRecordType,
-
+    /// Unknown variable.
     #[error("Unknown variable: {0}")]
     UnknownVariable(String),
-
+    /// Unknown unary function.
     #[error("Unknown unary function: {0}")]
     UnknownUUF(String),
-
-    #[error("Unexpected unary function form: {0}")]
+    /// Unexpected form of unary function model.
+    #[error("Unexpected form of unary function model: {0}")]
     UnexpectedUnaryFunctionForm(SExpr),
-
-    #[error("Unexpected symcc result error: {0}.")]
-    UnexpectedSymccResult(#[from] symcc::result::Error),
+    /// Bit-vector error.
+    #[error("Bit-vector error")]
+    BitVecError(#[from] BitVecError),
 }
 
 /// Types of tokens
@@ -408,10 +406,10 @@ fn tokenize(src: &[u8]) -> Result<Vec<Token>, DecodeError> {
                                 let width = Width::try_from(width)
                                     .map_err(|_| DecodeError::IntegerOverflow)?;
 
-                                tokens.push(Token::Atom(SExpr::BitVec(
-                                    BitVec::of_int(width, num.into())
-                                        .map_err(DecodeError::UnexpectedSymccResult)?,
-                                )));
+                                tokens.push(Token::Atom(SExpr::BitVec(BitVec::of_int(
+                                    width,
+                                    num.into(),
+                                )?)));
                             }
 
                             // TODO: support #x...
@@ -514,7 +512,7 @@ pub fn parse_sexpr(src: &[u8]) -> Result<SExpr, DecodeError> {
             Token::LeftParen => stack.push_back(Vec::new()),
             Token::RightParen => {
                 let Some(exprs) = stack.pop_back() else {
-                    return Err(DecodeError::RightParenWithoutLeftParen);
+                    return Err(DecodeError::UnclosedSExpr);
                 };
 
                 if let Some(last) = stack.back_mut() {

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -50,7 +50,7 @@ use super::op::Uuf;
 use super::term::{Term, TermPrim, TermVar};
 use super::term_type::TermType;
 
-#[derive(Debug, Clone, Diagnostic, Error)]
+#[derive(Debug, Diagnostic, Error)]
 pub enum DecodeError {
     /// Unexpected end of input.
     #[error("Unexpected end of input")]

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -455,7 +455,10 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                     }
                 }
                 TermPrim::Bitvec(bv) => encode_bitvec(bv),
-                TermPrim::String(s) => format!("\"{}\"", encode_string(s).ok_or_else(|| EncodeError::EncodeStringFailed(s.clone()))?),
+                TermPrim::String(s) => format!(
+                    "\"{}\"",
+                    encode_string(s).ok_or_else(|| EncodeError::EncodeStringFailed(s.clone()))?
+                ),
                 TermPrim::Entity(e) => self.define_entity(&ty_enc, e).await?,
                 TermPrim::Ext(x) => self.define_term(&ty_enc, &encode_ext(x)).await?,
             },

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -57,11 +57,12 @@
 //!  of every s-expression in the encoding consists of atomic subterms (identifiers
 //!  or literals).
 
-use anyhow::anyhow;
 use async_recursion::async_recursion;
 use itertools::Itertools;
+use miette::Diagnostic;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
+use thiserror::Error;
 
 use cedar_policy_core::ast::PatternElem;
 
@@ -78,6 +79,40 @@ use super::{
 };
 
 use crate::symcc::extension_types::ipaddr::{V4_WIDTH, V6_WIDTH};
+use crate::BitVecError;
+
+#[derive(Debug, Diagnostic, Error)]
+pub enum EncodeError {
+    /// IO error.
+    #[error("IO error during SMT encoding")]
+    Io(#[from] std::io::Error),
+    /// Missing member in enum entity.
+    #[error("missing member {0} in enum entity")]
+    EnumMissingMember(EntityUID),
+    /// Record missing attribute.
+    #[error("record missing attribute {0}")]
+    RecordMissingAttr(Attr),
+    /// Expecting a record type.
+    #[error("expecting a record type, got {0:?}")]
+    ExpectRecord(TermType),
+    /// Missing type encoding.
+    #[error("missing type encoding for {0:?}")]
+    MissingTypeEncoding(TermType),
+    /// Malformed record get.
+    #[error("malformed record get")]
+    MalformedRecordGet,
+    /// Unable to encode string.
+    #[error("unable to encode string \"{0}\" in SMT as it exceeds the max supported code point")]
+    EncodeStringFailed(String),
+    /// Unable to encode pattern.
+    #[error("unable to encode pattern {0:?} in SMT as it exceeds the max supported code point")]
+    EncodePatternFailed(OrdPattern),
+    /// Bit-vector error.
+    #[error("bit-vector error")]
+    BitVecError(#[from] BitVecError),
+}
+
+type Result<T> = std::result::Result<T, EncodeError>;
 
 #[derive(Debug)]
 pub struct Encoder<'a, S> {
@@ -119,7 +154,7 @@ fn record_attr_id(r: &str, n: usize) -> String {
 
 impl<'a, S> Encoder<'a, S> {
     /// Corresponds to `EncoderState.init` in Lean
-    pub fn new(env: &'a SymEnv, script: S) -> Result<Self, anyhow::Error> {
+    pub fn new(env: &'a SymEnv, script: S) -> Result<Self> {
         Ok(Encoder {
             terms: BTreeMap::new(),
             types: BTreeMap::new(),
@@ -140,12 +175,12 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         &mut self,
         id: &'i str,
         mks: impl IntoIterator<Item = String>,
-    ) -> Result<&'i str, anyhow::Error> {
+    ) -> Result<&'i str> {
         self.script.declare_datatype(id, vec![], mks).await?;
         Ok(id)
     }
 
-    pub async fn declare_entity_type(&mut self, ety: &EntityType) -> Result<String, anyhow::Error> {
+    pub async fn declare_entity_type(&mut self, ety: &EntityType) -> Result<String> {
         let ety_id = entity_type_id(self.types.len());
         match self.enums.get(ety) {
             Some(members) => {
@@ -168,7 +203,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         }
     }
 
-    pub async fn declare_ext_type(&mut self, ext_ty: &ExtType) -> Result<&str, anyhow::Error> {
+    pub async fn declare_ext_type(&mut self, ext_ty: &ExtType) -> Result<&str> {
         match ext_ty {
             ExtType::Decimal => {
                 self.declare_type(
@@ -207,7 +242,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     pub async fn declare_record_type<'r>(
         &mut self,
         rty: impl IntoIterator<Item = &'r (Attr, String)> + Clone,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String> {
         let rty_id = record_type_id(self.types.len());
         let mut attrs = rty
             .clone()
@@ -226,7 +261,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     }
 
     #[async_recursion]
-    pub async fn encode_type(&mut self, ty: &TermType) -> Result<String, anyhow::Error> {
+    pub async fn encode_type(&mut self, ty: &TermType) -> Result<String> {
         match self.types.get(ty) {
             Some(enc) => Ok(enc.clone()),
             None => {
@@ -254,22 +289,14 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         }
     }
 
-    pub async fn declare_var(
-        &mut self,
-        v: &TermVar,
-        ty_enc: &str,
-    ) -> Result<String, anyhow::Error> {
+    pub async fn declare_var(&mut self, v: &TermVar, ty_enc: &str) -> Result<String> {
         let id = term_id(self.terms.len());
         self.script.comment(&format!("{:?}", v.id)).await?;
         self.script.declare_const(&id, ty_enc).await?;
         Ok(id)
     }
 
-    pub async fn define_term(
-        &mut self,
-        ty_enc: &str,
-        t_enc: &str,
-    ) -> Result<String, anyhow::Error> {
+    pub async fn define_term(&mut self, ty_enc: &str, t_enc: &str) -> Result<String> {
         let id = term_id(self.terms.len());
         self.script.define_fun(&id, [], ty_enc, t_enc).await?;
         Ok(id)
@@ -279,7 +306,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         &mut self,
         ty_enc: &str,
         t_encs: impl IntoIterator<Item = &'s str>,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String> {
         let members = t_encs
             .into_iter()
             .fold(format!("(as set.empty {ty_enc})"), |acc, t| {
@@ -292,7 +319,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         &mut self,
         ty_enc: &str,
         t_encs: impl IntoIterator<Item = &'s str>,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String> {
         self.define_term(
             ty_enc,
             &format!("({ty_enc} {})", t_encs.into_iter().join(" ")),
@@ -300,7 +327,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         .await
     }
 
-    pub async fn encode_uuf(&mut self, uuf: &Uuf) -> Result<String, anyhow::Error> {
+    pub async fn encode_uuf(&mut self, uuf: &Uuf) -> Result<String> {
         match self.uufs.get(uuf) {
             Some(enc) => Ok(enc.clone()),
             None => {
@@ -317,16 +344,15 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         }
     }
 
-    pub async fn define_entity(
-        &mut self,
-        ty_enc: &str,
-        entity: &EntityUID,
-    ) -> Result<String, anyhow::Error> {
+    pub async fn define_entity(&mut self, ty_enc: &str, entity: &EntityUID) -> Result<String> {
         match self.enums.get(entity.type_name()) {
             Some(members) => {
-                let entity_ind = match members.iter().position(|s| s ==  <EntityID as AsRef<str>>::as_ref(entity.id())) {
+                let entity_ind = match members
+                    .iter()
+                    .position(|s| s == <EntityID as AsRef<str>>::as_ref(entity.id()))
+                {
                     Some(ind) => ind,
-                    None => return Err(anyhow!("members should contain entity.id()! Entity: {entity:?} \n Members: {members:?}"))
+                    None => return Err(EncodeError::EnumMissingMember(entity.clone())),
                 };
                 Ok(enum_id(ty_enc, entity_ind))
             }
@@ -335,8 +361,9 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                     ty_enc,
                     &format!(
                         "({ty_enc} \"{}\")",
-                        encode_string(<EntityID as AsRef<str>>::as_ref(entity.id()))
-                            .ok_or_else(|| anyhow!("unable to encode entity id in SMT as it exceeds the max supported code point: {:?}", entity.id()))?
+                        encode_string(<EntityID as AsRef<str>>::as_ref(entity.id())).ok_or_else(
+                            || EncodeError::EncodeStringFailed(format!("{:?}", entity.id()))
+                        )?
                     ),
                 )
                 .await
@@ -344,15 +371,15 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         }
     }
 
-    fn index_of_attr(a: &Attr, t_ty: &TermType) -> Result<usize, anyhow::Error> {
+    fn index_of_attr(a: &Attr, t_ty: &TermType) -> Result<usize> {
         // Getting the index of a key in `BTreeMap` should be ok
         // (it wouldn't be for `HashMap`)
         match t_ty {
             TermType::Record { rty } => match rty.keys().position(|k| k == a) {
                 Some(ind) => Ok(ind),
-                None => Err(anyhow!("Could not find {a:?} in {rty:?}")),
+                None => Err(EncodeError::RecordMissingAttr(a.clone())),
             },
-            _ => Err(anyhow!("Bad term: (record.get {a} {t_ty:?})")),
+            _ => Err(EncodeError::ExpectRecord(t_ty.clone())),
         }
     }
 
@@ -362,10 +389,10 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         a: &Attr,
         t_enc: &str,
         ty: &TermType,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String> {
         let r_id = match self.types.get(ty) {
             Some(t) => t,
-            None => return Err(anyhow!("Could not find {ty:?} in {:?}", self.types)),
+            None => return Err(EncodeError::MissingTypeEncoding(ty.clone())),
         };
         let a_id = Self::index_of_attr(a, ty)?;
         self.define_term(ty_enc, &format!("({} {t_enc})", record_attr_id(r_id, a_id)))
@@ -378,21 +405,23 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         op: &Op,
         t_encs: impl IntoIterator<Item = String>,
         ts: impl IntoIterator<Item = &'b Term>,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<String> {
         let args = t_encs.into_iter().join(" ");
-        let t = match ts.into_iter().next() {
-            Some(t) => t.type_of(),
-            None => return Err(anyhow!("cannot get type of non-existant type")),
-        };
         match op {
-            Op::RecordGet(a) => self.define_record_get(ty_enc, a, &args, &t).await,
+            Op::RecordGet(a) => {
+                let ty = match ts.into_iter().next() {
+                    Some(t) => t.type_of(),
+                    None => return Err(EncodeError::MalformedRecordGet),
+                };
+                self.define_record_get(ty_enc, a, &args, &ty).await
+            }
             Op::StringLike(p) => {
                 self.define_term(
                     ty_enc,
                     &format!(
                         "(str.in_re {args} {})",
                         encode_pattern(p)
-                            .ok_or_else(|| anyhow!("unable to encode pattern {:?} in SMT", p))?
+                            .ok_or_else(|| EncodeError::EncodePatternFailed(p.clone()))?
                     ),
                 )
                 .await
@@ -410,7 +439,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     }
 
     #[async_recursion]
-    pub async fn encode_term(&mut self, t: &Term) -> Result<String, anyhow::Error> {
+    pub async fn encode_term(&mut self, t: &Term) -> Result<String> {
         if let Some(enc) = self.terms.get(t) {
             return Ok(enc.clone());
         }
@@ -426,8 +455,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                     }
                 }
                 TermPrim::Bitvec(bv) => encode_bitvec(bv),
-                TermPrim::String(s) => format!("\"{}\"", encode_string(s)
-                    .ok_or_else(|| anyhow!("unable to encode string in SMT as it exceeds the max supported code point: {:?}", s))?),
+                TermPrim::String(s) => format!("\"{}\"", encode_string(s).ok_or_else(|| EncodeError::EncodeStringFailed(s.clone()))?),
                 TermPrim::Entity(e) => self.define_entity(&ty_enc, e).await?,
                 TermPrim::Ext(x) => self.define_term(&ty_enc, &encode_ext(x)).await?,
             },
@@ -515,10 +543,7 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     /// construct an `Encoder` (`EncoderState` in Lean), and then does the encoding.
     /// Here in Rust, we have this as a method on `Encoder`, so the caller first
     /// constructs an `Encoder` themselves with the `SymEnv`, then calls this.
-    pub async fn encode(
-        &mut self,
-        ts: impl IntoIterator<Item = &Term>,
-    ) -> Result<(), anyhow::Error> {
+    pub async fn encode(&mut self, ts: impl IntoIterator<Item = &Term>) -> Result<()> {
         self.script
             .declare_datatype(
                 "Option",

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -19,16 +19,16 @@
 //! A symbolic environment is _literal_ when it consists of literal terms and
 //! interpreted functions (UDFs).
 
-use crate::result::CompileError;
-use crate::symcc::function::{
+use super::function::{
     self,
     UnaryFunction::{self, Udf, Uuf},
 };
-use crate::symcc::op;
-use crate::symcc::tags::SymTags;
-use crate::symcc::term::{Term, TermPrim, TermVar};
-use crate::symcc::term_type::TermType;
-use crate::symcc::type_abbrevs::*;
+use super::op;
+use super::result::CompileError;
+use super::tags::SymTags;
+use super::term::{Term, TermPrim, TermVar};
+use super::term_type::TermType;
+use super::type_abbrevs::*;
 use cedar_policy_core::validator::ValidatorSchema;
 use cedar_policy_core::validator::{
     types::{Attributes, EntityRecordKind, OpenTag, Type},

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -19,18 +19,16 @@
 //! A symbolic environment is _literal_ when it consists of literal terms and
 //! interpreted functions (UDFs).
 
+use crate::result::CompileError;
+use crate::symcc::function::{
+    self,
+    UnaryFunction::{self, Udf, Uuf},
+};
 use crate::symcc::op;
 use crate::symcc::tags::SymTags;
 use crate::symcc::term::{Term, TermPrim, TermVar};
 use crate::symcc::term_type::TermType;
 use crate::symcc::type_abbrevs::*;
-use crate::symcc::{
-    function::{
-        self,
-        UnaryFunction::{self, Udf, Uuf},
-    },
-    result,
-};
 use cedar_policy_core::validator::ValidatorSchema;
 use cedar_policy_core::validator::{
     types::{Attributes, EntityRecordKind, OpenTag, Type},
@@ -178,7 +176,7 @@ impl SymEntityData {
         ety: &EntityType,
         validator_ety: &ValidatorEntityType,
         schema: &ValidatorSchema,
-    ) -> Result<Self, result::Error> {
+    ) -> Result<Self, CompileError> {
         match EntitySchemaEntry::of_schema(ety, validator_ety, schema) {
             // Corresponds to `SymEntityData.ofStandardEntityType` in Lean
             EntitySchemaEntry::Standard(sch) => {
@@ -194,7 +192,7 @@ impl SymEntityData {
                         out: TermType::set_of(entity(anc_ty.clone())), // more efficient than the Lean: avoids `TermType::of_type()` and constructs the `TermType` directly
                     })
                 };
-                let sym_tags = |tag_ty: Type| -> Result<SymTags, result::Error> {
+                let sym_tags = |tag_ty: Type| -> Result<SymTags, CompileError> {
                     Ok(SymTags {
                         keys: Uuf(op::Uuf {
                             id: format!("tagKeys[{ety}]"),
@@ -334,7 +332,7 @@ impl SymEntities {
     ///
     /// This function assumes that no entity types have tags, and that action types
     /// have no attributes.
-    pub fn of_schema(schema: &ValidatorSchema) -> Result<Self, result::Error> {
+    pub fn of_schema(schema: &ValidatorSchema) -> Result<Self, CompileError> {
         let e_data = schema.entity_types().map(|vdtr_ety| {
             let ety = core_entity_type_into_entity_type(vdtr_ety.name());
             match SymEntityData::of_entity_type(ety, vdtr_ety, schema) {
@@ -368,7 +366,7 @@ impl SymEntities {
 
 impl SymRequest {
     /// Creates a symbolic request for the given request type.
-    fn of_request_type(req_ty: &RequestType<'_>) -> Result<Self, result::Error> {
+    fn of_request_type(req_ty: &RequestType<'_>) -> Result<Self, CompileError> {
         Ok(Self {
             principal: Term::Var(TermVar {
                 id: "principal".to_string(),
@@ -394,7 +392,7 @@ impl SymRequest {
 impl SymEnv {
     /// Returns a symbolic environment that conforms to the given
     /// type Environment.
-    pub fn of_env(ty_env: &Environment<'_>) -> Result<Self, result::Error> {
+    pub fn of_env(ty_env: &Environment<'_>) -> Result<Self, CompileError> {
         Ok(SymEnv {
             request: SymRequest::of_request_type(&ty_env.req_ty)?,
             entities: SymEntities::of_schema(ty_env.schema)?,
@@ -510,15 +508,13 @@ impl ActionSchemaEntries {
     }
 }
 
-fn context_attributes(action: &ValidatorActionId) -> Result<&Attributes, result::Error> {
+fn context_attributes(action: &ValidatorActionId) -> Result<&Attributes, CompileError> {
     match action.context_type() {
         Type::EntityOrRecord(EntityRecordKind::Record {
             attrs,
             open_attributes: OpenTag::ClosedAttributes,
         }) => Ok(attrs),
-        _ => Err(result::Error::Unreachable(
-            "Context type should be a closed record".into(),
-        )),
+        _ => Err(CompileError::NonRecordContext),
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/extension_types/ipaddr.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/ipaddr.rs
@@ -32,7 +32,7 @@ use crate::symcc::{
 };
 
 /// Errors in [`IPNet`] operations.
-#[derive(Clone, Diagnostic, Debug, PartialEq, Eq, Error)]
+#[derive(Debug, Diagnostic, Error)]
 pub enum IPError {
     /// Errors in [`BitVec`] operations.
     #[error("bit-vector error when manipulating ip addresses")]

--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+use crate::result::CompileError;
+
 use super::bitvec::BitVec;
 use super::entity_tag::EntityTag;
 use super::ext::Ext;
@@ -259,10 +261,15 @@ pub fn bvneg(t: Term) -> Term {
     }
 }
 
-type Comparator = dyn Fn(&BitVec, &BitVec) -> Result<bool, super::result::Error>;
-type BVOp = dyn Fn(&BitVec, &BitVec) -> Result<BitVec, super::result::Error>;
+type Comparator<E> = dyn Fn(&BitVec, &BitVec) -> Result<bool, E>;
+type BVOp<E> = dyn Fn(&BitVec, &BitVec) -> Result<BitVec, E>;
 
-pub fn bvapp(op: Op, f: &BVOp, t1: Term, t2: Term) -> Term {
+pub fn bvapp<E: std::fmt::Debug + Into<CompileError>>(
+    op: Op,
+    f: &BVOp<E>,
+    t1: Term,
+    t2: Term,
+) -> Term {
     match (t1, t2) {
         #[allow(
             clippy::unwrap_used,
@@ -324,7 +331,12 @@ pub fn bvlshr(t1: Term, t2: Term) -> Term {
     bvapp(Op::Bvlshr, &BitVec::lshr, t1, t2)
 }
 
-fn bvcmp(op: Op, comp: &Comparator, t1: Term, t2: Term) -> Term {
+fn bvcmp<E: std::fmt::Debug + Into<CompileError>>(
+    op: Op,
+    comp: &Comparator<E>,
+    t1: Term,
+    t2: Term,
+) -> Term {
     match (t1, t2) {
         #[allow(
             clippy::unwrap_used,
@@ -376,7 +388,12 @@ pub fn bvnego(t: Term) -> Term {
     }
 }
 
-pub fn bvso(op: Op, f: &BVOp, t1: Term, t2: Term) -> Term {
+pub fn bvso<E: std::fmt::Debug + Into<CompileError>>(
+    op: Op,
+    f: &BVOp<E>,
+    t1: Term,
+    t2: Term,
+) -> Term {
     match (t1, t2) {
         (Term::Prim(TermPrim::Bitvec(bv1)), Term::Prim(TermPrim::Bitvec(bv2))) => {
             assert!(bv1.width() == bv2.width());

--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::result::CompileError;
+use super::CompileError;
 
 use super::bitvec::BitVec;
 use super::entity_tag::EntityTag;

--- a/cedar-policy-symcc/src/symcc/result.rs
+++ b/cedar-policy-symcc/src/symcc/result.rs
@@ -17,22 +17,35 @@
 //! This module would more typically be called `err` or similar, but we call it
 //! `result` to match the Lean
 
+use cedar_policy::EntityTypeName;
+use miette::Diagnostic;
 use thiserror::Error;
 
-#[allow(
-    clippy::enum_variant_names,
-    reason = "UnsupportedError reads better than just Unsupported"
-)]
-#[derive(Clone, Debug, PartialEq, Eq, Error)]
-pub enum Error {
-    #[error("noSuchEntityType")]
-    NoSuchEntityType,
-    #[error("noSuchAttribute")]
+use crate::{extension_types::ipaddr::IPError, symcc::bitvec::BitVecError};
+
+/// Corresponds to the Lean version at `Cedar.SymCC.Result.Error`.
+/// These are various errors that can occur during compilation.
+#[derive(Clone, Diagnostic, Debug, PartialEq, Eq, Error)]
+pub enum CompileError {
+    /// Failed to find an entity type.
+    #[error("entity type {0} does not exist")]
+    NoSuchEntityType(EntityTypeName),
+    /// Failed to find an attribute.
+    #[error("attribute does not exist")]
     NoSuchAttribute,
-    #[error("typeError")]
+    /// Type error when constructing a [`Term`].
+    #[error("term type error")]
     TypeError,
-    #[error("unsupportedError")]
-    UnsupportedError,
-    #[error("unreachableError: {0}")]
-    Unreachable(String),
+    /// Unsupported features.
+    #[error("unsupported feature in SymCC")]
+    UnsupportedFeature(String),
+    /// Bit-vector error.
+    #[error("bit-vector error ")]
+    BitVecError(#[from] BitVecError),
+    /// IP address error.
+    #[error("IP address error")]
+    IPError(#[from] IPError),
+    /// Context type is not a record.
+    #[error("context type is not a record")]
+    NonRecordContext,
 }

--- a/cedar-policy-symcc/src/symcc/result.rs
+++ b/cedar-policy-symcc/src/symcc/result.rs
@@ -21,18 +21,19 @@ use cedar_policy::EntityTypeName;
 use miette::Diagnostic;
 use thiserror::Error;
 
-use crate::{extension_types::ipaddr::IPError, symcc::bitvec::BitVecError};
+use super::bitvec::BitVecError;
+use super::extension_types::ipaddr::IPError;
 
-/// Corresponds to the Lean version at `Cedar.SymCC.Result.Error`.
-/// These are various errors that can occur during compilation.
-#[derive(Clone, Diagnostic, Debug, PartialEq, Eq, Error)]
+/// Errors that can occur during symbolic compilation.
+/// Corresponds to `Cedar.SymCC.Result.Error` in the Lean version.
+#[derive(Debug, Diagnostic, Error)]
 pub enum CompileError {
     /// Failed to find an entity type.
     #[error("entity type {0} does not exist")]
     NoSuchEntityType(EntityTypeName),
     /// Failed to find an attribute.
-    #[error("attribute does not exist")]
-    NoSuchAttribute,
+    #[error("attribute {0} does not exist")]
+    NoSuchAttribute(String),
     /// Type error when constructing a [`Term`].
     #[error("term type error")]
     TypeError,

--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -47,13 +47,13 @@ pub enum Decision {
 /// Corresponds to various errors in the Lean version at `Cedar.SymCC.Solver`
 #[derive(Debug, Diagnostic, Error)]
 pub enum SolverError {
-    /// IO error
-    #[error("IO error during a solver operation: {0}")]
+    /// IO error.
+    #[error("IO error during a solver operation")]
     Io(#[from] std::io::Error),
-    /// Error from the solver
+    /// Error from the solver.
     #[error("solver error: {0}")]
     Solver(String),
-    /// Unrecognized solver output
+    /// Unrecognized solver output.
     #[error("unrecognized solver output: {0}")]
     UnrecognizedSolverOutput(String),
 }

--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -31,6 +31,7 @@
 //! proofs about it on the Lean side.
 
 use super::smtlib_script::SmtLibScript;
+use miette::Diagnostic;
 use std::{future::Future, path::Path, process::Stdio};
 use thiserror::Error;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
@@ -43,19 +44,20 @@ pub enum Decision {
     Unknown,
 }
 
-#[derive(Debug, Error)]
-pub enum Error {
+/// Corresponds to various errors in the Lean version at `Cedar.SymCC.Solver`
+#[derive(Debug, Diagnostic, Error)]
+pub enum SolverError {
     /// IO error
     #[error("IO error during a solver operation: {0}")]
     Io(#[from] std::io::Error),
     /// Error from the solver
-    #[error("Solver error: '{0}'")]
+    #[error("solver error: {0}")]
     Solver(String),
     /// Unrecognized solver output
-    #[error("Unrecognized solver output: '{0}'")]
+    #[error("unrecognized solver output: {0}")]
     UnrecognizedSolverOutput(String),
 }
-pub type Result<T> = std::result::Result<T, Error>;
+type Result<T> = std::result::Result<T, SolverError>;
 
 /// Trait for things which are capable of solving SMTLib queries
 ///
@@ -108,7 +110,7 @@ impl LocalSolver {
         let (stdin, stdout, stderr) = match (child.stdin, child.stdout, child.stderr) {
             (Some(stdin), Some(stdout), Some(stderr)) => (stdin, stdout, stderr),
             _ => {
-                return Err(Error::Solver(
+                return Err(SolverError::Solver(
                     "Failed to fetch IO pipes for solver process".into(),
                 ))
             }
@@ -146,8 +148,8 @@ impl Solver for LocalSolver {
                 .strip_prefix("(error \"")
                 .and_then(|s| s.strip_suffix("\")\n"))
             {
-                Some(e) => Err(Error::Solver(e.to_string())),
-                _ => Err(Error::UnrecognizedSolverOutput(output)),
+                Some(e) => Err(SolverError::Solver(e.to_string())),
+                _ => Err(SolverError::UnrecognizedSolverOutput(output)),
             },
         }
     }
@@ -179,8 +181,8 @@ impl Solver for LocalSolver {
                 .strip_prefix("(error \"")
                 .and_then(|s| s.strip_suffix("\")\n"))
             {
-                Some(e) => Err(Error::Solver(e.to_string())),
-                _ => Err(Error::UnrecognizedSolverOutput(output)),
+                Some(e) => Err(SolverError::Solver(e.to_string())),
+                _ => Err(SolverError::UnrecognizedSolverOutput(output)),
             },
         }
     }

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -15,7 +15,7 @@
  */
 use cedar_policy_core::validator::types::OpenTag;
 
-use crate::result::CompileError;
+use super::result::CompileError;
 
 use super::{entity_tag::EntityTag, type_abbrevs::*};
 use std::collections::BTreeMap;

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -15,7 +15,7 @@
  */
 use cedar_policy_core::validator::types::OpenTag;
 
-use crate::symcc::result;
+use crate::result::CompileError;
 
 use super::{entity_tag::EntityTag, type_abbrevs::*};
 use std::collections::BTreeMap;
@@ -74,7 +74,7 @@ impl TermType {
 
     // This doesn't match the Lean because `cedar_policy_core::validator::types::Type` doesn't
     // TODO: test this
-    pub fn of_type(ty: cedar_policy_core::validator::types::Type) -> Result<Self, result::Error> {
+    pub fn of_type(ty: cedar_policy_core::validator::types::Type) -> Result<Self, CompileError> {
         use cedar_policy::EntityTypeName;
         use cedar_policy_core::validator::types::Type;
         use std::str::FromStr;
@@ -99,7 +99,9 @@ impl TermType {
                 "duration" => Ok(TermType::Ext {
                     xty: ExtType::Duration,
                 }),
-                _ => Err(result::Error::UnsupportedError),
+                name => Err(CompileError::UnsupportedFeature(format!(
+                    "unsupported extension {name}"
+                ))),
             },
             Type::EntityOrRecord(entity_record_kind) => {
                 match entity_record_kind {
@@ -131,21 +133,22 @@ impl TermType {
                             })
                         } else {
                             // Attributes should be closed
-                            Err(result::Error::UnsupportedError)
+                            Err(CompileError::UnsupportedFeature(
+                                "unsupported open attributes".into(),
+                            ))
                         }
                     }
-                    cedar_policy_core::validator::types::EntityRecordKind::AnyEntity => {
-                        Err(result::Error::Unreachable(
-                            "AnyEntity is not possible with Strict validation".into(),
-                        ))
-                    }
+                    cedar_policy_core::validator::types::EntityRecordKind::AnyEntity => Err(
+                        CompileError::UnsupportedFeature("AnyEntity is not supported".into()),
+                    ),
                     cedar_policy_core::validator::types::EntityRecordKind::Entity(entity_lub) => {
                         match entity_lub.get_single_entity() {
                             Some(name) => Ok(TermType::Entity {
                                 ety: core_entity_type_into_entity_type(name).clone(),
                             }),
-                            // EntityLUB has multiple elements
-                            None => Err(result::Error::UnsupportedError),
+                            None => Err(CompileError::UnsupportedFeature(
+                                "EntityLUB has multiple elements".into(),
+                            )),
                         }
                     }
                     cedar_policy_core::validator::types::EntityRecordKind::ActionEntity {
@@ -167,15 +170,19 @@ impl TermType {
                 Some(element_type) => Ok(TermType::Set {
                     ty: Arc::new(Self::of_type(*element_type)?),
                 }),
-                // Empty set. Unable to deduce type
-                None => Err(result::Error::UnsupportedError),
+                None => Err(CompileError::UnsupportedFeature(
+                    "empty set type is unsupported".into(),
+                )),
             },
-            // Analysis cannot handle Never,
-            Type::Never => Err(result::Error::UnsupportedError),
-            // Analysis cannot handle True,
-            Type::True => Err(result::Error::UnsupportedError),
-            // Analysis cannot handle False,
-            Type::False => Err(result::Error::UnsupportedError),
+            Type::Never => Err(CompileError::UnsupportedFeature(
+                "never type is not supported".into(),
+            )),
+            Type::True => Err(CompileError::UnsupportedFeature(
+                "singleton Bool type is not supported".into(),
+            )),
+            Type::False => Err(CompileError::UnsupportedFeature(
+                "singleton Bool type is not supported".into(),
+            )),
         }
     }
 }

--- a/cedar-policy-symcc/src/symcc/verifier.rs
+++ b/cedar-policy-symcc/src/symcc/verifier.rs
@@ -21,19 +21,19 @@
 
 use std::sync::Arc;
 
-use crate::symcc::authorizer::is_authorized;
-use crate::symcc::compiler::compile;
-use crate::symcc::enforcer::enforce;
-use crate::symcc::env::SymEnv;
-use crate::symcc::factory::{and, eq, implies, is_some, not};
-use crate::symcc::result;
-use crate::symcc::term::Term;
+use super::authorizer::is_authorized;
+use super::compiler::compile;
+use super::enforcer::enforce;
+use super::env::SymEnv;
+use super::factory::{and, eq, implies, is_some, not};
+use super::result::CompileError;
+use super::term::Term;
 
 use cedar_policy::Effect;
 use cedar_policy_core::ast::{Expr, Policy, PolicyID, PolicySet, Value};
 
 pub type Asserts = Arc<Vec<Term>>;
-type Result<T> = std::result::Result<T, result::Error>;
+type Result<T> = std::result::Result<T, CompileError>;
 
 /// Returns asserts that are unsatisfiable iff the evaluation of `policy`, represented as
 /// a Term of type .option .bool, satisfies `phi` on all inputs drawn from `env`.  See also


### PR DESCRIPTION
## Description of changes

This PR refactors error types in SymCC to be more idiomatic.

Major changes are:
- Merged `Error` in `src/symcc.rs` into `src/err.rs`
- Separated `BitVecError` and `IPError` from `CompileError` (previously `symcc::result::Error`)
- Made error messages more standard according to [common conventions](https://rust-lang.github.io/api-guidelines/interoperability.html#examples-of-error-messages).
- All error types should be exported now (see `src/err.rs` for a full list)
- Added `EncodeError` for errors from the encoder