### PR TITLE
SymCC: Better rustdoc

### DIFF
--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -30,7 +30,7 @@ miette = "7.6.0"
 
 [dev-dependencies]
 miette = { version = "7.5.0", features = ["fancy"] }
-tokio = { version = "1.0", features = ["rt", "macros"] } # for `tokio::test` unit tests
+tokio = { version = "1.0", features = ["full"] } # for `tokio::test` unit tests
 rstest = "0.25.0"
 
 [lints]

--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -1,5 +1,3 @@
-use cedar_policy_core::validator::ValidationError;
-use miette::Diagnostic;
 /*
  * Copyright Cedar Contributors
  *
@@ -15,6 +13,11 @@ use miette::Diagnostic;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! All error types in SymCC.
+
+use cedar_policy_core::validator::ValidationError;
+use miette::Diagnostic;
 use thiserror::Error;
 
 pub use crate::symcc::{

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -27,25 +27,18 @@ use symcc::{
     verify_never_errors, well_typed_policies, well_typed_policy,
 };
 
-pub use symcc::factory as term;
-pub use symcc::{
-    bitvec::BitVec,
-    ext::Ext,
-    extension_types,
-    op::{ExtOp, Op, Uuf},
-    term::Term,
-    term::TermPrim,
-    term::TermVar,
-    term_type::TermType,
-    type_abbrevs::*,
-    type_abbrevs::{ExtType, OrdPattern},
-    verifier::Asserts,
-};
-/// Public exports.
-pub use symcc::{solver, Env, Environment, Interpretation, SmtLibScript, SymEnv};
-
-/// Export various error types.
 pub use err::*;
+pub use symcc::bitvec::BitVec;
+pub use symcc::ext::Ext;
+pub use symcc::extension_types;
+pub use symcc::factory as term;
+pub use symcc::op::{ExtOp, Op, Uuf};
+pub use symcc::solver;
+pub use symcc::term::{Term, TermPrim, TermVar};
+pub use symcc::term_type::TermType;
+pub use symcc::type_abbrevs::*;
+pub use symcc::verifier::Asserts;
+pub use symcc::{Env, Environment, Interpretation, SmtLibScript, SymEnv};
 
 /// Cedar symbolic compiler, which takes your policies and schemas
 /// and converts them to SMT queries to perform various verification

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -70,7 +70,8 @@ pub use verifier::{
     verify_never_errors,
 };
 
-/// Corresponds to the `SolverM` monad in Lean
+/// Internal symbolic compiler.
+/// Corresponds to the `SolverM` monad in Lean.
 #[derive(Debug, Clone)]
 pub struct SymCompiler<S> {
     solver: S,

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -72,7 +72,7 @@ pub use verifier::{
 
 /// Internal symbolic compiler.
 /// Corresponds to the `SolverM` monad in Lean.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct SymCompiler<S> {
     solver: S,
 }

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! Implementation of [`BitVec`].
+
 use std::sync::LazyLock;
 
 use crate::symcc::type_abbrevs::{Int, Nat, Width};

--- a/cedar-policy-symcc/src/symcc/bitvec.rs
+++ b/cedar-policy-symcc/src/symcc/bitvec.rs
@@ -36,16 +36,16 @@ pub static TWO: LazyLock<BigUint> = LazyLock::new(|| BigUint::from(2u128));
 /// Errors in [`BitVec`] operations.
 #[derive(Debug, Diagnostic, Error)]
 pub enum BitVecError {
-    /// Extract out of bounds
+    /// Extract out of bounds.
     #[error("extract out of bounds")]
     ExtractOutOfBounds,
-    /// Attempting to create a bit-vector with zero width
+    /// Attempting to create a bit-vector with zero width.
     #[error("cannot create a bit-vector with zero width")]
     ZeroWidthBitVec,
-    /// Mismatched bit-vector widths in various operations
+    /// Mismatched bit-vector widths in various operations.
     #[error("mismatched bit-vector widths in {0}")]
     MismatchedWidths(String),
-    /// Shift amount too large to fit in u32
+    /// Shift amount too large to fit in u32.
     #[error("shift amount too large to fit in u32")]
     ShiftAmountTooLarge,
 }

--- a/cedar-policy-symcc/src/symcc/concretize.rs
+++ b/cedar-policy-symcc/src/symcc/concretize.rs
@@ -43,6 +43,9 @@ use super::function::{Udf, UnaryFunction};
 use super::term::{Term, TermPrim};
 use super::SymEnv;
 
+/// Errors that happen during concretization, i.e., the process
+/// of converting literal [`Term`]s back to representatinos in
+/// [`cedar_policy`]/[`cedar_policy_core`].
 #[derive(Debug, Diagnostic, Error)]
 pub enum ConcretizeError {
     /// Expecting a literal entity.

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -50,6 +50,8 @@ use super::op::Uuf;
 use super::term::{Term, TermPrim, TermVar};
 use super::term_type::TermType;
 
+/// Errors during decoding, i.e., converting SMT terms
+/// to our internal [`Term`] representation.
 #[derive(Debug, Diagnostic, Error)]
 pub enum DecodeError {
     /// Unexpected end of input.

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -81,6 +81,8 @@ use super::{
 use crate::symcc::extension_types::ipaddr::{V4_WIDTH, V6_WIDTH};
 use crate::BitVecError;
 
+/// Errors during encoding, i.e., converting [`Term`]
+/// to SMT-LIB 2 format.
 #[derive(Debug, Diagnostic, Error)]
 pub enum EncodeError {
     /// IO error.

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -67,7 +67,7 @@ use thiserror::Error;
 use cedar_policy_core::ast::PatternElem;
 
 use super::{
-    bitvec::BitVec,
+    bitvec::{BitVec, BitVecError},
     env::SymEnv,
     ext::Ext,
     extension_types::ipaddr::{CIDRv4, CIDRv6, IPNet, IPv4Prefix, IPv6Prefix},
@@ -78,8 +78,7 @@ use super::{
     type_abbrevs::*,
 };
 
-use crate::symcc::extension_types::ipaddr::{V4_WIDTH, V6_WIDTH};
-use crate::BitVecError;
+use super::extension_types::ipaddr::{V4_WIDTH, V6_WIDTH};
 
 /// Errors during encoding, i.e., converting [`Term`]
 /// to SMT-LIB 2 format.

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -158,6 +158,7 @@ impl SymEntities {
     }
 }
 
+/// Symbolic representation of a request environment.
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct SymEnv {
     pub request: SymRequest,

--- a/cedar-policy-symcc/src/symcc/ext.rs
+++ b/cedar-policy-symcc/src/symcc/ext.rs
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-//! This module defines Cedar extension values.
+
+//! Extension values in SymCC.
 
 use super::extension_types::datetime::{Datetime, Duration};
 use super::extension_types::decimal::Decimal;

--- a/cedar-policy-symcc/src/symcc/extension_types/mod.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/mod.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Implementations of various extension values.
+
 pub mod datetime;
 pub mod decimal;
 pub mod ipaddr;

--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Utility functions to construct [`Term`]s.
+
 use super::CompileError;
 
 use super::bitvec::BitVec;

--- a/cedar-policy-symcc/src/symcc/op.rs
+++ b/cedar-policy-symcc/src/symcc/op.rs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//! Various [`super::term::Term`] operations allowed in [`super::term::Term::App`].
+
 use std::sync::Arc;
 
 use super::term_type::TermType;

--- a/cedar-policy-symcc/src/symcc/result.rs
+++ b/cedar-policy-symcc/src/symcc/result.rs
@@ -34,7 +34,7 @@ pub enum CompileError {
     /// Failed to find an attribute.
     #[error("attribute {0} does not exist")]
     NoSuchAttribute(String),
-    /// Type error when constructing a [`Term`].
+    /// Type error when constructing a [`super::term::Term`].
     #[error("term type error")]
     TypeError,
     /// Unsupported features.

--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -14,7 +14,8 @@
  * limitations under the License.
  */
 
-//! This module defines a simple interface to an SMT solver.
+//! A simple interface to an SMT solver.
+//!
 //! Callers communicate with the solver by issuing commands with s-expressions
 //! encoded as strings. The interface is based on
 //! [lean-smt](https://github.com/ufmg-smite/lean-smt/).

--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -44,6 +44,7 @@ pub enum Decision {
     Unknown,
 }
 
+/// Errors when interacting with a [`Solver`] instance.
 /// Corresponds to various errors in the Lean version at `Cedar.SymCC.Solver`
 #[derive(Debug, Diagnostic, Error)]
 pub enum SolverError {

--- a/cedar-policy-symcc/src/symcc/term.rs
+++ b/cedar-policy-symcc/src/symcc/term.rs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-//! This file defines the Cedar Term language, a strongly and simply typed IR to
-//! which we reduce Cedar expressions during symbolic compilation. The Term language
-//! has a straightforward translation to SMTLib. It is designed to reduce the
-//! semantic gap between Cedar and SMTLib, and to facilitate proofs of soundness and
-//! completeness of the Cedar symbolic compiler.
+//! A simply typed IR to which we reduce Cedar expressions during symbolic compilation.
+//!
+//! The Term language has a straightforward translation to SMTLib. It is designed to
+//! reduce the semantic gap between Cedar and SMTLib, and to facilitate proofs of
+//! soundness and completeness of the Cedar symbolic compiler.
 //!
 //! Terms should _not_ be created directly using `Term` constructors. Instead, they
 //! should be created using the factory functions defined in `factory.rs`.

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! Definitions of term types.
+
 use cedar_policy_core::validator::types::OpenTag;
 
 use super::result::CompileError;

--- a/cedar-policy-symcc/src/symcc/type_abbrevs.rs
+++ b/cedar-policy-symcc/src/symcc/type_abbrevs.rs
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+//! Various type abbreviations used throughout SymCC.
+
 use num_bigint::{BigInt, BigUint};
 use ref_cast::RefCast;
 use smol_str::SmolStr;

--- a/cedar-policy-symcc/tests/term.rs
+++ b/cedar-policy-symcc/tests/term.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 
 use cedar_policy::{Authorizer, Schema, Validator};
 use cedar_policy_symcc::{
-    compile_always_denies, solver::LocalSolver, term, CedarSymCompiler, Term, TermType, TermVar,
-    WellFormedAsserts, WellTypedPolicies,
+    compile_always_denies, solver::LocalSolver, term::*, term_factory, term_type::*,
+    CedarSymCompiler, WellFormedAsserts, WellTypedPolicies,
 };
 
 use crate::utils::{assert_always_allows, assert_does_not_always_deny, Environments};
@@ -58,7 +58,7 @@ async fn term_basic_arith_unsat() {
         compiler
             .check_unsat(&WellFormedAsserts::from_asserts_unchecked(
                 &envs.symenv,
-                Arc::new(vec![term::not(term::eq(
+                Arc::new(vec![term_factory::not(term_factory::eq(
                     TermVar {
                         id: "x".to_string(),
                         ty: TermType::Bitvec { n: 64 }
@@ -80,7 +80,7 @@ async fn term_basic_arith_unsat() {
         compiler
             .check_unsat(&WellFormedAsserts::from_asserts_unchecked(
                 &envs.symenv,
-                Arc::new(vec![term::not(term::eq(
+                Arc::new(vec![term_factory::not(term_factory::eq(
                     TermVar {
                         id: "x".to_string(),
                         ty: TermType::Bitvec { n: 64 }
@@ -102,9 +102,9 @@ async fn term_basic_arith_unsat() {
         compiler
             .check_unsat(&WellFormedAsserts::from_asserts_unchecked(
                 &envs.symenv,
-                Arc::new(vec![term::not(term::implies(
-                    term::and(
-                        term::bvsle(
+                Arc::new(vec![term_factory::not(term_factory::implies(
+                    term_factory::and(
+                        term_factory::bvsle(
                             TermVar {
                                 id: "x".to_string(),
                                 ty: TermType::Bitvec { n: 64 }
@@ -116,7 +116,7 @@ async fn term_basic_arith_unsat() {
                             }
                             .into(),
                         ),
-                        term::bvsle(
+                        term_factory::bvsle(
                             TermVar {
                                 id: "y".to_string(),
                                 ty: TermType::Bitvec { n: 64 }
@@ -129,7 +129,7 @@ async fn term_basic_arith_unsat() {
                             .into(),
                         ),
                     ),
-                    term::bvsle(
+                    term_factory::bvsle(
                         TermVar {
                             id: "x".to_string(),
                             ty: TermType::Bitvec { n: 64 }


### PR DESCRIPTION
## Description of changes

This PR refactors comments and exports to make rustdoc look nicer.

I also added a crate-level intro and example of using the library: https://github.com/cedar-policy/cedar/pull/1763/files#diff-ad3943d8195fb3d0a0b7529a2593efc4b2d3455f5ea62291bfa1210725f38a31R17-R73