### PR TITLE
Fixes for Rust 1.89.0

### DIFF
--- a/cedar-language-server/src/utils.rs
+++ b/cedar-language-server/src/utils.rs
@@ -63,16 +63,17 @@ fn to_lsp_severity(severity: miette::Severity) -> lsp_types::DiagnosticSeverity 
 /// (a source range with a message). Errors wanting to provide more information
 /// can use this function while building a richer diagnostic with something like
 /// `to_lsp_diagnostic(error, src).map(|d| Diagnostic { data: my_data, ..d })`
-#[allow(clippy::unwrap_used, reason = "LSP code is experimental")]
 pub(crate) fn to_lsp_diagnostics<'a>(
     diagnostic: &'a dyn miette::Diagnostic,
     src: &'a str,
 ) -> Vec<lsp_types::Diagnostic> {
     let mut message = diagnostic.to_string();
     if let Some(source) = diagnostic.source() {
+        #[allow(clippy::unwrap_used, reason="writing string cannot fail")]
         write!(&mut message, ". {source}").unwrap();
     }
     if let Some(help) = diagnostic.help() {
+        #[allow(clippy::unwrap_used, reason="writing string cannot fail")]
         write!(&mut message, ". {help}").unwrap();
     }
 

--- a/cedar-language-server/src/utils.rs
+++ b/cedar-language-server/src/utils.rs
@@ -63,6 +63,7 @@ fn to_lsp_severity(severity: miette::Severity) -> lsp_types::DiagnosticSeverity 
 /// (a source range with a message). Errors wanting to provide more information
 /// can use this function while building a richer diagnostic with something like
 /// `to_lsp_diagnostic(error, src).map(|d| Diagnostic { data: my_data, ..d })`
+#[allow(clippy::unwrap_used, reason="LSP code is experimental")]
 pub(crate) fn to_lsp_diagnostics<'a>(
     diagnostic: &'a dyn miette::Diagnostic,
     src: &'a str,

--- a/cedar-language-server/src/utils.rs
+++ b/cedar-language-server/src/utils.rs
@@ -69,11 +69,11 @@ pub(crate) fn to_lsp_diagnostics<'a>(
 ) -> Vec<lsp_types::Diagnostic> {
     let mut message = diagnostic.to_string();
     if let Some(source) = diagnostic.source() {
-        #[allow(clippy::unwrap_used, reason="writing string cannot fail")]
+        #[allow(clippy::unwrap_used, reason = "writing string cannot fail")]
         write!(&mut message, ". {source}").unwrap();
     }
     if let Some(help) = diagnostic.help() {
-        #[allow(clippy::unwrap_used, reason="writing string cannot fail")]
+        #[allow(clippy::unwrap_used, reason = "writing string cannot fail")]
         write!(&mut message, ". {help}").unwrap();
     }
 

--- a/cedar-language-server/src/utils.rs
+++ b/cedar-language-server/src/utils.rs
@@ -63,7 +63,7 @@ fn to_lsp_severity(severity: miette::Severity) -> lsp_types::DiagnosticSeverity 
 /// (a source range with a message). Errors wanting to provide more information
 /// can use this function while building a richer diagnostic with something like
 /// `to_lsp_diagnostic(error, src).map(|d| Diagnostic { data: my_data, ..d })`
-#[allow(clippy::unwrap_used, reason="LSP code is experimental")]
+#[allow(clippy::unwrap_used, reason = "LSP code is experimental")]
 pub(crate) fn to_lsp_diagnostics<'a>(
     diagnostic: &'a dyn miette::Diagnostic,
     src: &'a str,

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1695,20 +1695,6 @@ where
         .map_err(|e| serde::de::Error::custom(format!("failed to parse entities: {e}")))
 }
 
-#[derive(Error, Diagnostic, Debug)]
-enum TestCaseError {
-    #[error("error when parsing JSON")]
-    JsonParseError(#[from] serde_json::Error),
-    #[error("error when parsing entity UID")]
-    EntityUidParseError(#[from] ParseErrors),
-    #[error("error when parsing context JSON")]
-    ContextJsonError(#[from] ContextJsonError),
-    #[error("error when validating request against schema")]
-    RequestValidationError(#[from] RequestValidationError),
-    #[error("error when parsing entities")]
-    EntitiesError(#[from] EntitiesError),
-}
-
 /// Load partially parsed tests from a JSON file
 /// (as JSON values first without parsing to TestCase)
 fn load_partial_tests(tests_filename: impl AsRef<Path>) -> Result<Vec<serde_json::Value>> {

--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -19,9 +19,8 @@
 // omitted.
 #![allow(clippy::needless_return)]
 
-use cedar_policy::entities_errors::EntitiesError;
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
-use miette::{miette, Diagnostic, IntoDiagnostic, NamedSource, Report, Result, WrapErr};
+use miette::{miette, IntoDiagnostic, NamedSource, Report, Result, WrapErr};
 use owo_colors::OwoColorize;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeSet;
@@ -35,7 +34,6 @@ use std::{
     str::FromStr,
     time::Instant,
 };
-use thiserror::Error;
 
 use cedar_policy::*;
 use cedar_policy_formatter::{policies_str_to_pretty, Config};

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,6 +17,7 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![warn(missing_docs)]
 #![cfg_attr(feature = "wasm", allow(non_snake_case))]
+#![allow(text_direction_codepoint_in_literal, reason="Must specify at crate level to allow for tests with direction codepoints")]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,7 +17,10 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![warn(missing_docs)]
 #![cfg_attr(feature = "wasm", allow(non_snake_case))]
-#![allow(text_direction_codepoint_in_literal, reason="Must specify at crate level to allow for tests with direction codepoints")]
+#![allow(
+    text_direction_codepoint_in_literal,
+    reason = "Must specify at crate level to allow for tests with direction codepoints"
+)]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/validator/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/to_json_schema.rs
@@ -842,14 +842,14 @@ mod preserves_source_locations {
         assert_matches!(ns
             .entity_types
             .get(&"C".parse().unwrap())
-            .expect("couldn't find entity C"), EntityType { kind: EntityTypeKind::Standard(entityC), ..} => {
-        assert_matches!(entityC.member_of_types.first().unwrap().loc(), Some(loc) => {
+            .expect("couldn't find entity C"), EntityType { kind: EntityTypeKind::Standard(entity_c), ..} => {
+        assert_matches!(entity_c.member_of_types.first().unwrap().loc(), Some(loc) => {
             assert_matches!(loc.snippet(), Some("A"));
         });
-        assert_matches!(entityC.shape.0.loc(), Some(loc) => {
+        assert_matches!(entity_c.shape.0.loc(), Some(loc) => {
             assert_matches!(loc.snippet(), Some("{\n                bool: Bool,\n                s: S,\n                a: Set<A>,\n                b: { inner: B },\n            }"));
         });
-        assert_matches!(&entityC.shape.0, json_schema::Type::Type { ty: json_schema::TypeVariant::Record(rty), .. } => {
+        assert_matches!(&entity_c.shape.0, json_schema::Type::Type { ty: json_schema::TypeVariant::Record(rty), .. } => {
             let b = rty.attributes.get("bool").expect("couldn't find attribute `bool` on entity C");
             assert_matches!(b.ty.loc(), Some(loc) => {
                 assert_matches!(loc.snippet(), Some("Bool"));

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1100,7 +1100,7 @@ impl ValidatorSchema {
 #[serde(transparent)]
 #[allow(
     dead_code,
-    reason = "Not actually dead, but linter mistakenly things this code is dead"
+    reason = "Not actually dead, but linter mistakenly thinks this code is dead"
 )]
 pub(crate) struct NamespaceDefinitionWithActionAttributes<N>(
     pub(crate) json_schema::NamespaceDefinition<N>,

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1098,6 +1098,7 @@ impl ValidatorSchema {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
+#[allow(dead_code, reason="Not actually dead, but linter mistakenly things this code is dead")]
 pub(crate) struct NamespaceDefinitionWithActionAttributes<N>(
     pub(crate) json_schema::NamespaceDefinition<N>,
 );

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1098,7 +1098,10 @@ impl ValidatorSchema {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
-#[allow(dead_code, reason="Not actually dead, but linter mistakenly things this code is dead")]
+#[allow(
+    dead_code,
+    reason = "Not actually dead, but linter mistakenly things this code is dead"
+)]
 pub(crate) struct NamespaceDefinitionWithActionAttributes<N>(
     pub(crate) json_schema::NamespaceDefinition<N>,
 );

--- a/cedar-policy-core/src/validator/str_checks.rs
+++ b/cedar-policy-core/src/validator/str_checks.rs
@@ -298,7 +298,6 @@ mod test {
     }
 
     #[test]
-    #[allow(text_direction_codepoint_in_literal)]
     fn trojan_source() {
         let src = r#"
         permit(principal, action, resource) when {

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -29,7 +29,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
-/// Takes a PolicySet represented as string and return the policies
+/// Takes a `PolicySet`` represented as string and return the policies
 /// and templates split into vecs and sorted by id.
 #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policySetTextToParts"))]
 pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnswer {

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -29,7 +29,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
-/// Takes a `PolicySet`` represented as string and return the policies
+/// Takes a `PolicySet` represented as string and return the policies
 /// and templates split into vecs and sorted by id.
 #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policySetTextToParts"))]
 pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnswer {


### PR DESCRIPTION
## Description of changes

Fixes compilation errors caused by upgrade to rust 1.89.0

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
