### PR TITLE
Change policy to expression

### DIFF
--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -411,7 +411,11 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
         self.clone().not(self.less(e1, e2))
     }
 
-    fn and_nary(self, first: Self::Expr, others: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    fn and_naryl(
+        self,
+        first: Self::Expr,
+        others: impl IntoIterator<Item = Self::Expr>,
+    ) -> Self::Expr
     where
         Self: Sized,
     {

--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -287,7 +287,7 @@ impl Policy {
         let conditions = match conditions_iter.next() {
             None => ast::Expr::val(true),
             Some(first) => ast::ExprBuilder::with_data(())
-                .and_nary(first?, conditions_iter.collect::<Result<Vec<_>, _>>()?),
+                .and_naryl(first?, conditions_iter.collect::<Result<Vec<_>, _>>()?),
         };
         Ok(ast::Template::new(
             id,

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -262,14 +262,19 @@ pub trait ExprBuilder: Clone {
         self.clone().not(self.less(e1, e2))
     }
 
-    /// Create an `and` expression that may have more than two subexpressions (A && B && C)
+    /// Create an `and` expression that may have more than two subexpressions (A && B && C) and associate them from left to right
+    /// .e.g, [A, B, C] to (A && B) && C
     /// or may have only one subexpression, in which case no `&&` is performed at all.
     /// Arguments must evaluate to Bool type.
     ///
     /// This may create multiple AST `&&` nodes. If it does, all the nodes will have the same
     /// source location and the same `T` data (taken from this builder) unless overridden, e.g.,
     /// with another call to `with_source_loc()`.
-    fn and_nary(self, first: Self::Expr, others: impl IntoIterator<Item = Self::Expr>) -> Self::Expr
+    fn and_naryl(
+        self,
+        first: Self::Expr,
+        others: impl IntoIterator<Item = Self::Expr>,
+    ) -> Self::Expr
     where
         Self: Sized,
     {

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2354,14 +2354,16 @@ fn construct_template_policy(
             non_scope_constraint,
         )
     };
-    let mut conds_iter = conds.into_iter();
-    if let Some(first_expr) = conds_iter.next() {
-        // a left fold of conditions
-        // e.g., [c1, c2, c3,] --> ((c1 && c2) && c3)
+
+    // a right fold of conditions
+    // e.g., [c1, c2, c3,] --> c1 && (c2 && c3)
+    let mut conds_rev_iter = conds.into_iter().rev();
+    if let Some(last_expr) = conds_rev_iter.next() {
+        let builder = ast::ExprBuilder::new().with_maybe_source_loc(loc);
         construct_template(
-            ast::ExprBuilder::new()
-                .with_maybe_source_loc(loc)
-                .and_nary(first_expr, conds_iter),
+            conds_rev_iter
+                .into_iter()
+                .fold(last_expr, |acc, prev| builder.clone().and(prev, acc)),
         )
     } else {
         // use `true` to mark the absence of non-scope constraints

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1425,7 +1425,7 @@ impl Node<Option<cst::And>> {
             first.into_expr::<Build>().map(|first| ExprOrSpecial::Expr {
                 expr: Build::new()
                     .with_maybe_source_loc(self.loc.as_loc_ref())
-                    .and_nary(first, rest),
+                    .and_naryl(first, rest),
                 loc: self.loc.clone(),
             })
         }


### PR DESCRIPTION
Construct conjunctions that associate to the right

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
