### PR TITLE
Fixes for rust 1.89.0

### DIFF
--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,6 +17,10 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![warn(missing_docs)]
 #![cfg_attr(feature = "wasm", allow(non_snake_case))]
+#![allow(
+    text_direction_codepoint_in_literal,
+    reason = "Must specify at crate level to allow for tests with direction codepoints"
+)]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -1098,6 +1098,10 @@ impl ValidatorSchema {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(bound(deserialize = "N: Deserialize<'de> + From<RawName>"))]
 #[serde(transparent)]
+#[allow(
+    dead_code,
+    reason = "Not actually dead, but linter mistakenly thinks this code is dead"
+)]
 pub(crate) struct NamespaceDefinitionWithActionAttributes<N>(
     pub(crate) json_schema::NamespaceDefinition<N>,
 );

--- a/cedar-policy-core/src/validator/str_checks.rs
+++ b/cedar-policy-core/src/validator/str_checks.rs
@@ -298,7 +298,6 @@ mod test {
     }
 
     #[test]
-    #[allow(text_direction_codepoint_in_literal)]
     fn trojan_source() {
         let src = r#"
         permit(principal, action, resource) when {

--- a/cedar-policy/src/ffi/convert.rs
+++ b/cedar-policy/src/ffi/convert.rs
@@ -29,7 +29,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 #[cfg(feature = "wasm")]
 extern crate tsify;
 
-/// Takes a PolicySet represented as string and return the policies
+/// Takes a `PolicySet` represented as string and return the policies
 /// and templates split into vecs and sorted by id.
 #[cfg_attr(feature = "wasm", wasm_bindgen(js_name = "policySetTextToParts"))]
 pub fn policy_set_text_to_parts(policyset_str: &str) -> PolicySetTextToPartsAnswer {


### PR DESCRIPTION
Rust 1.89.0 breaks things. This PR resolves build and clippy errors. (similar to the fix in #1764 )

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
