### PR TITLE
More precise policy validation for action hierarchy

### DIFF
--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -1817,6 +1817,18 @@ impl<'a> SingleEnvTypechecker<'a> {
         }
     }
 
+    /// Checks if `lhs_ety` may be a descendant of `rhs_ety` in the action hierarchy.
+    /// Lean counterpart: https://github.com/cedar-policy/cedar-spec/blob/7e231a68b0e0eb1b8ce1362e81de4568671a668a/cedar-lean/Cedar/Validation/Types.lean#L202
+    fn check_action_descendant(&self, lhs_ety: &EntityType, rhs_ety: &EntityType) -> bool {
+        lhs_ety == rhs_ety
+            || self.schema.action_ids().any(|action| {
+                action.name().entity_type() == rhs_ety
+                    && action
+                        .descendants()
+                        .any(|desc| desc.entity_type() == lhs_ety)
+            })
+    }
+
     /// Handles typechecking of `in` expressions. This is complicated because it
     /// requires searching the schema to determine if an `in` expression
     /// consisting of variables and literals can ever be true. When we find that
@@ -1929,17 +1941,86 @@ impl<'a> SingleEnvTypechecker<'a> {
                             rhs_expr,
                         ),
 
-                    // If none of the cases apply, then all we know is that `in` has
-                    // type boolean. Importantly for partial schema
-                    // validation, this case captures an `in` between entity
-                    // literals where the LHS is not an action defined in
-                    // the schema and does not have an entity type defined
-                    // in the schema.
-                    _ => TypecheckAnswer::success(
-                        ExprBuilder::with_data(Some(Type::primitive_boolean()))
-                            .with_same_source_loc(in_expr)
-                            .is_in(lhs_expr, rhs_expr),
-                    ),
+                    _ => match (lhs_expr.data(), rhs_expr.data()) {
+                        // If both sides have action entity types, we conservatively
+                        // check if any of the actions of type `rhs_ety` have descendant
+                        // action entities with type `lhs_ety`. If there is none, we
+                        // can soundly type it as false.
+                        (
+                            Some(Type::EntityOrRecord(EntityRecordKind::ActionEntity {
+                                name: lhs_ety,
+                                ..
+                            })),
+                            Some(Type::EntityOrRecord(EntityRecordKind::ActionEntity {
+                                name: rhs_ety,
+                                ..
+                            })),
+                        ) if !self.check_action_descendant(lhs_ety, rhs_ety) => {
+                            TypecheckAnswer::success(
+                                ExprBuilder::with_data(Some(Type::False))
+                                    .with_same_source_loc(in_expr)
+                                    .is_in(lhs_expr, rhs_expr),
+                            )
+                        }
+
+                        // Similar to the case above, but checks the case when the RHS
+                        // could be a collection of entity types.
+                        (
+                            Some(Type::EntityOrRecord(EntityRecordKind::ActionEntity {
+                                name: lhs_ety,
+                                ..
+                            })),
+                            Some(Type::EntityOrRecord(EntityRecordKind::Entity(rhs_etys))),
+                        ) if rhs_etys
+                            .iter()
+                            .all(|rhs_ety| !self.check_action_descendant(lhs_ety, rhs_ety)) =>
+                        {
+                            TypecheckAnswer::success(
+                                ExprBuilder::with_data(Some(Type::False))
+                                    .with_same_source_loc(in_expr)
+                                    .is_in(lhs_expr, rhs_expr),
+                            )
+                        }
+
+                        // Similar to the cases above, but for when the RHS is a set
+                        (
+                            Some(Type::EntityOrRecord(EntityRecordKind::ActionEntity {
+                                name: lhs_ety,
+                                ..
+                            })),
+                            Some(Type::Set {
+                                element_type: Some(rhs_elem_ty),
+                            }),
+                        ) if match rhs_elem_ty.as_ref() {
+                            Type::EntityOrRecord(EntityRecordKind::ActionEntity {
+                                name: rhs_ety,
+                                ..
+                            }) => !self.check_action_descendant(lhs_ety, rhs_ety),
+                            Type::EntityOrRecord(EntityRecordKind::Entity(rhs_etys)) => rhs_etys
+                                .iter()
+                                .all(|rhs_ety| !self.check_action_descendant(lhs_ety, rhs_ety)),
+                            _ => false,
+                        } =>
+                        {
+                            TypecheckAnswer::success(
+                                ExprBuilder::with_data(Some(Type::False))
+                                    .with_same_source_loc(in_expr)
+                                    .is_in(lhs_expr, rhs_expr),
+                            )
+                        }
+
+                        // If none of the cases apply, then all we know is that `in` has
+                        // type boolean. Importantly for partial schema
+                        // validation, this case captures an `in` between entity
+                        // literals where the LHS is not an action defined in
+                        // the schema and does not have an entity type defined
+                        // in the schema.
+                        _ => TypecheckAnswer::success(
+                            ExprBuilder::with_data(Some(Type::primitive_boolean()))
+                                .with_same_source_loc(in_expr)
+                                .is_in(lhs_expr, rhs_expr),
+                        ),
+                    },
                 }
                 .then_typecheck(|type_of_in, _| TypecheckAnswer::success(type_of_in))
             })

--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -1818,7 +1818,7 @@ impl<'a> SingleEnvTypechecker<'a> {
     }
 
     /// Checks if `lhs_ety` may be a descendant of `rhs_ety` in the action hierarchy.
-    /// Lean counterpart: https://github.com/cedar-policy/cedar-spec/blob/7e231a68b0e0eb1b8ce1362e81de4568671a668a/cedar-lean/Cedar/Validation/Types.lean#L202
+    /// Lean counterpart: <https://github.com/cedar-policy/cedar-spec/blob/7e231a68b0e0eb1b8ce1362e81de4568671a668a/cedar-lean/Cedar/Validation/Types.lean#L202>
     fn check_action_descendant(&self, lhs_ety: &EntityType, rhs_ety: &EntityType) -> bool {
         lhs_ety == rhs_ety
             || self.schema.action_ids().any(|action| {

--- a/cedar-policy-core/src/validator/typecheck/test/expr.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/expr.rs
@@ -805,6 +805,29 @@ fn in_set_typechecks_strict() {
 }
 
 #[test]
+fn action_in_non_action_typechecks_false() {
+    let schema: json_schema::NamespaceDefinition<RawName> = serde_json::from_value(json!(
+    {
+        "entityTypes": {},
+        "actions": {
+            "view": { },
+            "modify": { }
+        }
+    }))
+    .expect("Expected that schema would parse");
+    assert_typechecks(
+        schema,
+        &Expr::is_in(
+            Expr::val(
+                EntityUID::with_eid_and_type("Action", "view").expect("Expected EntityUID parse."),
+            ),
+            Expr::var(Var::Principal),
+        ),
+        &Type::False,
+    );
+}
+
+#[test]
 fn in_typecheck_fails() {
     let src = "0 in true";
     let errors =


### PR DESCRIPTION
## Description of changes

This PR makes the policy validation more precise, mimicking the behavior of a [recent Lean validator change](https://github.com/cedar-policy/cedar-spec/pull/648#discussion_r2172668108).
Basically, when type checking `x in y`, when x has an action entity type, and any action of x's type does not have an ancestor of y's entity type, then we type `x in y` as the singleton false type.

This this should only make the validator more precise, no existing validated policy should break.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

**Not sure**
- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
