### PR TITLE
SymCC: Fix bvso implementation

### DIFF
--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -390,12 +390,7 @@ pub fn bvnego(t: Term) -> Term {
     }
 }
 
-pub fn bvso<E: std::fmt::Debug + Into<CompileError>>(
-    op: Op,
-    f: &BVOp<E>,
-    t1: Term,
-    t2: Term,
-) -> Term {
+pub fn bvso(op: Op, f: &dyn Fn(&Int, &Int) -> Int, t1: Term, t2: Term) -> Term {
     match (t1, t2) {
         (Term::Prim(TermPrim::Bitvec(bv1)), Term::Prim(TermPrim::Bitvec(bv2))) => {
             assert!(bv1.width() == bv2.width());
@@ -403,7 +398,7 @@ pub fn bvso<E: std::fmt::Debug + Into<CompileError>>(
                 clippy::unwrap_used,
                 reason = "Assert above guarantees same bit-vector width."
             )]
-            BitVec::overflows(bv1.width(), &f(&bv1, &bv2).unwrap().to_int())
+            BitVec::overflows(bv1.width(), &f(&bv1.to_int(), &bv2.to_int()))
                 .unwrap()
                 .into()
         }
@@ -416,15 +411,15 @@ pub fn bvso<E: std::fmt::Debug + Into<CompileError>>(
 }
 
 pub fn bvsaddo(t1: Term, t2: Term) -> Term {
-    bvso(Op::Bvsaddo, &BitVec::add, t1, t2)
+    bvso(Op::Bvsaddo, &|a, b| a + b, t1, t2)
 }
 
 pub fn bvssubo(t1: Term, t2: Term) -> Term {
-    bvso(Op::Bvssubo, &BitVec::sub, t1, t2)
+    bvso(Op::Bvssubo, &|a, b| a - b, t1, t2)
 }
 
 pub fn bvsmulo(t1: Term, t2: Term) -> Term {
-    bvso(Op::Bvsmulo, &BitVec::mul, t1, t2)
+    bvso(Op::Bvsmulo, &|a, b| a * b, t1, t2)
 }
 
 /// Note that Lean's Std.BitVec defines zero_extend differently from SMTLib,

--- a/cedar-policy-symcc/tests/properties.rs
+++ b/cedar-policy-symcc/tests/properties.rs
@@ -208,6 +208,12 @@ check_prop!(prop_datetime_offset_commute,
 check_prop!(prop_long_add_error,
     exists_error |a : Long, b : Long| $a + $b);
 
+check_prop!(prop_long_add_error_const,
+    exists_error | | 9223372036854775807 + 1);
+
+check_prop!(prop_long_sub_error_const,
+    exists_error | | -2 - 9223372036854775807);
+
 check_prop!(prop_long_add_commute,
     forall_or_error |a : Long, b : Long| $a + $b == $b + $a);
 
@@ -216,6 +222,9 @@ check_prop!(prop_long_add_assoc,
 
 check_prop!(prop_long_mul_error,
     exists_error |a : Long, b : Long| $a * $b);
+
+check_prop!(prop_long_mul_error_const,
+    exists_error | | 9223372036854775807 * 2);
 
 check_prop!(prop_long_mul_commute,
     forall_or_error |a : Long, b : Long| $a * $b == $b * $a);
@@ -339,6 +348,9 @@ check_prop!(prop_to_days_upper,
 
 check_prop!(prop_to_days_lower,
     forall |a : duration| $a.toDays() >= -106751991167);
+
+check_prop!(prop_offset_overflow,
+    exists_error | | datetime("9281-10-19").offset(duration("9223372036854775807ms")));
 
 check_prop!(prop_str_empty_pattern,
     forall |a : String, b : String| !($a like "" && $b like "") || $a == $b);


### PR DESCRIPTION
## Description of changes

Integer overflow checks for literals would previously always succeed in SymCC (found by @shaobo-he-aws in DRT!)