### PR TITLE
SymCC README typo

### DIFF
--- a/cedar-policy-symcc/README.md
+++ b/cedar-policy-symcc/README.md
@@ -15,8 +15,8 @@ Currently SymCC supports formally verifying the following properties:
 - Policy set equivalence (`CedarSymCompiler::check_equivalent`).
 - Policy set disjointness (`CedarSymCompiler::check_disjoint`).
 
-For each of them, we also have the `CedarSymCompiler::check_*_with_counterexample` counterparts which
-produces a counterexample (a synthesized request and entity store) of the property if it's not true.
+For each of them, we also have the `CedarSymCompiler::check_*_with_counterexample` counterparts that
+produce a counterexample (a synthesized request and entity store) if the property is not true.
 
 ## Setup
 

--- a/cedar-policy-symcc/README.md
+++ b/cedar-policy-symcc/README.md
@@ -69,7 +69,8 @@ async fn main() {
         let always_denies = compiler.check_always_allows(&typed_policies, &sym_env).await.unwrap();
         assert!(!always_denies);
 
-        // Similar to above, but returns a counterexample (synthesized request and entity store)
+        // Similar to above, but returns a counterexample (synthesized request
+        // and entity store) that is denied by the policy set.
         let cex = compiler.check_always_allows_with_counterexample(&typed_policies, &sym_env).await.unwrap().unwrap();
         let resp = Authorizer::new().is_authorized(&cex.request, &policy_set, &cex.entities);
         assert!(resp.decision() == Decision::Deny);

--- a/cedar-policy-symcc/README.md
+++ b/cedar-policy-symcc/README.md
@@ -79,7 +79,7 @@ async fn main() {
 
 To learn more about what you can do with SymCC, see the documentation of `CedarSymCompiler`.
 
-## Devlopement
+## Developement
 
 To build and test this crate, run from the root of the repository:
 ```sh


### PR DESCRIPTION
## Description of changes

Fixing some typos in README

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
