### PR TITLE
WIP: Extended ip.isInRange to take a variadic number of arguments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50fd97c9dc2399518aa331917ac6f274280ec5eb34e555dd291899745c48ec6f"
+checksum = "1c1f056bae57e3e54c3375c41ff79619ddd13460a17d7438712bd0d83fda4ff8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -522,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.43"
+version = "4.5.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c35b5830294e1fa0462034af85cc95225a4cb07092c088c55bda3147cfcd8f65"
+checksum = "b3e7f4214277f3c7aa526a59dd3fbe306a370daee1f8b7b8c987069cd8e888a8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1043,9 +1043,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -1113,9 +1113,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -1195,7 +1195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
  "serde",
 ]
 
@@ -1351,9 +1351,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1859,7 +1859,7 @@ dependencies = [
  "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand 0.9.1",
+ "rand 0.9.2",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.5",
@@ -1963,9 +1963,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -2346,7 +2346,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.10.0",
  "schemars 0.9.0",
- "schemars 1.0.3",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -2589,12 +2589,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/cedar-language-server/src/documentation/markdown/extension/ip/is_in_range.md
+++ b/cedar-language-server/src/documentation/markdown/extension/ip/is_in_range.md
@@ -6,6 +6,6 @@
 ```
 
 Function that evaluates to true if the receiver is an IP address or a range
-of addresses that fall completely within the range specified by the operand.
+of addresses that fall completely within the range specified by the operands.
 This function evaluates (and validates) to an error if either operand does
 not have ipaddr type.

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -113,8 +113,13 @@ impl IPAddr {
         self.addr.is_multicast() && self.prefix >= if self.is_ipv4() { 4 } else { 8 }
     }
 
+    // Return true if this `IpAddr` is contained in any of the other given addresses
+    fn is_in_range(&self, others: &Vec<&Self>) -> bool {
+        others.iter().any(|other| self.is_in_single_range(other))
+    }
+
     /// Return true if this is contained in the given `IPAddr`
-    fn is_in_range(&self, other: &Self) -> bool {
+    fn is_in_single_range(&self, other: &Self) -> bool {
         match (&self.addr, &other.addr) {
             (std::net::IpAddr::V4(self_v4), std::net::IpAddr::V4(other_v4)) => {
                 let netmask = |prefix: u8| {
@@ -382,10 +387,13 @@ fn is_multicast(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
 /// Cedar function which tests whether the first `ipaddr` Cedar type is
 /// in the IP range represented by the second `ipaddr` Cedar type, returning
 /// a Cedar bool
-fn is_in_range(child: &Value, parent: &Value) -> evaluator::Result<ExtensionOutputValue> {
+fn is_in_range(child: &Value, parents: &[Value]) -> evaluator::Result<ExtensionOutputValue> {
     let child_ip = as_ipaddr(child)?;
-    let parent_ip = as_ipaddr(parent)?;
-    Ok(child_ip.is_in_range(parent_ip).into())
+    let parent_ips = parents
+        .iter()
+        .map(|parent| as_ipaddr(parent))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(child_ip.is_in_range(&parent_ips).into())
 }
 
 /// Construct the extension
@@ -431,7 +439,7 @@ pub fn extension() -> Extension {
                 SchemaType::Bool,
                 ipaddr_type.clone(),
             ),
-            ExtensionFunction::binary(
+            ExtensionFunction::variadic(
                 names::IS_IN_RANGE.clone(),
                 CallStyle::MethodStyle,
                 Box::new(is_in_range),
@@ -465,6 +473,22 @@ mod tests {
             assert_eq!(
                 extension_name,
                 Name::parse_unqualified_name("ipaddr")
+                    .expect("should be a valid identifier")
+            );
+        });
+    }
+
+    /// This helper function asserts that a `Result` is actually an
+    /// `Err::ExtensionErr` with our extension name
+    #[track_caller] // report the caller's location as the location of the panic, not the location in this function
+    fn assert_ipaddr_wrong_num_args_err<T: std::fmt::Debug>(
+        res: evaluator::Result<T>,
+        expected_name: &str,
+    ) {
+        assert_matches!(res, Err(EvaluationError::WrongNumArguments(evaluation_errors::WrongNumArgumentsError { function_name, .. })) => {
+            assert_eq!(
+                function_name,
+                Name::parse_unqualified_name(expected_name)
                     .expect("should be a valid identifier")
             );
         });
@@ -985,6 +1009,157 @@ mod tests {
             eval.interpret_inline_policy(&Expr::call_extension_fn(
                 Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
                 vec![ip("192.168.0.1"), ip("1:2:3:4::/48")]
+            )),
+            Ok(Value::from(false))
+        );
+        // test for variadic isInRange extension function
+        // Multiple ranges - first address matches one of them
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("192.168.1.100"),
+                    ip("10.0.0.0/8"),
+                    ip("192.168.0.0/16"),
+                    ip("172.16.0.0/12")
+                ]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // Multiple ranges - first address doesn't match any
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("8.8.8.8"),
+                    ip("192.168.0.0/16"),
+                    ip("10.0.0.0/8"),
+                    ip("172.16.0.0/12")
+                ]
+            )),
+            Ok(Value::from(false))
+        );
+
+        // IPv6 multiple ranges - matches last one
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("2001:db8::1"),
+                    ip("fe80::/10"),
+                    ip("::1/128"),
+                    ip("2001:db8::/32")
+                ]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // Mixed IPv4/IPv6 ranges - IPv4 address, only IPv4 ranges should match
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("192.168.1.1"),
+                    ip("2001:db8::/32"),
+                    ip("192.168.0.0/16"),
+                    ip("fe80::/10")
+                ]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // Edge case: IPv4 loopback in multiple ranges
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("127.0.0.1"),
+                    ip("192.168.0.0/16"),
+                    ip("127.0.0.0/8"),
+                    ip("10.0.0.0/8")
+                ]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // Edge case: IPv6 loopback
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("::1"),
+                    ip("fe80::/10"),
+                    ip("::1/128"),
+                    ip("2001:db8::/32")
+                ]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // Boundary test: IPv4 at network boundary
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![ip("192.168.0.0"), ip("10.0.0.0/8"), ip("192.168.0.0/24")]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // Boundary test: IPv4 at broadcast boundary
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![ip("192.168.0.255"), ip("192.168.0.0/24"), ip("10.0.0.0/8")]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // No short-circuiting semantics: this will error even if the first address is within the range of the second.
+        assert_ipaddr_err(eval.interpret_inline_policy(&Expr::call_extension_fn(
+            Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+            vec![
+                ip("192.168.0.255"),
+                ip("192.168.0.0/24"),
+                ip("not ipaddr"),
+                ip("::ffff:192.168.0.0/112"),
+                ip("2001:db8::/32"),
+            ],
+        )));
+
+        // Requires at least one argument.
+        assert_ipaddr_wrong_num_args_err(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![],
+            )),
+            "isInRange",
+        );
+
+        // Single address ranges (implicit /32 and /128)
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("10.0.0.1"),
+                    ip("192.168.1.1"),
+                    ip("10.0.0.1"),
+                    ip("172.16.1.1")
+                ]
+            )),
+            Ok(Value::from(true))
+        );
+
+        // No match in multiple ranges
+        assert_eq!(
+            eval.interpret_inline_policy(&Expr::call_extension_fn(
+                Name::parse_unqualified_name("isInRange").expect("should be a valid identifier"),
+                vec![
+                    ip("203.0.113.1"),
+                    ip("192.168.0.0/16"),
+                    ip("10.0.0.0/8"),
+                    ip("172.16.0.0/12")
+                ]
             )),
             Ok(Value::from(false))
         );

--- a/cedar-policy-core/src/validator/extension_schema.rs
+++ b/cedar-policy-core/src/validator/extension_schema.rs
@@ -81,6 +81,8 @@ pub struct ExtensionFunctionType {
     return_type: Type,
     /// Custom argument validation (optional)
     check_arguments: Option<ArgumentCheckFn>,
+    /// Whether it is a variadic function or not. A variadic function can take 0 or more arguments of the last argument type.
+    is_variadic: bool,
 }
 
 impl ExtensionFunctionType {
@@ -90,12 +92,14 @@ impl ExtensionFunctionType {
         argument_types: Vec<Type>,
         return_type: Type,
         check_arguments: Option<ArgumentCheckFn>,
+        is_variadic: bool,
     ) -> Self {
         Self {
             name,
             argument_types,
             return_type,
             check_arguments,
+            is_variadic,
         }
     }
 
@@ -126,6 +130,10 @@ impl ExtensionFunctionType {
     /// function defined.
     pub fn has_argument_check(&self) -> bool {
         self.check_arguments.is_some()
+    }
+
+    pub fn is_variadic(&self) -> bool {
+        self.is_variadic
     }
 }
 

--- a/cedar-policy-core/src/validator/extensions/datetime.rs
+++ b/cedar-policy-core/src/validator/extensions/datetime.rs
@@ -111,6 +111,7 @@ pub fn extension_schema() -> ExtensionSchema {
             get_argument_types(f.name(), &datetime_ty, &duration_ty),
             return_type,
             get_argument_check(f.name()),
+            false,
         )
     });
     ExtensionSchema::new(

--- a/cedar-policy-core/src/validator/extensions/decimal.rs
+++ b/cedar-policy-core/src/validator/extensions/decimal.rs
@@ -95,6 +95,7 @@ pub fn extension_schema() -> ExtensionSchema {
             get_argument_types(f.name(), &decimal_ty),
             return_type,
             get_argument_check(f.name()),
+            false,
         )
     });
     ExtensionSchema::new(decimal_ext.name().clone(), fun_tys, std::iter::empty())

--- a/cedar-policy-core/src/validator/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/validator/extensions/ipaddr.rs
@@ -89,11 +89,13 @@ pub fn extension_schema() -> ExtensionSchema {
             .return_type()
             .map(|ty| return_type.is_consistent_with(ty))
             .unwrap_or_else(|| return_type == Type::Never));
+
         ExtensionFunctionType::new(
             f.name().clone(),
             get_argument_types(f.name(), &ipaddr_ty),
             return_type,
             get_argument_check(f.name()),
+            f.is_variadic(),
         )
     });
     ExtensionSchema::new(ipaddr_ext.name().clone(), fun_tys, std::iter::empty())

--- a/cedar-policy-core/src/validator/extensions/partial_evaluation.rs
+++ b/cedar-policy-core/src/validator/extensions/partial_evaluation.rs
@@ -65,6 +65,7 @@ pub fn extension_schema() -> ExtensionSchema {
             get_argument_types(&fstring),
             return_type,
             None,
+            f.is_variadic(),
         )
     });
     ExtensionSchema::new(pe_ext.name().clone(), fun_tys, std::iter::empty())

--- a/cedar-policy-core/src/validator/level_validate.rs
+++ b/cedar-policy-core/src/validator/level_validate.rs
@@ -955,6 +955,11 @@ mod levels_validation_tests {
             1,
         );
         assert_requires_level(
+            r#"permit(principal, action, resource) when { ip("192.168.0.0").isInRange(ip("192.168.0.2/12"), principal.ip) };"#,
+            [r#"principal.ip"#],
+            1,
+        );
+        assert_requires_level(
             r#"permit(principal, action, resource) when { principal.other like "*"};"#,
             ["principal.other"],
             1,

--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -2547,7 +2547,20 @@ impl<'a> SingleEnvTypechecker<'a> {
                 // since we mutate several times, I think readability is better if we keep a consistent pattern, rather than using Clippy's suggestion for the first block
                 #[allow(clippy::useless_let_if_seq)]
                 let mut failed = false;
-                if args.len() != arg_tys.len() {
+
+                // variadic functions can take one or more arguments of the last argument type
+                if efunc.is_variadic() && args.len() < arg_tys.len() {
+                    type_errors.push(ValidationError::wrong_number_args(
+                        ext_expr.source_loc().into_maybe_loc(),
+                        self.policy_id.clone(),
+                        arg_tys.len(),
+                        args.len(),
+                    ));
+                    failed = true;
+                }
+
+                // non-variadic functions must take the exact number of argument as the number of argument types
+                if !efunc.is_variadic() && args.len() != arg_tys.len() {
                     type_errors.push(ValidationError::wrong_number_args(
                         ext_expr.source_loc().into_maybe_loc(),
                         self.policy_id.clone(),
@@ -2588,7 +2601,14 @@ impl<'a> SingleEnvTypechecker<'a> {
                         None => TypecheckAnswer::RecursionLimit,
                     }
                 } else {
-                    let typechecked_args = zip(args.as_ref(), arg_tys).map(|(arg, ty)| {
+                    let typechecked_args = args.iter().enumerate().map(|(index, arg)| {
+                        // PANIC SAFETY: only variadic functions can have more arguments than argument types, and by construction
+                        // variadic functions have at least 2 argument types. See [`crate::crate::ast::ExtensionFunction::variadic`]
+                        #[allow(clippy::unwrap_used)]
+                        let ty: &Type = match arg_tys.get(index) {
+                            Some(ty) => ty,
+                            None => arg_tys.last().unwrap(),
+                        };
                         self.expect_type(prior_capability, arg, ty.clone(), type_errors, |_| None)
                     });
                     TypecheckAnswer::sequence_all_then_typecheck(

--- a/cedar-policy-core/src/validator/typecheck/test/extensions.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/extensions.rs
@@ -38,6 +38,11 @@ fn ip_extension_typechecks() {
     let expr = Expr::from_str("ip(\"127.0.0.1\").isInRange(ip(\"1:2:3:4::/48\"))")
         .expect("parsing should succeed");
     assert_typechecks_empty_schema(&expr, &Type::primitive_boolean());
+    let expr = Expr::from_str(
+        "ip(\"127.0.0.1\").isInRange(ip(\"192.168.0.1/24\"), ip(\"192.167.0.1/24\"), ip(\"192.167.0.3/24\"))",
+    )
+    .expect("parsing should succeed");
+    assert_typechecks_empty_schema(&expr, &Type::primitive_boolean());
 }
 
 #[test]
@@ -83,6 +88,20 @@ fn ip_extension_typecheck_fails() {
         ValidationError::wrong_number_args(get_loc(src, src), expr_id_placeholder(), 1, 2,)
     );
     let src = "ip(\"127.0.0.1\").isInRange(3)";
+    let expr = Expr::from_str(src).expect("parsing should succeed");
+    let errors = assert_typecheck_fails_empty_schema(&expr, &Type::primitive_boolean());
+    let type_error = assert_exactly_one_diagnostic(errors);
+    assert_eq!(
+        type_error,
+        ValidationError::expected_type(
+            get_loc(src, "3"),
+            expr_id_placeholder(),
+            Type::extension(ipaddr_name.clone()),
+            Type::primitive_long(),
+            None,
+        )
+    );
+    let src = "ip(\"192.168.0.1\").isInRange(ip(\"192.168.0.1/24\"), 3)";
     let expr = Expr::from_str(src).expect("parsing should succeed");
     let errors = assert_typecheck_fails_empty_schema(&expr, &Type::primitive_boolean());
     let type_error = assert_exactly_one_diagnostic(errors);

--- a/cedar-policy-core/src/validator/typecheck/test/strict.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/strict.rs
@@ -656,9 +656,19 @@ fn test_extension() {
             Type::extension("ipaddr".parse().unwrap()),
         );
         assert_types_must_match(
-            s,
+            s.clone(),
             &q,
             &Expr::from_str(r#"ip("192.168.1.0/8").isInRange(if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
+            r#"1 == false"#,
+            Type::primitive_boolean(),
+            [Type::primitive_long(), Type::singleton_boolean(false)],
+            LubHelp::None,
+            LubContext::Equality,
+        );
+        assert_types_must_match(
+            s,
+            &q,
+            &Expr::from_str(r#"ip("192.168.1.0/8").isInRange(ip("127.0.0.3"), if 1 == false then ip("127.0.0.1") else ip("192.168.1.1"))"#).unwrap(),
             r#"1 == false"#,
             Type::primitive_boolean(),
             [Type::primitive_long(), Type::singleton_boolean(false)],

--- a/cedar-policy/src/ffi/is_authorized.rs
+++ b/cedar-policy/src/ffi/is_authorized.rs
@@ -881,7 +881,7 @@ mod test {
              }
             },
             "policies": {
-                "staticPolicies": "permit(principal == User::\"alice\", action, resource) when { context.is_authenticated && context.source_ip.isInRange(ip(\"222.222.222.0/24\")) };"
+                "staticPolicies": "permit(principal == User::\"alice\", action, resource) when { context.is_authenticated && context.source_ip.isInRange(ip(\"192.167.0.1/24\"), ip(\"222.222.222.0/24\")) };"
             },
             "entities": []
         });


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)

This PR only includes changes to the type-checker and evaluator. Updates to `cedar-policy-symcc` and the corresponding Lean code are still pending.

