### PR TITLE
SymCC: Add symbolizer to match Lean model

### DIFF
--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -41,6 +41,7 @@ pub use symcc::term;
 pub use symcc::term_type;
 pub use symcc::type_abbrevs;
 pub use symcc::verifier::Asserts;
+pub use symcc::Interpretation;
 pub use symcc::{Env, SmtLibScript, SymEnv};
 
 impl SymEnv {

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -36,6 +36,7 @@ pub mod op;
 mod result;
 mod smtlib_script;
 pub mod solver;
+mod symbolizer;
 mod tags;
 pub mod term;
 pub mod term_type;

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -243,7 +243,7 @@ impl SymEntityData {
         }
     }
 
-    pub fn of_action_type<'a>(
+    pub(super) fn of_action_type<'a>(
         act_ty: &EntityType,
         act_tys: impl IntoIterator<Item = &'a EntityType>,
         schema: &ValidatorSchema,
@@ -333,7 +333,7 @@ impl SymEntities {
     ///
     /// This function assumes that no entity types have tags, and that action types
     /// have no attributes.
-    pub fn of_schema(schema: &ValidatorSchema) -> Result<Self, CompileError> {
+    fn of_schema(schema: &ValidatorSchema) -> Result<Self, CompileError> {
         let e_data = schema.entity_types().map(|vdtr_ety| {
             let ety = core_entity_type_into_entity_type(vdtr_ety.name());
             match SymEntityData::of_entity_type(ety, vdtr_ety, schema) {
@@ -428,15 +428,13 @@ fn record(attrs: Attributes) -> Type {
 }
 
 // From `Validation/Types.lean`
-#[derive(Debug)]
-pub struct StandardEntitySchemaEntry {
-    pub ancestors: BTreeSet<EntityType>,
-    pub attrs: Attributes,
-    pub tags: Option<Type>,
+pub(super) struct StandardEntitySchemaEntry {
+    pub(super) ancestors: BTreeSet<EntityType>,
+    pub(super) attrs: Attributes,
+    pub(super) tags: Option<Type>,
 }
 
-#[derive(Debug)]
-pub enum EntitySchemaEntry {
+pub(super) enum EntitySchemaEntry {
     Standard(StandardEntitySchemaEntry),
     Enum(BTreeSet<SmolStr>),
 }

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -184,7 +184,7 @@ impl SymEntityData {
                 let attrs_uuf = Uuf(op::Uuf {
                     id: format!("attrs[{ety}]"),
                     arg: entity(ety.clone()), // more efficient than the Lean: avoids `TermType::of_type()` and constructs the `TermType` directly
-                    out: TermType::of_type(record(sch.attrs))?,
+                    out: TermType::of_type(&record(sch.attrs))?,
                 });
                 let ancs_uuf = |anc_ty: &EntityType| {
                     Uuf(op::Uuf {
@@ -203,7 +203,7 @@ impl SymEntityData {
                         vals: Uuf(op::Uuf {
                             id: format!("tagVals[{ety}]"),
                             arg: TermType::tag_for(ety.clone()), // record representing the pair type (ety, .string)
-                            out: TermType::of_type(tag_ty)?,
+                            out: TermType::of_type(&tag_ty)?,
                         }),
                     })
                 };
@@ -384,7 +384,7 @@ impl SymRequest {
             }),
             context: Term::Var(TermVar {
                 id: "context".to_string(),
-                ty: TermType::of_type(record(req_ty.context.clone()))?,
+                ty: TermType::of_type(&record(req_ty.context.clone()))?,
             }),
         })
     }

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -554,6 +554,11 @@ impl<'a> Environment<'a> {
             },
         })
     }
+
+    /// Returns the type of the context.
+    pub fn context_type(&self) -> Type {
+        Type::record_with_attributes(self.req_ty.context.clone(), OpenTag::ClosedAttributes)
+    }
 }
 
 pub fn to_validator_request_env<'a>(

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -243,7 +243,7 @@ impl SymEntityData {
         }
     }
 
-    fn of_action_type<'a>(
+    pub fn of_action_type<'a>(
         act_ty: &EntityType,
         act_tys: impl IntoIterator<Item = &'a EntityType>,
         schema: &ValidatorSchema,
@@ -428,19 +428,21 @@ fn record(attrs: Attributes) -> Type {
 }
 
 // From `Validation/Types.lean`
-struct StandardEntitySchemaEntry {
-    ancestors: BTreeSet<EntityType>,
-    attrs: Attributes,
-    tags: Option<Type>,
+#[derive(Debug)]
+pub struct StandardEntitySchemaEntry {
+    pub ancestors: BTreeSet<EntityType>,
+    pub attrs: Attributes,
+    pub tags: Option<Type>,
 }
 
-enum EntitySchemaEntry {
+#[derive(Debug)]
+pub enum EntitySchemaEntry {
     Standard(StandardEntitySchemaEntry),
     Enum(BTreeSet<SmolStr>),
 }
 
 impl EntitySchemaEntry {
-    fn of_schema(
+    pub fn of_schema(
         ety: &EntityType,
         validator_ety: &ValidatorEntityType,
         schema: &ValidatorSchema,
@@ -553,6 +555,10 @@ impl<'a> Environment<'a> {
                 context: context_attributes(schema.get_action_id(renv.action().as_ref())?).ok()?,
             },
         })
+    }
+
+    pub fn schema(&self) -> &'a ValidatorSchema {
+        self.schema
     }
 
     /// Returns the type of the context.

--- a/cedar-policy-symcc/src/symcc/symbolizer.rs
+++ b/cedar-policy-symcc/src/symcc/symbolizer.rs
@@ -1,0 +1,108 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This module includes functions to convert
+//! concrete Cedar values, requests, and entities to
+//! (literal) symbolic terms or environments.
+
+use cedar_policy_core::ast::{Literal, Value, ValueKind};
+use cedar_policy_core::validator::types::{EntityRecordKind, OpenTag, Type};
+use miette::Diagnostic;
+use thiserror::Error;
+
+use super::factory;
+use super::term::Term;
+use super::term_type::TermType;
+use super::type_abbrevs::EntityUID;
+use super::CompileError;
+
+/// Errors that happen when converting concrete
+/// values to symbolic terms
+#[derive(Debug, Diagnostic, Error)]
+pub enum SymbolizeError {
+    #[error("unable to symbolize value {0}")]
+    UnableToSymbolizeValue(Value),
+    #[error("compile error")]
+    CompileError(#[from] CompileError),
+}
+
+impl Term {
+    /// Corresponds to `Prim.symbolize`
+    pub fn from_literal(l: &Literal) -> Self {
+        match l {
+            Literal::Bool(b) => (*b).into(),
+            Literal::Long(i) => (*i).into(),
+            Literal::String(s) => s.clone().into(),
+            Literal::EntityUID(euid) => EntityUID::from(euid.as_ref().clone()).into(),
+        }
+    }
+
+    /// Corresponds to `Value.symbolize?` in Lean.
+    pub fn from_value(v: &Value, ty: &Type) -> Result<Self, SymbolizeError> {
+        match (v.value_kind(), ty) {
+            (ValueKind::Lit(l), _) => Ok(Term::from_literal(l)),
+            (
+                ValueKind::Set(s),
+                Type::Set {
+                    element_type: Some(elem_ty),
+                },
+            ) => {
+                let elems = s
+                    .iter()
+                    .map(|elem| Term::from_value(elem, elem_ty))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(factory::set_of(elems, TermType::of_type(elem_ty.as_ref())?))
+            }
+            (
+                ValueKind::Record(rec),
+                Type::EntityOrRecord(EntityRecordKind::Record {
+                    attrs,
+                    open_attributes: OpenTag::ClosedAttributes,
+                }),
+            ) => {
+                let attrs = attrs
+                    .iter()
+                    .map(|(attr, attr_ty)| {
+                        Ok::<_, SymbolizeError>(if let Some(attr_val) = rec.get(attr) {
+                            if attr_ty.is_required() {
+                                (
+                                    attr.clone(),
+                                    Term::from_value(attr_val, &attr_ty.attr_type)?,
+                                )
+                            } else {
+                                (
+                                    attr.clone(),
+                                    factory::some_of(Term::from_value(
+                                        attr_val,
+                                        &attr_ty.attr_type,
+                                    )?),
+                                )
+                            }
+                        } else {
+                            (
+                                attr.clone(),
+                                factory::none_of(TermType::of_type(&attr_ty.attr_type)?),
+                            )
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(factory::record_of(attrs))
+            }
+            (ValueKind::ExtensionValue(_), _) => todo!("symbolizing extension values"),
+            _ => Err(SymbolizeError::UnableToSymbolizeValue(v.clone())),
+        }
+    }
+}

--- a/cedar-policy-symcc/tests/utils/mod.rs
+++ b/cedar-policy-symcc/tests/utils/mod.rs
@@ -29,8 +29,8 @@ use cedar_policy::{
 use cedar_policy_core::{ast::RequestSchema, extensions::Extensions};
 use cedar_policy_symcc::{
     compile_always_allows, compile_always_denies, compile_disjoint, compile_equivalent,
-    compile_implies, compile_never_errors, solver::Solver, CedarSymCompiler, Env, SymEnv,
-    WellTypedPolicies, WellTypedPolicy,
+    compile_implies, compile_never_errors, solver::Solver, CedarSymCompiler, Env, Interpretation,
+    SymEnv, WellTypedPolicies, WellTypedPolicy,
 };
 
 #[track_caller]
@@ -157,6 +157,14 @@ pub async fn assert_never_errors_ok<S: Solver>(
         let asserts = compile_never_errors(&typed_policy, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
+    } else {
+        // Test that the default interpretation does satisfy the property
+        let interp = Interpretation::default(&envs.symenv);
+        let literal_symenv = envs.symenv.interpret(&interp);
+        let asserts = compile_never_errors(&typed_policy, &literal_symenv).unwrap();
+        // There should be some literal false in the assertions
+        assert!(asserts.asserts().iter().all(|t| t.is_literal()));
+        assert!(asserts.asserts().iter().any(|t| t == &false.into()));
     }
 
     res
@@ -201,6 +209,14 @@ pub async fn assert_always_allows_ok<S: Solver>(
         let asserts = compile_always_allows(&typed_pset, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
+    } else {
+        // Test that the default interpretation does satisfy the property
+        let interp = Interpretation::default(&envs.symenv);
+        let literal_symenv = envs.symenv.interpret(&interp);
+        let asserts = compile_always_allows(&typed_pset, &literal_symenv).unwrap();
+        // There should be some literal false in the assertions
+        assert!(asserts.asserts().iter().all(|t| t.is_literal()));
+        assert!(asserts.asserts().iter().any(|t| t == &false.into()));
     }
 
     res
@@ -256,6 +272,14 @@ pub async fn assert_always_denies_ok<S: Solver>(
         let asserts = compile_always_denies(&typed_pset, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
+    } else {
+        // Test that the default interpretation does satisfy the property
+        let interp = Interpretation::default(&envs.symenv);
+        let literal_symenv = envs.symenv.interpret(&interp);
+        let asserts = compile_always_denies(&typed_pset, &literal_symenv).unwrap();
+        // There should be some literal false in the assertions
+        assert!(asserts.asserts().iter().all(|t| t.is_literal()));
+        assert!(asserts.asserts().iter().any(|t| t == &false.into()));
     }
 
     res
@@ -314,6 +338,14 @@ pub async fn assert_equivalent_ok<S: Solver>(
         let asserts = compile_equivalent(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
+    } else {
+        // Test that the default interpretation does satisfy the property
+        let interp = Interpretation::default(&envs.symenv);
+        let literal_symenv = envs.symenv.interpret(&interp);
+        let asserts = compile_equivalent(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
+        // There should be some literal false in the assertions
+        assert!(asserts.asserts().iter().all(|t| t.is_literal()));
+        assert!(asserts.asserts().iter().any(|t| t == &false.into()));
     }
 
     res
@@ -374,6 +406,14 @@ pub async fn assert_implies_ok<S: Solver>(
         let asserts = compile_implies(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
+    } else {
+        // Test that the default interpretation does satisfy the property
+        let interp = Interpretation::default(&envs.symenv);
+        let literal_symenv = envs.symenv.interpret(&interp);
+        let asserts = compile_implies(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
+        // There should be some literal false in the assertions
+        assert!(asserts.asserts().iter().all(|t| t.is_literal()));
+        assert!(asserts.asserts().iter().any(|t| t == &false.into()));
     }
 
     res
@@ -434,6 +474,14 @@ pub async fn assert_disjoint_ok<S: Solver>(
         let asserts = compile_disjoint(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
+    } else {
+        // Test that the default interpretation does satisfy the property
+        let interp = Interpretation::default(&envs.symenv);
+        let literal_symenv = envs.symenv.interpret(&interp);
+        let asserts = compile_disjoint(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
+        // There should be some literal false in the assertions
+        assert!(asserts.asserts().iter().all(|t| t.is_literal()));
+        assert!(asserts.asserts().iter().any(|t| t == &false.into()));
     }
 
     res

--- a/cedar-policy-symcc/tests/utils/mod.rs
+++ b/cedar-policy-symcc/tests/utils/mod.rs
@@ -154,6 +154,7 @@ pub async fn assert_never_errors_ok<S: Solver>(
         );
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
+        assert!(literal_symenv.is_literal());
         let asserts = compile_never_errors(&typed_policy, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
@@ -161,6 +162,7 @@ pub async fn assert_never_errors_ok<S: Solver>(
         // Test that the default interpretation does satisfy the property
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
+        assert!(literal_symenv.is_literal());
         let asserts = compile_never_errors(&typed_policy, &literal_symenv).unwrap();
         // There should be some literal false in the assertions
         assert!(asserts.asserts().iter().all(|t| t.is_literal()));
@@ -206,6 +208,7 @@ pub async fn assert_always_allows_ok<S: Solver>(
         );
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
+        assert!(literal_symenv.is_literal());
         let asserts = compile_always_allows(&typed_pset, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
@@ -213,6 +216,7 @@ pub async fn assert_always_allows_ok<S: Solver>(
         // Test that the default interpretation does satisfy the property
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
+        assert!(literal_symenv.is_literal());
         let asserts = compile_always_allows(&typed_pset, &literal_symenv).unwrap();
         // There should be some literal false in the assertions
         assert!(asserts.asserts().iter().all(|t| t.is_literal()));
@@ -269,6 +273,7 @@ pub async fn assert_always_denies_ok<S: Solver>(
         );
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
+        assert!(literal_symenv.is_literal());
         let asserts = compile_always_denies(&typed_pset, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
@@ -276,6 +281,7 @@ pub async fn assert_always_denies_ok<S: Solver>(
         // Test that the default interpretation does satisfy the property
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
+        assert!(literal_symenv.is_literal());
         let asserts = compile_always_denies(&typed_pset, &literal_symenv).unwrap();
         // There should be some literal false in the assertions
         assert!(asserts.asserts().iter().all(|t| t.is_literal()));
@@ -335,6 +341,7 @@ pub async fn assert_equivalent_ok<S: Solver>(
         );
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
+        assert!(literal_symenv.is_literal());
         let asserts = compile_equivalent(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
@@ -342,6 +349,7 @@ pub async fn assert_equivalent_ok<S: Solver>(
         // Test that the default interpretation does satisfy the property
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
+        assert!(literal_symenv.is_literal());
         let asserts = compile_equivalent(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // There should be some literal false in the assertions
         assert!(asserts.asserts().iter().all(|t| t.is_literal()));
@@ -403,6 +411,7 @@ pub async fn assert_implies_ok<S: Solver>(
         );
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
+        assert!(literal_symenv.is_literal());
         let asserts = compile_implies(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
@@ -410,6 +419,7 @@ pub async fn assert_implies_ok<S: Solver>(
         // Test that the default interpretation does satisfy the property
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
+        assert!(literal_symenv.is_literal());
         let asserts = compile_implies(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // There should be some literal false in the assertions
         assert!(asserts.asserts().iter().all(|t| t.is_literal()));
@@ -471,6 +481,7 @@ pub async fn assert_disjoint_ok<S: Solver>(
         );
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
+        assert!(literal_symenv.is_literal());
         let asserts = compile_disjoint(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // All asserts should be simplified to literal true's
         assert!(asserts.asserts().iter().all(|t| t == &true.into()));
@@ -478,6 +489,7 @@ pub async fn assert_disjoint_ok<S: Solver>(
         // Test that the default interpretation does satisfy the property
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
+        assert!(literal_symenv.is_literal());
         let asserts = compile_disjoint(&typed_pset1, &typed_pset2, &literal_symenv).unwrap();
         // There should be some literal false in the assertions
         assert!(asserts.asserts().iter().all(|t| t.is_literal()));


### PR DESCRIPTION
## Description of changes

Lean SymCC recently got added a new set of [`symbolize?` functions](https://github.com/cedar-policy/cedar-spec/blob/main/cedar-lean/Cedar/SymCC/Symbolizer.lean) to convert concrete values/requests/entities into the symbolic versions.
This PR adds the same for the Rust version.

Main use cases:
- We can use `SymEnv::from_concrete_env` to load a concrete entity store with a verification task.
- This also allows the generated counterexamples to be "symbolized" and used to test the factory functions more thoroughly on concrete values (as some of the updated `assert_` functions in integeration tests are doing). Improved line coverage of symcc by about 2%

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
