### PR TITLE
SymCC: allow configuring `LocalSolver`

### DIFF
--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -106,9 +106,9 @@ pub struct LocalSolver {
 impl LocalSolver {
     /// Creates a new [`LocalSolver`] from a custom [`Command`].
     ///
-    /// The input command is expected to act as an interactive SMT solver
+    /// The input command is expected to behave as an interactive SMT solver
     /// that reads queries from stdin in SMT-LIB 2 format (e.g., `cvc5 --lang smt` or `z3`).
-    pub fn from_command(mut cmd: Command) -> Result<Self> {
+    pub fn from_command(cmd: &mut Command) -> Result<Self> {
         let child = cmd
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -131,19 +131,14 @@ impl LocalSolver {
 
     pub fn cvc5() -> Result<Self> {
         let path = std::env::var("CVC5").unwrap_or_else(|_| "cvc5".into());
-        let mut cmd = Command::new(path);
-        // limit of 60000ms = 1 min of wall time for local solves, for now
-        cmd.args(["--lang", "smt", "--tlimit=60000"]);
-        Self::from_command(cmd)
+        // Limit of 60000ms = 1 min of wall time for local solves, for now
+        Self::from_command(Command::new(path).args(["--lang", "smt", "--tlimit=60000"]))
     }
 
     /// Similar to [`Self::cvc5`] but with custom arguments.
     pub fn cvc5_with_args(args: impl IntoIterator<Item = impl AsRef<OsStr>>) -> Result<Self> {
         let path = std::env::var("CVC5").unwrap_or_else(|_| "cvc5".into());
-        let mut cmd = Command::new(path);
-        cmd.args(["--lang", "smt"]);
-        cmd.args(args);
-        Self::from_command(cmd)
+        Self::from_command(Command::new(path).args(["--lang", "smt"]).args(args))
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -93,8 +93,27 @@ pub trait Solver {
     fn get_model(&mut self) -> impl Future<Output = Result<Option<String>>> + Send;
 }
 
-/// Implements `Solver` by launching an SMT solver in a new process and
-/// communicating with it
+/// A solver instance that communicates with a local SMT solver process
+/// through stdin/stdout.
+///
+/// We officially support [cvc5](https://github.com/cvc5/cvc5),
+/// but other SMT solvers such as [Z3](https://github.com/Z3Prover/z3)
+/// may also work with a subset of SymCC's functionality.
+///
+/// Examples:
+/// ```no_run
+/// use tokio::process::Command;
+/// use cedar_policy_symcc::solver::LocalSolver;
+///
+/// // Spawns a cvc5 process with the default arguments
+/// let solver = LocalSolver::cvc5().unwrap();
+///
+/// // Spawns a cvc5 process with custom arguments
+/// let solver = LocalSolver::cvc5_with_args(["--rlimit=1000"]).unwrap();
+///
+/// // Spawns a custom solver process
+/// let solver = LocalSolver::from_command(Command::new("z3").args(["rlimit", "1000"])).unwrap();
+/// ```
 #[derive(Debug)]
 pub struct LocalSolver {
     solver_stdin: BufWriter<ChildStdin>,

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -2167,3 +2167,20 @@ async fn entity_uid_quote() {
     assert_does_not_always_deny(&mut compiler, &pset, &envs).await;
     assert_does_not_always_allow(&mut compiler, &pset, &envs).await;
 }
+
+/// Tests `LocalSolver::cvc5_with_args`
+#[tokio::test]
+async fn cvc5_with_args() {
+    let validator = Validator::new(attributes_schema());
+    let mut compiler =
+        CedarSymCompiler::new(LocalSolver::cvc5_with_args(["--rlimit=1000"]).unwrap()).unwrap();
+    let envs = Environments::new(validator.schema(), "User", "Action::\"view\"", "Dept");
+    let pset = utils::pset_from_text(
+        r#"
+        permit(principal, action, resource)
+        when { principal == User::"alice" };
+    "#,
+        &validator,
+    );
+    assert_does_not_always_allow(&mut compiler, &pset, &envs).await;
+}


### PR DESCRIPTION
## Description of changes

Minor change to support #1794 (i.e., allowing users to tweak flags to `LocalSolver`). Examples:
```
// Different time limit
LocalSolver::cvc5_with_args(["--tlimit=120000"])

// Different solver
LocalSolver::from_command(Command::new("z3").args(["rlimit=1000"]))
```