### PR TITLE
Fix SymCC parsing of `duration` function application

### DIFF
--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -31,10 +31,10 @@ pub enum Error {
     #[error("action not found in schema: {0}")]
     ActionNotInSchema(String),
     /// Errors during symbolic compilation.
-    #[error("symbolic compilation failed")]
+    #[error("symbolic compilation failed: {0}")]
     CompileError(#[from] CompileError),
     /// Errors from the SMT encoder.
-    #[error("failed to encode SMT terms")]
+    #[error("failed to encode SMT terms: {0}")]
     EncodeError(#[from] EncodeError),
     /// Solver-related errors.
     #[error(transparent)]
@@ -46,10 +46,10 @@ pub enum Error {
     #[error("input policy (set) is not well typed with respect to the schema {errs:?}")]
     PolicyNotWellTyped { errs: Vec<ValidationError> },
     /// Failed to decode the SMT model.
-    #[error("failed to decode model")]
+    #[error("failed to decode model: {0}")]
     DecodeModel(#[from] DecodeError),
     /// Errors during concretization.
-    #[error("failed to recover a concrete counterexample")]
+    #[error("failed to recover a concrete counterexample: {0}")]
     ConcretizeError(#[from] ConcretizeError),
 }
 

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -973,7 +973,7 @@ mod datetime_tests {
         assert!(
             matches!(
                 compile(&datetime_lit(str), &sym_env),
-                Err(CompileError::TypeError),
+                Err(CompileError::ExtError(_)),
             ),
             "{msg}"
         );

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -422,12 +422,12 @@ pub fn compile_record(ats: Vec<(Attr, Term)>) -> Result<Term> {
     ))
 }
 
-pub fn compile_call0(mk: impl Fn(String) -> Option<Ext>, arg: Term) -> Result<Term> {
+pub fn compile_call0(mk: impl Fn(String) -> Option<Ext>, arg: Term, fn_name: &str) -> Result<Term> {
     match arg {
         Term::Some(t) => match Arc::unwrap_or_clone(t) {
             Term::Prim(TermPrim::String(s)) => match mk(s) {
                 Some(v) => Ok(some_of(v.into())),
-                None => Err(CompileError::TypeError),
+                None => Err(CompileError::ExtensionFunctionApp(fn_name.to_owned())),
             },
             _ => Err(CompileError::TypeError),
         },
@@ -515,7 +515,7 @@ pub fn compile_call(xfn: &cedar_policy_core::ast::Name, ts: Vec<Term>) -> Result
     match (xfn.to_string().as_str(), ts.len()) {
         ("decimal", 1) => {
             let t1 = extract_first(ts);
-            compile_call0(Ext::parse_decimal, t1)
+            compile_call0(Ext::parse_decimal, t1, "decimal")
         }
         ("lessThan", 2) => {
             let (t1, t2) = extract_first2(ts);
@@ -535,7 +535,7 @@ pub fn compile_call(xfn: &cedar_policy_core::ast::Name, ts: Vec<Term>) -> Result
         }
         ("ip", 1) => {
             let t1 = extract_first(ts);
-            compile_call0(Ext::parse_ip, t1)
+            compile_call0(Ext::parse_ip, t1, "ip")
         }
         ("isIpv4", 1) => {
             let t1 = extract_first(ts);
@@ -559,11 +559,11 @@ pub fn compile_call(xfn: &cedar_policy_core::ast::Name, ts: Vec<Term>) -> Result
         }
         ("datetime", 1) => {
             let t1 = extract_first(ts);
-            compile_call0(Ext::parse_datetime, t1)
+            compile_call0(Ext::parse_datetime, t1, "datetime")
         }
         ("duration", 1) => {
             let t1 = extract_first(ts);
-            compile_call0(Ext::parse_duration, t1)
+            compile_call0(Ext::parse_duration, t1, "duration")
         }
         ("offset", 2) => {
             let (t1, t2) = extract_first2(ts);

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -723,7 +723,7 @@ mod decimal_tests {
     use cedar_policy_core::ast::Name;
 
     use cedar_policy::{RequestEnv, Schema};
-    use cool_asserts::{assert_matches, assert_panics};
+    use cool_asserts::assert_matches;
 
     use crate::symcc::{extension_types::decimal::Decimal, result::CompileError};
 
@@ -794,12 +794,11 @@ mod decimal_tests {
     #[track_caller]
     fn test_invalid(str: &str, msg: &str) {
         let sym_env = SymEnv::new(&decimal_schema(), &request_env()).expect("Malformed sym env.");
-        assert_panics!(
-            assert_matches!(
-                compile(&dec_lit(str), &sym_env),
-                Err(CompileError::TypeError),
-            ),
-            includes(msg)
+        assert_matches!(
+            compile(&dec_lit(str), &sym_env),
+            Err(CompileError::ExtError(_)),
+            "{}",
+            msg
         );
     }
 
@@ -836,12 +835,11 @@ mod decimal_tests {
         test_invalid("922337203685477.5808", "overflow");
         test_invalid("-922337203685477.5809", "overflow");
         let s = Expr::get_attr(Expr::var(Var::Context), "s".into());
-        assert_panics!(
-            assert_matches!(
-                compile(&dec_expr(s), &sym_env()),
-                Err(CompileError::TypeError),
-            ),
-            includes("Error: applying decimal constructor to a non-literal")
+        assert_matches!(
+            compile(&dec_expr(s), &sym_env()),
+            Err(CompileError::TypeError),
+            "{}",
+            "Error: applying decimal constructor to a non-literal"
         );
     }
 
@@ -870,7 +868,7 @@ mod datetime_tests {
     use cedar_policy_core::ast::Name;
 
     use cedar_policy::{RequestEnv, Schema};
-    use cool_asserts::{assert_matches, assert_panics};
+    use cool_asserts::assert_matches;
 
     use crate::symcc::{
         extension_types::datetime::{Datetime, Duration},
@@ -972,12 +970,11 @@ mod datetime_tests {
     #[track_caller]
     fn test_invalid_datetime_constructor(str: &str, msg: &str) {
         let sym_env = SymEnv::new(&datetime_schema(), &request_env()).expect("Malformed sym env.");
-        assert_panics!(
-            assert_matches!(
-                compile(&datetime_lit(str), &sym_env),
-                Err(CompileError::ExtError(_)),
-            ),
-            includes(msg)
+        assert_matches!(
+            compile(&datetime_lit(str), &sym_env),
+            Err(CompileError::ExtError(_)),
+            "{}",
+            msg
         );
     }
 
@@ -995,12 +992,11 @@ mod datetime_tests {
     #[track_caller]
     fn test_invalid_duration_constructor(str: &str, msg: &str) {
         let sym_env = SymEnv::new(&duration_schema(), &request_env()).expect("Malformed sym env.");
-        assert_panics!(
-            assert_matches!(
-                compile(&duration_lit(str), &sym_env),
-                Err(CompileError::TypeError),
-            ),
-            includes(msg)
+        assert_matches!(
+            compile(&duration_lit(str), &sym_env),
+            Err(CompileError::ExtError(_)),
+            "{}",
+            msg
         );
     }
 

--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -723,6 +723,7 @@ mod decimal_tests {
     use cedar_policy_core::ast::Name;
 
     use cedar_policy::{RequestEnv, Schema};
+    use cool_asserts::{assert_matches, assert_panics};
 
     use crate::symcc::{extension_types::decimal::Decimal, result::CompileError};
 
@@ -793,12 +794,12 @@ mod decimal_tests {
     #[track_caller]
     fn test_invalid(str: &str, msg: &str) {
         let sym_env = SymEnv::new(&decimal_schema(), &request_env()).expect("Malformed sym env.");
-        assert!(
-            matches!(
+        assert_panics!(
+            assert_matches!(
                 compile(&dec_lit(str), &sym_env),
                 Err(CompileError::TypeError),
             ),
-            "{msg}"
+            includes(msg)
         );
     }
 
@@ -835,12 +836,12 @@ mod decimal_tests {
         test_invalid("922337203685477.5808", "overflow");
         test_invalid("-922337203685477.5809", "overflow");
         let s = Expr::get_attr(Expr::var(Var::Context), "s".into());
-        assert!(
-            matches!(
+        assert_panics!(
+            assert_matches!(
                 compile(&dec_expr(s), &sym_env()),
                 Err(CompileError::TypeError),
             ),
-            "Error: applying decimal constructor to a non-literal"
+            includes("Error: applying decimal constructor to a non-literal")
         );
     }
 
@@ -869,6 +870,7 @@ mod datetime_tests {
     use cedar_policy_core::ast::Name;
 
     use cedar_policy::{RequestEnv, Schema};
+    use cool_asserts::{assert_matches, assert_panics};
 
     use crate::symcc::{
         extension_types::datetime::{Datetime, Duration},
@@ -970,12 +972,12 @@ mod datetime_tests {
     #[track_caller]
     fn test_invalid_datetime_constructor(str: &str, msg: &str) {
         let sym_env = SymEnv::new(&datetime_schema(), &request_env()).expect("Malformed sym env.");
-        assert!(
-            matches!(
+        assert_panics!(
+            assert_matches!(
                 compile(&datetime_lit(str), &sym_env),
                 Err(CompileError::ExtError(_)),
             ),
-            "{msg}"
+            includes(msg)
         );
     }
 
@@ -993,12 +995,12 @@ mod datetime_tests {
     #[track_caller]
     fn test_invalid_duration_constructor(str: &str, msg: &str) {
         let sym_env = SymEnv::new(&duration_schema(), &request_env()).expect("Malformed sym env.");
-        assert!(
-            matches!(
+        assert_panics!(
+            assert_matches!(
                 compile(&duration_lit(str), &sym_env),
                 Err(CompileError::TypeError),
             ),
-            "{msg}"
+            includes(msg)
         );
     }
 

--- a/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
@@ -322,13 +322,11 @@ impl Duration {
                     i64::MIN
                 } else {
                     // Parse absolute value. Any remaining overflow / parse errors
-                    let abs_val = digits.parse::<i64>()?;
+                    let abs_val = digits.parse::<i128>()?;
                     // negate as necessary
-                    if is_neg {
-                        -abs_val
-                    } else {
-                        abs_val
-                    }
+                    if is_neg { -abs_val } else { abs_val }
+                        .try_into()
+                        .map_err(|_| DatetimeError::IntegerOverflowDuringParsing)?
                 };
                 let ms_val = match suffix {
                     "ms" => val,

--- a/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
@@ -18,11 +18,11 @@
 //! It is based on
 //! <https://github.com/cedar-policy/cedar-spec/blob/main/cedar-lean/Cedar/Spec/Ext/Datetime.lean>
 
-use std::num::ParseIntError;
 use std::str::FromStr;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
 use miette::Diagnostic;
+use num_bigint::{BigInt, BigUint, ParseBigIntError, Sign};
 use thiserror::Error;
 
 /// Internal representation of Cedar `datetime` values.
@@ -61,7 +61,7 @@ pub enum DatetimeError {
     InvalidUnit(String),
     /// Unable to parse int.
     #[error("unable to parse int")]
-    ParseIntError(#[from] ParseIntError),
+    ParseIntError(#[from] ParseBigIntError),
 }
 
 const MILLISECONDS_PER_SECOND: i64 = 1000;
@@ -316,18 +316,13 @@ impl Duration {
                 // PANIC SAFETY: by construction pos must be a valid index into prefix
                 let (prefix, digits) = prefix.split_at(pos);
 
-                // Compute the unscaled unit value (# of days/hrs/min/sec/ms)
-                let val = if is_neg && digits == "9223372036854775808" {
-                    // ensure we don't overflow when parsing
-                    i64::MIN
-                } else {
-                    // Parse absolute value. Any remaining overflow / parse errors
-                    let abs_val = digits.parse::<i128>()?;
-                    // negate as necessary
-                    if is_neg { -abs_val } else { abs_val }
-                        .try_into()
-                        .map_err(|_| DatetimeError::IntegerOverflowDuringParsing)?
-                };
+                let val: i64 = BigInt::from_biguint(
+                    if is_neg { Sign::Minus } else { Sign::Plus },
+                    digits.parse::<BigUint>()?,
+                )
+                .try_into()
+                .map_err(|_| DatetimeError::IntegerOverflowDuringParsing)?;
+
                 let ms_val = match suffix {
                     "ms" => val,
                     "s" => val

--- a/cedar-policy-symcc/src/symcc/result.rs
+++ b/cedar-policy-symcc/src/symcc/result.rs
@@ -38,15 +38,18 @@ pub enum CompileError {
     #[error("term type error")]
     TypeError,
     /// Unsupported features.
-    #[error("unsupported feature in SymCC")]
+    #[error("unsupported feature in SymCC: {0}")]
     UnsupportedFeature(String),
     /// Bit-vector error.
-    #[error("bit-vector error ")]
+    #[error("bit-vector error: {0}")]
     BitVecError(#[from] BitVecError),
     /// IP address error.
-    #[error("IP address error")]
+    #[error("IP address error: {0}")]
     IPError(#[from] IPError),
     /// Context type is not a record.
     #[error("context type is not a record")]
     NonRecordContext,
+    /// Extension function application error.
+    #[error("fail to apply extension function: {0}")]
+    ExtensionFunctionApp(String),
 }


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
