### PR TITLE
Don't allow text-direction characters in literals

### DIFF
--- a/cedar-policy-core/src/lib.rs
+++ b/cedar-policy-core/src/lib.rs
@@ -17,10 +17,6 @@
 //! Implementation of the Cedar parser and evaluation engine in Rust.
 #![warn(missing_docs)]
 #![cfg_attr(feature = "wasm", allow(non_snake_case))]
-#![allow(
-    text_direction_codepoint_in_literal,
-    reason = "Must specify at crate level to allow for tests with direction codepoints"
-)]
 
 #[macro_use]
 extern crate lalrpop_util;

--- a/cedar-policy-core/src/validator/str_checks.rs
+++ b/cedar-policy-core/src/validator/str_checks.rs
@@ -299,11 +299,15 @@ mod test {
 
     #[test]
     fn trojan_source() {
-        let src = r#"
+        // The unicode directional markers make this string
+        // display as if the closing quotation mark is after
+        // "user" when it is logically at the end of the line,
+        // completely changing the meaning of the condition.
+        let src = "
         permit(principal, action, resource) when {
-            principal.access_level != "user‮ ⁦&& principal.is_admin⁩ ⁦"
+            principal.access_level != \"user\u{202e} \u{2066}&& principal.is_admin\u{2069} \u{2066}\"
         };
-        "#;
+        ";
         let mut s = PolicySet::new();
         let p = parse_policy(Some(PolicyID::from_string("test")), src).unwrap();
         s.add_static(p).unwrap();
@@ -316,12 +320,12 @@ mod test {
             &ValidationWarning::bidi_chars_strings(
                 Loc::new(90..131, Arc::from(src)).into_maybe_loc(),
                 PolicyID::from_string("test"),
-                r#"user‮ ⁦&& principal.is_admin⁩ ⁦"#
+                "user\u{202e} \u{2066}&& principal.is_admin\u{2069} \u{2066}"
             )
         );
         assert_eq!(
             format!("{warning}"),
-            "for policy `test`, string `\"user‮ ⁦&& principal.is_admin⁩ ⁦\"` contains BIDI control characters"
+            "for policy `test`, string `\"user\u{202e} \u{2066}&& principal.is_admin\u{2069} \u{2066}\"` contains BIDI control characters"
         );
     }
 }


### PR DESCRIPTION
## Description of changes

Replace text-direction marker codepoints in test string literals with unicode escapes. This removes the need for a crate-level allow of the `text_direction_codepoint_in_literal` lint.

In rust 1.89 this lint was changed to function only crate-wide, to better handle string literals produced by macro expansion. As such it is not possible to limit the scope of the `allow` only to test strings.

A downside of using escape sequences are that they can make mixed rtl language text unreadable. That is not an issue here.

A more significant downside is that escape sequences conflict with raw strings, so the test policy stanzas must also be manually escaped for other meaningful punctuation like quotation marks. This is tedious and error-prone, but considered the better option against the malicious obfuscation attacks possible where text-direction markers interaction with ltr text.

## Issue #, if available

Resolves #1777.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
