### PR TITLE
Stateful isAuthorization method

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -24,6 +24,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Implemented variadic `ipaddr.isInRange` that returns true if the child `ipaddr` is in range for any of the arguments [RFC 99](github.com/cedar-policy/rfcs/pull/99)
 - Implemented batched evaluation under the experimental flag `tpe`. Batched evaluation allows for permission queries against large databases of entities. (#1812) 
 - Added `calculate_minimum_level` which computes the minimum level at which policies validate. (#1812)
+- Added `stateful_is_authorized`, `preparse_policy_set` and `preparse_schema` to support stateful evaluation using a cached policy set and schema, in the `ffi` module. (#1829)
 
 ### Changed
 


### PR DESCRIPTION
## Description of changes
Adds `stateful_is_authorized`, `preparse_policy_set` and `preparse_schema` that can be used to pre-load an immutable schema/policy set.

This way, we don't have to build a massive JSON struct on each authorization request.

In our tests where we perform approximately 50000 evaluations the execution time went from:

```
real    13m33.222s
user    132m49.959s
sys     1m43.130s
```
to
```
real    0m52.297s
user    7m55.203s
sys     1m8.939s
```

Or, in other words, a 15x performance increase.

## Issue #, if available
https://github.com/cedar-policy/cedar/issues/1829

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
