### PR TITLE
Fix validation for action entitites in TPE

### DIFF
--- a/cedar-policy-core/src/tpe/entities.rs
+++ b/cedar-policy-core/src/tpe/entities.rs
@@ -355,12 +355,7 @@ impl PartialEntity {
         let etype = uid.entity_type();
 
         if self.uid.is_action() {
-            if self.attrs.is_none() || self.tags.is_none() {
-                return Err(UnknownActionComponentError {
-                    action: uid.clone(),
-                }
-                .into());
-            }
+            // An Action entity cannot have attributes
             if let Some(attrs) = &self.attrs {
                 if let Some((attr, _)) = attrs.first_key_value() {
                     return Err(EntitySchemaConformanceError::unexpected_entity_attr(
@@ -370,6 +365,7 @@ impl PartialEntity {
                     .into());
                 }
             }
+            // An Action entity cannot have tags
             if let Some(tags) = &self.tags {
                 if let Some((tag, _)) = tags.first_key_value() {
                     return Err(EntitySchemaConformanceError::unexpected_entity_tag(
@@ -379,6 +375,7 @@ impl PartialEntity {
                     .into());
                 }
             }
+            // The Action must exist in the schema, and have the same ancestors as in the schema.
             if let Some(action) = core_schema.action(uid) {
                 if let Some(ancestors) = &self.ancestors {
                     let schema_ancestors: HashSet<EntityUID> =


### PR DESCRIPTION
## Description of changes

In the Cedar+Kubernetes integration, I noticed that I could not use TPE correctly. At first, I did not add the action entities to the entities list when running TPE, but then the residual contained things like `action in Action::"foo"`, which I did not want, as this data is in fact known at this point.

However, adding the actions to the entity list manually [here](https://github.com/upbound/kubernetes-cedar-authorizer/blob/main/src/cedar_authorizer/authorizer.rs#L414-L435) yielded an error, as `PartialEntity.validate` both [errors](https://github.com/cedar-policy/cedar/blob/22ec17872ca100485b235e6fe925b715619ad898/cedar-policy-core/src/tpe/entities.rs#L358-L381) if the action has `None` and `Some` attributes and tags, which I presume is a bug.

With this patch the k8s integration works as expected.

As a side point: it'd be nice to not have to do the extra work of adding the action entities at all, but let that be done automatically by TPE, as it anyways has the schema at hand.

FYI @shaobo-he-aws 

I'll make a unit test once you've confirmed removing this if statement was desired.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

Not sure if this is covered (or should be) by DRT.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
