### PR TITLE
Fixed "Nightly downstream" workflow

### DIFF
--- a/.github/workflows/nightly_build_downstream.yml
+++ b/.github/workflows/nightly_build_downstream.yml
@@ -1,4 +1,4 @@
-name: Nightly downstream
+name: Nightly Build Downstream Dependencies
 on:
   workflow_dispatch:
   schedule:
@@ -10,8 +10,11 @@ env:
   CARGO_TERM_COLOR: always
 jobs:
   build-cedar-java:
-    needs: get-branch-name
     uses: cedar-policy/cedar-java/.github/workflows/run_cedar_java_reusable.yml@main
     with:
-      cedar_policy_ref: 'main'
-      cedar_java_ref: 'main'
+      # The fully-formed ref of the branch or tag that triggered the workflow run.
+      cedar_policy_ref: ${{ github.ref }}
+      # Since this workflow is not triggered by pull request events, 
+      # this will be the short ref name of the branch or tag that triggered the workflow run.
+      # For more information see: https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context
+      cedar_java_ref: ${{ github.ref_name }} 


### PR DESCRIPTION
## Description of changes
* Updated name of "Nightly downstream" workflow to "Nightly Build Downstream Dependencies" for consistency
* Removed the "needs" dependency on undeclared job "get-branch-name"
* Updated refs passed to "run_cedar_java_reusable" workflow to be based on the branch or tag that triggered the workflow run.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
