### PR TITLE
Fixed "Release" workflow

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   create_related_repo_tags:
     runs-on: ubuntu-latest
-    if: ${{ vars.APP_ID && secrets.APP_PRIVATE_KEY }}
+    # Check if APP_ID has been set
+    if: vars.APP_ID
     steps:
       - name: Generate GitHub App token
         id: app-token


### PR DESCRIPTION
## Description of changes
Fixed the "Release" workflow to remove direct access of "secrets" in if-conditionals. [Workflows are not able to directly access "secret" in if-conditionals](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-using-secrets).

## Issue #, if available
 N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
