### PR TITLE
Added clean up method for LocalSolver

### DIFF
--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -249,8 +249,7 @@ impl LocalSolver {
         }
     }
 
-    /// Forces this solver's child process to exit.
-    /// Waits for the child to exit completely.
+    /// Kills this solver's child process and waits for the child process to exit completely.
     pub async fn clean_up(mut self) -> Result<()> {
         self.child.kill().await.map_err(|e| e.into())
     }

--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -248,6 +248,12 @@ impl LocalSolver {
             _ => SolverError::UnrecognizedSolverOutput(s.to_string()),
         }
     }
+
+    /// Forces this solver's child process to exit.
+    /// Waits for the child to exit completely.
+    pub async fn clean_up(mut self) -> Result<()> {
+        self.child.kill().await.map_err(|e| e.into())
+    }
 }
 
 /// Implements `Solver` by writing all issued commands to the given
@@ -370,5 +376,11 @@ mod test {
         // Attempt to reset the solver.
         my_solver.smtlib_input().reset().await.unwrap();
         assert_matches!(my_solver.check_sat().await, Err(SolverError::Solver(x)) => { assert_eq!(x, "Encountered EOF while reading from solver output"); });
+    }
+
+    #[tokio::test]
+    async fn clean_up_succeeds() {
+        let my_solver = LocalSolver::cvc5().unwrap();
+        my_solver.clean_up().await.unwrap();
     }
 }


### PR DESCRIPTION
## Description of changes
Added clean up method for `LocalSolver` which forces the spawned child process to exit. This allows callers (like the fuzzing targets) to ensure that the spawned process is reaped.

## Issue #, if available
N/A 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
