### PR TITLE
Fast-forward 4.6.x release branch to current `main`

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -102,6 +102,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: sudo apt-get update && sudo apt-get install protobuf-compiler
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: rustup component add clippy
       # Clippy is configured by `.cargo/config.toml` to deny on lints like
       # `unwrap_used`. They aren't detected by `panic_safety.sh` which only
       # looks for comments where we've added an `allow` directive for clippy.
@@ -119,6 +120,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: rustup component add rustfmt
       - run: cargo fmt --all --check
 
   cargo-deny:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -156,9 +156,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -166,7 +166,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -266,9 +266,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.38"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -329,7 +329,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "smol_str",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tsify",
  "wasm-bindgen",
 ]
@@ -352,7 +352,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ dependencies = [
  "similar-asserts",
  "smol_str",
  "stacker",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tsify",
  "unicode-security",
  "wasm-bindgen",
@@ -417,7 +417,7 @@ dependencies = [
  "ref-cast",
  "rstest",
  "smol_str",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -730,12 +730,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
 dependencies = [
  "powerfmt",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1026,9 +1026,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
@@ -1284,9 +1284,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1341,9 +1341,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "linked-hash-map"
@@ -1443,9 +1443,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "miette"
@@ -1586,9 +1586,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -1657,7 +1657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
@@ -1812,13 +1812,13 @@ dependencies = [
 
 [[package]]
 name = "pretty"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac98773b7109bc75f475ab5a134c9b64b87e59d776d31098d8f346922396a477"
+checksum = "0d22152487193190344590e4f30e219cf3fe140d9e7a3fdb683d82aa2c5f4156"
 dependencies = [
  "arrayvec",
  "typed-arena",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.1",
 ]
 
 [[package]]
@@ -2020,18 +2020,18 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2040,9 +2040,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.2"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2052,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2226,9 +2226,9 @@ checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2247,18 +2247,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2534,9 +2534,9 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
-version = "3.22.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
  "getrandom",
@@ -2591,11 +2591,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2611,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3083,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab10a69fbd0a177f5f649ad4d8d3305499c42bab9aef2f7ff592d0ec8f833819"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3096,9 +3096,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb702423545a6007bbc368fde243ba47ca275e549c8a28617f56f6ba53b1d1c"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
@@ -3110,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.53"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0b221ff421256839509adbb55998214a70d829d3a28c69b4a6672e9d2a42f67"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3123,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc65f4f411d91494355917b605e1480033152658d71f722a90647f56a70c88a0"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3133,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc003a991398a8ee604a401e194b6b3a39677b3173d6e74495eb51b82e99a32"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3146,18 +3146,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.103"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "293c37f4efa430ca14db3721dfbe48d8c33308096bd44d80ebaa775ab71ba1cf"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee0a0f5343de9221a0d233b04520ed8dc2e6728dce180b1dcd9288ec9d9fa3c"
+checksum = "4e381134e148c1062f965a42ed1f5ee933eef2927c3f70d1812158f711d39865"
 dependencies = [
  "js-sys",
  "minicov",
@@ -3168,9 +3168,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.53"
+version = "0.3.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a369369e4360c2884c3168d22bded735c43cccae97bbc147586d4b480edd138d"
+checksum = "b673bca3298fe582aeef8352330ecbad91849f85090805582400850f8270a2e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3179,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.80"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbe734895e869dc429d78c4b433f8d17d95f8d05317440b4fad5ab2d33e596dc"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3198,9 +3198,9 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57fe7168f7de578d2d8a05b07fd61870d2e73b4020e9f49aa00da8471723497c"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -3211,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3222,9 +3222,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/cedar-language-server/Cargo.toml
+++ b/cedar-language-server/Cargo.toml
@@ -22,7 +22,7 @@ smol_str = "0.3"
 tracing = "0.1.41"
 serde = "1"
 serde_json = "1.0.145"
-regex = "1.11.2"
+regex = "1.11.3"
 tower-lsp-server = "0.22.1"
 
 # Dependencies needed only for the language server binary

--- a/cedar-language-server/src/policy/completion/provider/ast.rs
+++ b/cedar-language-server/src/policy/completion/provider/ast.rs
@@ -56,7 +56,9 @@ impl<'a> ConditionCompletionVisitor<'a> {
     pub(crate) fn get_completion_context(
         document_context: &DocumentContext<'_>,
     ) -> CompletionContextKind {
-        let expr = document_context.policy.non_scope_constraints();
+        let Some(expr) = document_context.policy.non_scope_constraints() else {
+            return CompletionContextKind::None;
+        };
         if !is_cursor_in_condition_braces(
             document_context.cursor_position,
             document_context.policy_text,

--- a/cedar-language-server/src/policy/definition/visitor.rs
+++ b/cedar-language-server/src/policy/definition/visitor.rs
@@ -82,7 +82,7 @@ impl<'a> PolicyGotoSchemaDefinition<'a> {
             return visitor.get_scope_ranges();
         }
 
-        let ranges = visitor.visit_expr(cx.policy.non_scope_constraints())?;
+        let ranges = visitor.visit_expr(cx.policy.non_scope_constraints()?)?;
         if ranges.is_empty() {
             None
         } else {

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1246,14 +1246,11 @@ fn test_translate_policy() {
     let translated_cedar = std::str::from_utf8(&translate_to_cedar.get_output().stdout)
         .expect("output should be decodable");
 
-    // Converting back from JSON adds an extra `when { true }`
     let expected_translated_cedar = r#"permit(
   principal == User::"alice",
   action == Action::"update",
   resource == Photo::"VacationPhoto94.jpg"
-) when {
-  true
-};
+);
 "#;
 
     assert_eq!(

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -642,7 +642,7 @@ mod test {
     use super::*;
     use crate::{
         ast::{
-            annotation::Annotations, ActionConstraint, Effect, Expr, PrincipalConstraint,
+            annotation::Annotations, ActionConstraint, Effect, PrincipalConstraint,
             ResourceConstraint,
         },
         parser,
@@ -926,7 +926,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
 
         let mut s = PolicySet::new();
@@ -955,7 +955,7 @@ mod test {
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::any(),
             ResourceConstraint::is_in_slot(),
-            Expr::val(true),
+            None,
         );
 
         let mut s = PolicySet::new();
@@ -991,7 +991,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         )
         .expect("Policy Creation Failed");
         s.add_static(p).unwrap();
@@ -1020,7 +1020,7 @@ mod test {
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
         s.add_template(t).unwrap();
 
@@ -1055,7 +1055,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         )
         .expect("Policy Creation Failed");
         let template1 = Template::new(
@@ -1066,7 +1066,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
         let added = pset.add_static(policy1.clone()).is_ok();
         assert!(added);
@@ -1086,7 +1086,7 @@ mod test {
             PrincipalConstraint::is_eq(Arc::new(EntityUID::with_eid("jane"))),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         )
         .expect("Policy Creation Failed");
         let added = pset.add_static(policy2).is_ok();
@@ -1101,7 +1101,7 @@ mod test {
             PrincipalConstraint::is_eq_slot(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
         let id3 = PolicyID::from_string("link");
         let added = pset.add_template(template2).is_ok();

--- a/cedar-policy-core/src/authorizer.rs
+++ b/cedar-policy-core/src/authorizer.rs
@@ -281,7 +281,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         )
         .expect("Policy Creation Failed")
     }
@@ -297,7 +297,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::get_attr(Expr::var(Var::Context), "test".into()),
+            Some(Expr::get_attr(Expr::var(Var::Context), "test".into())),
         )
         .expect("Policy Creation Failed")
     }

--- a/cedar-policy-core/src/authorizer/partial_response.rs
+++ b/cedar-policy-core/src/authorizer/partial_response.rs
@@ -736,7 +736,7 @@ mod test {
         assert_eq!(p.principal_constraint(), PrincipalConstraint::any());
         assert_eq!(p.resource_constraint(), ResourceConstraint::any());
         assert_eq!(p.id(), &id);
-        assert_eq!(p.non_scope_constraints(), e.as_ref());
+        assert_eq!(p.non_scope_constraints(), Some(e.as_ref()));
     }
 
     #[test]
@@ -750,7 +750,7 @@ mod test {
         assert_eq!(p.principal_constraint(), PrincipalConstraint::any());
         assert_eq!(p.resource_constraint(), ResourceConstraint::any());
         assert_eq!(p.id(), &id);
-        assert_eq!(p.non_scope_constraints(), e.as_ref());
+        assert_eq!(p.non_scope_constraints(), Some(e.as_ref()));
     }
 
     #[test]

--- a/cedar-policy-core/src/parser.rs
+++ b/cedar-policy-core/src/parser.rs
@@ -379,14 +379,26 @@ mod tests {
             );
             assert_eq!(parsed.action_constraint(), template.action_constraint());
             assert_eq!(parsed.resource_constraint(), template.resource_constraint());
-            assert!(
-                parsed
-                    .non_scope_constraints()
-                    .eq_shape(template.non_scope_constraints()),
-                "{:?} and {:?} should have the same shape.",
+            match (
                 parsed.non_scope_constraints(),
-                template.non_scope_constraints()
-            );
+                template.non_scope_constraints(),
+            ) {
+                (Some(parsed), Some(template)) => {
+                    assert!(
+                        parsed.eq_shape(template),
+                        "{:?} and {:?} should have the same shape.",
+                        parsed,
+                        template
+                    );
+                }
+                (Some(_), None) | (None, Some(_)) => {
+                    panic!(
+                        "{:?} and {:?} should have the same shape.",
+                        parsed, template
+                    )
+                }
+                (None, None) => (),
+            }
         }
     }
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -2320,12 +2320,11 @@ fn construct_template_policy(
     let mut conds_rev_iter = conds.into_iter().rev();
     if let Some(last_expr) = conds_rev_iter.next() {
         let builder = ast::ExprBuilder::new().with_maybe_source_loc(loc);
-        construct_template(
+        construct_template(Some(
             conds_rev_iter.fold(last_expr, |acc, prev| builder.clone().and(prev, acc)),
-        )
+        ))
     } else {
-        // use `true` to mark the absence of non-scope constraints
-        construct_template(ast::ExprBuilder::new().with_maybe_source_loc(loc).val(true))
+        construct_template(None)
     }
 }
 fn construct_string_from_var(v: ast::Var) -> SmolStr {

--- a/cedar-policy-core/src/validator/expr_iterator.rs
+++ b/cedar-policy-core/src/validator/expr_iterator.rs
@@ -53,7 +53,12 @@ pub(super) fn policy_entity_uids(template: &Template) -> impl Iterator<Item = &E
                 .into_iter()
                 .map(|euid| euid.as_ref()),
         )
-        .chain(expr_entity_uids(template.non_scope_constraints()))
+        .chain(
+            template
+                .non_scope_constraints()
+                .into_iter()
+                .flat_map(expr_entity_uids),
+        )
 }
 
 /// Returns an iterator over all entity type names in the policy. This iterates
@@ -70,7 +75,12 @@ pub(super) fn policy_entity_type_names(template: &Template) -> impl Iterator<Ite
                 .as_inner()
                 .iter_entity_type_names(),
         )
-        .chain(expr_entity_type_names(template.non_scope_constraints()))
+        .chain(
+            template
+                .non_scope_constraints()
+                .into_iter()
+                .flat_map(expr_entity_type_names),
+        )
 }
 
 /// The 3 different "classes" of text in an expression.

--- a/cedar-policy-core/src/validator/rbac.rs
+++ b/cedar-policy-core/src/validator/rbac.rs
@@ -432,7 +432,7 @@ mod test {
     use std::collections::{HashMap, HashSet};
 
     use crate::{
-        ast::{Effect, Eid, EntityUID, Expr, PolicyID, PrincipalConstraint, ResourceConstraint},
+        ast::{Effect, Eid, EntityUID, PolicyID, PrincipalConstraint, ResourceConstraint},
         est::Annotations,
         parser::{parse_policy, parse_policy_or_template},
         test_utils::{expect_err, ExpectedErrorMessageBuilder},
@@ -539,7 +539,7 @@ mod test {
                 EntityUID::with_eid_and_type(foo_type, "foo_name")
                     .expect("should be a valid identifier"),
             )),
-            Expr::val(true),
+            None,
         );
 
         let validate = Validator::new(singleton_schema);
@@ -633,7 +633,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
 
         let validate = Validator::new(singleton_schema);
@@ -875,7 +875,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::is_eq(entity),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
 
         let validate = Validator::new(schema);
@@ -942,7 +942,7 @@ mod test {
             ))),
             ActionConstraint::any(),
             ResourceConstraint::any(),
-            Expr::val(true),
+            None,
         );
 
         let validate = Validator::new(schema);
@@ -1224,7 +1224,7 @@ mod test {
             PrincipalConstraint::is_eq(Arc::new(principal)),
             ActionConstraint::is_eq(action),
             ResourceConstraint::is_eq(Arc::new(resource)),
-            Expr::val(true),
+            None,
         );
 
         let validator = Validator::new(schema);
@@ -1613,7 +1613,7 @@ mod test {
             PrincipalConstraint::any(),
             ActionConstraint::is_in([action_grandparent_euid]),
             ResourceConstraint::is_in(Arc::new(resource_grandparent_euid)),
-            Expr::val(true),
+            None,
         );
 
         let validator = Validator::new(schema);

--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -12,11 +12,11 @@ repository.workspace = true
 
 [dependencies]
 cedar-policy-core = { version = "=4.5.1", path = "../cedar-policy-core" }
-pretty = "0.12.4"
+pretty = "0.12.5"
 logos = "0.15.1"
 itertools = "0.14"
 smol_str = { version = "0.3", features = ["serde"] }
-regex = { version= "1.11.2", features = ["unicode"] }
+regex = { version= "1.11.3", features = ["unicode"] }
 miette = { version = "7.6.0" }
 
 [dev-dependencies]

--- a/cedar-policy-formatter/src/pprint/fmt.rs
+++ b/cedar-policy-formatter/src/pprint/fmt.rs
@@ -82,14 +82,26 @@ fn soundness_check(ps: &str, ast: &PolicySet) -> Result<()> {
         if !(f_p.effect() == p.effect()
             && f_p.principal_constraint() == p.principal_constraint()
             && f_p.action_constraint() == p.action_constraint()
-            && f_p.resource_constraint() == p.resource_constraint()
-            && f_p
-                .non_scope_constraints()
-                .eq_shape(p.non_scope_constraints()))
+            && f_p.resource_constraint() == p.resource_constraint())
         {
             return Err(miette!(
-                "formatter changed the policy structure:\noriginal:\n{p}\nformatted:\n{f_p}"
+                "formatter changed the policy scope:\noriginal:\n{p}\nformatted:\n{f_p}"
             ));
+        }
+        match (f_p.non_scope_constraints(), p.non_scope_constraints()) {
+            (Some(f_p_constraints), Some(p_constraints))
+                if !f_p_constraints.eq_shape(p_constraints) =>
+            {
+                return Err(miette!(
+                    "formatter changed the policy condition:\noriginal:\n{p}\nformatted:\n{f_p}"
+                ));
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                return Err(miette!(
+                    "formatter changed the policy condition:\noriginal:\n{p}\nformatted:\n{f_p}"
+                ));
+            }
+            _ => (),
         }
     }
     Ok(())

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -21,6 +21,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Implemented batched evaluation under the experimental flag `tpe`. Batched evaluation allows for permission queries against large databases of entities. (#1812) 
 - Added `calculate_minimum_level` which computes the minimum level at which policies validate. (#1812)
 - Added `stateful_is_authorized`, `preparse_policy_set` and `preparse_schema` to support stateful evaluation using a cached policy set and schema, in the `ffi` module. (#1829)
+- Added `has_non_scope_constraint` for `Policy` and `Template`, returning `true` if the policy or template has a `when` or `unless` condition.
 
 ### Changed
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3147,6 +3147,11 @@ impl Template {
         self.ast.effect()
     }
 
+    /// Returns `true` if this template has a `when` or `unless` clause.
+    pub fn has_non_scope_constraint(&self) -> bool {
+        self.ast.non_scope_constraints().is_some()
+    }
+
     /// Get an annotation value of this `Template`.
     /// If the annotation is present without an explicit value (e.g., `@annotation`),
     /// then this function returns `Some("")`. Returns `None` when the
@@ -3500,6 +3505,11 @@ impl Policy {
     /// Get the `Effect` (`Permit` or `Forbid`) for this instance
     pub fn effect(&self) -> Effect {
         self.ast.effect()
+    }
+
+    /// Returns `true` if this policy has a `when` or `unless` clause.
+    pub fn has_non_scope_constraint(&self) -> bool {
+        self.ast.non_scope_constraints().is_some()
     }
 
     /// Get an annotation value of this template-linked or static policy.
@@ -6055,7 +6065,7 @@ mod test_lossless_empty {
         assert_eq!(
             lossy_policy0.to_cedar(),
             Some(String::from(
-                "permit(\n  principal,\n  action,\n  resource\n) when {\n  true\n};"
+                "permit(\n  principal,\n  action,\n  resource\n);"
             ))
         );
         // The EST representation is obtained from the AST
@@ -6078,9 +6088,7 @@ mod test_lossless_empty {
         // The `to_cedar` representation becomes lossy since we didn't provide text
         assert_eq!(
             lossy_template0.to_cedar(),
-            String::from(
-                "permit(\n  principal == ?principal,\n  action,\n  resource\n) when {\n  true\n};"
-            )
+            String::from("permit(\n  principal == ?principal,\n  action,\n  resource\n);")
         );
         // The EST representation is obtained from the AST
         let lossy_template0_est = lossy_template0

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -143,11 +143,7 @@ impl From<&models::TemplateBody> for ast::TemplateBody {
                     .as_ref()
                     .expect("resource_constraint field should exist"),
             ),
-            ast::Expr::from(
-                v.non_scope_constraints
-                    .as_ref()
-                    .expect("non_scope_constraints field should exist"),
-            ),
+            v.non_scope_constraints.as_ref().map(|e| ast::Expr::from(e)),
         )
     }
 }
@@ -170,7 +166,7 @@ impl From<&ast::TemplateBody> for models::TemplateBody {
             resource_constraint: Some(models::PrincipalOrResourceConstraint::from(
                 v.resource_constraint(),
             )),
-            non_scope_constraints: Some(models::Expr::from(v.non_scope_constraints())),
+            non_scope_constraints: v.non_scope_constraints().map(|e| models::Expr::from(e)),
         }
     }
 }
@@ -638,7 +634,7 @@ mod test {
             pc.clone(),
             ac1.clone(),
             rc.clone(),
-            ast::Expr::val(true),
+            None,
         );
         assert_eq!(
             tb,
@@ -666,7 +662,7 @@ mod test {
             pc,
             ac1,
             rc,
-            ast::Expr::val(true),
+            None,
         );
         assert_eq!(
             tb,
@@ -709,7 +705,7 @@ mod test {
             ast::ResourceConstraint::is_entity_type(
                 ast::EntityType::from(ast::Name::from_normalized_str("photo").unwrap()).into(),
             ),
-            ast::Expr::val(true),
+            None,
         );
 
         let policy1 = ast::Policy::from_when_clause(
@@ -779,7 +775,7 @@ mod test {
             ast::ResourceConstraint::is_entity_type(
                 ast::EntityType::from(ast::Name::from_normalized_str("photo").unwrap()).into(),
             ),
-            ast::Expr::val(true),
+            None,
         );
 
         let policy1 = ast::Policy::from_when_clause(

--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -29,7 +29,7 @@ default = ["console_error_panic_hook"]
 crate-type = ["cdylib", "rlib"]
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.53"
+wasm-bindgen-test = "0.3.54"
 cool_asserts = "2.0"
 
 [lints]


### PR DESCRIPTION

Pulls in the new methods from #1852 as well as

* two changes impacting symcc only
* one change impacting CI only
* and one dependency update
