### PR TITLE
Docs/add deny example and bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ CLI output:
 ALLOW
 ```
 
-This request is allowed because `VacationPhoto94.jpg` belongs to `Album::"jane_secrets"`, and `alice` can view photos in `Album::"jane_vacation"`.
+This request is allowed because `VacationPhoto94.jpg` belongs to `Album::"jane_vacation"`, and `alice` can view photos in `Album::"jane_vacation"`.
 
 Let's test out policy again with a photo that `alice` shouldn't have access:
 
@@ -122,7 +122,7 @@ CLI output:
 DENY
 ```
 
-This request is denied because `SecretPhoto94.jpg` belongs to `Album::"jane_vacation"`, and `alice` doesn't have explicit permission to view photos there. 
+This request is denied because `SecretPhoto94.jpg` belongs to `Album::"jane_secrets"`, and `alice` doesn't have explicit permission to view photos from this Album. 
 
 If you'd like to see more details on what can be expressed as Cedar policies, see the [documentation](https://docs.cedarpolicy.com).
 


### PR DESCRIPTION
## Description of changes
* Add --bin to the cargo run in the main README file so the command will work. 
Without this fix, the command 
```sh
 cargo run authorize \
    --policies examples/policy.cedar \
    --entities examples/entities.json \
    --principal 'User::"alice"' \
    --action 'Action::"view"' \
    --resource 'Photo::"VacationPhoto94.jpg"'
```
fails with 
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: cedar, cedar-language-server
```

* Added DENI example to the main README file for completeness.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
