### PR TITLE
Fix formatting when coverting `json_schema::Fragment` to cedar schema string representation.

### DIFF
--- a/cedar-policy-core/src/validator/cedar_schema/fmt.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/fmt.rs
@@ -328,7 +328,11 @@ impl<N: Display> IndentedDisplay for json_schema::ActionType<N> {
                     if spec.context.0.is_empty_record() {
                         write!(f, ",\n{member_indent}context: {{}}")?;
                     } else {
-                        write!(f, ",\n{member_indent}context: {}", Indented(&spec.context.0, &member_indent))?;
+                        write!(
+                            f,
+                            ",\n{member_indent}context: {}",
+                            Indented(&spec.context.0, &member_indent)
+                        )?;
                     }
 
                     write!(f, "\n{base_indentation}}}")?;


### PR DESCRIPTION
Previously calling `json_schema::Fragment::to_cedarschema` would return a string formatted as follows:

```
namespace example {
  entity User {
    "name": String,
  };

  entity Server {
    "allowlist": Set<ipaddr>
  };

  action Connect appliesTo {
    principal: [User],
    resource: [Server],
    context: {
  "session": {
    "origin": ipaddr,
  }
    }
  };
}
```

This PR fixes it so that the action context is properly indents as follows:

```
namespace example {
  entity User {
    "name": String,
  };

  entity Server {
    "allowlist": Set<ipaddr>
  };

  action Connect appliesTo {
    principal: [User],
    resource: [Server],
    context: {
      "session": {
        "origin": ipaddr,
      }
    }
  };
}
```

## Description of changes

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
