### PR TITLE
Use `macos-15-intel` instead of `macos-latest-large` in wasm CI

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -143,7 +143,7 @@ jobs:
     name: run wasm build script
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest-large, macos-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest]
     runs-on: ${{ matrix.os }}
 
     env:
@@ -152,7 +152,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: update llvm (macOS)
-        if: ${{ matrix.os  == 'macos-latest-large' }}
+        if: ${{ matrix.os  == 'macos-15-intel' }}
         run: brew install llvm && echo "/usr/local/opt/llvm/bin" >> $GITHUB_PATH
       - name: update llvm (macOSarm64)
         if: ${{ matrix.os  == 'macos-latest' }}


### PR DESCRIPTION
`macos-15-intel` is a free runner OS for whatever it matters  