### PR TITLE
Fix APIs to get residual policies

### DIFF
--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -470,25 +470,39 @@ when { principal in resource.editors };
             .static_policies()
             .find(|p| matches!(p.annotation(&id), Some(Annotation {val, ..}) if val == "3"))
             .unwrap();
-        let false_permits: HashSet<&PolicyID> = residuals.false_permits().map(|p| p.id()).collect();
+        let false_permits: HashSet<PolicyID> = residuals
+            .false_permits()
+            .map(|p| p.get_policy_id())
+            .collect();
         assert!(false_permits.len() == 2);
         assert!(false_permits.contains(policy0.id()));
         assert!(false_permits.contains(policy3.id()));
-        let false_forbids: HashSet<&PolicyID> = residuals.false_forbids().map(|p| p.id()).collect();
+        let false_forbids: HashSet<PolicyID> = residuals
+            .false_forbids()
+            .map(|p| p.get_policy_id())
+            .collect();
         assert!(false_forbids.is_empty());
-        let true_permits: HashSet<&PolicyID> =
-            residuals.satisfied_permits().map(|p| p.id()).collect();
+        let true_permits: HashSet<PolicyID> = residuals
+            .satisfied_permits()
+            .map(|p| p.get_policy_id())
+            .collect();
         assert!(true_permits.is_empty());
-        let true_forbids: HashSet<&PolicyID> =
-            residuals.satisfied_forbids().map(|p| p.id()).collect();
+        let true_forbids: HashSet<PolicyID> = residuals
+            .satisfied_forbids()
+            .map(|p| p.get_policy_id())
+            .collect();
         assert!(true_forbids.is_empty());
-        let non_trivial_permits: HashSet<&PolicyID> =
-            residuals.residual_permits().map(|p| p.id()).collect();
+        let non_trivial_permits: HashSet<PolicyID> = residuals
+            .residual_permits()
+            .map(|p| p.get_policy_id())
+            .collect();
         assert!(non_trivial_permits.len() == 2);
         assert!(non_trivial_permits.contains(policy1.id()));
         assert!(non_trivial_permits.contains(policy2.id()));
-        let non_trivial_forbids: HashSet<&PolicyID> =
-            residuals.residual_forbids().map(|p| p.id()).collect();
+        let non_trivial_forbids: HashSet<PolicyID> = residuals
+            .residual_forbids()
+            .map(|p| p.get_policy_id().clone())
+            .collect();
         assert!(non_trivial_forbids.is_empty());
         assert_matches!(residuals.decision(), None);
         // (resource["owner"]) == User::"aaron"

--- a/cedar-policy-core/src/tpe/response.rs
+++ b/cedar-policy-core/src/tpe/response.rs
@@ -180,58 +180,58 @@ impl<'a> Response<'a> {
         }
     }
 
-    /// Get policy ids of satisified permit residual policies
-    pub fn satisfied_permits(&self) -> impl Iterator<Item = &Policy> {
+    /// Get satisfied permit residual policies
+    pub fn satisfied_permits(&self) -> impl Iterator<Item = &ResidualPolicy> {
         // PANIC SAFETY: we know that the policy ids are in the residuals map
         #[allow(clippy::unwrap_used)]
         self.satisfied_permits
             .iter()
-            .map(|id| self.residuals.get(id).unwrap().policy.as_ref())
+            .map(|id| self.residuals.get(id).unwrap())
     }
 
-    /// Get policy ids of satisified forbid residual policies
-    pub fn satisfied_forbids(&self) -> impl Iterator<Item = &Policy> {
+    /// Get satisfied forbid residual policies
+    pub fn satisfied_forbids(&self) -> impl Iterator<Item = &ResidualPolicy> {
         // PANIC SAFETY: we know that the policy ids are in the residuals map
         #[allow(clippy::unwrap_used)]
         self.satisfied_forbids
             .iter()
-            .map(|id| self.residuals.get(id).unwrap().policy.as_ref())
+            .map(|id| self.residuals.get(id).unwrap())
     }
 
-    /// Get policy ids of trivially false permit residual policies
-    pub fn false_permits(&self) -> impl Iterator<Item = &Policy> {
+    /// Get trivially false permit residual policies
+    pub fn false_permits(&self) -> impl Iterator<Item = &ResidualPolicy> {
         // PANIC SAFETY: we know that the policy ids are in the residuals map
         #[allow(clippy::unwrap_used)]
         self.false_permits
             .iter()
-            .map(|id| self.residuals.get(id).unwrap().policy.as_ref())
+            .map(|id| self.residuals.get(id).unwrap())
     }
 
-    /// Get policy ids of trivially false forbid residual policies
-    pub fn false_forbids(&self) -> impl Iterator<Item = &Policy> {
+    /// Get trivially false forbid residual policies
+    pub fn false_forbids(&self) -> impl Iterator<Item = &ResidualPolicy> {
         // PANIC SAFETY: we know that the policy ids are in the residuals map
         #[allow(clippy::unwrap_used)]
         self.false_forbids
             .iter()
-            .map(|id| self.residuals.get(id).unwrap().policy.as_ref())
+            .map(|id| self.residuals.get(id).unwrap())
     }
 
-    /// Get policy ids of non-trivial permit residual policies
-    pub fn residual_permits(&self) -> impl Iterator<Item = &Policy> {
+    /// Get non-trivial permit residual policies
+    pub fn residual_permits(&self) -> impl Iterator<Item = &ResidualPolicy> {
         // PANIC SAFETY: we know that the policy ids are in the residuals map
         #[allow(clippy::unwrap_used)]
         self.residual_permits
             .iter()
-            .map(|id| self.residuals.get(id).unwrap().policy.as_ref())
+            .map(|id| self.residuals.get(id).unwrap())
     }
 
-    /// Get policy ids of non-trivial forbid residual policies
-    pub fn residual_forbids(&self) -> impl Iterator<Item = &Policy> {
+    /// Get non-trivial forbid residual policies
+    pub fn residual_forbids(&self) -> impl Iterator<Item = &ResidualPolicy> {
         // PANIC SAFETY: we know that the policy ids are in the residuals map
         #[allow(clippy::unwrap_used)]
         self.residual_forbids
             .iter()
-            .map(|id| self.residuals.get(id).unwrap().policy.as_ref())
+            .map(|id| self.residuals.get(id).unwrap())
     }
 
     /// Look up the [`Residual`] by [`PolicyID`]
@@ -272,7 +272,7 @@ impl<'a> Response<'a> {
     }
 
     /// Get residual policies
-    pub fn residual_policies(&self) -> impl Iterator<Item = &Policy> {
-        self.residuals.values().map(|rp| rp.policy.as_ref())
+    pub fn residual_policies(&self) -> impl Iterator<Item = &ResidualPolicy> {
+        self.residuals.values()
     }
 }

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -5358,18 +5358,29 @@ mod tpe {
                 .map_err(Into::into)
         }
 
-        /// Return residual policies for each policy in the input policy set
+        /// Return residuals as [`Policy`]s
+        /// A [`Policy`] returned inherits [`crate::PolicyId`] and annotations from
+        /// the corresponding input policy
+        /// Its scope is unconstrained and its condition is in the form of a
+        /// single `when` clause with the residual as the expression
         /// Use [`TpeResponse::nontrivial_residual_policies`] to get non-trivial residual policies
         pub fn residual_policies(&self) -> impl Iterator<Item = Policy> + '_ {
-            self.0.residual_policies().map(|p| p.clone().into())
+            self.0
+                .residual_policies()
+                .map(|p| Policy::from_ast(p.clone().into()))
         }
 
-        /// Returns an iterator of non-trivial (meaning more than just `true` or `false`) residual policies
+        /// Returns an iterator of non-trivial (meaning more than just `true`
+        /// or `false`) residuals as [`Policy`]s
+        /// A [`Policy`] returned inherits [`crate::PolicyId`] and annotations from
+        /// the corresponding input policy
+        /// Its scope is unconstrained and its condition is in the form of a
+        /// single `when` clause with the residual as the expression
         pub fn nontrivial_residual_policies(&'_ self) -> impl Iterator<Item = Policy> + '_ {
             self.0
                 .residual_permits()
                 .chain(self.0.residual_forbids())
-                .map(|p| p.clone().into())
+                .map(|p| Policy::from_ast(p.clone().into()))
         }
     }
 
@@ -5493,7 +5504,7 @@ mod tpe {
                     .0
                     .residual_policies()
                     .into_iter()
-                    .map(|p| p.clone().into()),
+                    .map(|p| Policy::from_ast(p.clone().into())),
             )
             .unwrap();
             // PANIC SAFETY: request construction should succeed because each entity passes validation
@@ -5546,7 +5557,7 @@ mod tpe {
                     .0
                     .residual_policies()
                     .into_iter()
-                    .map(|p| p.clone().into()),
+                    .map(|p| Policy::from_ast(p.clone().into())),
             )
             .unwrap();
             // PANIC SAFETY: request construction should succeed because each entity passes validation

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -8276,9 +8276,10 @@ mod tpe_tests {
         use similar_asserts::assert_eq;
 
         use crate::{
-            ActionQueryRequest, Context, Entities, EntityId, EntityUid, PartialEntities,
-            PartialEntityUid, PartialRequest, PolicySet, PrincipalQueryRequest, Request,
-            ResourceQueryRequest, RestrictedExpression, Schema,
+            ActionConstraint, ActionQueryRequest, Context, Entities, EntityId, EntityUid,
+            PartialEntities, PartialEntityUid, PartialRequest, PolicySet, PrincipalConstraint,
+            PrincipalQueryRequest, Request, ResourceConstraint, ResourceQueryRequest,
+            RestrictedExpression, Schema,
         };
 
         #[track_caller]
@@ -8597,6 +8598,11 @@ unless
                 response.residual_policies().count(),
                 policies.num_of_policies()
             );
+            for p in response.residual_policies() {
+                assert_matches!(p.action_constraint(), ActionConstraint::Any);
+                assert_matches!(p.principal_constraint(), PrincipalConstraint::Any);
+                assert_matches!(p.resource_constraint(), ResourceConstraint::Any);
+            }
             assert_eq!(
                 response
                     .nontrivial_residual_policies()


### PR DESCRIPTION
## Description of changes

Previously these APIs actually return original policies instead of residual policies.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
