### PR TITLE
Handle residual records in has_attr partial evaluation

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -17,6 +17,7 @@ Cedar Language Version: TBD
 ### Added
 
 - Added `TpeResponse::residual_policies` and `TpeResponse::nontrivial_residual_policies` to get residual policies under experimental feature `tpe`. (#1906)
+- Handle residual records in has_attr partial evaluation. (#1912)
 
 ### Changed
 


### PR DESCRIPTION
## Description of changes

Handle residual records in has_attr partial evaluation.

Current partial evaluation of `residual_record({"key": unknown("value")}) has key` always returns residual `residual_record({"key": unknown("value")} has key` instead of returnning `true`.

Same for partial eval of `residual_record({}) has key` that returns residual `residual_record({}) has key` instead of returning `false`.

This PR propose an enhancement so that `has` operator is properly partially evaluated on residual records.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.

