### PR TITLE
Changed the "Cargo audit" workflow to use "EmbarkStudios/cargo-deny-action"

### DIFF
--- a/.github/workflows/cargo_audit.yml
+++ b/.github/workflows/cargo_audit.yml
@@ -1,12 +1,62 @@
 name: Cargo audit
 on:
+  workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    # Run on a nightly schedule.
+    - cron: "0 0 * * *"
+
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Allow repository contents to be read.
+      issues: write # Allow issues to be created.
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - uses: actions-rs/audit-check@35b7b53b1e25b55642157ac01b4adceb5b9ebef3 # v1.2.0
+      - uses: EmbarkStudios/cargo-deny-action@f2ba7abc2abebaf185c833c3961145a3c275caad # v2.0.13
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: check advisories
+        id: cargo_deny
+        # Continue the job if this step fails.
+        continue-on-error: true
+      - name: Open an issue on failure
+        # Run only if the cargo deny step failed.
+        if: steps.cargo_deny.outcome == 'failure'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const issueLabel = 'advisories-check-failure';
+            const issueTitle = 'Security Advisories Check Failed';
+
+            // Search for open issues with the specific label
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: issueLabel,
+              per_page: 100
+            });
+
+            // If no open issues with the label exist, create a new one
+            if (issues.data.length === 0) {
+              const newIssue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                labels: [issueLabel],
+                body: `The cargo-deny security advisories check failed in the latest run.
+                
+              Workflow: ${context.workflow}
+              Run ID: ${context.runId}
+              Run Number: ${context.runNumber}
+                
+              Please review the run log for more details: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              });
+              console.log('Created new issue:', newIssue.data.html_url);
+            } else {
+              console.log('Found existing open issue with label, skipping creation');
+            }


### PR DESCRIPTION
## Description of changes
Resolves #1823 by changing the "Cargo audit" workflow to use "EmbarkStudios/cargo-deny-action" instead of "actions-rs/audit-check".

I read through the documentation and skimmed the code for the "EmbarkStudios/cargo-deny-action" and "actions-rs/audit-check". My understanding is that, yes, we can use "EmbarkStudios/cargo-deny-action" to audit Cargo.lock files and identify crates with security vulnerabilities in the same way we are currently using "actions-rs/audit-check". Additionally, both actions use [the RustSec advisory database](https://github.com/RustSec/advisory-db) to identity vulnerable crates.

However, "actions-rs/audit-check" [will also create a GitHub issue (when triggered by a schedule event) for each advisory](https://github.com/actions-rs/audit-check/blob/master/src/reporter.ts#L224), which is a nice feature. Whereas, "EmbarkStudios/cargo-deny-action" will just fail the workflow which is less visible.
To address this, I added a second step to the workflow which will create an issue when the security advisories check fails and there is not already an open issue with the label "advisories-check-failure". The label check is so we don't have multiple issue opened when we are not able to address the first issue before the nightly run.

I checked this workflow by running it twice from my fork on a branch where I intentionally inserted a vulnerability dependency. It worked as expected. The first run created a new issue, the second run did not, because of the open issue from the first run.

## Issue #, if available
Resolves #1823

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
