### PR TITLE
Increase PE precision for lazy expressions

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -27,6 +27,7 @@ Cedar Language Version: TBD
 - Deprecated schema parsing errors `ActionAttributesContainEmptySet`, `UnsupportedActionAttribute`, `ActionAttrEval`, and `ExprEscapeUsed`.
   These errors are never returned, so it is safe to delete any associated error handling code.
 - Made policy validation for `in`, `==`, and `hasTag` slightly more permissive to match the formally verified Lean model.
+- Increase partial evaluation precision for `if-then-else`, `or`, `and` expressions (#1940)
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes

Increase partial evaluation precision for lazy expressions using the Level 1 approach suggested in #880.

* Improved partial evaluation for `And` and `Or` expressions to attempt partial interpretation of the right-hand side when LHS is residual; if it fails, the original right-hand side is used instead.
* Improved partial evaluation of conditional (`if`) expressions to best-effort partial interpret both the consequent and alternative branches, falling back to the original branch if partial evaluation of a branch fails.

## Issue #, if available

Implements `Level 1` suggested in #880 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
