### PR TITLE
[4.8.x] BackPort Fix parsing of small negative decimal literals (#1964)

### DIFF
--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -122,35 +122,35 @@ impl Decimal {
             return Err(Error::FailedParse(str.as_ref().to_owned()));
         }
 
-        // pull out the components before and after the decimal point
+        // pull out the components: integer part, and fractional part
         // (the check above should ensure that .captures() and .get() succeed,
         // but we include proper error handling for posterity)
         let caps = constants::DECIMAL_REGEX
             .captures(str.as_ref())
             .ok_or_else(|| Error::FailedParse(str.as_ref().to_owned()))?;
-        let l = caps
+        let l_str = caps
             .get(1)
             .ok_or_else(|| Error::FailedParse(str.as_ref().to_owned()))?
             .as_str();
-        let r = caps
+        let r_str = caps
             .get(2)
             .ok_or_else(|| Error::FailedParse(str.as_ref().to_owned()))?
             .as_str();
 
-        // convert the left component to i64 and multiply by `10 ^ NUM_DIGITS`
-        let l = i64::from_str(l).map_err(|_| Error::Overflow)?;
+        // convert the integer component to i64 and multiply by `10 ^ NUM_DIGITS`
+        let l = i64::from_str(l_str).map_err(|_| Error::Overflow)?;
         let l = checked_mul_pow(l, NUM_DIGITS)?;
 
-        // convert the right component to i64 and multiply by `10 ^ (NUM_DIGITS - len)`
-        let len: u32 = r.len().try_into().map_err(|_| Error::Overflow)?;
+        // convert the fractional component to i64 and multiply by `10 ^ (NUM_DIGITS - len)`
+        let len: u32 = r_str.len().try_into().map_err(|_| Error::Overflow)?;
         if NUM_DIGITS < len {
             return Err(Error::TooManyDigits(str.as_ref().to_string()));
         }
-        let r = i64::from_str(r).map_err(|_| Error::Overflow)?;
+        let r = i64::from_str(r_str).map_err(|_| Error::Overflow)?;
         let r = checked_mul_pow(r, NUM_DIGITS - len)?;
 
         // compute the value
-        if l >= 0 {
+        if !l_str.starts_with('-') {
             l.checked_add(r)
         } else {
             l.checked_sub(r)
@@ -660,6 +660,37 @@ mod tests {
         );
         // bad use of `lessThan` as function
         parse_expr(r#"lessThan(decimal("-1.23"), decimal("1.23"))"#).expect_err("should fail");
+
+        assert_eq!(
+            eval.interpret_inline_policy(
+                &parse_expr(r#"decimal("-0.23") != decimal("0.23")"#).expect("parsing error")
+            ),
+            Ok(true.into())
+        );
+
+        assert_eq!(
+            eval.interpret_inline_policy(
+                &parse_expr(r#"decimal("-0.0001").lessThan(decimal("0.0"))"#)
+                    .expect("parsing error")
+            ),
+            Ok(true.into())
+        );
+
+        assert_eq!(
+            eval.interpret_inline_policy(
+                &parse_expr(r#"decimal("-0.0023").lessThan(decimal("-0.23"))"#)
+                    .expect("parsing error")
+            ),
+            Ok(false.into())
+        );
+
+        assert_eq!(
+            eval.interpret_inline_policy(
+                &parse_expr(r#"decimal("-1.0000").lessThan(decimal("-0.9999"))"#)
+                    .expect("parsing error")
+            ),
+            Ok(true.into())
+        );
     }
 
     fn check_round_trip(s: &str) {

--- a/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/datetime.rs
@@ -536,6 +536,9 @@ mod tests {
         test_valid_duration("12s340ms", 12340);
         test_valid_duration("1s234ms", 1234);
         test_valid_duration("-1ms", -1);
+        test_valid_duration("-0h1ms", -1);
+        test_valid_duration("-0h0m1ms", -1);
+        test_valid_duration("-0h2s1ms", -2001);
         test_valid_duration("-1s", -1000);
         test_valid_duration("-4s200ms", -4200);
         test_valid_duration("-9s876ms", -9876);

--- a/cedar-policy-symcc/src/symcc/extension_types/decimal.rs
+++ b/cedar-policy-symcc/src/symcc/extension_types/decimal.rs
@@ -84,7 +84,7 @@ impl FromStr for Decimal {
                             let rlen_u32: u32 = rlen.try_into().unwrap();
                             let r: i128 = r.into();
                             let r_prime = r * 10_i128.pow(DECIMAL_DIGITS - rlen_u32);
-                            let i = if l >= 0 {
+                            let i = if !left.starts_with("-") {
                                 l_prime + r_prime
                             } else {
                                 l_prime - r_prime
@@ -134,6 +134,10 @@ mod tests {
     fn tests_for_valid_strings() {
         test_valid("0.0", 0);
         test_valid("0.0000", 0);
+        test_valid("-0.0001", -1);
+        test_valid("-0.9999", -9999);
+        test_valid("-0.23", -2300);
+        test_valid("-0.0023", -23);
         test_valid("12.34", 123400);
         test_valid("1.2345", 12345);
         test_valid("-1.0", -10000);


### PR DESCRIPTION
## Description of changes

Backports #1964 to 4.8.x

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
