### PR TITLE
add always-matches and never-matches operations

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -13,6 +13,7 @@ Cedar Language Version: TBD
 - New optimized interface (`*_opt` methods on `CedarSymCompiler`) allowing you
 to precompile policies (see `CompiledPolicy` and `CompiledPolicies`) and reuse
 them across many queries.
+- `always_matches` and `never_matches` primitives for single policies
 
 ## [0.1.2] - 2025-11-26
 Cedar Language Version: 4.4

--- a/cedar-policy-symcc/src/symcc/verifier.rs
+++ b/cedar-policy-symcc/src/symcc/verifier.rs
@@ -25,7 +25,7 @@ use super::authorizer::is_authorized;
 use super::compiler::compile;
 use super::enforcer::enforce;
 use super::env::SymEnv;
-use super::factory::{and, eq, implies, is_some, not};
+use super::factory::{and, eq, implies, is_some, not, some_of};
 use super::result::CompileError;
 use super::term::Term;
 
@@ -85,6 +85,20 @@ pub fn verify_is_authorized(
 /// which `policy` errors.
 pub fn verify_never_errors(policy: &Policy, env: &SymEnv) -> Result<Asserts> {
     verify_evaluate(is_some, policy, env)
+}
+
+/// Returns asserts that are unsatisfiable iff `policy` matches all inputs in `env`.
+/// If the asserts are satisfiable, then there is some input in `env` which
+/// `policy` doesn't match.
+pub fn verify_always_matches(policy: &Policy, env: &SymEnv) -> Result<Asserts> {
+    verify_evaluate(|term| eq(term, some_of(true.into())), policy, env)
+}
+
+/// Returns asserts that are unsatisfiable iff `policy` matches no inputs in `env`.
+/// If the asserts are satisfiable, then there is some input in `env` which `policy`
+/// does match.
+pub fn verify_never_matches(policy: &Policy, env: &SymEnv) -> Result<Asserts> {
+    verify_evaluate(|term| not(eq(term, some_of(true.into()))), policy, env)
 }
 
 /// Returns asserts that are unsatisfiable iff the authorization decision of `policies1`

--- a/cedar-policy-symcc/src/symccopt/verifier.rs
+++ b/cedar-policy-symcc/src/symccopt/verifier.rs
@@ -72,6 +72,27 @@ pub fn verify_never_errors_opt(policy: &CompiledPolicy) -> Asserts {
     verify_evaluate_opt(|term| factory::is_some(term.clone()), policy)
 }
 
+/// Returns asserts that are unsatisfiable iff `policy` matches all inputs in
+/// the `SymEnv` it was compiled for. If the asserts are satisfiable, then there
+/// is some input in the `SymEnv` which `policy` doesn't match.
+pub fn verify_always_matches_opt(policy: &CompiledPolicy) -> Asserts {
+    verify_evaluate_opt(
+        |term| factory::eq(term.clone(), factory::some_of(true.into())),
+        policy,
+    )
+}
+
+/// Returns asserts that are unsatisfiable iff `policy` matches no inputs in the
+/// `SymEnv` it was compiled for.
+/// If the asserts are satisfiable, then there is some input in the `SymEnv`
+/// which `policy` does match.
+pub fn verify_never_matches_opt(policy: &CompiledPolicy) -> Asserts {
+    verify_evaluate_opt(
+        |term| factory::not(factory::eq(term.clone(), factory::some_of(true.into()))),
+        policy,
+    )
+}
+
 /// Returns asserts that are unsatisfiable iff the authorization decision of
 /// `policies1` implies that of `policies2` for every input in the `SymEnv` that
 /// the policysets were compiled for.


### PR DESCRIPTION
## Description of changes

Updates cedar-policy-symcc with the same changes as in https://github.com/cedar-policy/cedar-spec/pull/800 on the Lean side. See that PR for rationale.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
