### PR TITLE
fix some warnings with Rust 1.92

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ unsafe_code = "forbid"
 unexpected_cfgs = { level = 'deny', check-cfg = ['cfg(kani)', 'cfg(fuzzing)'] }
 missing_debug_implementations = "deny"
 rust-2018-idioms = "deny"
+unused_assignments = "allow" # In Rust 1.92 this one erroneously identifies some fields in error structs as unused, when they are actually used in the `#[error]` attribute
 
 # For clippy lints CI will only block on errors, so setting one to "warn" just
 # means we'll see it in local runs.

--- a/cedar-policy-core/src/validator/cedar_schema/err.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/err.rs
@@ -24,7 +24,6 @@ use std::{
 
 use crate::{
     ast::AnyId,
-    impl_diagnostic_from_source_loc_opt_field, impl_diagnostic_from_two_source_loc_opt_fields,
     parser::{
         err::{expected_to_string, ExpectedTokenConfig},
         unescape::UnescapeError,
@@ -744,7 +743,7 @@ impl Diagnostic for DuplicateNamespace {
 
 /// Error subtypes for [`SchemaWarning`]
 pub mod schema_warnings {
-    use crate::{impl_diagnostic_from_source_loc_opt_field, parser::Loc};
+    use crate::parser::Loc;
     use miette::Diagnostic;
     use smol_str::SmolStr;
     use thiserror::Error;

--- a/cedar-policy-core/src/validator/cedar_schema/fmt.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/fmt.rs
@@ -25,9 +25,8 @@ use nonempty::NonEmpty;
 use smol_str::{format_smolstr, SmolStr};
 use thiserror::Error;
 
-use crate::ast::is_normalized_ident;
+use crate::ast::{is_normalized_ident, InternalName};
 use crate::validator::{json_schema, RawName};
-use crate::{ast::InternalName, impl_diagnostic_from_method_on_nonempty_field};
 
 /// Number of spaces of indentation per level in the Cedarschema file
 pub const NUM_INDENTATION_SPACES: usize = 2;

--- a/cedar-policy-core/src/validator/coreschema.rs
+++ b/cedar-policy-core/src/validator/coreschema.rs
@@ -424,7 +424,6 @@ pub enum RequestValidationError {
 /// Errors related to validation
 pub mod request_validation_errors {
     use crate::ast;
-    use crate::impl_diagnostic_from_method_on_field;
     use itertools::Itertools;
     use miette::Diagnostic;
     use std::sync::Arc;

--- a/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
@@ -24,7 +24,6 @@ use thiserror::Error;
 use std::fmt::Display;
 
 use crate::fuzzy_match::fuzzy_search;
-use crate::impl_diagnostic_from_source_loc_opt_field;
 
 use std::collections::BTreeSet;
 

--- a/cedar-policy-core/src/validator/diagnostics/validation_warnings.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_warnings.rs
@@ -27,7 +27,7 @@ macro_rules! impl_diagnostic_warning {
     };
 }
 
-use crate::{ast::PolicyID, impl_diagnostic_from_source_loc_opt_field, parser::Loc};
+use crate::{ast::PolicyID, parser::Loc};
 use miette::Diagnostic;
 use thiserror::Error;
 

--- a/cedar-policy-core/src/validator/schema/err.rs
+++ b/cedar-policy-core/src/validator/schema/err.rs
@@ -347,10 +347,7 @@ pub mod schema_errors {
 
     use crate::ast::{EntityType, EntityUID, InternalName, Name};
     use crate::parser::{join_with_conjunction, Loc};
-    use crate::{
-        impl_diagnostic_from_method_on_field, impl_diagnostic_from_method_on_nonempty_field,
-        transitive_closure,
-    };
+    use crate::transitive_closure;
     use itertools::Itertools;
     use miette::Diagnostic;
     use nonempty::NonEmpty;


### PR DESCRIPTION
## Description of changes

Fixes some warnings that are present with Rust 1.92. In particular, sets one warning class (`unused_assignments`) to `allow` as it seems to erroneously identify some fields in error structs as unused.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
