### PR TITLE
Fixing some unicode issues 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ dependencies = [
  "insta",
  "itertools 0.14.0",
  "miette",
+ "proptest",
  "regex",
  "ropey",
  "serde",

--- a/cedar-language-server/Cargo.toml
+++ b/cedar-language-server/Cargo.toml
@@ -44,6 +44,7 @@ cool_asserts = "2.0.4"
 similar-asserts = "1.7.0"
 insta = "1.44.3"
 tempfile = "3.23.0"
+proptest = "1.5"
 
 [features]
 default = ["bin"]


### PR DESCRIPTION
## Description of changes
Found some issues int he language server's unicode handling:
1. The `get_policy_scope_ranges` function incorrectly uses `char_indices()` which returns byte indices, but stores them as `Position.character` which should be character indices. This causes scope detection to fail for policies containing Unicode characters.
2. The `to_range` function panics when given a `SourceSpan` with a byte offset that falls in the middle of a multi-byte UTF-8 character. The function uses byte slicing (`&src[..offset]`) without validating that the offset is at a character boundary.
3. The `get_word_at_position` function panics when the text contains multi-byte UTF-8 characters and `position.character` points to a byte offset that falls inside a multi-byte character. The function incorrectly treats `position.character` as a byte offset when slicing the string.
4. The `get_operator_at_position` function panics when the text contains multi-byte UTF-8 characters and `position.character` points to a byte offset that falls inside a multi-byte character. This is the same bug as in `get_word_at_position` - the function incorrectly treats `position.character` as a byte offset when slicing the string.

Also adds some new tests that pass, happy to remove them if you don't want them. Let me know if there's any noise at all in the request that you don't want.

## Issue #, if available
N/A
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
