### PR TITLE
fix-issue-2049: draw dashed lines for transitive edges

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -413,6 +413,9 @@ impl Entities {
                 to_dot_id(f, &entity.uid())?;
                 write!(f, " -> ")?;
                 to_dot_id(f, &ancestor)?;
+                if !entity.is_child_of(&ancestor) {
+                    write!(f, " [style=dashed]")?;
+                }
                 writeln!(f)?;
             }
         }


### PR DESCRIPTION
## Description of changes
Changes on the visualize tool. Avoids drawing a continuous line between transitive edges (draws a dashed line instead).
There is another version of this PR that doesn't draw any line between transitive edges


## Issue #2049 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.