### PR TITLE
fix-issue-2049-without-dash-lines: do not draw lines between transiti…

### DIFF
--- a/cedar-policy-core/src/entities.rs
+++ b/cedar-policy-core/src/entities.rs
@@ -409,11 +409,13 @@ impl Entities {
         // adding edges
         for entity in self.iter() {
             for ancestor in entity.ancestors() {
-                write!(f, "\t")?;
-                to_dot_id(f, &entity.uid())?;
-                write!(f, " -> ")?;
-                to_dot_id(f, &ancestor)?;
-                writeln!(f)?;
+                if entity.is_child_of(&ancestor) {
+                    write!(f, "\t")?;
+                    to_dot_id(f, &entity.uid())?;
+                    write!(f, " -> ")?;
+                    to_dot_id(f, &ancestor)?;
+                    writeln!(f)?;
+                }
             }
         }
         writeln!(f, "}}")?;


### PR DESCRIPTION
## Description of changes
Changes on the visualize tool. Do not draw any line for transitive edges.
There is another version of this PR that draw dashed lines for transitive edges.

## Issue #2049 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.