### PR TITLE
Cedar 3.4.x formatter regex fix

### DIFF
--- a/cedar-policy-formatter/Cargo.toml
+++ b/cedar-policy-formatter/Cargo.toml
@@ -18,7 +18,6 @@ itertools = "0.12"
 smol_str = { version = "0.2", features = ["serde"] }
 regex = { version = "1.9.1", features = ["unicode"] }
 miette = { version = "7.1.0" }
-lazy_static = "1.4.0"
 
 [dev-dependencies]
 insta = { version = "1.38.0", features = ["glob"] }

--- a/cedar-policy-formatter/src/pprint/token.rs
+++ b/cedar-policy-formatter/src/pprint/token.rs
@@ -21,14 +21,14 @@ use logos::{Logos, Span};
 use smol_str::SmolStr;
 use std::fmt::{self, Display};
 
-// PANIC SAFETY: These regex patterns are valid
-#[allow(clippy::unwrap_used)]
+#[expect(clippy::unwrap_used, reason = "These regex patterns are valid")]
 pub(crate) mod regex_constants {
     use regex::Regex;
-    lazy_static::lazy_static! {
-        pub static ref COMMENT : Regex = Regex::new(r"//[^\n\r]*").unwrap();
-        pub static ref STRING : Regex = Regex::new(r#""(\\.|[^"\\])*""#).unwrap();
-    }
+    use std::sync::LazyLock;
+
+    pub static COMMENT: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"//[^\n\r]*").unwrap());
+    pub static STRING: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#""(\\.|[^"\\])*""#).unwrap());
 }
 
 pub fn get_comment(text: &str) -> String {


### PR DESCRIPTION
## Description of changes

Porting constructing formatter regex in lazy block. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.