### PR TITLE
optimize decoder using references and SmolStr

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -13,6 +13,7 @@ Cedar Language Version: TBD
 - `matches_equivalent`, `matches_implies`, and `matches_disjoint` primitives
 for single policies (#2047)
 - `.effect()` for `CompiledPolicy` (#2047)
+- Performance optimization (#2073)
 
 ## [0.2.0] - 2025-12-12
 Cedar Language Version: 4.4

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -195,6 +195,7 @@ impl<S: Solver> SymCompiler<S> {
                 .encode(asserts.iter())
                 .await
                 .map_err(Error::EncodeError)?;
+            let encoder = encoder.finalize(); // drops borrows of `self.solver.smtlib_input()`, so that we can run `self.solver.check_sat()`
             let id_maps = IdMaps::from_encoder(&encoder);
             match self.solver.check_sat().await? {
                 Decision::Unsat => Ok(None),

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -169,6 +169,18 @@ impl<'a, S> Encoder<'a, S> {
             script,
         })
     }
+
+    /// "Finalize" the encoder, removing the ability to write to the `script`, and thus also dropping all borrows inherent in the `S` type.
+    /// The resulting encoder can have its state inspected (e.g., by the decoder), but can no longer encode anything new.
+    pub fn finalize(self) -> Encoder<'a, ()> {
+        Encoder {
+            terms: self.terms,
+            types: self.types,
+            uufs: self.uufs,
+            enums: self.enums,
+            script: (),
+        }
+    }
 }
 
 impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {


### PR DESCRIPTION
## Description of changes

Rust-specific performance optimization to the SymCC decoder -- use references instead of owned types in `IdMaps`, and (somewhat relatedly) use `SmolStr` instead of `String` in some places where we expect typical strings to be small.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
