### PR TITLE
Use the standard library's `NonZeroU32` to enforce that bitvector widths are nonzero

### DIFF
--- a/cedar-policy-symcc/src/symcc/compiler.rs
+++ b/cedar-policy-symcc/src/symcc/compiler.rs
@@ -50,7 +50,7 @@ type Result<T> = std::result::Result<T, CompileError>;
 fn compile_prim(p: &Prim, es: &SymEntities) -> Result<Term> {
     match p {
         Prim::Bool(b) => Ok(some_of((*b).into())),
-        Prim::Long(i) => Ok(some_of(BitVec::of_i128(64, i128::from(*i))?.into())),
+        Prim::Long(i) => Ok(some_of(BitVec::of_i128(SIXTY_FOUR, i128::from(*i)).into())),
         Prim::String(s) => Ok(some_of(s.clone().into())),
         Prim::EntityUID(uid) => {
             let uid = core_uid_into_uid(uid);
@@ -99,7 +99,7 @@ fn compile_var(v: Var, req: &SymRequest) -> Result<Term> {
 fn compile_app1(op1: UnaryOp, t: Term) -> Result<Term> {
     match (op1, t.type_of()) {
         (UnaryOp::Not, TermType::Bool) => Ok(some_of(factory::not(t))),
-        (UnaryOp::Neg, TermType::Bitvec { n: 64 }) => Ok(factory::if_false(
+        (UnaryOp::Neg, TermType::Bitvec { n: SIXTY_FOUR }) => Ok(factory::if_false(
             factory::bvnego(t.clone()),
             factory::bvneg(t),
         )),
@@ -215,7 +215,9 @@ pub fn compile_app2(op2: BinaryOp, t1: Term, t2: Term, es: &SymEntities) -> Resu
                 Ok(some_of(false.into()))
             }
         }
-        (Less, Bitvec { n: 64 }, Bitvec { n: 64 }) => Ok(some_of(factory::bvslt(t1, t2))),
+        (Less, Bitvec { n: SIXTY_FOUR }, Bitvec { n: SIXTY_FOUR }) => {
+            Ok(some_of(factory::bvslt(t1, t2)))
+        }
         (Less, Ext { xty: DateTime }, Ext { xty: DateTime }) => Ok(some_of(factory::bvslt(
             factory::ext_datetime_val(t1),
             factory::ext_datetime_val(t2),
@@ -224,7 +226,9 @@ pub fn compile_app2(op2: BinaryOp, t1: Term, t2: Term, es: &SymEntities) -> Resu
             factory::ext_duration_val(t1),
             factory::ext_duration_val(t2),
         ))),
-        (LessEq, Bitvec { n: 64 }, Bitvec { n: 64 }) => Ok(some_of(factory::bvsle(t1, t2))),
+        (LessEq, Bitvec { n: SIXTY_FOUR }, Bitvec { n: SIXTY_FOUR }) => {
+            Ok(some_of(factory::bvsle(t1, t2)))
+        }
         (LessEq, Ext { xty: DateTime }, Ext { xty: DateTime }) => Ok(some_of(factory::bvsle(
             factory::ext_datetime_val(t1),
             factory::ext_datetime_val(t2),
@@ -233,15 +237,15 @@ pub fn compile_app2(op2: BinaryOp, t1: Term, t2: Term, es: &SymEntities) -> Resu
             factory::ext_duration_val(t1),
             factory::ext_duration_val(t2),
         ))),
-        (Add, Bitvec { n: 64 }, Bitvec { n: 64 }) => Ok(factory::if_false(
+        (Add, Bitvec { n: SIXTY_FOUR }, Bitvec { n: SIXTY_FOUR }) => Ok(factory::if_false(
             factory::bvsaddo(t1.clone(), t2.clone()),
             factory::bvadd(t1, t2),
         )),
-        (Sub, Bitvec { n: 64 }, Bitvec { n: 64 }) => Ok(factory::if_false(
+        (Sub, Bitvec { n: SIXTY_FOUR }, Bitvec { n: SIXTY_FOUR }) => Ok(factory::if_false(
             factory::bvssubo(t1.clone(), t2.clone()),
             factory::bvsub(t1, t2),
         )),
-        (Mul, Bitvec { n: 64 }, Bitvec { n: 64 }) => Ok(factory::if_false(
+        (Mul, Bitvec { n: SIXTY_FOUR }, Bitvec { n: SIXTY_FOUR }) => Ok(factory::if_false(
             factory::bvsmulo(t1.clone(), t2.clone()),
             factory::bvmul(t1, t2),
         )),

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -545,8 +545,8 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
                         self.define_app(
                             &ty_enc,
                             &Op::Eq,
-                            [t_enc, encode_bitvec(&BitVec::int_min(n)?)],
-                            [t, &BitVec::int_min(n)?.into()],
+                            [t_enc, encode_bitvec(&BitVec::int_min(n))],
+                            [t, &BitVec::int_min(n).into()],
                         )
                         .await?
                     }
@@ -658,11 +658,7 @@ fn encode_ipaddr_prefix_v6(pre: &IPv6Prefix) -> SmolStr {
 fn encode_ext(e: &Ext) -> SmolStr {
     match e {
         Ext::Decimal { d } => {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "Cannot panic because bitwidth is non-zero."
-            )]
-            let bv_enc = encode_bitvec(&BitVec::of_int(64, d.0.into()).unwrap());
+            let bv_enc = encode_bitvec(&BitVec::of_int(SIXTY_FOUR, d.0.into()));
             format_smolstr!("(Decimal {bv_enc})")
         }
         Ext::Ipaddr {
@@ -680,19 +676,11 @@ fn encode_ext(e: &Ext) -> SmolStr {
             format_smolstr!("(V6 {addr} {pre})")
         }
         Ext::Duration { d } => {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "Cannot panic because bitwidth is non-zero."
-            )]
-            let bv_enc = encode_bitvec(&BitVec::of_int(64, d.to_milliseconds().into()).unwrap());
+            let bv_enc = encode_bitvec(&BitVec::of_int(SIXTY_FOUR, d.to_milliseconds().into()));
             format_smolstr!("(Duration {bv_enc})")
         }
         Ext::Datetime { dt } => {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "Cannot panic because bitwidth is non-zero."
-            )]
-            let bv_enc = encode_bitvec(&BitVec::of_i128(64, i64::from(dt).into()).unwrap());
+            let bv_enc = encode_bitvec(&BitVec::of_i128(SIXTY_FOUR, i64::from(dt).into()));
             format_smolstr!("(Datetime {bv_enc})")
         }
     }

--- a/cedar-policy-symcc/src/symcc/factory.rs
+++ b/cedar-policy-symcc/src/symcc/factory.rs
@@ -378,14 +378,7 @@ pub fn bvule(t1: Term, t2: Term) -> Term {
 /// Does negation overflow
 pub fn bvnego(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Bitvec(bv)) =>
-        {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "By construction bit-vectors have non-zero width."
-            )]
-            BitVec::overflows(bv.width(), &-bv.to_int()).unwrap().into()
-        }
+        Term::Prim(TermPrim::Bitvec(bv)) => BitVec::overflows(bv.width(), &-bv.to_int()).into(),
         t => Term::App {
             op: Op::Bvnego,
             args: Arc::new(vec![t]),
@@ -398,13 +391,7 @@ pub fn bvso(op: Op, f: &dyn Fn(&Int, &Int) -> Int, t1: Term, t2: Term) -> Term {
     match (t1, t2) {
         (Term::Prim(TermPrim::Bitvec(bv1)), Term::Prim(TermPrim::Bitvec(bv2))) => {
             assert!(bv1.width() == bv2.width());
-            #[expect(
-                clippy::unwrap_used,
-                reason = "Assert above guarantees same bit-vector width."
-            )]
-            BitVec::overflows(bv1.width(), &f(&bv1.to_int(), &bv2.to_int()))
-                .unwrap()
-                .into()
+            BitVec::overflows(bv1.width(), &f(&bv1.to_int(), &bv2.to_int())).into()
         }
         (t1, t2) => Term::App {
             op,
@@ -430,23 +417,41 @@ pub fn bvsmulo(t1: Term, t2: Term) -> Term {
 /// so we compensate for the difference in partial evaluation.
 ///
 /// This function adds `n` to the existing width. It does not pad the width to `n`.
-pub fn zero_extend(n: Width, t: Term) -> Term {
+///
+/// `n` is allowed to be 0, and this function will perform correctly.
+///
+/// Panics if the new width exceeds u32::MAX.
+/// As of this writing, we shouldn't ever construct any bitvector longer than 128,
+/// which is an extremely long way from u32::MAX.
+pub fn zero_extend(n: u32, t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Bitvec(bv)) =>
-        {
+        Term::Prim(TermPrim::Bitvec(bv)) => {
             #[expect(
-                clippy::unwrap_used,
-                reason = "By construction bit-vectors have non-zero width."
+                clippy::expect_used,
+                reason = "Function is documented to panic if the new width exceeds u32::MAX"
             )]
-            BitVec::zero_extend(&bv, n + bv.width()).unwrap().into()
+            let new_width = bv
+                .width()
+                .checked_add(n)
+                .expect("width will not overflow u32");
+            BitVec::zero_extend(&bv, new_width).into()
         }
         t => {
             match t.type_of() {
-                TermType::Bitvec { n: cur_width } => Term::App {
-                    op: Op::ZeroExtend(n),
-                    args: Arc::new(vec![t]),
-                    ret_ty: TermType::Bitvec { n: cur_width + n },
-                },
+                TermType::Bitvec { n: cur_width } => {
+                    #[expect(
+                        clippy::expect_used,
+                        reason = "Function is documented to panic if the new width exceeds u32::MAX"
+                    )]
+                    let new_width = cur_width
+                        .checked_add(n)
+                        .expect("width will not overflow u32");
+                    Term::App {
+                        op: Op::ZeroExtend(n),
+                        args: Arc::new(vec![t]),
+                        ret_ty: TermType::Bitvec { n: new_width },
+                    }
+                }
                 _ => t, // should be ruled out by callers
             }
         }
@@ -589,18 +594,13 @@ pub fn string_like(t: Term, p: OrdPattern) -> Term {
 
 pub fn ext_decimal_val(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Ext(Ext::Decimal { d })) =>
-        {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "Cannot panic because bitwidth is guaranteed to be non-zero."
-            )]
-            Term::Prim(TermPrim::Bitvec(BitVec::of_int(64, d.0.into()).unwrap()))
+        Term::Prim(TermPrim::Ext(Ext::Decimal { d })) => {
+            Term::Prim(TermPrim::Bitvec(BitVec::of_int(SIXTY_FOUR, d.0.into())))
         }
         t => Term::App {
             op: Op::Ext(ExtOp::DecimalVal),
             args: Arc::new(vec![t]),
-            ret_ty: TermType::Bitvec { n: 64 },
+            ret_ty: TermType::Bitvec { n: SIXTY_FOUR },
         },
     }
 }
@@ -622,7 +622,7 @@ pub fn ext_ipaddr_addr_v4(t: Term) -> Term {
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrAddrV4),
             args: Arc::new(vec![t]),
-            ret_ty: TermType::Bitvec { n: 32 },
+            ret_ty: TermType::Bitvec { n: THIRTY_TWO },
         },
     }
 }
@@ -630,14 +630,14 @@ pub fn ext_ipaddr_addr_v4(t: Term) -> Term {
 pub fn ext_ipaddr_prefix_v4(t: Term) -> Term {
     match t {
         Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip: IPNet::V4(v4) })) => match v4.prefix.val {
-            None => Term::None(TermType::Bitvec { n: 5 }),
+            None => Term::None(TermType::Bitvec { n: FIVE }),
             Some(p) => some_of(p.into()),
         },
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrPrefixV4),
             args: Arc::new(vec![t]),
             ret_ty: TermType::Option {
-                ty: Arc::new(TermType::Bitvec { n: 5 }),
+                ty: Arc::new(TermType::Bitvec { n: FIVE }),
             },
         },
     }
@@ -649,7 +649,9 @@ pub fn ext_ipaddr_addr_v6(t: Term) -> Term {
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrAddrV6),
             args: Arc::new(vec![t]),
-            ret_ty: TermType::Bitvec { n: 128 },
+            ret_ty: TermType::Bitvec {
+                n: HUNDRED_TWENTY_EIGHT,
+            },
         },
     }
 }
@@ -657,14 +659,14 @@ pub fn ext_ipaddr_addr_v6(t: Term) -> Term {
 pub fn ext_ipaddr_prefix_v6(t: Term) -> Term {
     match t {
         Term::Prim(TermPrim::Ext(Ext::Ipaddr { ip: IPNet::V6(v6) })) => match v6.prefix.val {
-            None => Term::None(TermType::Bitvec { n: 7 }),
+            None => Term::None(TermType::Bitvec { n: SEVEN }),
             Some(p) => some_of(p.into()),
         },
         t => Term::App {
             op: Op::Ext(ExtOp::IpaddrPrefixV6),
             args: Arc::new(vec![t]),
             ret_ty: TermType::Option {
-                ty: Arc::new(TermType::Bitvec { n: 7 }),
+                ty: Arc::new(TermType::Bitvec { n: SEVEN }),
             },
         },
     }
@@ -672,27 +674,20 @@ pub fn ext_ipaddr_prefix_v6(t: Term) -> Term {
 
 pub fn ext_datetime_val(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Ext(Ext::Datetime { dt })) =>
-        {
-            #[expect(
-                clippy::unwrap_used,
-                reason = "Cannot panic because bitwidth is guaranteed to be non-zero."
-            )]
-            Term::Prim(TermPrim::Bitvec(
-                BitVec::of_i128(64, i64::from(dt).into()).unwrap(),
-            ))
-        }
+        Term::Prim(TermPrim::Ext(Ext::Datetime { dt })) => Term::Prim(TermPrim::Bitvec(
+            BitVec::of_i128(SIXTY_FOUR, i64::from(dt).into()),
+        )),
         t => Term::App {
             op: Op::Ext(ExtOp::DatetimeVal),
             args: Arc::new(vec![t]),
-            ret_ty: TermType::Bitvec { n: 64 },
+            ret_ty: TermType::Bitvec { n: SIXTY_FOUR },
         },
     }
 }
 
 pub fn ext_datetime_of_bitvec(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Bitvec(bv)) if bv.width() == 64 =>
+        Term::Prim(TermPrim::Bitvec(bv)) if bv.width() == SIXTY_FOUR =>
         {
             #[expect(
                 clippy::unwrap_used,
@@ -714,24 +709,20 @@ pub fn ext_datetime_of_bitvec(t: Term) -> Term {
 
 pub fn ext_duration_val(t: Term) -> Term {
     match t {
-        #[expect(
-            clippy::unwrap_used,
-            reason = "Cannot panic because bitwidth is guaranteed to be non-zero."
-        )]
         Term::Prim(TermPrim::Ext(Ext::Duration { d })) => Term::Prim(TermPrim::Bitvec(
-            BitVec::of_i128(64, d.to_milliseconds().into()).unwrap(),
+            BitVec::of_i128(SIXTY_FOUR, d.to_milliseconds().into()),
         )),
         t => Term::App {
             op: Op::Ext(ExtOp::DurationVal),
             args: Arc::new(vec![t]),
-            ret_ty: TermType::Bitvec { n: 64 },
+            ret_ty: TermType::Bitvec { n: SIXTY_FOUR },
         },
     }
 }
 
 pub fn ext_duration_of_bitvec(t: Term) -> Term {
     match t {
-        Term::Prim(TermPrim::Bitvec(bv)) if bv.width() == 64 =>
+        Term::Prim(TermPrim::Bitvec(bv)) if bv.width() == SIXTY_FOUR =>
         {
             #[expect(
                 clippy::unwrap_used,

--- a/cedar-policy-symcc/src/symcc/term.rs
+++ b/cedar-policy-symcc/src/symcc/term.rs
@@ -107,14 +107,7 @@ impl From<bool> for Term {
 
 impl From<i64> for Term {
     fn from(i: i64) -> Self {
-        #[expect(
-            clippy::expect_used,
-            reason = "Cannot panic because bitwidth passed in is non-zero."
-        )]
-        Term::Prim(TermPrim::Bitvec(
-            BitVec::of_int(64, i.into())
-                .expect("Cannot panic because bitwidth passed in is non-zero."),
-        ))
+        Term::Prim(TermPrim::Bitvec(BitVec::of_int(SIXTY_FOUR, i.into())))
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -101,7 +101,7 @@ impl TermType {
         match ty {
             Type::Primitive { primitive_type } => match primitive_type {
                 Primitive::Bool => Ok(TermType::Bool),
-                Primitive::Long => Ok(TermType::Bitvec { n: 64 }),
+                Primitive::Long => Ok(TermType::Bitvec { n: SIXTY_FOUR }),
                 Primitive::String => Ok(TermType::String),
             },
             Type::ExtensionType { name } => match name.basename().to_string().as_str() {

--- a/cedar-policy-symcc/src/symcc/type_abbrevs.rs
+++ b/cedar-policy-symcc/src/symcc/type_abbrevs.rs
@@ -19,7 +19,7 @@
 use num_bigint::{BigInt, BigUint};
 use ref_cast::RefCast;
 use smol_str::SmolStr;
-use std::{cmp::Ordering, ops::Deref};
+use std::{cmp::Ordering, num::NonZeroU32, ops::Deref};
 
 #[expect(missing_docs, reason = "existing code")]
 pub type EntityType = cedar_policy::EntityTypeName;
@@ -36,8 +36,32 @@ pub type Prim = cedar_policy_core::ast::Literal;
 pub type Nat = BigUint;
 #[expect(missing_docs, reason = "existing code")]
 pub type Int = BigInt;
-#[expect(missing_docs, reason = "existing code")]
-pub type Width = u32;
+/// In our code, widths are not allowed to be 0.
+///
+/// In Lean, we do not enforce this at the type level, as our proofs ensure things all work properly.
+/// Here in Rust, we enforce this at the type level using the standard library's `NonZeroU32`.
+pub type Width = NonZeroU32;
+
+/// Width of one bit
+pub const ONE: Width = NonZeroU32::new(1).expect("1 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of two bits
+pub const TWO: Width = NonZeroU32::new(2).expect("2 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of five bits
+pub const FIVE: Width = NonZeroU32::new(5).expect("5 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of seven bits
+pub const SEVEN: Width = NonZeroU32::new(7).expect("7 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of eight bits
+pub const EIGHT: Width = NonZeroU32::new(8).expect("8 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of 16 bits
+pub const SIXTEEN: Width = NonZeroU32::new(16).expect("16 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of 32 bits
+pub const THIRTY_TWO: Width = NonZeroU32::new(32).expect("32 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of 64 bits
+pub const SIXTY_FOUR: Width = NonZeroU32::new(64).expect("64 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of 120 bits
+pub const HUNDRED_TWENTY: Width = NonZeroU32::new(120).expect("120 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
+/// Width of 128 bits
+pub const HUNDRED_TWENTY_EIGHT: Width = NonZeroU32::new(128).expect("128 is not 0"); // this `expect()` is evaluated at compile-time because this is a `const`. Clippy is smart enough not to require `expect_used` for this.
 
 /// Convert `ast::EntityType` into `EntityType` in O(1)
 pub fn core_entity_type_into_entity_type(

--- a/cedar-policy-symcc/tests/term.rs
+++ b/cedar-policy-symcc/tests/term.rs
@@ -21,7 +21,8 @@ use std::{str::FromStr, sync::Arc};
 use cedar_policy::{Authorizer, Schema, Validator};
 use cedar_policy_symcc::{
     compile_always_allows, compile_always_denies, solver::LocalSolver, term::*, term_factory,
-    term_type::*, CedarSymCompiler, SymEnv, WellFormedAsserts, WellTypedPolicies,
+    term_type::*, type_abbrevs::SIXTY_FOUR, CedarSymCompiler, SymEnv, WellFormedAsserts,
+    WellTypedPolicies,
 };
 
 use crate::utils::{assert_always_allows_ok, assert_always_denies_ok, Environments, Pathway};
@@ -65,12 +66,12 @@ async fn term_basic_arith_unsat() {
                 Arc::new(vec![term_factory::not(term_factory::eq(
                     TermVar {
                         id: "x".into(),
-                        ty: TermType::Bitvec { n: 64 }
+                        ty: TermType::Bitvec { n: SIXTY_FOUR }
                     }
                     .into(),
                     TermVar {
                         id: "x".into(),
-                        ty: TermType::Bitvec { n: 64 }
+                        ty: TermType::Bitvec { n: SIXTY_FOUR }
                     }
                     .into(),
                 ))]),
@@ -87,12 +88,12 @@ async fn term_basic_arith_unsat() {
                 Arc::new(vec![term_factory::not(term_factory::eq(
                     TermVar {
                         id: "x".into(),
-                        ty: TermType::Bitvec { n: 64 }
+                        ty: TermType::Bitvec { n: SIXTY_FOUR }
                     }
                     .into(),
                     TermVar {
                         id: "y".into(),
-                        ty: TermType::Bitvec { n: 64 }
+                        ty: TermType::Bitvec { n: SIXTY_FOUR }
                     }
                     .into(),
                 ))]),
@@ -111,24 +112,24 @@ async fn term_basic_arith_unsat() {
                         term_factory::bvsle(
                             TermVar {
                                 id: "x".into(),
-                                ty: TermType::Bitvec { n: 64 }
+                                ty: TermType::Bitvec { n: SIXTY_FOUR }
                             }
                             .into(),
                             TermVar {
                                 id: "y".into(),
-                                ty: TermType::Bitvec { n: 64 }
+                                ty: TermType::Bitvec { n: SIXTY_FOUR }
                             }
                             .into(),
                         ),
                         term_factory::bvsle(
                             TermVar {
                                 id: "y".into(),
-                                ty: TermType::Bitvec { n: 64 }
+                                ty: TermType::Bitvec { n: SIXTY_FOUR }
                             }
                             .into(),
                             TermVar {
                                 id: "z".into(),
-                                ty: TermType::Bitvec { n: 64 }
+                                ty: TermType::Bitvec { n: SIXTY_FOUR }
                             }
                             .into(),
                         ),
@@ -136,12 +137,12 @@ async fn term_basic_arith_unsat() {
                     term_factory::bvsle(
                         TermVar {
                             id: "x".into(),
-                            ty: TermType::Bitvec { n: 64 }
+                            ty: TermType::Bitvec { n: SIXTY_FOUR }
                         }
                         .into(),
                         TermVar {
                             id: "z".into(),
-                            ty: TermType::Bitvec { n: 64 }
+                            ty: TermType::Bitvec { n: SIXTY_FOUR }
                         }
                         .into(),
                     ),


### PR DESCRIPTION
## Description of changes

Uses the standard library's `NonZeroU32` to enforce that bitvector widths are nonzero. This gives us some additional safety by allowing us to remove a lot of `.unwrap()`s.

In the process, also ended up better-documenting some other existing sources of panics.

See comments in `type_abbrevs.rs` for more justification on why to (slightly) deviate from the Lean in this way. I feel that this adjustment is inside the scope of "natural translation from Lean to idiomatic Rust".

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
