### PR TITLE
add more entity getter methods

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -14,6 +14,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 Cedar Language Version: TBD
 
+### Added
+
+- `Entity::attrs()` and `Entity::tags()` to iterate over all attributes/tags of an `Entity` (#2084)
+
 ## [4.8.2] - 2025-12-09
 
 Cedar Language Version: 4.4

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -245,6 +245,21 @@ impl Entity {
         }
     }
 
+    /// Iterate over all attributes of the entity, as (name, value) pairs
+    ///
+    /// The value for any individual attribute may be `Err` if the attribute is
+    /// not a value (i.e., is unknown due to partial evaluation).
+    pub fn attrs(
+        &self,
+    ) -> impl Iterator<Item = (&str, Result<EvalResult, PartialValueToValueError>)> {
+        self.0.attrs().map(|(k, v)| {
+            (
+                k.as_ref(),
+                ast::Value::try_from(v.clone()).map(EvalResult::from),
+            )
+        })
+    }
+
     /// Get the value for the given tag, or `None` if not present.
     ///
     /// This can also return Some(Err) if the tag is not a value (i.e., is
@@ -254,6 +269,21 @@ impl Entity {
             Ok(v) => Some(Ok(EvalResult::from(v))),
             Err(e) => Some(Err(e)),
         }
+    }
+
+    /// Iterate over all tags of the entity, as (name, value) pairs
+    ///
+    /// The value for any individual tag may be `Err` if the tag is not a value
+    /// (i.e., is unknown due to partial evaluation).
+    pub fn tags(
+        &self,
+    ) -> impl Iterator<Item = (&str, Result<EvalResult, PartialValueToValueError>)> {
+        self.0.tags().map(|(k, v)| {
+            (
+                k.as_ref(),
+                ast::Value::try_from(v.clone()).map(EvalResult::from),
+            )
+        })
     }
 
     /// Consume the entity and return the entity's owned Uid, attributes and parents.


### PR DESCRIPTION
## Description of changes

Adds `attrs()` and `tags()` methods on `Entity`, to iterate over all attributes/tags. The current API only allows getting specific attribute/tag values, not iterating over all attribute/tag values.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
