### PR TITLE
Added workflow for publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,7 @@
-# Note: This workflow is intended to always be run from the 'main' branch to
+# Note: This workflow can only be run from the 'main' branch to
 # ensure that the latest version of this workflow is used.
+# However, the release will not necessarily be performed from the 'main' branch 
+# as the input `tag` is used to determine which GitHub tag will be checked out for the release.
 name: Publish base Cedar crates to crates.io
 on:
     # This workflow must be triggered manually.


### PR DESCRIPTION
## Description of changes
Added a GitHub workflow which can publish a GitHub tag to crates.io. This workflow must be manually dispatched. The workflow is set up to use [trusted publishing](https://crates.io/docs/trusted-publishing). I have not yet configured trusted publishing for our crates. I will do so after this is merged. I added a GitHub environment for the workflow called [release](https://github.com/cedar-policy/cedar/settings/environments). If we had a visible (non-secret) GitHub team, then we could restrict the "Required reviewers" for the environment to that team which I think will limit who can trigger this workflow.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
