### PR TITLE
optimized version of the extractor

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -13,7 +13,7 @@ Cedar Language Version: TBD
 - `matches_equivalent`, `matches_implies`, and `matches_disjoint` primitives
 for single policies (#2047)
 - `.effect()` for `CompiledPolicy` (#2047)
-- Performance optimizations (#2070, #2073, #2079)
+- Performance optimizations (#2070, #2073, #2079, #2092)
 
 ### Fixed
 - Bug where returned counterexamples could occasionally be invalid by containing

--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -22,8 +22,8 @@ use thiserror::Error;
 
 pub use crate::symcc::{
     ext::ExtError, extension_types::datetime::DatetimeError,
-    extension_types::decimal::DecimalError, extension_types::ipaddr::IPError, BitVecError,
-    CompileError, ConcretizeError, DecodeError, EncodeError, SolverError,
+    extension_types::decimal::DecimalError, extension_types::ipaddr::IPError, term::Term,
+    BitVecError, CompileError, ConcretizeError, DecodeError, EncodeError, SolverError,
 };
 
 /// Top-level errors from the whole `cedar-policy-symcc` crate.
@@ -56,6 +56,15 @@ pub enum Error {
     /// Errors during concretization.
     #[error("failed to recover a concrete counterexample: {0}")]
     ConcretizeError(#[from] ConcretizeError),
+    /// Model successfully decoded and concretized, but the resulting model is invalid.
+    #[error("model is invalid: violates assertion {assert:?}")]
+    ModelInvalid {
+        /// Assertion that was violated
+        assert: Term,
+    },
+    /// Empty-list of policies was passed to a function that expects at least one policy
+    #[error("expected to have at least one policy")]
+    NoPolicies,
 }
 
 /// A result type that potentially returns a SymCC [`enum@Error`].

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -234,7 +234,7 @@ impl<S: Solver> CedarSymCompiler<S> {
     /// NOTE: This is an experimental feature that may break or change in the future.
     pub async fn check_sat(&mut self, asserts: &WellFormedAsserts<'_>) -> Result<Option<Env>> {
         self.symcc
-            .check_sat_asserts(
+            .sat_asserts(
                 asserts.asserts(),
                 asserts.symenv(),
                 asserts.footprint.iter(),

--- a/cedar-policy-symcc/src/symcc/concretizer.rs
+++ b/cedar-policy-symcc/src/symcc/concretizer.rs
@@ -47,6 +47,9 @@ use super::SymEnv;
 /// [`cedar_policy`]/[`cedar_policy_core`].
 #[derive(Debug, Diagnostic, Error)]
 pub enum ConcretizeError {
+    /// Got no policies, expected to have at least one.
+    #[error("expected to have at least one policy")]
+    NoPolicies,
     /// Expecting a literal entity.
     #[error("Not a literal entity: {0:?}")]
     NotLiteralEntity(Term),

--- a/cedar-policy-symcc/src/symcc/env.rs
+++ b/cedar-policy-symcc/src/symcc/env.rs
@@ -87,12 +87,21 @@ impl SymRequest {
 // `entityIn` relation on entities. The symbolic store partitions this relation
 // into multiple maps, one for each pair of an entity type and its ancestor type.
 
+/// Represents the entity data for _all entities_ of a _single type_
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct SymEntityData {
     pub attrs: UnaryFunction,
+    /// Let `t1` be the entity type which this `SymEntityData` represents the data for.
+    /// Let `t2` be an entity type in this map's keys.
+    /// The `UnaryFunction` here maps entities of type `t1` to the set of
+    /// entities of type `t2` which are ancestors of that entity.
+    /// (Of course, the `UnaryFunction` is on SMT-level values, so the domain is
+    /// essentially `t1`-typed `Term`s, and the output is essentially a
+    /// `Set<t2>`-typed `Term`.)
     pub ancestors: BTreeMap<EntityType, UnaryFunction>,
-    /// Specifies EIDs of enum members, if applicable
+    /// Specifies EIDs of enum members for this entity type, if applicable
     pub members: Option<BTreeSet<SmolStr>>,
+    /// `None` means this entity type has no tags
     pub tags: Option<SymTags>,
 }
 

--- a/cedar-policy-symcc/src/symccopt/extractor.rs
+++ b/cedar-policy-symcc/src/symccopt/extractor.rs
@@ -1,0 +1,70 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! This file defines the function `extract_opt`, which turns interpretations
+//! into concrete, strongly well-formed counterexamples to verification queries.
+//!
+//! See notes on the unoptimized version, `SymEnv::extract()` in `symcc/extractor.rs`.
+//!
+//! This module is as straightforward a translation as possible of
+//! <https://github.com/cedar-policy/cedar-spec/blob/main/cedar-lean/Cedar/SymCCOpt/Extractor.lean>.
+
+use cedar_policy_core::ast::Policy;
+
+use super::{CompiledPolicies, CompiledPolicy};
+use crate::{err::ConcretizeError, Env, Interpretation};
+
+impl CompiledPolicies {
+    /// Caller guarantees that all of the `CompiledPolicies` were compiled for the same `env`.
+    pub fn extract_opt<'a>(
+        cps: impl IntoIterator<Item = &'a Self> + Clone,
+        interp: &Interpretation<'_>,
+    ) -> Result<Env, ConcretizeError> {
+        let mut cps2 = cps.clone().into_iter().peekable();
+        match cps2.peek() {
+            None => Err(ConcretizeError::NoPolicies),
+            Some(Self { symenv, .. }) => {
+                let ps = cps2.flat_map(|cps| cps.policies.policies().map(Policy::condition));
+                let footprint = cps.into_iter().flat_map(|cps| cps.footprint.iter());
+                symenv
+                    .interpret(&interp.repair_as_counterexample(footprint))
+                    .concretize(ps)
+            }
+        }
+    }
+}
+
+impl CompiledPolicy {
+    /// Like `CompiledPolicies::extract_opt()`, but takes a list of `CompiledPolicy` rather than `CompiledPolicies`.
+    ///
+    /// Caller guarantees that all of the `CompiledPolicy`s were compiled for the same `env`.
+    pub fn extract_opt<'a>(
+        cps: impl IntoIterator<Item = &'a Self> + Clone,
+        interp: &Interpretation<'_>,
+    ) -> Result<Env, ConcretizeError> {
+        let mut cps2 = cps.clone().into_iter().peekable();
+        match cps2.peek() {
+            None => Err(ConcretizeError::NoPolicies),
+            Some(Self { symenv, .. }) => {
+                let ps = cps2.map(|cp| cp.policy.condition());
+                let footprint = cps.into_iter().flat_map(|cps| cps.footprint.iter());
+                symenv
+                    .interpret(&interp.repair_as_counterexample(footprint))
+                    .concretize(ps)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description of changes

Rust port of the changes in https://github.com/cedar-policy/cedar-spec/pull/822; see notes there.

Along with the changes in https://github.com/cedar-policy/cedar-spec/pull/822, I also had to split the Rust unoptimized `check_sat_asserts()` into `check_sat_asserts()` and `sat_asserts()`, like it is in the Lean.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
