### PR TITLE
more generic extractor implementation

### DIFF
--- a/cedar-policy-symcc/src/symccopt.rs
+++ b/cedar-policy-symcc/src/symccopt.rs
@@ -40,13 +40,12 @@ impl<S: Solver> SymCompiler<S> {
     /// Optimized version of `sat_asserts()`.
     ///
     /// Corresponds to `satAssertsOpt?` in the Lean.
-    pub async fn sat_asserts_opt<'a, I: Iterator<Item = &'a CompiledPolicys<'a>> + Clone>(
+    pub async fn sat_asserts_opt<'a>(
         &mut self,
         asserts: &Asserts,
-        cps: impl IntoIterator<Item = &'a CompiledPolicys<'a>, IntoIter = I>,
+        cps: impl IntoIterator<Item = &'a CompiledPolicys<'a>> + Clone,
     ) -> Result<Option<Env>> {
-        let mut cps = cps.into_iter().peekable();
-        match cps.peek() {
+        match cps.clone().into_iter().next() {
             None => Err(Error::NoPolicies),
             Some(cp_s) => match self.check_sat_asserts(asserts, cp_s.symenv()).await? {
                 None => Ok(None),

--- a/cedar-policy-symcc/src/symccopt/compiled_policies.rs
+++ b/cedar-policy-symcc/src/symccopt/compiled_policies.rs
@@ -186,6 +186,7 @@ impl CompiledPolicies {
 
 /// Represents a `CompiledPolicy` or a `CompiledPolicies`, for APIs that don't care
 /// which one they get.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CompiledPolicys<'a> {
     Policy(&'a CompiledPolicy),
     Policies(&'a CompiledPolicies),

--- a/cedar-policy-symcc/src/symccopt/extractor.rs
+++ b/cedar-policy-symcc/src/symccopt/extractor.rs
@@ -31,14 +31,14 @@ use crate::{err::ConcretizeError, Env, Interpretation};
 ///
 /// Caller guarantees that all of the `CompiledPolicys` were compiled for the same `symenv`.
 pub fn extract_opt<'a>(
-    cps: impl Iterator<Item = &'a CompiledPolicys<'a>> + Clone,
+    cps: impl IntoIterator<Item = &'a CompiledPolicys<'a>> + Clone,
     interp: &Interpretation<'_>,
 ) -> Result<Env, ConcretizeError> {
-    match cps.clone().peekable().peek() {
+    match cps.clone().into_iter().next() {
         None => Err(ConcretizeError::NoPolicies),
         Some(cp_s) => {
-            let ps = cps.clone().flat_map(|cp_s| cp_s.all_policies());
-            let footprint = cps.flat_map(|cp_s| cp_s.footprint().iter());
+            let ps = cps.clone().into_iter().flat_map(|cp_s| cp_s.all_policies());
+            let footprint = cps.into_iter().flat_map(|cp_s| cp_s.footprint().iter());
             cp_s.symenv()
                 .interpret(&interp.repair_as_counterexample(footprint))
                 .concretize(ps.map(Policy::condition))


### PR DESCRIPTION
## Description of changes

Corresponds to https://github.com/cedar-policy/cedar-spec/pull/826 on the Lean side. See notes there.

Open to naming suggestions for the type representing a `CompiledPolicy(ies)`, which on the Lean side I've named `CompiledPolicyₛ` for now, and thus on the Rust side I've just named `CompiledPolicys` for now.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
