### PR TITLE
add two more getters to SymCC public API

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -13,6 +13,7 @@ Cedar Language Version: TBD
 - `matches_equivalent`, `matches_implies`, and `matches_disjoint` primitives
 for single policies (#2047)
 - `.effect()` for `CompiledPolicy` (#2047)
+- `CompiledPolicy::policy()` and `CompiledPolicies::policies()` (#2103)
 - Performance optimizations (#2070, #2073, #2079, #2093, #2094)
 
 ### Fixed

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -157,6 +157,11 @@ impl CompiledPolicy {
         self.policy.effect()
     }
 
+    /// Get the (post-typecheck) `Policy` that this `CompiledPolicy` represents
+    pub fn policy(&self) -> &cedar_policy_core::ast::Policy {
+        &self.policy.policy
+    }
+
     /// Convert a `CompiledPolicy` to a `CompiledPolicies` representing a
     /// singleton policyset with just that policy.
     ///
@@ -187,6 +192,11 @@ impl CompiledPolicies {
         Ok(Self {
             policies: symccopt::CompiledPolicies::compile(pset.as_ref(), env, schema)?,
         })
+    }
+
+    /// Get the (post-typecheck) `PolicySet` that this `CompiledPolicies` represents
+    pub fn policies(&self) -> &cedar_policy_core::ast::PolicySet {
+        &self.policies.policies
     }
 }
 

--- a/cedar-policy-symcc/src/symccopt/compiled_policies.rs
+++ b/cedar-policy-symcc/src/symccopt/compiled_policies.rs
@@ -37,9 +37,9 @@ pub struct CompiledPolicy {
     /// typechecked policy compiled to a `Term` of type Option<bool>
     pub(super) term: Term,
     /// `SymEnv` representing the environment this policy was compiled for
-    pub(super) symenv: symcc::SymEnv,
+    pub(crate) symenv: symcc::SymEnv,
     /// typechecked policy
-    pub(super) policy: Policy,
+    pub(crate) policy: Policy,
     /// footprint of the policy
     pub(super) footprint: BTreeSet<Term>,
     /// acyclicity constraints for this policy
@@ -120,9 +120,9 @@ pub struct CompiledPolicies {
     /// representing the authorization decision
     pub(super) term: Term,
     /// `SymEnv` representing the environment these policies were compiled for
-    pub(super) symenv: symcc::SymEnv,
+    pub(crate) symenv: symcc::SymEnv,
     /// typechecked policies
-    pub(super) policies: PolicySet,
+    pub(crate) policies: PolicySet,
     /// footprint of the policies
     pub(super) footprint: BTreeSet<Term>,
     /// acyclicity constraints for these policies


### PR DESCRIPTION
## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
