### PR TITLE
renames matching cedar-spec#829

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -15,12 +15,13 @@ for single policies (#2047)
 - `.effect()` for `CompiledPolicy` (#2047)
 - `CompiledPolicy::policy()` and `CompiledPolicies::policies()` (#2103)
 - `CompiledPolicy::compile_with_custom_symenv()` and
-`CompiledPolicies::compile_with_custom_symenv()` experimental APIs -- note the
+`CompiledPolicySet::compile_with_custom_symenv()` experimental APIs -- note the
 documented caveats and use at your own risk (#2102)
 - Performance optimizations (#2070, #2073, #2079, #2093, #2094)
 
 ### Changed
 
+- Renamed `CompiledPolicies` to `CompiledPolicySet`
 - Deprecated the unoptimized interface on `CedarSymCompiler` in favor of the
 optimized interface (`*_opt` methods) introduced in 0.2.0 (#2095)
 - Experimental functions `compile_always_matches()` and friends were refactored

--- a/cedar-policy-symcc/src/symccopt/extractor.rs
+++ b/cedar-policy-symcc/src/symccopt/extractor.rs
@@ -24,22 +24,22 @@
 
 use cedar_policy_core::ast::Policy;
 
-use super::CompiledPolicys;
+use super::CompiledPolicies;
 use crate::{err::ConcretizeError, Env, Interpretation};
 
 /// Optimized version of `SymEnv::extract()`.
 ///
-/// Caller guarantees that all of the `CompiledPolicys` were compiled for the same `symenv`.
+/// Caller guarantees that all of the `CompiledPolicies` were compiled for the same `symenv`.
 pub fn extract_opt<'a>(
-    cps: impl IntoIterator<Item = &'a CompiledPolicys<'a>> + Clone,
+    cpss: impl IntoIterator<Item = &'a CompiledPolicies<'a>> + Clone,
     interp: &Interpretation<'_>,
 ) -> Result<Env, ConcretizeError> {
-    match cps.clone().into_iter().next() {
+    match cpss.clone().into_iter().next() {
         None => Err(ConcretizeError::NoPolicies),
-        Some(cp_s) => {
-            let ps = cps.clone().into_iter().flat_map(|cp_s| cp_s.all_policies());
-            let footprint = cps.into_iter().flat_map(|cp_s| cp_s.footprint().iter());
-            cp_s.symenv()
+        Some(cps) => {
+            let ps = cpss.clone().into_iter().flat_map(|cps| cps.all_policies());
+            let footprint = cpss.into_iter().flat_map(|cps| cps.footprint().iter());
+            cps.symenv()
                 .interpret(&interp.repair_as_counterexample(footprint))
                 .concretize(ps.map(Policy::condition))
         }

--- a/cedar-policy-symcc/tests/term.rs
+++ b/cedar-policy-symcc/tests/term.rs
@@ -21,7 +21,7 @@ use std::{str::FromStr, sync::Arc};
 use cedar_policy::{Authorizer, Schema, Validator};
 use cedar_policy_symcc::{
     always_denies_asserts, solver::LocalSolver, term::*, term_factory, term_type::*,
-    type_abbrevs::SIXTY_FOUR, CedarSymCompiler, CompiledPolicies,
+    type_abbrevs::SIXTY_FOUR, CedarSymCompiler, CompiledPolicySet,
 };
 
 use crate::utils::{assert_always_allows_ok, assert_always_denies_ok, Environments, Pathway};
@@ -161,7 +161,7 @@ async fn term_always_denies_cex() {
         r#"permit(principal, action, resource) when { context.x >= context.y };"#,
         &validator,
     );
-    let compiled_pset = CompiledPolicies::compile(&pset, &envs.req_env, envs.schema).unwrap();
+    let compiled_pset = CompiledPolicySet::compile(&pset, &envs.req_env, envs.schema).unwrap();
     let asserts = always_denies_asserts(&compiled_pset);
     let cex = compiler.check_sat(&asserts).await.unwrap().unwrap();
     let resp = Authorizer::new().is_authorized(&cex.request, &pset, &cex.entities);
@@ -298,6 +298,6 @@ fn duration() {
 
     for req_env in schema.request_envs() {
         // just test that compiling works
-        CompiledPolicies::compile(&policies, &req_env, &schema).unwrap();
+        CompiledPolicySet::compile(&policies, &req_env, &schema).unwrap();
     }
 }

--- a/cedar-policy-symcc/tests/utils/mod.rs
+++ b/cedar-policy-symcc/tests/utils/mod.rs
@@ -37,7 +37,7 @@ use cedar_policy_symcc::{
     always_allows_asserts, always_denies_asserts, always_matches_asserts, disjoint_asserts,
     equivalent_asserts, implies_asserts, matches_disjoint_asserts, matches_equivalent_asserts,
     matches_implies_asserts, never_errors_asserts, never_matches_asserts, solver::Solver,
-    CedarSymCompiler, CompiledPolicies, CompiledPolicy, Env, Interpretation, SymEnv,
+    CedarSymCompiler, CompiledPolicy, CompiledPolicySet, Env, Interpretation, SymEnv,
     WellTypedPolicies, WellTypedPolicy,
 };
 
@@ -167,9 +167,9 @@ impl<'a> Environments<'a> {
     }
 
     #[track_caller]
-    pub fn compile_policies(&self, pset: &PolicySet) -> CompiledPolicies {
+    pub fn compile_policies(&self, pset: &PolicySet) -> CompiledPolicySet {
         if self.has_custom_symenv {
-            CompiledPolicies::compile_with_custom_symenv(
+            CompiledPolicySet::compile_with_custom_symenv(
                 pset,
                 &self.req_env,
                 self.schema,
@@ -177,8 +177,8 @@ impl<'a> Environments<'a> {
             )
             .unwrap()
         } else {
-            // in the common case, where the symenv wasn't created custom, test the standard `CompiledPolicies::compile()` API
-            CompiledPolicies::compile(pset, &self.req_env, self.schema).unwrap()
+            // in the common case, where the symenv wasn't created custom, test the standard `CompiledPolicySet::compile()` API
+            CompiledPolicySet::compile(pset, &self.req_env, self.schema).unwrap()
         }
     }
 }
@@ -940,7 +940,7 @@ pub async fn assert_always_allows_ok<S: Solver>(
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
         assert!(literal_symenv.is_literal());
-        let custom_compiled = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled = CompiledPolicySet::compile_with_custom_symenv(
             pset,
             &envs.req_env,
             envs.schema,
@@ -955,7 +955,7 @@ pub async fn assert_always_allows_ok<S: Solver>(
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
         assert!(literal_symenv.is_literal());
-        let custom_compiled = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled = CompiledPolicySet::compile_with_custom_symenv(
             pset,
             &envs.req_env,
             envs.schema,
@@ -1039,7 +1039,7 @@ pub async fn assert_always_denies_ok<S: Solver>(
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
         assert!(literal_symenv.is_literal());
-        let custom_compiled = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled = CompiledPolicySet::compile_with_custom_symenv(
             pset,
             &envs.req_env,
             envs.schema,
@@ -1054,7 +1054,7 @@ pub async fn assert_always_denies_ok<S: Solver>(
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
         assert!(literal_symenv.is_literal());
-        let custom_compiled = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled = CompiledPolicySet::compile_with_custom_symenv(
             pset,
             &envs.req_env,
             envs.schema,
@@ -1142,14 +1142,14 @@ pub async fn assert_equivalent_ok<S: Solver>(
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
         assert!(literal_symenv.is_literal());
-        let custom_compiled_1 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_1 = CompiledPolicySet::compile_with_custom_symenv(
             pset1,
             &envs.req_env,
             envs.schema,
             literal_symenv.clone(),
         )
         .unwrap();
-        let custom_compiled_2 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_2 = CompiledPolicySet::compile_with_custom_symenv(
             pset2,
             &envs.req_env,
             envs.schema,
@@ -1164,14 +1164,14 @@ pub async fn assert_equivalent_ok<S: Solver>(
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
         assert!(literal_symenv.is_literal());
-        let custom_compiled_1 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_1 = CompiledPolicySet::compile_with_custom_symenv(
             pset1,
             &envs.req_env,
             envs.schema,
             literal_symenv.clone(),
         )
         .unwrap();
-        let custom_compiled_2 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_2 = CompiledPolicySet::compile_with_custom_symenv(
             pset2,
             &envs.req_env,
             envs.schema,
@@ -1260,14 +1260,14 @@ pub async fn assert_implies_ok<S: Solver>(
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
         assert!(literal_symenv.is_literal());
-        let custom_compiled_1 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_1 = CompiledPolicySet::compile_with_custom_symenv(
             pset1,
             &envs.req_env,
             envs.schema,
             literal_symenv.clone(),
         )
         .unwrap();
-        let custom_compiled_2 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_2 = CompiledPolicySet::compile_with_custom_symenv(
             pset2,
             &envs.req_env,
             envs.schema,
@@ -1282,14 +1282,14 @@ pub async fn assert_implies_ok<S: Solver>(
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
         assert!(literal_symenv.is_literal());
-        let custom_compiled_1 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_1 = CompiledPolicySet::compile_with_custom_symenv(
             pset1,
             &envs.req_env,
             envs.schema,
             literal_symenv.clone(),
         )
         .unwrap();
-        let custom_compiled_2 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_2 = CompiledPolicySet::compile_with_custom_symenv(
             pset2,
             &envs.req_env,
             envs.schema,
@@ -1378,14 +1378,14 @@ pub async fn assert_disjoint_ok<S: Solver>(
         // Re-perform the check with a symbolized concrete `Env`
         let literal_symenv = SymEnv::from_concrete_env(&envs.req_env, envs.schema, &cex).unwrap();
         assert!(literal_symenv.is_literal());
-        let custom_compiled_1 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_1 = CompiledPolicySet::compile_with_custom_symenv(
             pset1,
             &envs.req_env,
             envs.schema,
             literal_symenv.clone(),
         )
         .unwrap();
-        let custom_compiled_2 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_2 = CompiledPolicySet::compile_with_custom_symenv(
             pset2,
             &envs.req_env,
             envs.schema,
@@ -1400,14 +1400,14 @@ pub async fn assert_disjoint_ok<S: Solver>(
         let interp = Interpretation::default(&envs.symenv);
         let literal_symenv = envs.symenv.interpret(&interp);
         assert!(literal_symenv.is_literal());
-        let custom_compiled_1 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_1 = CompiledPolicySet::compile_with_custom_symenv(
             pset1,
             &envs.req_env,
             envs.schema,
             literal_symenv.clone(),
         )
         .unwrap();
-        let custom_compiled_2 = CompiledPolicies::compile_with_custom_symenv(
+        let custom_compiled_2 = CompiledPolicySet::compile_with_custom_symenv(
             pset2,
             &envs.req_env,
             envs.schema,


### PR DESCRIPTION
## Description of changes

Applies to Rust the renames performed on the Lean side in https://github.com/cedar-policy/cedar-spec/pull/829

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A breaking change requiring a major version bump to `cedar-policy-symcc` (e.g., changes to the signature of an existing API).

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
