### PR TITLE
Tweak feature cfg guard to avoid rust-analyzer error in IDE

### DIFF
--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -163,13 +163,11 @@ impl LocatedType {
     /// is defined. If `extend-schema` is not enabled, then the location
     /// returned by this function is always `None`.
     pub fn into_type_and_loc(self) -> (Type, Option<Loc>) {
-        (
-            self.ty,
-            #[cfg(feature = "extended-schema")]
-            self.loc,
-            #[cfg(not(feature = "extended-schema"))]
-            None,
-        )
+        #[cfg(feature = "extended-schema")]
+        let loc = self.loc;
+        #[cfg(not(feature = "extended-schema"))]
+        let loc = None;
+        (self.ty, loc)
     }
 }
 


### PR DESCRIPTION
## Description of changes

The original code builds as expected in both configurations, but I think rust-analyzer gets confused and interpreted it as a 3-tuple, so it highlighted this as an error in vscode for me. A small tweak resolves this and IMO is even a little easier to read. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
