### PR TITLE
remove getters added by #2103

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -13,7 +13,6 @@ Cedar Language Version: TBD
 - `matches_equivalent`, `matches_implies`, and `matches_disjoint` primitives
 for single policies (#2047)
 - `.effect()` for `CompiledPolicy` (#2047)
-- `CompiledPolicy::policy()` and `CompiledPolicies::policies()` (#2103)
 - `CompiledPolicy::compile_with_custom_symenv()` and
 `CompiledPolicySet::compile_with_custom_symenv()` experimental APIs -- note the
 documented caveats and use at your own risk (#2102)

--- a/cedar-policy-symcc/src/lib.rs
+++ b/cedar-policy-symcc/src/lib.rs
@@ -195,11 +195,6 @@ impl CompiledPolicy {
         self.policy.effect()
     }
 
-    /// Get the (post-typecheck) `Policy` that this `CompiledPolicy` represents
-    pub fn policy(&self) -> &cedar_policy_core::ast::Policy {
-        &self.policy.policy
-    }
-
     /// Convert a `CompiledPolicy` to a `CompiledPolicySet` representing a
     /// singleton policyset with just that policy.
     ///
@@ -260,11 +255,6 @@ impl CompiledPolicySet {
                 symenv,
             )?,
         })
-    }
-
-    /// Get the (post-typecheck) `PolicySet` that this `CompiledPolicySet` represents
-    pub fn policies(&self) -> &cedar_policy_core::ast::PolicySet {
-        &self.policies.policies
     }
 }
 


### PR DESCRIPTION
## Description of changes

Removes two getters that were added by #2103. These have not been released yet, and it turns out they are not needed (any longer, after https://github.com/cedar-policy/cedar-spec/pull/854).  Seems prudent to remove them before a 0.3.0 release happens, particularly as they exposed Core types in the `cedar-policy-symcc` interface, which is undesirable. Better and cleaner to avoid releasing them since they are not needed.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
