### PR TITLE
Updated ordering of symcc terms (#2139)

### DIFF
--- a/cedar-policy-symcc/src/symcc/term.rs
+++ b/cedar-policy-symcc/src/symcc/term.rs
@@ -50,40 +50,25 @@ pub struct TermVar {
 }
 
 /// Primitive terms.
+/// Variants must be defined in alphabetical order.
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum TermPrim {
-    /// Literal bool
-    Bool(bool),
     /// Literal bitvec
     Bitvec(BitVec),
-    /// Literal string
-    String(SmolStr),
+    /// Literal bool
+    Bool(bool),
     /// Literal EntityUID
     Entity(EntityUID),
     /// Literal extension value
     Ext(Ext),
+    /// Literal string
+    String(SmolStr),
 }
 
 /// Intermediate representation of [`Term`]s.
+/// Variants must be defined in alphabetical order.
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub enum Term {
-    /// Literal
-    Prim(TermPrim),
-    /// Variable
-    Var(TermVar),
-    /// None
-    None(TermType),
-    /// Some
-    Some(Arc<Term>),
-    /// Sets
-    Set {
-        /// Elements of the set (as `Term`)
-        elts: Arc<BTreeSet<Term>>,
-        /// Type shared by all elements of the set
-        elts_ty: TermType,
-    },
-    /// Records
-    Record(Arc<BTreeMap<Attr, Term>>),
     /// Function calls
     App {
         /// Function being called
@@ -93,6 +78,23 @@ pub enum Term {
         /// Return type of the function
         ret_ty: TermType,
     },
+    /// None
+    None(TermType),
+    /// Literal
+    Prim(TermPrim),
+    /// Records
+    Record(Arc<BTreeMap<Attr, Term>>),
+    /// Sets
+    Set {
+        /// Elements of the set (as `Term`)
+        elts: Arc<BTreeSet<Term>>,
+        /// Type shared by all elements of the set
+        elts_ty: TermType,
+    },
+    /// Some
+    Some(Arc<Term>),
+    /// Variable
+    Var(TermVar),
 }
 
 // Corresponding to the `Coe` instances in Lean

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -25,25 +25,27 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 /// Types of the intermediate [`super::term::Term`] representation.
+//  Note: The declaration order of variants for this enum affects the derived definitions of `Ord`
+//  and `PartialOrd` which must be consistent with the Lean.
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[expect(missing_docs, reason = "fields are self explanatory")]
 pub enum TermType {
-    /// Bool type
-    Bool,
-    /// Bitvec type
-    Bitvec { n: Width },
-    /// String type
-    String,
     /// Option type
     Option { ty: Arc<TermType> },
+    /// Bitvec type
+    Bitvec { n: Width },
+    /// Bool type
+    Bool,
     /// Entity type
     Entity { ety: EntityType },
-    /// (Finite) set type
-    Set { ty: Arc<TermType> },
-    /// Record type
-    Record { rty: Arc<BTreeMap<Attr, TermType>> },
     /// Extension type
     Ext { xty: ExtType },
+    /// String type
+    String,
+    /// Record type
+    Record { rty: Arc<BTreeMap<Attr, TermType>> },
+    /// (Finite) set type
+    Set { ty: Arc<TermType> },
 }
 
 impl TermType {


### PR DESCRIPTION
## Description of changes
Cherry picked symcc term reordering change from d8f6c75bca799d1e7e4ed5760c8b4060443f99c3.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.