### PR TITLE
Have cedar-wasm package inherit repository information from workspace

### DIFF
--- a/cedar-wasm/Cargo.toml
+++ b/cedar-wasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "cedar-wasm"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+repository.workspace = true
 description = "Wasm bindings and typescript types for Cedar lib"
 license.workspace = true
 


### PR DESCRIPTION
## Description of changes
Have cedar-wasm package inherit repository information from workspace. This appears to be necessary for NPM trusted publishing to work.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
