### PR TITLE
Add `--expression` option to `check-parse`

### DIFF
--- a/cedar-policy-cli/CHANGELOG.md
+++ b/cedar-policy-cli/CHANGELOG.md
@@ -5,6 +5,10 @@ Changes to the Cedar language, which are likely to affect users of the CLI, are 
 
 ## Unreleased
 
+### Added
+
+- `--expression` option to `check-parse` command to check if a Cedar expression parses
+
 ## 4.9.0
 
 ### Added

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -45,6 +45,7 @@ fn run_check_parse_test(
             policy_format: PolicyFormat::Cedar,
             template_linked_file: None,
         },
+        expression: None,
         schema: OptionalSchemaArgs {
             schema_file: Some(schema_file.into()),
             schema_format: SchemaFormat::Cedar,
@@ -1662,4 +1663,28 @@ fn test_tpe() {
         .arg(schema)
         .assert()
         .code(0);
+}
+
+#[rstest]
+#[case("principal")]
+#[case("1 + 1")]
+fn check_parse_expr_ok(#[case] expr: &str) {
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("check-parse")
+        .arg("--expression")
+        .arg(expr)
+        .assert()
+        .code(0);
+}
+
+#[rstest]
+#[case("")]
+#[case("1+foo")]
+fn check_parse_expr_err(#[case] expr: &str) {
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("check-parse")
+        .arg("--expression")
+        .arg(expr)
+        .assert()
+        .code(1);
 }


### PR DESCRIPTION
## Description of changes

A utility for testing if an expression parses without typing out a full policy

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
