### PR TITLE
Reorganize primitive and boolean types to match Lean model

### DIFF
--- a/cedar-language-server/src/policy/types/cedar.rs
+++ b/cedar-language-server/src/policy/types/cedar.rs
@@ -25,7 +25,7 @@ use std::{
 use cedar_policy_core::{
     ast::EntityUID,
     validator::{
-        types::{EntityKind, Primitive, Type},
+        types::{EntityKind, Type},
         ValidatorSchema,
     },
 };
@@ -215,12 +215,9 @@ impl From<Type> for CedarTypeKind {
     fn from(ty: Type) -> Self {
         match ty {
             Type::Never => Self::Error,
-            Type::True | Type::False => Self::Bool,
-            Type::Primitive { primitive_type } => match primitive_type {
-                Primitive::Bool => Self::Bool,
-                Primitive::Long => Self::Long,
-                Primitive::String => Self::String,
-            },
+            Type::Bool(_) => Self::Bool,
+            Type::Long => Self::Long,
+            Type::String => Self::String,
             Type::Set { element_type } => element_type.map_or(Self::EmptySet, |ty| {
                 Self::Set(Box::new(Self::from(ty.as_ref().clone())))
             }),

--- a/cedar-language-server/src/schema/definition.rs
+++ b/cedar-language-server/src/schema/definition.rs
@@ -196,9 +196,9 @@ impl FindDefinition for Type {
             }
             Self::Entity(EntityKind::AnyEntity)
             | Self::Never
-            | Self::True
-            | Self::False
-            | Self::Primitive { .. }
+            | Self::Bool(_)
+            | Self::String
+            | Self::Long
             | Self::ExtensionType { .. } => None,
         }
     }

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -533,7 +533,7 @@ mod test {
     use crate::parser::parse_expr;
     use crate::tpe::request::{PartialEntityUID, PartialRequest};
     use crate::validator::typecheck::{PolicyCheck, Typechecker};
-    use crate::validator::types::Primitive;
+    use crate::validator::types::BoolType;
     use crate::validator::{ValidationMode, Validator, ValidatorSchema};
     use similar_asserts::assert_eq;
 
@@ -716,10 +716,7 @@ mod test {
             true
         );
         assert_eq!(
-            Residual::Error(Type::Primitive {
-                primitive_type: Primitive::Bool
-            })
-            .can_error_assuming_well_formed(),
+            Residual::Error(Type::Bool(BoolType::AnyBool)).can_error_assuming_well_formed(),
             true
         );
     }

--- a/cedar-policy-core/src/validator/cedar_schema/test.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/test.rs
@@ -1244,6 +1244,7 @@ mod translator_tests {
     use crate::ast as cedar_ast;
     use crate::extensions::Extensions;
     use crate::test_utils::{expect_err, ExpectedErrorMessageBuilder};
+    use crate::validator::types::BoolType;
     use crate::FromNormalizedStr;
     use cool_asserts::assert_matches;
 
@@ -1255,7 +1256,7 @@ mod translator_tests {
         },
         json_schema,
         schema::test::utils::collect_warnings,
-        types::{EntityKind, EntityLUB, Primitive, Type},
+        types::{EntityKind, EntityLUB, Type},
         ValidatorSchema,
     };
 
@@ -1437,7 +1438,7 @@ mod translator_tests {
                             "groups" => assert_matches!(
                                 attr.attr_type.as_ref(),
                                 Type::Set { element_type: Some(t) } => {
-                                    assert_eq!(**t, Type::Primitive { primitive_type: Primitive::String });
+                                    assert_eq!(**t, Type::String);
                                 }
                             ),
                             _ => panic!("unexpected attr: {attr_name}"),
@@ -1555,12 +1556,7 @@ mod translator_tests {
             ))
             .unwrap();
         let attr = et.attr("foo").unwrap();
-        assert_matches!(
-            attr.attr_type.as_ref(),
-            Type::Primitive {
-                primitive_type: Primitive::Bool
-            },
-        );
+        assert_matches!(attr.attr_type.as_ref(), Type::Bool(BoolType::AnyBool),);
 
         let (schema, _) = json_schema::Fragment::from_cedarschema_str(
             r#"namespace A {

--- a/cedar-policy-core/src/validator/entity_manifest/analysis.rs
+++ b/cedar-policy-core/src/validator/entity_manifest/analysis.rs
@@ -267,9 +267,9 @@ fn type_to_access_trie(ty: &Type) -> AccessTrie {
         // if it's not an entity or record, slice ends here
         Type::ExtensionType { .. }
         | Type::Never
-        | Type::True
-        | Type::False
-        | Type::Primitive { .. }
+        | Type::Bool(_)
+        | Type::Long
+        | Type::String
         | Type::Set { .. } => AccessTrie::new(),
         Type::Record { attrs, .. } => {
             let mut fields = HashMap::new();

--- a/cedar-policy-core/src/validator/entity_manifest/type_annotations.rs
+++ b/cedar-policy-core/src/validator/entity_manifest/type_annotations.rs
@@ -120,9 +120,9 @@ impl AccessTrie {
     ) -> Result<Fields, MismatchedEntityManifestError> {
         let attributes = match ty {
             Type::Never
-            | Type::True
-            | Type::False
-            | Type::Primitive { .. }
+            | Type::Bool(_)
+            | Type::Long
+            | Type::String
             | Type::Set { .. }
             | Type::ExtensionType { .. } => {
                 assert!(self.children.is_empty());

--- a/cedar-policy-core/src/validator/schema.rs
+++ b/cedar-policy-core/src/validator/schema.rs
@@ -37,9 +37,6 @@ use std::collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::Arc;
 
-#[cfg(feature = "extended-schema")]
-use crate::validator::types::Primitive;
-
 use crate::validator::{
     cedar_schema::SchemaWarning,
     json_schema,
@@ -828,7 +825,7 @@ impl ValidatorSchema {
             .filter(|ct| {
                 // Only collect common types that are not primitives and have location data
                 let ct_name = ct.0.clone();
-                ct_name.loc().is_some() && !Primitive::is_primitive(ct_name.basename().as_ref())
+                ct_name.loc().is_some() && !Type::is_primitive(ct_name.basename().as_ref())
             })
             .map(|ct| LocatedCommonType::new(ct.0, ct.1))
             .collect();
@@ -4892,11 +4889,10 @@ mod entity_tags {
     use crate::{
         extensions::Extensions,
         test_utils::{expect_err, ExpectedErrorMessageBuilder},
+        validator::types::BoolType,
     };
     use cool_asserts::assert_matches;
     use serde_json::json;
-
-    use crate::validator::types::Primitive;
 
     #[test]
     fn cedar_syntax_tags() {
@@ -4913,11 +4909,11 @@ mod entity_tags {
             assert!(warnings.is_empty());
             let user = assert_entity_type_exists(&schema, "User");
             assert_matches!(user.tag_type(), Some(Type::Set { element_type: Some(el_ty) }) => {
-                assert_matches!(&**el_ty, Type::Primitive { primitive_type: Primitive::String });
+                assert_matches!(&**el_ty, Type::String);
             });
             let doc = assert_entity_type_exists(&schema, "Document");
             assert_matches!(doc.tag_type(), Some(Type::Set { element_type: Some(el_ty) }) => {
-                assert_matches!(&**el_ty, Type::Primitive { primitive_type: Primitive::String });
+                assert_matches!(&**el_ty, Type::String);
             });
         });
     }
@@ -4962,11 +4958,11 @@ mod entity_tags {
         assert_matches!(ValidatorSchema::from_json_value(json, Extensions::all_available()), Ok(schema) => {
             let user = assert_entity_type_exists(&schema, "User");
             assert_matches!(user.tag_type(), Some(Type::Set { element_type: Some(el_ty) }) => {
-                assert_matches!(&**el_ty, Type::Primitive { primitive_type: Primitive::String });
+                assert_matches!(&**el_ty, Type::String);
             });
             let doc = assert_entity_type_exists(&schema, "Document");
             assert_matches!(doc.tag_type(), Some(Type::Set { element_type: Some(el_ty) }) => {
-                assert_matches!(&**el_ty, Type::Primitive { primitive_type: Primitive::String });
+                assert_matches!(&**el_ty, Type::String);
             });
         });
     }
@@ -4997,7 +4993,7 @@ mod entity_tags {
             let e = assert_entity_type_exists(&schema, "E");
             assert_matches!(e.tag_type(), None);
             let foo1 = assert_entity_type_exists(&schema, "Foo1");
-            assert_matches!(foo1.tag_type(), Some(Type::Primitive { primitive_type: Primitive::Bool }));
+            assert_matches!(foo1.tag_type(), Some(Type::Bool(BoolType::AnyBool)));
             let foo2 = assert_entity_type_exists(&schema, "Foo2");
             assert_matches!(foo2.tag_type(), Some(Type::Record{ .. }));
             let foo3 = assert_entity_type_exists(&schema, "Foo3");

--- a/cedar-policy-core/src/validator/typecheck/test/expr.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/expr.rs
@@ -22,6 +22,7 @@ use std::{str::FromStr, vec};
 use crate::{
     ast::{BinaryOp, EntityUID, Expr, Pattern, PatternElem, SlotId, Var},
     extensions::Extensions,
+    validator::types::BoolType,
 };
 use itertools::Itertools;
 use serde_json::json;
@@ -519,7 +520,7 @@ fn entity_eq_is_false() {
                 "bar".into(),
             ),
         ),
-        &Type::False,
+        &Type::Bool(BoolType::False),
     );
 }
 
@@ -908,7 +909,7 @@ fn action_in_non_action_typechecks_false() {
             ),
             Expr::var(Var::Principal),
         ),
-        &Type::False,
+        &Type::Bool(BoolType::False),
     );
 }
 

--- a/cedar-policy-core/src/validator/typecheck/test/namespace.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/namespace.rs
@@ -27,6 +27,7 @@ use crate::{
     ast::{Expr, PolicyID, StaticPolicy},
     extensions::Extensions,
     parser::parse_policy,
+    validator::types::BoolType,
 };
 
 use super::test_utils::{
@@ -77,23 +78,23 @@ fn namespaced_entity_eq() {
     assert_typechecks(
         namespaced_entity_type_schema(),
         &Expr::from_str(r#"N::S::Foo::"alice" == N::S::Foo::"alice""#).expect("Expr should parse."),
-        &Type::True,
+        &Type::Bool(BoolType::True),
     );
     assert_typechecks(
         namespaced_entity_type_schema(),
         &Expr::from_str(r#"N::S::Foo::"alice" == N::S::Foo::"bob""#).expect("Expr should parse."),
-        &Type::False,
+        &Type::Bool(BoolType::False),
     );
     assert_typechecks(
         namespaced_entity_type_schema(),
         &Expr::from_str(r#"N::S::Foo::"alice" == N::S::Bar::"bob""#).expect("Expr should parse."),
-        &Type::False,
+        &Type::Bool(BoolType::False),
     );
     assert_typechecks(
         namespaced_entity_type_schema(),
         &Expr::from_str(r#"N::S::Action::"baz" == N::S::Action::"baz""#)
             .expect("Expr should parse."),
-        &Type::True,
+        &Type::Bool(BoolType::True),
     );
 }
 
@@ -107,7 +108,7 @@ fn namespaced_entity_in() {
     assert_typechecks(
         namespaced_entity_type_schema(),
         &Expr::from_str(r#"N::S::Foo::"alice" in N::S::Bar::"bob""#).expect("Expr should parse."),
-        &Type::False,
+        &Type::Bool(BoolType::False),
     );
 }
 
@@ -116,7 +117,7 @@ fn namespaced_entity_has() {
     assert_typechecks(
         namespaced_entity_type_schema(),
         &Expr::from_str(r#"N::S::Foo::"alice" has foo"#).expect("Expr should parse."),
-        &Type::False,
+        &Type::Bool(BoolType::False),
     );
     assert_typechecks(
         namespaced_entity_type_schema(),

--- a/cedar-policy-core/src/validator/typecheck/test/policy.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/policy.rs
@@ -23,6 +23,7 @@ use crate::{
     ast::{EntityUID, Expr, PolicyID, Template},
     extensions::Extensions,
     parser::{parse_policy, parse_policy_or_template},
+    validator::types::BoolType,
 };
 
 use super::test_utils::{
@@ -837,7 +838,7 @@ fn type_error_is_not_reported_for_every_cross_product_element() {
             get_loc(src, "true"),
             PolicyID::from_string("0"),
             vec![Type::primitive_long()],
-            Type::True,
+            Type::Bool(BoolType::True),
             None,
         )
     );

--- a/cedar-policy-core/src/validator/typecheck/test/type_annotation.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/type_annotation.rs
@@ -28,7 +28,7 @@ use crate::{
     validator::{
         json_schema,
         typecheck::{PolicyCheck, TypecheckAnswer, Typechecker},
-        types::Type,
+        types::{BoolType, Type},
         ValidationMode, ValidatorSchema,
     },
 };
@@ -121,7 +121,7 @@ fn expr_typechecks_with_correct_annotation() {
     assert_expr_has_annotated_ast(
         &Expr::ite(Expr::val(true), Expr::val("bar"), Expr::val("foo")),
         &ExprBuilder::with_data(Some(Type::primitive_string())).ite(
-            ExprBuilder::with_data(Some(Type::True)).val(true),
+            ExprBuilder::with_data(Some(Type::Bool(BoolType::True))).val(true),
             ExprBuilder::with_data(Some(Type::primitive_string())).val("bar"),
             // Contains `bar` instead of `foo` because we didn't typecheck the `else` branch
             ExprBuilder::with_data(Some(Type::primitive_string())).val("bar"),
@@ -130,7 +130,7 @@ fn expr_typechecks_with_correct_annotation() {
     assert_expr_has_annotated_ast(
         &Expr::ite(Expr::val(false), Expr::val("bar"), Expr::val("foo")),
         &ExprBuilder::with_data(Some(Type::primitive_string())).ite(
-            ExprBuilder::with_data(Some(Type::False)).val(false),
+            ExprBuilder::with_data(Some(Type::Bool(BoolType::False))).val(false),
             // Contains `foo` instead of `bar` because we didn't typecheck the `else` branch
             ExprBuilder::with_data(Some(Type::primitive_string())).val("foo"),
             ExprBuilder::with_data(Some(Type::primitive_string())).val("foo"),

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -106,13 +106,11 @@ impl TermType {
     ///
     /// This doesn't match the Lean model because [`Type`] doesn't.
     pub fn of_type(ty: &Type) -> Result<Self, CompileError> {
-        use cedar_policy_core::validator::types::{EntityKind, Primitive};
+        use cedar_policy_core::validator::types::{BoolType, EntityKind};
         match ty {
-            Type::Primitive { primitive_type } => match primitive_type {
-                Primitive::Bool => Ok(TermType::Bool),
-                Primitive::Long => Ok(TermType::Bitvec { n: SIXTY_FOUR }),
-                Primitive::String => Ok(TermType::String),
-            },
+            Type::Bool(BoolType::AnyBool) => Ok(TermType::Bool),
+            Type::Long => Ok(TermType::Bitvec { n: SIXTY_FOUR }),
+            Type::String => Ok(TermType::String),
             Type::ExtensionType { name } => match name.basename().to_string().as_str() {
                 "ipaddr" => Ok(TermType::Ext {
                     xty: ExtType::IpAddr,
@@ -185,10 +183,7 @@ impl TermType {
             Type::Never => Err(CompileError::UnsupportedFeature(
                 "never type is not supported".into(),
             )),
-            Type::True => Err(CompileError::UnsupportedFeature(
-                "singleton Bool type is not supported".into(),
-            )),
-            Type::False => Err(CompileError::UnsupportedFeature(
+            Type::Bool(BoolType::True | BoolType::False) => Err(CompileError::UnsupportedFeature(
                 "singleton Bool type is not supported".into(),
             )),
         }

--- a/cedar-policy/src/proto/validator.rs
+++ b/cedar-policy/src/proto/validator.rs
@@ -204,17 +204,15 @@ impl From<&types::Type> for models::Type {
     fn from(v: &types::Type) -> Self {
         match v {
             types::Type::Never => panic!("can't encode Never type in protobuf; Never should never appear in a Schema"),
-            types::Type::True | types::Type::False => panic!("can't encode singleton boolean type in protobuf; singleton boolean types should never appear in a Schema"),
-            types::Type::Primitive { primitive_type } => match primitive_type {
-                types::Primitive::Bool => Self {
-                    data: Some(models::r#type::Data::Prim(models::r#type::Prim::Bool.into())),
-                },
-                types::Primitive::Long => Self {
-                    data: Some(models::r#type::Data::Prim(models::r#type::Prim::Long.into())),
-                },
-                types::Primitive::String => Self {
-                    data: Some(models::r#type::Data::Prim(models::r#type::Prim::String.into())),
-                },
+            types::Type::Bool(types::BoolType::True | types::BoolType::False) => panic!("can't encode singleton boolean type in protobuf; singleton boolean types should never appear in a Schema"),
+            types::Type::Bool(types::BoolType::AnyBool) => Self {
+                data: Some(models::r#type::Data::Prim(models::r#type::Prim::Bool.into())),
+            },
+            types::Type::Long => Self {
+                data: Some(models::r#type::Data::Prim(models::r#type::Prim::Long.into())),
+            },
+            types::Type::String => Self {
+                data: Some(models::r#type::Data::Prim(models::r#type::Prim::String.into())),
             },
             types::Type::Set { element_type } => Self {
                 data: Some(models::r#type::Data::SetElem(Box::new(models::Type::from(


### PR DESCRIPTION
Primitive types inlined into the `Type` enum. Boolean types split out into a `BoolType` enum.

This matches the organization in the Lean model and feels like a slightly nicer design in a few places.

https://github.com/cedar-policy/cedar-spec/pull/878

## Description of changes

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
