### PR TITLE
PoC: Return the same evaluation errors from TPE as from concrete evaluation

### DIFF
--- a/cedar-policy-core/src/evaluator.rs
+++ b/cedar-policy-core/src/evaluator.rs
@@ -41,7 +41,7 @@ const REQUIRED_STACK_SPACE: usize = 1024 * 100;
 type UnknownsMapper<'e> = Box<dyn Fn(&str) -> Option<Value> + 'e>;
 
 #[expect(clippy::expect_used, reason = "`Name`s in here are valid `Name`s")]
-mod names {
+pub(crate) mod names {
     use super::Name;
     use std::sync::LazyLock;
 
@@ -1159,7 +1159,7 @@ impl Value {
 }
 
 #[inline(always)]
-fn stack_size_check() -> Result<()> {
+pub(crate) fn stack_size_check() -> Result<()> {
     // We assume there's enough space if we cannot determine it with `remaining_stack`
     if stacker::remaining_stack().unwrap_or(REQUIRED_STACK_SPACE) < REQUIRED_STACK_SPACE {
         return Err(EvaluationError::recursion_limit(None));

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -22,6 +22,7 @@ pub mod evaluator;
 pub mod request;
 pub mod residual;
 pub mod response;
+pub(crate) mod test_utils;
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/cedar-policy-core/src/tpe/test_utils.rs
+++ b/cedar-policy-core/src/tpe/test_utils.rs
@@ -1,0 +1,69 @@
+use crate::ast::{Effect, Policy};
+use crate::extensions::Extensions;
+use crate::parser::parse_expr;
+use crate::tpe::request::{PartialEntityUID, PartialRequest};
+use crate::tpe::residual::Residual;
+use crate::validator::typecheck::{PolicyCheck, Typechecker};
+use crate::validator::{ValidationMode, Validator, ValidatorSchema};
+
+#[track_caller]
+pub(crate) fn parse_residual(expr_str: &str) -> Residual {
+    let expr = parse_expr(expr_str).unwrap();
+    let policy_id = crate::ast::PolicyID::from_string("test");
+    let policy = Policy::from_when_clause(Effect::Permit, expr, policy_id, None);
+    let t = policy.template();
+
+    let schema = ValidatorSchema::from_cedarschema_str(r#"
+        entity User in Organization { foo: Bool, str: String, num: Long, period: __cedar::duration, set: Set<String> } tags String;
+        entity Organization;
+        entity Document in Organization; 
+        action get appliesTo { principal: [User], resource: [Document] };"#,
+        &Extensions::all_available(),
+    )
+    .unwrap()
+    .0;
+
+    let typechecker = Typechecker::new(&schema, ValidationMode::Strict);
+
+    let request = PartialRequest::new(
+        PartialEntityUID {
+            ty: "User".parse().unwrap(),
+            eid: None,
+        },
+        r#"Action::"get""#.parse().unwrap(),
+        PartialEntityUID {
+            ty: "Document".parse().unwrap(),
+            eid: None,
+        },
+        None,
+        &schema,
+    )
+    .unwrap();
+    let env = request.find_request_env(&schema).unwrap();
+
+    let errs: Vec<_> = Validator::validate_entity_types_and_literals(&schema, t).collect();
+    if !errs.is_empty() {
+        panic!("unexpected type error in expression");
+    }
+    match typechecker.typecheck_by_single_request_env(t, &env) {
+        PolicyCheck::Success(expr) => Residual::try_from(&expr).unwrap(),
+        PolicyCheck::Fail(errs) => {
+            println!("got {} type errors", errs.len());
+            for e in errs {
+                println!("{:?}", miette::Report::new(e));
+            }
+            panic!("unexpected type error in expression")
+        }
+        PolicyCheck::Irrelevant(errs, expr) => {
+            if errs.is_empty() {
+                Residual::try_from(&expr).unwrap()
+            } else {
+                println!("got {} type errors", errs.len());
+                for e in errs {
+                    println!("{:?}", miette::Report::new(e));
+                }
+                panic!("unexpected type error in expression")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Description of changes

Draft PR, I need to double-check some of the logic here still and add some more unit tests, but it should be good enough to discuss at least. What do you think about this rewrite? I think it could help make the code between TPE and the concrete evaluator more similar and hopefully comparable, especially when the older `partial-eval` is deprecated and removed from the concrete evaluator.

Discussed this with @john-h-kastner-aws. The idea is to return a concrete error whenever the concrete evaluator would, and just exactly the same error as the concrete evaluator would. However, cases like `<residual> && <error>` do not fold to `<error>`, as `<residual>` could evaluate to another error.

Also noted that the stack overflow check was not added to TPE. Also I'm trying to make the errors nice by preserving the Loc information, but it seems like I need to do some other thing still to produce nice reports in miette to show where the error came from.

Fixes: https://github.com/cedar-policy/cedar/issues/1736

(at least part of, we could add the `Diagnostics` in a follow-up PR)

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

Not sure, do you want a release note for this one? I can add one.

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)

Would you be interested in updating cedar-spec with a theorem that the errors should be the same between concrete and TPE?

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
