### PR TITLE
Avoid allocation for empty footprints in symcc

### DIFF
--- a/cedar-policy-symcc/src/symccopt/authorizer.rs
+++ b/cedar-policy-symcc/src/symccopt/authorizer.rs
@@ -49,7 +49,7 @@ pub fn satisfied_policies(
             |term| eq(term, some_of(true.into())),
             ress.iter().map(|res| res.term.clone()),
         ),
-        footprint: Footprint::from_iter(ress.into_iter().flat_map(|res| res.footprint)),
+        footprint: Footprint::flatten(ress.into_iter().map(|res| res.footprint)),
     })
 }
 
@@ -58,6 +58,6 @@ pub fn is_authorized(policies: &PolicySet, env: &SymEnv) -> Result<CompileResult
     let permits = satisfied_policies(Effect::Permit, policies, env)?;
     Ok(CompileResult {
         term: and(permits.term, not(forbids.term)),
-        footprint: Footprint::from_iter(permits.footprint.chain(forbids.footprint)),
+        footprint: permits.footprint.chain(forbids.footprint),
     })
 }


### PR DESCRIPTION
## Description of changes

Optimized symcc has a bunch of cases where it creates a `Footprint` which is always empty for well-typed policies. In these cases it currently allocates two `Arc`s, one wrapping an empty iterator, and another wrapping the result of chaining the operand footprint with the empty footprint.

This PR introduces an `Option` wrapper to the footprint terms so that an empty footprint is efficiently represented as null pointer. It also adds new methods to `Footprint` for chaining footprints while maintaining the efficient representation.

I've also changed from using an `Arc` to a `Box`. As noted in the comments, we always have unique ownership of the allocations, and do not implement `Clone` for the `Footprint` type, so I don't think there's any reason to use an `Arc` here.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
