### PR TITLE
refactor extension syntax information to extension module

### DIFF
--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -25,11 +25,9 @@ use crate::entities::json::{
     CedarValueJson, FnAndArgs,
 };
 use crate::expr_builder::ExprBuilder;
-use crate::extensions::Extensions;
+use crate::extensions::{ExtStyles, Extensions};
 use crate::jsonvalue::JsonValueWithNoDuplicateKeys;
-use crate::parser::err::ParseErrors;
-use crate::parser::{cst, Loc};
-use crate::parser::{cst_to_ast, Node};
+use crate::parser::{cst, err::ParseErrors, Loc, Node};
 use crate::FromNormalizedStr;
 use itertools::Itertools;
 use nonempty::NonEmpty;
@@ -92,7 +90,7 @@ impl<'de> Deserialize<'de> for Expr {
                         return Err(serde::de::Error::custom(format!("JSON object representing an `Expr` should have only one key, but found two keys: `{k}` and `{k2}`")));
                     }
                 };
-                if cst_to_ast::is_known_extension_func_str(&k) {
+                if ExtStyles::is_known_extension_func_str(&k) {
                     // `k` is the name of an extension function or method. We assume that
                     // no such keys are valid keys for `ExprNoExt`, so we must parse as an
                     // `ExtFuncCall`.
@@ -1077,7 +1075,7 @@ impl Expr {
                     let fn_name = Name::from_normalized_str(&fn_name).map_err(|errs| {
                         JsonDeserializationError::parse_escape(EscapeKind::Extension, fn_name, errs)
                     })?;
-                    if cst_to_ast::is_known_extension_func_name(&fn_name) {
+                    if ExtStyles::is_known_extension_func_name(&fn_name) {
                         Ok(ast::Expr::call_extension_fn(
                             fn_name,
                             args.into_iter()


### PR DESCRIPTION
## Description of changes
This moves the implementation of how the CST -> AST translation reasons about method- and function- call style for extensions to the extensions module. This is in order to make the functionality easier to use from other representation conversion functions in the future (e.g. suggesting function/method names, validating that method calls have at least a receiver).

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
