### PR TITLE
Fixed #2016 issue - Allow referencing entities JSON files in run-test…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,6 +401,7 @@ dependencies = [
  "cool_asserts",
  "educe",
  "either",
+ "insta",
  "itertools 0.14.0",
  "lalrpop",
  "lalrpop-util",

--- a/cedar-policy-cli/sample-data/tiny_sandboxes/sample1/tests-external-entities.json
+++ b/cedar-policy-cli/sample-data/tiny_sandboxes/sample1/tests-external-entities.json
@@ -1,0 +1,27 @@
+[
+  {
+    "request": {
+      "principal": "User::\"alice\"",
+      "action": "Action::\"view\"",
+      "resource": "Photo::\"VacationPhoto94.jpg\"",
+      "context": {}
+    },
+    "entities": "entity.json",
+    "decision": "allow",
+    "reason": ["policy0"],
+    "num_errors": 0
+  },
+  {
+    "name": "test with external entities - deny case",
+    "request": {
+      "principal": "User::\"bob\"",
+      "action": "Action::\"view\"",
+      "resource": "Photo::\"VacationPhoto94.jpg\"",
+      "context": {}
+    },
+    "entities": "entity.json",
+    "decision": "deny",
+    "reason": [],
+    "num_errors": 0
+  }
+]

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1603,6 +1603,25 @@ fn test_run_tests_samples(
 }
 
 #[test]
+fn test_run_tests_with_external_entities() {
+    // Test the new feature from issue #2016: referencing external entity files
+    let cmd = RunTestsArgs {
+        policies: PoliciesArgs {
+            policies_file: Some("sample-data/tiny_sandboxes/sample1/policy.cedar".into()),
+            policy_format: PolicyFormat::Cedar,
+            template_linked_file: None,
+        },
+        tests: "sample-data/tiny_sandboxes/sample1/tests-external-entities.json".into(),
+        schema: OptionalSchemaArgs {
+            schema_file: Some("sample-data/tiny_sandboxes/sample1/schema.cedarschema.json".into()),
+            schema_format: SchemaFormat::Json,
+        },
+    };
+    let output = run_tests(&cmd);
+    assert_eq!(CedarExitCode::Success, output, "{cmd:#?}");
+}
+
+#[test]
 #[cfg(feature = "tpe")]
 fn test_tpe() {
     let policies: &str = "sample-data/tpe_rfc/policies.cedar";


### PR DESCRIPTION
…s input

## Description of changes
Added support for referencing external entity JSON files in the cedar/cedar-policy-cli/src/lib.rs (run-tests) .
Added support for referencing external entity JSON files in the cedar/cedar-policy-cli/tests/sample.rs (cedar run-tests) command instead of requiring entities to be defined inline in test JSON. 
Changes:
Modified CheckedTestCaseSeed to track the test file directory for resolving relative paths;
Updated the deserializer to detect when entities is a string (file path) vs. inline JSON array;
Entity file paths are resolved relative to the test file's directory;
Added test case demonstrating the new functionality;

## Issue #, if available
Fixed issue #2016

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):


- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.


I confirm that this PR (choose one, and delete the other options):

- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
