### PR TITLE
refactor extension functions in PST into binary and unary operators

### DIFF
--- a/cedar-policy-core/src/pst/mod.rs
+++ b/cedar-policy-core/src/pst/mod.rs
@@ -31,5 +31,8 @@ mod expr;
 mod policy;
 
 pub use constraints::{ActionConstraint, EntityOrSlot, PrincipalConstraint, ResourceConstraint};
-pub use expr::{BinaryOp, EntityType, EntityUID, Expr, Literal, Name, PatternElem, SlotId, Var};
+pub use expr::{
+    BinaryOp, EntityType, EntityUID, Expr, ExprConstructionError, Literal, Name, PatternElem,
+    SlotId, UnaryOp, Var,
+};
 pub use policy::{Clause, Effect, Policy};


### PR DESCRIPTION
## Description of changes

This changes the representation of the proposed `Expr` for the public syntax tree:
- extension functions are enumerated binary or unary operators instead of free function names in the `Expr`,
- some enums are marked as `#[non_exhaustive]`, allowing future backwards-compatible changes to them,
- unary operations moved into UnaryOp instead of being their own top-level entities in the `Expr` enum

This PR is for the `public-syntax-tree-data` base, not mainline. `public-syntax-tree-data` will be merged later on when we agree on a PST representation.

## Checklist for requesting a review



The change in this PR is (choose one, and delete the other options):

- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
