### PR TITLE
refactor pst errors to follow style guide

### DIFF
--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -25,6 +25,9 @@ use super::{
 };
 use crate::ast;
 use crate::expr_builder;
+use crate::pst::err::error_body::{
+    InvalidConversionError, InvalidExpressionError, NotImplementedError, ParsingFailedError,
+};
 use crate::pst::expr::{ErrorNode, PstBuilder};
 use itertools::Itertools;
 use std::str::FromStr;
@@ -39,10 +42,11 @@ impl TryFrom<Policy> for ast::Policy {
         ast::StaticPolicy::try_from(template)
             .map(Into::into)
             .map_err(|e| {
-                PstConstructionError::InvalidConversion(format!(
+                InvalidConversionError::new(format!(
                     "Failed to convert template to static policy: {:?}",
                     e
                 ))
+                .into()
             })
     }
 }
@@ -118,7 +122,7 @@ impl TryFrom<PrincipalConstraint> for ast::PrincipalConstraint {
                     Arc::new(eos.try_into()?),
                 ))
             }
-            _ => Err(PstConstructionError::NotImplemented("templates".into())),
+            _ => Err(NotImplementedError::new("templates".to_string()).into()),
         }
     }
 }
@@ -144,7 +148,7 @@ impl TryFrom<ResourceConstraint> for ast::ResourceConstraint {
                     Arc::new(eos.try_into()?),
                 ))
             }
-            _ => Err(PstConstructionError::NotImplemented("templates".into())),
+            _ => Err(NotImplementedError::new("templates".to_string()).into()),
         }
     }
 }
@@ -197,7 +201,7 @@ impl Expr {
                 }
             },
             Expr::Var(v) => Ok(builder.var(v.into())),
-            Expr::Slot(_) => Err(PstConstructionError::NotImplemented("slots".to_string())),
+            Expr::Slot(_) => Err(NotImplementedError::new("slots".into()).into()),
             Expr::UnaryOp { op, expr } => {
                 let inner = Arc::unwrap_or_clone(expr).try_into_expr::<B>()?;
                 Ok(match op {
@@ -208,9 +212,8 @@ impl Expr {
                     _ => match op.to_name() {
                         Some(fn_name) => builder.call_extension_fn(fn_name.clone(), vec![inner]),
                         // This should never occur!
-                        None => Err(PstConstructionError::InvalidExpression(format!(
-                            "unknown unary operator: {}",
-                            op
+                        None => Err(PstConstructionError::from(InvalidExpressionError::new(
+                            format!("unknown unary operator: {}", op),
                         )))?,
                     },
                 })
@@ -243,9 +246,8 @@ impl Expr {
                             builder.call_extension_fn(fn_name.clone(), vec![left_ast, right_ast])
                         }
                         // This should never occur!
-                        None => Err(PstConstructionError::InvalidExpression(format!(
-                            "unknown binary operator: {}",
-                            op
+                        None => Err(PstConstructionError::from(InvalidExpressionError::new(
+                            format!("unknown binary operator: {}", op),
                         )))?,
                     },
                 })
@@ -302,7 +304,7 @@ impl Expr {
                         .collect::<Result<Vec<_>, PstConstructionError>>()?,
                 )
                 .map_err(|cstr_err: ast::ExpressionConstructionError| {
-                    PstConstructionError::InvalidConversion(cstr_err.to_string())
+                    InvalidConversionError::new(cstr_err.to_string()).into()
                 }),
             Expr::Unknown { name } => Ok(builder.unknown(ast::Unknown {
                 name,
@@ -338,9 +340,7 @@ impl TryFrom<EntityOrSlot> for ast::EntityReference {
     fn try_from(eos: EntityOrSlot) -> Result<Self, Self::Error> {
         match eos {
             EntityOrSlot::Entity(uid) => Ok(ast::EntityReference::euid(Arc::new(uid.try_into()?))),
-            EntityOrSlot::Slot(_) => Err(PstConstructionError::NotImplemented(
-                "templates".to_string(),
-            )),
+            EntityOrSlot::Slot(_) => Err(NotImplementedError::new("templates".to_string()).into()),
         }
     }
 }
@@ -403,12 +403,13 @@ impl TryFrom<Name> for ast::Name {
     type Error = PstConstructionError;
 
     fn try_from(name: Name) -> Result<Self, Self::Error> {
-        let basename = ast::Id::from_str(&name.id)?;
+        let basename = ast::Id::from_str(&name.id).map_err(ParsingFailedError::from)?;
         let path: Vec<ast::Id> = name
             .namespace
             .iter()
             .map(|s| ast::Id::from_str(s.as_str()))
-            .try_collect()?;
+            .try_collect()
+            .map_err(ParsingFailedError::from)?;
         Ok(ast::Name(ast::InternalName::new(basename, path, None)))
     }
 }
@@ -1065,15 +1066,15 @@ mod tests {
         use crate::pst::expr::ErrorNode;
 
         let error_expr = Expr::Error(ErrorNode {
-            error: PstConstructionError::InvalidExpression("test error".into()),
+            error: InvalidExpressionError::new("test error".into()).into(),
         });
 
         let result: Result<ast::Expr, PstConstructionError> = error_expr.try_into();
         assert!(result.is_err(), "ErrorNode should fail conversion");
 
         match result {
-            Err(PstConstructionError::InvalidExpression(msg)) => {
-                assert_eq!(msg, "test error");
+            Err(PstConstructionError::InvalidExpression(err)) => {
+                assert_eq!(err.description, "test error");
                 println!("✓ ErrorNode correctly produces conversion error");
             }
             Err(e) => panic!("Expected InvalidExpression error, got: {:?}", e),

--- a/cedar-policy-core/src/pst/err.rs
+++ b/cedar-policy-core/src/pst/err.rs
@@ -1,0 +1,319 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Error types for PST (Public Syntax Tree) construction and conversion.
+//!
+//! This module defines errors that can occur when:
+//! - Programmatically constructing PST expressions, policies, and constraints
+//! - Converting between PST and other representations (EST, AST)
+//! - Validating PST structure and semantics
+
+use miette::Diagnostic;
+use thiserror::Error;
+
+/// Errors that can occur during PST construction or conversion
+#[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+#[non_exhaustive]
+pub enum PstConstructionError {
+    /// Action constraints cannot contain template slots
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ActionConstraintCannotHaveSlots(#[from] error_body::ActionConstraintCannotHaveSlotsError),
+
+    /// Duplicate key found in a record literal
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    DuplicateRecordKey(#[from] error_body::DuplicateRecordKeyError),
+
+    /// Failed to parse a Cedar name (e.g., entity type, attribute name)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidName(#[from] error_body::InvalidNameError),
+
+    /// Invalid entity UID format or structure
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidEntityUid(#[from] error_body::InvalidEntityUidError),
+
+    /// Invalid entity type name
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidEntityType(#[from] error_body::InvalidEntityTypeError),
+
+    /// Invalid attribute path format or structure
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidAttributePath(#[from] error_body::InvalidAttributePathError),
+
+    /// Attempted to construct a `has` expression with an empty attribute path
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    EmptyAttributePath(#[from] error_body::EmptyAttributePathError),
+
+    /// Invalid record structure (e.g., malformed key-value pairs)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidRecord(#[from] error_body::InvalidRecordError),
+
+    /// A generic invalid expression error with a description
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidExpression(#[from] error_body::InvalidExpressionError),
+
+    /// Unknown function name (not a built-in or registered extension function)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnknownFunction(#[from] error_body::UnknownFunctionError),
+
+    /// Function called with wrong number of arguments
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    WrongArity(#[from] error_body::WrongArityError),
+
+    /// Extension function lookup failed (function not found or invalid)
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    FunctionLookup(#[from] error_body::FunctionLookupError),
+
+    /// Invalid conversion between representations with description
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    InvalidConversion(#[from] error_body::InvalidConversionError),
+
+    /// Error nodes from parsing are not supported in PST conversion
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    UnsupportedErrorNode(#[from] error_body::UnsupportedErrorNode),
+
+    /// Conversion functionality not yet implemented
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    NotImplemented(#[from] error_body::NotImplementedError),
+
+    /// A parsing error occurred, usually in names
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    ParsingFailed(#[from] error_body::ParsingFailedError),
+}
+
+/// Error subtypes for [`PstConstructionError`]
+pub mod error_body {
+    use crate::extensions::ExtensionFunctionLookupError;
+    use miette::Diagnostic;
+    use smol_str::SmolStr;
+    use thiserror::Error;
+
+    /// Action constraints cannot contain template slots
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("action constraint cannot have slots")]
+    pub struct ActionConstraintCannotHaveSlotsError;
+
+    /// Duplicate key found in a record literal
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("duplicate record key: `{key}`")]
+    pub struct DuplicateRecordKeyError {
+        pub(crate) key: String,
+    }
+
+    impl DuplicateRecordKeyError {
+        /// The duplicate key
+        pub fn key(&self) -> &str {
+            &self.key
+        }
+    }
+
+    /// Failed to parse a Cedar name
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("invalid name: `{name}`")]
+    pub struct InvalidNameError {
+        pub(crate) name: SmolStr,
+    }
+
+    impl InvalidNameError {
+        /// The invalid name
+        pub fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    /// Invalid entity UID format or structure
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("invalid entity UID: {description}")]
+    pub struct InvalidEntityUidError {
+        pub(crate) description: String,
+    }
+
+    /// Invalid entity type name
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("invalid entity type: `{entity_type}`")]
+    pub struct InvalidEntityTypeError {
+        pub(crate) entity_type: String,
+    }
+
+    impl InvalidEntityTypeError {
+        /// The invalid entity type
+        pub fn entity_type(&self) -> &str {
+            &self.entity_type
+        }
+    }
+
+    /// Invalid attribute path format or structure
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("invalid attribute path: {description}")]
+    pub struct InvalidAttributePathError {
+        pub(crate) description: String,
+    }
+
+    /// Attempted to construct a `has` expression with an empty attribute path
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("attribute path cannot be empty")]
+    pub struct EmptyAttributePathError;
+
+    /// Invalid record structure
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("invalid record: {description}")]
+    pub struct InvalidRecordError {
+        pub(crate) description: String,
+    }
+
+    /// A generic invalid expression error with a description
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("invalid expression: {description}")]
+    pub struct InvalidExpressionError {
+        pub(crate) description: String,
+    }
+
+    impl InvalidExpressionError {
+        pub(crate) fn new(description: String) -> Self {
+            Self { description }
+        }
+    }
+
+    /// Unknown function name
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("unknown function: `{name}`")]
+    pub struct UnknownFunctionError {
+        pub(crate) name: SmolStr,
+    }
+
+    impl UnknownFunctionError {
+        pub(crate) fn new(name: SmolStr) -> Self {
+            Self { name }
+        }
+
+        /// The unknown function name
+        pub fn name(&self) -> &str {
+            &self.name
+        }
+    }
+
+    /// Function called with wrong number of arguments
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("function `{name}` expects {expected} argument(s), got {got}")]
+    pub struct WrongArityError {
+        pub(crate) name: String,
+        pub(crate) expected: usize,
+        pub(crate) got: usize,
+    }
+
+    impl WrongArityError {
+        pub(crate) fn new(name: String, expected: usize, got: usize) -> Self {
+            Self {
+                name,
+                expected,
+                got,
+            }
+        }
+
+        /// The function name
+        pub fn name(&self) -> &str {
+            &self.name
+        }
+
+        /// The expected number of arguments
+        pub fn expected(&self) -> usize {
+            self.expected
+        }
+
+        /// The actual number of arguments provided
+        pub fn got(&self) -> usize {
+            self.got
+        }
+    }
+
+    /// Extension function lookup failed
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error(transparent)]
+    pub struct FunctionLookupError(pub(crate) ExtensionFunctionLookupError);
+
+    impl From<ExtensionFunctionLookupError> for FunctionLookupError {
+        fn from(err: ExtensionFunctionLookupError) -> Self {
+            Self(err)
+        }
+    }
+
+    /// Invalid conversion between representations
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("conversion failed: {description}")]
+    pub struct InvalidConversionError {
+        pub(crate) description: String,
+    }
+
+    impl InvalidConversionError {
+        pub(crate) fn new(description: String) -> Self {
+            Self { description }
+        }
+    }
+
+    /// Error nodes from parsing are not supported in PST conversion
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("error nodes not supported in conversion: {description}")]
+    pub struct UnsupportedErrorNode {
+        pub(crate) description: String,
+    }
+
+    /// Conversion functionality not yet implemented
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("not implemented: {description}")]
+    pub struct NotImplementedError {
+        pub(crate) description: String,
+    }
+
+    impl NotImplementedError {
+        pub(crate) fn new(description: String) -> Self {
+            Self { description }
+        }
+    }
+
+    /// A parsing error occurred
+    #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
+    #[error("parse error: {description}")]
+    pub struct ParsingFailedError {
+        pub(crate) description: String,
+    }
+
+    impl ParsingFailedError {
+        pub(crate) fn new(description: String) -> Self {
+            Self { description }
+        }
+    }
+
+    impl From<crate::parser::err::ParseErrors> for ParsingFailedError {
+        fn from(value: crate::parser::err::ParseErrors) -> Self {
+            Self::new(format!("{value:?}"))
+        }
+    }
+}

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -16,7 +16,7 @@
 
 //! Expression types for PST
 
-use super::errors::PstConstructionError;
+use super::err::{error_body, PstConstructionError};
 use crate::ast;
 use crate::expr_builder::ExprBuilder;
 use crate::extensions::Extensions;
@@ -514,17 +514,13 @@ impl Expr {
     ) -> Result<Expr, PstConstructionError> {
         let extension = Extensions::all_available()
             .func(ast_name)
-            .map_err(PstConstructionError::FunctionLookupError)?;
+            .map_err(error_body::FunctionLookupError)?;
 
         let expected = extension.arg_types().len();
         let got = args.len();
 
         if expected != got {
-            return Err(PstConstructionError::WrongArity {
-                name: name.into(),
-                expected,
-                got,
-            });
+            return Err(error_body::WrongArityError::new(name.into(), expected, got).into());
         }
         Ok(match args.len() {
             1 => {
@@ -537,12 +533,12 @@ impl Expr {
                     });
                 }
                 let op = UnaryOp::from_function_name(&ast_name.to_string())
-                    .ok_or(PstConstructionError::UnknownFunction(name))?;
+                    .ok_or_else(|| error_body::UnknownFunctionError::new(name.clone()))?;
                 Expr::UnaryOp { op, expr }
             }
             2 => {
                 let op = BinaryOp::from_function_name(&ast_name.to_string())
-                    .ok_or(PstConstructionError::UnknownFunction(name))?;
+                    .ok_or_else(|| error_body::UnknownFunctionError::new(name.clone()))?;
                 let mut iter = args.into_iter();
                 Expr::BinaryOp {
                     op,
@@ -552,7 +548,7 @@ impl Expr {
                     right: iter.next().unwrap(),
                 }
             }
-            _ => return Err(PstConstructionError::UnknownFunction(name)),
+            _ => return Err(error_body::UnknownFunctionError::new(name).into()),
         })
     }
 }
@@ -930,7 +926,7 @@ mod tests {
         let result = Expr::from_function_ast_name_and_args(&name, args);
         assert!(matches!(
             result,
-            Err(PstConstructionError::FunctionLookupError { .. })
+            Err(PstConstructionError::FunctionLookup(..))
         ));
     }
 
@@ -943,10 +939,7 @@ mod tests {
         ];
 
         let result = Expr::from_function_ast_name_and_args(&name, args);
-        assert!(matches!(
-            result,
-            Err(PstConstructionError::WrongArity { .. })
-        ));
+        assert!(matches!(result, Err(PstConstructionError::WrongArity(..))));
     }
 
     #[test]
@@ -1002,14 +995,12 @@ mod tests {
 
     #[test]
     fn test_expr_construction_error_display() {
-        let err = PstConstructionError::UnknownFunction("foo".to_smolstr());
+        let err: PstConstructionError =
+            error_body::UnknownFunctionError::new("foo".to_smolstr()).into();
         assert!(err.to_string().contains("foo"));
 
-        let err = PstConstructionError::WrongArity {
-            name: "bar".to_string(),
-            expected: 2,
-            got: 1,
-        };
+        let err: PstConstructionError =
+            error_body::WrongArityError::new("bar".to_string(), 2, 1).into();
         assert!(err.to_string().contains("bar"));
         assert!(err.to_string().contains("2"));
         assert!(err.to_string().contains("1"));

--- a/cedar-policy-core/src/pst/mod.rs
+++ b/cedar-policy-core/src/pst/mod.rs
@@ -28,12 +28,12 @@
 
 pub(crate) mod ast_conversions;
 mod constraints;
-mod errors;
+mod err;
 mod expr;
 mod policy;
 
 pub use constraints::{ActionConstraint, EntityOrSlot, PrincipalConstraint, ResourceConstraint};
-pub use errors::PstConstructionError;
+pub use err::PstConstructionError;
 pub use expr::{
     BinaryOp, EntityType, EntityUID, Expr, Literal, Name, PatternElem, SlotId, UnaryOp, Var,
 };


### PR DESCRIPTION
Refactors the construction and conversion errors in the PST.

A follow-up on @john-h-kastner-aws 's comments on https://github.com/cedar-policy/cedar/pull/2186 , the errors for the PST construction / translation should follow the style guide. 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
