### PR TITLE
Added workflow for publishing cedar-policy-symcc

### DIFF
--- a/.github/workflows/publish_symcc.yml
+++ b/.github/workflows/publish_symcc.yml
@@ -1,0 +1,74 @@
+# Note: This workflow can only be run from the 'main' branch to
+# ensure that the latest version of this workflow is used.
+# However, the release will not necessarily be performed from the 'main' branch
+# as the input `tag` is used to determine which GitHub tag will be checked out for the release.
+name: Publish Cedar SymCC to crates.io
+on:
+    # This workflow must be triggered manually.
+    workflow_dispatch:
+        inputs:
+            tag:
+                required: true
+                type: string
+                description: "The GitHub tag to be released. Must be of the form 'cedar-policy-symcc-v<MAJOR>.<MINOR>.<PATCH>'"
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+    validate:
+        runs-on: ubuntu-latest
+        steps:
+            # Check that this workflow was triggered from the 'main' branch.
+            - name: Validate branch
+              if: github.ref != 'refs/heads/main'
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+              with:
+                  script: core.setFailed('This workflow must be triggered from the "main" branch.')
+
+            # Check that the input tag is welformed.
+            - name: Validate tag
+              run: |
+                  REGEX_PATTERN="^cedar-policy-symcc-v[0-9]+\.[0-9]+\.[0-9]+$"
+                  if [[ ! "$TAG_NAME" =~ $REGEX_PATTERN ]]; then 
+                      echo "Specified tag must match $REGEX_PATTERN"
+                      exit 1
+                  fi
+              env:
+                  TAG_NAME: ${{ inputs.tag }}
+
+            # Check that the cargo package's version matches the input tag.
+            - name: Checkout tag
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: refs/tags/${{ inputs.tag }}
+            - name: Configure rust toolchain
+              run: rustup update stable && rustup default stable
+            - name: Install toml-cli
+              run: cargo install toml-cli --locked
+            - name: Validate workspace version
+              run: test "cedar-policy-symcc-v$(toml get --raw ./cedar-policy-symcc/Cargo.toml package.version)" = "$TAG_NAME"
+              env:
+                  TAG_NAME: ${{ inputs.tag }}
+
+    publish-crate:
+        # Only publish if validation succeeds.
+        needs: [validate]
+        runs-on: ubuntu-latest
+        environment: release # See https://github.com/cedar-policy/cedar/settings/environments
+        permissions:
+            id-token: write # Required for OIDC token exchange
+        steps:
+            - name: Checkout tag
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+              with:
+                  ref: refs/tags/${{ inputs.tag }}
+            - name: Configure rust toolchain
+              run: rustup update stable && rustup default stable
+            - name: Authenticate with crates.io
+              id: auth
+              uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1.0.3
+            - name: Publish to crates.io
+              run: cargo publish -p cedar-policy-symcc
+              env:
+                  CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Description of changes
Added GHA workflow for publishing cedar-policy-symcc to crates.io.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.