### PR TITLE
pst <-> est conversions

### DIFF
--- a/cedar-policy-core/src/est.rs
+++ b/cedar-policy-core/src/est.rs
@@ -57,19 +57,19 @@ extern crate tsify;
 #[cfg_attr(feature = "wasm", serde(rename = "PolicyJson"))]
 pub struct Policy {
     /// `Effect` of the policy or template
-    effect: ast::Effect,
+    pub(crate) effect: ast::Effect,
     /// Principal scope constraint
-    principal: PrincipalConstraint,
+    pub(crate) principal: PrincipalConstraint,
     /// Action scope constraint
-    action: ActionConstraint,
+    pub(crate) action: ActionConstraint,
     /// Resource scope constraint
-    resource: ResourceConstraint,
+    pub(crate) resource: ResourceConstraint,
     /// `when` and/or `unless` clauses
-    conditions: Vec<Clause>,
+    pub(crate) conditions: Vec<Clause>,
     /// annotations
     #[serde(default)]
     #[serde(skip_serializing_if = "Annotations::is_empty")]
-    annotations: Annotations,
+    pub(crate) annotations: Annotations,
 }
 
 /// Serde JSON structure for a `when` or `unless` clause in the EST format

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -431,6 +431,41 @@ pub struct ExtFuncCall {
     call: HashMap<SmolStr, Vec<Expr>>,
 }
 
+impl ExtFuncCall {
+    /// Check the invariant.
+    ///
+    /// Returns `FromJsonError::MissingOperator` or `FromJsonError::MultipleOperators` as appropriate.
+    fn invariant(&self) -> Result<(), FromJsonError> {
+        match self.call.len() {
+            0 => Err(FromJsonError::MissingOperator),
+            1 => Ok(()),
+            _ => Err(FromJsonError::MultipleOperators {
+                ops: self.call.clone().into_keys().collect(),
+            }),
+        }
+    }
+
+    /// Attempt to extract the function name and arguments, returns the error of `self.invariant()`
+    /// if invariant doesn't hold.
+    pub(crate) fn try_into_components(self) -> Result<(SmolStr, Vec<Expr>), FromJsonError> {
+        self.invariant()?;
+        match self.call.into_iter().next() {
+            Some((fn_name, args)) => Ok((fn_name, args)),
+            None => Err(FromJsonError::MissingOperator),
+        }
+    }
+
+    /// Attempt to extract references to the function name and arguments,
+    /// Returns the error of `self.invariant()` if invariant doesn't hold.
+    pub(crate) fn try_components(&self) -> Result<(&SmolStr, &[Expr]), FromJsonError> {
+        self.invariant()?;
+        match self.call.iter().next() {
+            Some((fn_name, args)) => Ok((fn_name, args)),
+            None => Err(FromJsonError::MissingOperator),
+        }
+    }
+}
+
 /// Construct an [`Expr`].
 #[derive(Clone, Debug)]
 pub struct Builder;
@@ -1064,32 +1099,22 @@ impl Expr {
                 )
                 .expect("can't have duplicate keys here because the input was already a HashMap"))
             }
-            Expr::ExtFuncCall(ExtFuncCall { call }) => match call.len() {
-                0 => Err(FromJsonError::MissingOperator),
-                1 => {
-                    #[expect(clippy::expect_used, reason = "checked that `call.len() == 1`")]
-                    let (fn_name, args) = call
-                        .into_iter()
-                        .next()
-                        .expect("already checked that len was 1");
-                    let fn_name = Name::from_normalized_str(&fn_name).map_err(|errs| {
-                        JsonDeserializationError::parse_escape(EscapeKind::Extension, fn_name, errs)
-                    })?;
-                    if ExtStyles::is_known_extension_func_name(&fn_name) {
-                        Ok(ast::Expr::call_extension_fn(
-                            fn_name,
-                            args.into_iter()
-                                .map(|arg| arg.try_into_ast(id))
-                                .collect::<Result<_, _>>()?,
-                        ))
-                    } else {
-                        Err(FromJsonError::UnknownExtensionFunction(fn_name))
-                    }
+            Expr::ExtFuncCall(e) => {
+                let (fn_name, args) = e.try_into_components()?;
+                let fn_name = Name::from_normalized_str(&fn_name).map_err(|errs| {
+                    JsonDeserializationError::parse_escape(EscapeKind::Extension, fn_name, errs)
+                })?;
+                if ExtStyles::is_known_extension_func_name(&fn_name) {
+                    Ok(ast::Expr::call_extension_fn(
+                        fn_name,
+                        args.into_iter()
+                            .map(|arg| arg.try_into_ast(id))
+                            .collect::<Result<_, _>>()?,
+                    ))
+                } else {
+                    Err(FromJsonError::UnknownExtensionFunction(fn_name))
                 }
-                _ => Err(FromJsonError::MultipleOperators {
-                    ops: call.into_keys().collect(),
-                }),
-            },
+            }
             #[cfg(feature = "tolerant-ast")]
             Expr::ExprNoExt(ExprNoExt::Error(_)) => Err(FromJsonError::ASTErrorNode),
         }
@@ -1555,10 +1580,8 @@ impl std::fmt::Display for ExtFuncCall {
 
 impl BoundedDisplay for ExtFuncCall {
     fn fmt(&self, f: &mut impl std::fmt::Write, n: Option<usize>) -> std::fmt::Result {
-        #[expect(clippy::unreachable, reason = "safe due to INVARIANT on `ExtFuncCall`")]
-        let Some((fn_name, args)) = self.call.iter().next() else {
-            unreachable!("invariant violated: empty ExtFuncCall")
-        };
+        #[expect(clippy::unwrap_used, reason = "safe due to INVARIANT on `ExtFuncCall`")]
+        let (fn_name, args) = self.try_components().unwrap();
         // search for the name and callstyle
         let style = Extensions::all_available().all_funcs().find_map(|ext_fn| {
             if &ext_fn.name().to_smolstr() == fn_name {

--- a/cedar-policy-core/src/est/scope_constraints.rs
+++ b/cedar-policy-core/src/est/scope_constraints.rs
@@ -143,10 +143,16 @@ pub enum PrincipalOrResourceInConstraint {
 #[cfg_attr(feature = "wasm", tsify(into_wasm_abi, from_wasm_abi))]
 pub struct PrincipalOrResourceIsConstraint {
     #[cfg_attr(feature = "wasm", tsify(type = "string"))]
-    entity_type: SmolStr,
+    pub(crate) entity_type: SmolStr,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "in")]
-    in_entity: Option<PrincipalOrResourceInConstraint>,
+    pub(crate) in_entity: Option<PrincipalOrResourceInConstraint>,
+}
+
+impl PrincipalOrResourceIsConstraint {
+    pub(crate) fn into_components(self) -> (SmolStr, Option<PrincipalOrResourceInConstraint>) {
+        (self.entity_type, self.in_entity)
+    }
 }
 
 /// Serde JSON structure for an `in` scope constraint for action in the EST

--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -186,7 +186,9 @@ impl TryFrom<Expr> for ast::Expr {
 }
 
 impl Expr {
-    fn try_into_expr<B: expr_builder::ExprBuilder>(self) -> Result<B::Expr, PstConstructionError> {
+    pub(crate) fn try_into_expr<B: expr_builder::ExprBuilder>(
+        self,
+    ) -> Result<B::Expr, PstConstructionError> {
         let builder = B::new();
         match self {
             Expr::Literal(lit) => match lit {

--- a/cedar-policy-core/src/pst/builders.rs
+++ b/cedar-policy-core/src/pst/builders.rs
@@ -1,0 +1,413 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Public builder API for constructing PST expressions
+
+use super::{
+    BinaryOp, EntityType, EntityUID, Expr, Literal, PatternElem, PstConstructionError, SlotId,
+    UnaryOp, Var,
+};
+use crate::ast;
+use crate::pst::err::error_body;
+use itertools::Itertools;
+use smol_str::SmolStr;
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+// Expr provides convenience functions to build expressions. This is not the private ExprBuilder API,
+// which is in expr.rs.
+impl Expr {
+    /// Create a literal expression
+    pub fn literal(lit: Literal) -> Self {
+        Self::Literal(lit)
+    }
+
+    /// Create a boolean literal
+    pub fn bool(b: bool) -> Self {
+        Self::Literal(Literal::Bool(b))
+    }
+
+    /// Create an integer literal
+    pub fn long(i: i64) -> Self {
+        Self::Literal(Literal::Long(i))
+    }
+
+    /// Create a string literal
+    pub fn string(s: impl Into<SmolStr>) -> Self {
+        Self::Literal(Literal::String(s.into()))
+    }
+
+    /// Create an entity UID literal
+    pub fn entity_uid(uid: EntityUID) -> Self {
+        Self::Literal(Literal::EntityUID(uid))
+    }
+
+    /// Create a variable expression
+    pub fn var(var: Var) -> Self {
+        Self::Var(var)
+    }
+
+    /// Create a principal variable
+    pub fn principal() -> Self {
+        Self::Var(Var::Principal)
+    }
+
+    /// Create an action variable
+    pub fn action() -> Self {
+        Self::Var(Var::Action)
+    }
+
+    /// Create a resource variable
+    pub fn resource() -> Self {
+        Self::Var(Var::Resource)
+    }
+
+    /// Create a context variable
+    pub fn context() -> Self {
+        Self::Var(Var::Context)
+    }
+
+    /// Create a slot expression
+    pub fn slot(slot: SlotId) -> Self {
+        Self::Slot(slot)
+    }
+
+    /// Create a logical NOT expression
+    pub fn not(expr: Self) -> Self {
+        Self::UnaryOp {
+            op: UnaryOp::Not,
+            expr: Arc::new(expr),
+        }
+    }
+
+    /// Create an arithmetic negation expression
+    pub fn neg(expr: Self) -> Self {
+        Self::UnaryOp {
+            op: UnaryOp::Neg,
+            expr: Arc::new(expr),
+        }
+    }
+
+    /// Create a binary operation expression
+    pub fn binary_op(op: BinaryOp, left: Self, right: Self) -> Self {
+        Self::BinaryOp {
+            op,
+            left: Arc::new(left),
+            right: Arc::new(right),
+        }
+    }
+
+    /// Create an equality expression
+    pub fn eq(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Eq, left, right)
+    }
+
+    /// Create an inequality expression
+    pub fn not_eq(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::NotEq, left, right)
+    }
+
+    /// Create a less-than expression
+    pub fn less(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Less, left, right)
+    }
+
+    /// Create a less-than-or-equal expression
+    pub fn less_eq(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::LessEq, left, right)
+    }
+
+    /// Create a greater-than expression
+    pub fn greater(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Greater, left, right)
+    }
+
+    /// Create a greater-than-or-equal expression
+    pub fn greater_eq(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::GreaterEq, left, right)
+    }
+
+    /// Create a logical AND expression
+    pub fn and(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::And, left, right)
+    }
+
+    /// Create a logical OR expression
+    pub fn or(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Or, left, right)
+    }
+
+    /// Create an addition expression
+    pub fn add(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Add, left, right)
+    }
+
+    /// Create a subtraction expression
+    pub fn sub(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Sub, left, right)
+    }
+
+    /// Create a multiplication expression
+    pub fn mul(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Mul, left, right)
+    }
+
+    /// Create an `in` expression (hierarchy membership)
+    pub fn in_expr(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::In, left, right)
+    }
+
+    /// Create a `contains` expression
+    pub fn contains(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::Contains, left, right)
+    }
+
+    /// Create a `containsAll` expression
+    pub fn contains_all(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::ContainsAll, left, right)
+    }
+
+    /// Create a `containsAny` expression
+    pub fn contains_any(left: Self, right: Self) -> Self {
+        Self::binary_op(BinaryOp::ContainsAny, left, right)
+    }
+
+    /// Create a `getTag` expression
+    pub fn get_tag(expr: Self, tag: Self) -> Self {
+        Self::binary_op(BinaryOp::GetTag, expr, tag)
+    }
+
+    /// Create a `hasTag` expression
+    pub fn has_tag(expr: Self, tag: Self) -> Self {
+        Self::binary_op(BinaryOp::HasTag, expr, tag)
+    }
+
+    /// Create an attribute access expression
+    pub fn get_attr(expr: Self, attr: impl Into<SmolStr>) -> Self {
+        Self::GetAttr {
+            expr: Arc::new(expr),
+            attr: attr.into(),
+        }
+    }
+
+    /// Create a single attribute existence check expression
+    pub fn has_attr(expr: Self, attr: SmolStr) -> Self {
+        Self::HasAttr {
+            expr: Arc::new(expr),
+            attrs: nonempty::nonempty![attr],
+        }
+    }
+
+    /// Create an attribute existence check expression
+    ///
+    /// # Errors
+    /// - Returns an [`ExprConstructionError::EmptyAttributePath`] error if the attribute path is
+    ///   empty.
+    /// - Returns an [`ExprConstructionError::InvalidAttributePath`] error if there is more than
+    ///   one attribute, and some attribute name is not a valid identifier.
+    pub fn has_attrs(
+        expr: Self,
+        attrs: impl IntoIterator<Item = impl Into<SmolStr>>,
+    ) -> Result<Self, PstConstructionError> {
+        let attrs_vec: Vec<SmolStr> = attrs.into_iter().map(Into::into).collect();
+        let attrs_nonempty = nonempty::NonEmpty::from_vec(attrs_vec).ok_or(
+            PstConstructionError::EmptyAttributePath(error_body::EmptyAttributePathError),
+        )?;
+        if attrs_nonempty.len() > 1
+            && attrs_nonempty
+                .iter()
+                .any(|attr| !ast::is_normalized_ident(attr))
+        {
+            Err(error_body::InvalidAttributePathError::new(attrs_nonempty.iter().join(".")).into())
+        } else {
+            Ok(Self::HasAttr {
+                expr: Arc::new(expr),
+                attrs: attrs_nonempty,
+            })
+        }
+    }
+
+    /// Create a pattern matching expression
+    pub fn like(expr: Self, pattern: Vec<PatternElem>) -> Self {
+        Self::Like {
+            expr: Arc::new(expr),
+            pattern,
+        }
+    }
+
+    /// Create a type test expression
+    pub fn is_type(expr: Self, entity_type: EntityType) -> Self {
+        Self::Is {
+            expr: Arc::new(expr),
+            entity_type,
+            in_expr: None,
+        }
+    }
+
+    /// Create a type test with hierarchy check expression
+    pub fn is_type_in(expr: Self, entity_type: EntityType, in_expr: Self) -> Self {
+        Self::Is {
+            expr: Arc::new(expr),
+            entity_type,
+            in_expr: Some(Arc::new(in_expr)),
+        }
+    }
+
+    /// Create an if-then-else expression
+    pub fn if_then_else(cond: Self, then_expr: Self, else_expr: Self) -> Self {
+        Self::IfThenElse {
+            cond: Arc::new(cond),
+            then_expr: Arc::new(then_expr),
+            else_expr: Arc::new(else_expr),
+        }
+    }
+
+    /// Create a set expression
+    pub fn set(elements: impl IntoIterator<Item = Self>) -> Self {
+        Self::Set(elements.into_iter().map(Arc::new).collect())
+    }
+
+    /// Create a record expression
+    ///
+    /// # Errors
+    /// Returns an [`ExprConstructionError::DuplicateRecordKey`] error if there are duplicate keys
+    pub fn record(
+        pairs: impl IntoIterator<Item = (impl Into<String>, Self)>,
+    ) -> Result<Self, PstConstructionError> {
+        let mut map = BTreeMap::new();
+        for (k, v) in pairs {
+            let key = k.into();
+            if map.insert(key.clone(), Arc::new(v)).is_some() {
+                return Err(error_body::DuplicateRecordKeyError::new(key).into());
+            }
+        }
+        Ok(Self::Record(map))
+    }
+
+    /// Create a binary operation expression
+    pub fn bin_op(op: BinaryOp, left: Self, right: Self) -> Self {
+        Self::BinaryOp {
+            op,
+            left: Arc::new(left),
+            right: Arc::new(right),
+        }
+    }
+
+    /// Create a unary operation expression
+    pub fn un_op(op: UnaryOp, expr: Self) -> Self {
+        Self::UnaryOp {
+            op,
+            expr: Arc::new(expr),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cool_asserts::assert_matches;
+    use nonempty::nonempty;
+
+    #[test]
+    fn test_expr_literals() {
+        let expr = Expr::bool(true);
+        assert!(matches!(expr, Expr::Literal(_)));
+
+        let expr = Expr::long(42);
+        assert!(matches!(expr, Expr::Literal(_)));
+
+        let expr = Expr::string("hello");
+        assert!(matches!(expr, Expr::Literal(_)));
+    }
+
+    #[test]
+    fn test_expr_vars() {
+        let expr = Expr::principal();
+        assert!(matches!(expr, Expr::Var(_)));
+
+        let expr = Expr::context();
+        assert!(matches!(expr, Expr::Var(_)));
+    }
+
+    #[test]
+    fn test_expr_binary_ops() {
+        let left = Expr::long(1);
+        let right = Expr::long(2);
+
+        let expr = Expr::eq(left.clone(), right.clone());
+        assert!(matches!(expr, Expr::BinaryOp { .. }));
+
+        let expr = Expr::add(left, right);
+        assert!(matches!(expr, Expr::BinaryOp { .. }));
+    }
+
+    #[test]
+    fn test_expr_record() {
+        let pairs = vec![("a", Expr::long(1)), ("b", Expr::long(2))];
+
+        let expr = Expr::record(pairs).unwrap();
+        assert!(matches!(expr, Expr::Record(_)));
+    }
+
+    #[test]
+    fn test_expr_record_duplicate_key() {
+        let pairs = vec![("a", Expr::long(1)), ("a", Expr::long(2))];
+
+        let result = Expr::record(pairs);
+        assert!(matches!(
+            result,
+            Err(PstConstructionError::DuplicateRecordKey(_))
+        ));
+    }
+
+    #[test]
+    fn test_expr_has_attr_empty() {
+        let expr = Expr::principal();
+        let result = Expr::has_attrs(expr, Vec::<SmolStr>::new());
+        assert!(matches!(
+            result,
+            Err(PstConstructionError::EmptyAttributePath(..))
+        ));
+    }
+
+    #[test]
+    fn test_expr_has_attr_multi_nonident() {
+        let expr = Expr::principal();
+        let result = Expr::has_attrs(expr, nonempty!["ok", "oh snap®"]);
+        assert!(matches!(
+            result,
+            Err(PstConstructionError::InvalidAttributePath(_))
+        ));
+    }
+
+    #[test]
+    fn test_expr_has_attr_single_nonident() {
+        let expr = Expr::principal();
+        let result = Expr::has_attrs(expr, nonempty!["ok ∞ path"]).unwrap();
+        assert_matches!(result, Expr::HasAttr { .. })
+    }
+
+    #[test]
+    fn test_expr_complex() {
+        // Build: if principal.age > 18 then true else false
+        let age_attr = Expr::get_attr(Expr::principal(), "age");
+        let eighteen = Expr::long(18);
+        let cond = Expr::greater(age_attr, eighteen);
+        let expr = Expr::if_then_else(cond, Expr::bool(true), Expr::bool(false));
+
+        assert!(matches!(expr, Expr::IfThenElse { .. }));
+    }
+}

--- a/cedar-policy-core/src/pst/err.rs
+++ b/cedar-policy-core/src/pst/err.rs
@@ -129,6 +129,9 @@ pub mod error_body {
     }
 
     impl DuplicateRecordKeyError {
+        pub(crate) fn new(key: String) -> Self {
+            Self { key }
+        }
         /// The duplicate key
         pub fn key(&self) -> &str {
             &self.key
@@ -177,6 +180,12 @@ pub mod error_body {
         pub(crate) description: String,
     }
 
+    impl InvalidAttributePathError {
+        pub(crate) fn new(description: String) -> Self {
+            Self { description }
+        }
+    }
+
     /// Attempted to construct a `has` expression with an empty attribute path
     #[derive(Debug, Clone, PartialEq, Eq, Diagnostic, Error)]
     #[error("attribute path cannot be empty")]
@@ -187,6 +196,12 @@ pub mod error_body {
     #[error("invalid record: {description}")]
     pub struct InvalidRecordError {
         pub(crate) description: String,
+    }
+
+    impl InvalidRecordError {
+        pub(crate) fn new(description: String) -> Self {
+            Self { description }
+        }
     }
 
     /// A generic invalid expression error with a description

--- a/cedar-policy-core/src/pst/est_conversions.rs
+++ b/cedar-policy-core/src/pst/est_conversions.rs
@@ -1,0 +1,1368 @@
+/*
+ * Copyright Cedar Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Conversions between EST and PST representations.
+
+use super::{
+    ActionConstraint, Clause, Effect, EntityOrSlot, EntityType, EntityUID, Expr, Literal, Name,
+    PatternElem, Policy, PolicyID, PrincipalConstraint, PstConstructionError, ResourceConstraint,
+    UnaryOp,
+};
+use crate::ast;
+use crate::entities;
+use crate::entities::json::CedarValueJson;
+use crate::est;
+#[cfg(feature = "tolerant-ast")]
+use crate::pst::err::error_body::InvalidExpressionError;
+use crate::pst::err::error_body::{
+    InvalidAttributePathError, InvalidConversionError, InvalidEntityUidError, InvalidRecordError,
+};
+#[cfg(feature = "tolerant-ast")]
+use crate::pst::expr::ErrorNode;
+use itertools::Itertools;
+use std::sync::Arc;
+
+impl TryFrom<est::Policy> for Policy {
+    type Error = PstConstructionError;
+
+    fn try_from(est_policy: est::Policy) -> Result<Self, Self::Error> {
+        let clauses: Result<Vec<_>, _> = est_policy
+            .conditions
+            .into_iter()
+            .map(|c| c.try_into())
+            .collect();
+
+        Ok(Policy {
+            id: PolicyID("policy".into()),
+            effect: match est_policy.effect {
+                ast::Effect::Permit => Effect::Permit,
+                ast::Effect::Forbid => Effect::Forbid,
+            },
+            principal: est_policy.principal.try_into()?,
+            action: est_policy.action.try_into()?,
+            resource: est_policy.resource.try_into()?,
+            clauses: clauses?,
+            annotations: est_policy
+                .annotations
+                .0
+                .into_iter()
+                .map(|(k, v)| (k.to_string(), v.map(|a| a.val).unwrap_or_default()))
+                .collect(),
+        })
+    }
+}
+
+impl TryFrom<est::Clause> for Clause {
+    type Error = PstConstructionError;
+
+    fn try_from(clause: est::Clause) -> Result<Self, Self::Error> {
+        match clause {
+            est::Clause::When(expr) => Ok(Clause::When(Arc::new(expr.try_into()?))),
+            est::Clause::Unless(expr) => Ok(Clause::Unless(Arc::new(expr.try_into()?))),
+        }
+    }
+}
+
+impl TryFrom<entities::EntityUidJson> for EntityUID {
+    type Error = PstConstructionError;
+
+    fn try_from(entity: entities::EntityUidJson) -> Result<Self, Self::Error> {
+        let ctx = || crate::entities::json::err::JsonDeserializationErrorContext::Context;
+        entity
+            .into_euid(&ctx)
+            .map_err(|e| {
+                InvalidEntityUidError {
+                    description: e.to_string(),
+                }
+                .into()
+            })
+            .map(EntityUID::from)
+    }
+}
+
+impl TryFrom<est::PrincipalConstraint> for PrincipalConstraint {
+    type Error = PstConstructionError;
+
+    fn try_from(constraint: est::PrincipalConstraint) -> Result<Self, Self::Error> {
+        use est::{EqConstraint, PrincipalConstraint as E, PrincipalOrResourceInConstraint};
+        match constraint {
+            E::All => Ok(PrincipalConstraint::Any),
+            E::Eq(EqConstraint::Entity { entity }) => Ok(PrincipalConstraint::Eq(
+                EntityOrSlot::Entity(entity.try_into()?),
+            )),
+            E::Eq(EqConstraint::Slot { slot }) => {
+                Ok(PrincipalConstraint::Eq(EntityOrSlot::Slot(slot.into())))
+            }
+            E::In(PrincipalOrResourceInConstraint::Entity { entity }) => Ok(
+                PrincipalConstraint::In(EntityOrSlot::Entity(entity.try_into()?)),
+            ),
+            E::In(PrincipalOrResourceInConstraint::Slot { slot }) => {
+                Ok(PrincipalConstraint::In(EntityOrSlot::Slot(slot.into())))
+            }
+            E::Is(is_c) => {
+                let (entity_type_ast, in_constraint) = is_c.into_components();
+                let entity_type = EntityType::from_name(Name::unqualified(entity_type_ast));
+                match in_constraint {
+                    None => Ok(PrincipalConstraint::Is(entity_type)),
+                    Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
+                        Ok(PrincipalConstraint::IsIn(
+                            entity_type,
+                            EntityOrSlot::Entity(entity.try_into()?),
+                        ))
+                    }
+                    Some(PrincipalOrResourceInConstraint::Slot { slot }) => Ok(
+                        PrincipalConstraint::IsIn(entity_type, EntityOrSlot::Slot(slot.into())),
+                    ),
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<est::ResourceConstraint> for ResourceConstraint {
+    type Error = PstConstructionError;
+
+    fn try_from(constraint: est::ResourceConstraint) -> Result<Self, Self::Error> {
+        use est::{EqConstraint, PrincipalOrResourceInConstraint, ResourceConstraint as E};
+        match constraint {
+            E::All => Ok(ResourceConstraint::Any),
+            E::Eq(EqConstraint::Entity { entity }) => Ok(ResourceConstraint::Eq(
+                EntityOrSlot::Entity(entity.try_into()?),
+            )),
+            E::Eq(EqConstraint::Slot { slot }) => {
+                Ok(ResourceConstraint::Eq(EntityOrSlot::Slot(slot.into())))
+            }
+            E::In(PrincipalOrResourceInConstraint::Entity { entity }) => Ok(
+                ResourceConstraint::In(EntityOrSlot::Entity(entity.try_into()?)),
+            ),
+            E::In(PrincipalOrResourceInConstraint::Slot { slot }) => {
+                Ok(ResourceConstraint::In(EntityOrSlot::Slot(slot.into())))
+            }
+            E::Is(is_c) => {
+                let (entity_type_ast, in_constraint) = is_c.into_components();
+                let entity_type = EntityType::from_name(Name::unqualified(entity_type_ast));
+                match in_constraint {
+                    None => Ok(ResourceConstraint::Is(entity_type)),
+                    Some(PrincipalOrResourceInConstraint::Entity { entity }) => {
+                        Ok(ResourceConstraint::IsIn(
+                            entity_type,
+                            EntityOrSlot::Entity(entity.try_into()?),
+                        ))
+                    }
+                    Some(PrincipalOrResourceInConstraint::Slot { slot }) => Ok(
+                        ResourceConstraint::IsIn(entity_type, EntityOrSlot::Slot(slot.into())),
+                    ),
+                }
+            }
+        }
+    }
+}
+
+impl TryFrom<est::ActionConstraint> for ActionConstraint {
+    type Error = PstConstructionError;
+
+    fn try_from(constraint: est::ActionConstraint) -> Result<Self, Self::Error> {
+        use est::{ActionConstraint as E, ActionInConstraint, EqConstraint};
+        match constraint {
+            E::All => Ok(ActionConstraint::Any),
+            E::Eq(EqConstraint::Entity { entity }) => Ok(ActionConstraint::Eq(entity.try_into()?)),
+            E::Eq(EqConstraint::Slot { .. }) => {
+                Err(super::err::error_body::ActionConstraintCannotHaveSlotsError.into())
+            }
+            E::In(ActionInConstraint::Single { entity }) => {
+                Ok(ActionConstraint::In(vec![entity.try_into()?]))
+            }
+            E::In(ActionInConstraint::Set { entities }) => {
+                let euids: Vec<EntityUID> =
+                    entities.into_iter().map(TryInto::try_into).try_collect()?;
+                Ok(ActionConstraint::In(euids))
+            }
+            #[cfg(feature = "tolerant-ast")]
+            E::ErrorConstraint => Err(InvalidEntityUidError {
+                description: "Cannot convert EST error constraint to PST".to_string(),
+            }
+            .into()),
+        }
+    }
+}
+
+impl TryFrom<Expr> for est::Expr {
+    type Error = PstConstructionError;
+
+    fn try_from(expr: Expr) -> Result<Self, PstConstructionError> {
+        expr.try_into_expr::<est::Builder>()
+    }
+}
+
+impl TryFrom<est::Expr> for Expr {
+    type Error = PstConstructionError;
+
+    fn try_from(est_expr: est::Expr) -> Result<Self, PstConstructionError> {
+        match est_expr {
+            est::Expr::ExprNoExt(e) => e.try_into(),
+            est::Expr::ExtFuncCall(e) => {
+                let (fn_name, est_args) = e.try_into_components().map_err(|e| {
+                    // This should not fail if the EST is well-formed,
+                    // but we still return an error, just not a very good one.
+                    // Alternative would require adding a new error type.
+                    PstConstructionError::from(InvalidConversionError::new(e.to_string()))
+                })?;
+                let pst_args: Vec<Arc<Expr>> = est_args
+                    .into_iter()
+                    .map(|a: est::Expr| a.try_into().map(Arc::new))
+                    .try_collect()?;
+                Expr::from_function_name_and_args(fn_name, pst_args)
+            }
+        }
+    }
+}
+
+impl TryFrom<est::ExprNoExt> for Expr {
+    type Error = PstConstructionError;
+
+    fn try_from(est_expr: est::ExprNoExt) -> Result<Self, PstConstructionError> {
+        use est::ExprNoExt as E;
+
+        // The conversion doesn't use the ExprBuilder's interface, which currently desugars some
+        // expressions. We want the PST to be close to the EST, so we avoid desugaring here.
+        match est_expr {
+            E::Value(v) => {
+                // Convert CedarValueJson to AST Expr via RestrictedExpr, then to PST
+                let ctx = || crate::entities::json::err::JsonDeserializationErrorContext::Context;
+                let restricted_expr = v.into_expr(&ctx).map_err(|e| InvalidEntityUidError {
+                    description: e.to_string(),
+                })?;
+                Ok(ast::Expr::from(restricted_expr).into())
+            }
+            E::Var(v) => Ok(Expr::var(v.into())),
+            E::Slot(s) => Ok(Expr::slot(s.into())),
+            E::Not { arg } => Ok(Expr::not(Arc::unwrap_or_clone(arg).try_into()?)),
+            E::Neg { arg } => Ok(Expr::neg(Arc::unwrap_or_clone(arg).try_into()?)),
+            E::Eq { left, right } => Ok(Expr::eq(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::NotEq { left, right } => Ok(Expr::not_eq(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::In { left, right } => Ok(Expr::in_expr(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Less { left, right } => Ok(Expr::less(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::LessEq { left, right } => Ok(Expr::less_eq(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Greater { left, right } => Ok(Expr::greater(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::GreaterEq { left, right } => Ok(Expr::greater_eq(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::And { left, right } => Ok(Expr::and(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Or { left, right } => Ok(Expr::or(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Add { left, right } => Ok(Expr::add(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Sub { left, right } => Ok(Expr::sub(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Mul { left, right } => Ok(Expr::mul(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::Contains { left, right } => Ok(Expr::contains(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::ContainsAll { left, right } => Ok(Expr::contains_all(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::ContainsAny { left, right } => Ok(Expr::contains_any(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::IsEmpty { arg } => Ok(Expr::UnaryOp {
+                op: UnaryOp::IsEmpty,
+                expr: Arc::new(Arc::unwrap_or_clone(arg).try_into()?),
+            }),
+            E::GetTag { left, right } => Ok(Expr::get_tag(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::HasTag { left, right } => Ok(Expr::has_tag(
+                Arc::unwrap_or_clone(left).try_into()?,
+                Arc::unwrap_or_clone(right).try_into()?,
+            )),
+            E::GetAttr { left, attr } => {
+                Ok(Expr::get_attr(Arc::unwrap_or_clone(left).try_into()?, attr))
+            }
+            E::HasAttr(repr) => match repr {
+                est::HasAttrRepr::Simple { left, attr } => {
+                    Ok(Expr::has_attr(Arc::unwrap_or_clone(left).try_into()?, attr))
+                }
+                est::HasAttrRepr::Extended { left, attr } => {
+                    // Validate that if length of attr > 1, all elements are identifiers
+                    if attr.len() > 1 && attr.iter().any(|attr| !ast::is_normalized_ident(attr)) {
+                        Err(InvalidAttributePathError {
+                            description: format!(
+                                "attribute sequence .{} contains non-identifiers",
+                                attr.iter().join(".")
+                            ),
+                        }
+                        .into())
+                    } else {
+                        Expr::has_attrs(Arc::unwrap_or_clone(left).try_into()?, attr).map_err(|e| {
+                            InvalidAttributePathError {
+                                description: e.to_string(),
+                            }
+                            .into()
+                        })
+                    }
+                }
+            },
+            E::Like { left, pattern } => {
+                let pattern_elems: Vec<PatternElem> = pattern
+                    .iter()
+                    .flat_map(|e| match e {
+                        est::PatternElem::Wildcard => vec![PatternElem::Wildcard],
+                        est::PatternElem::Literal(s) => s.chars().map(PatternElem::Char).collect(),
+                    })
+                    .collect();
+                // We don't use the ExprBuilder trait here; avoids a conversion est -> ast,
+                // instead we do directly est -> pst
+                Ok(Self::like(
+                    Arc::unwrap_or_clone(left).try_into()?,
+                    pattern_elems,
+                ))
+            }
+            E::Is {
+                left,
+                entity_type,
+                in_expr,
+            } => {
+                let et_name = Name::unqualified(entity_type);
+                let et = EntityType::from_name(et_name);
+                match in_expr {
+                    None => Ok(Expr::is_type(Arc::unwrap_or_clone(left).try_into()?, et)),
+                    Some(in_e) => Ok(Expr::is_type_in(
+                        Arc::unwrap_or_clone(left).try_into()?,
+                        et,
+                        Arc::unwrap_or_clone(in_e).try_into()?,
+                    )),
+                }
+            }
+            E::If {
+                cond_expr,
+                then_expr,
+                else_expr,
+            } => Ok(Expr::if_then_else(
+                Arc::unwrap_or_clone(cond_expr).try_into()?,
+                Arc::unwrap_or_clone(then_expr).try_into()?,
+                Arc::unwrap_or_clone(else_expr).try_into()?,
+            )),
+            E::Set(elems) => {
+                let converted: Result<Vec<_>, _> =
+                    elems.into_iter().map(|e| e.try_into()).collect();
+                Ok(Expr::set(converted?))
+            }
+            E::Record(map) => {
+                let converted: Result<Vec<_>, _> = map
+                    .into_iter()
+                    .map(|(k, v)| v.try_into().map(|v| (k, v)))
+                    .collect();
+                Expr::record(converted?).map_err(|e| InvalidRecordError::new(e.to_string()).into())
+            }
+            #[cfg(feature = "tolerant-ast")]
+            E::Error(e) => Ok(Expr::Error(ErrorNode {
+                error: InvalidExpressionError::new(e.to_string()).into(),
+            })),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pst;
+
+    #[test]
+    fn test_est_expr_values() {
+        let json = r#"{"Value": true}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Literal(_)));
+    }
+
+    #[test]
+    fn test_est_expr_var() {
+        let json = r#"{"Var": "principal"}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Var(pst::expr::Var::Principal)));
+    }
+
+    #[test]
+    fn test_est_expr_slot() {
+        let json = r#"{"Slot": "?principal"}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Slot(_)));
+    }
+
+    #[test]
+    fn test_est_expr_not() {
+        let json = r#"{"!": {"arg": {"Var": "principal"}}}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::UnaryOp {
+                op: UnaryOp::Not,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_est_expr_neg() {
+        let json = r#"{"neg": {"arg": {"Value": 5}}}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::UnaryOp {
+                op: UnaryOp::Neg,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_est_expr_binary_ops() {
+        // Test multiple binary operators: (a < b) && (c > d)
+        let json = r#"{
+            "&&": {
+                "left": {"<": {"left": {"Var": "principal"}, "right": {"Var": "action"}}},
+                "right": {">": {"left": {"Var": "resource"}, "right": {"Var": "context"}}}
+            }
+        }"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::BinaryOp {
+                op: pst::expr::BinaryOp::And,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_est_expr_if_then_else() {
+        let json = r#"{
+            "if-then-else": {
+                "if": {"Var": "principal"},
+                "then": {"Value": true},
+                "else": {"Value": false}
+            }
+        }"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::IfThenElse { .. }));
+    }
+
+    #[test]
+    fn test_est_expr_set() {
+        let json = r#"{"Set": [{"Var": "principal"}, {"Var": "action"}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        if let Expr::Set(elems) = pst_expr {
+            assert_eq!(elems.len(), 2);
+        } else {
+            panic!("Expected Set");
+        }
+    }
+
+    #[test]
+    fn test_est_expr_record() {
+        let json = r#"{"Record": {"foo": {"Var": "principal"}}}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Record(_)));
+    }
+
+    #[test]
+    fn test_est_expr_get_attr() {
+        let json = r#"{".": {"left": {"Var": "principal"}, "attr": "name"}}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::GetAttr { .. }));
+    }
+
+    #[test]
+    fn test_est_expr_has_attr() {
+        let json = r#"{"has": {"left": {"Var": "principal"}, "attr": "name"}}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::HasAttr { .. }));
+        // Extended has attr
+        let json2 = r#"{"has": {"left": {"Var": "principal"}, "attr": ["name", "nested"]}}"#;
+        let est_expr2: est::Expr = serde_json::from_str(json2).unwrap();
+        let pst_expr2: Expr = est_expr2.try_into().unwrap();
+        assert!(matches!(pst_expr2, Expr::HasAttr { .. }));
+    }
+
+    #[test]
+    fn test_est_expr_like() {
+        let json = r#"{"like": {"left": {"Var": "principal"}, "pattern": [{"Wildcard": null}, {"Literal": "@example.com"}]}}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Like { .. }));
+    }
+
+    #[test]
+    fn test_est_expr_is() {
+        let json = r#"{"is": {
+           "left": { "Var": "principal" },
+            "entity_type": "User",
+            "in": {"Value": {"__entity": { "type": "Folder", "id": "Public" }}}
+    }}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Is { .. }));
+    }
+
+    #[test]
+    fn test_est_to_pst_simple() {
+        // Test simple value conversion
+        let est_expr = est::ExprNoExt::Var(ast::Var::Principal);
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Var(pst::expr::Var::Principal)));
+    }
+
+    #[test]
+    fn test_est_to_pst_binary_ops() {
+        let test_cases = vec![
+            ("==", pst::expr::BinaryOp::Eq),
+            ("!=", pst::expr::BinaryOp::NotEq),
+            ("in", pst::expr::BinaryOp::In),
+            ("<", pst::expr::BinaryOp::Less),
+            ("<=", pst::expr::BinaryOp::LessEq),
+            (">", pst::expr::BinaryOp::Greater),
+            (">=", pst::expr::BinaryOp::GreaterEq),
+            ("&&", pst::expr::BinaryOp::And),
+            ("||", pst::expr::BinaryOp::Or),
+            ("+", pst::expr::BinaryOp::Add),
+            ("-", pst::expr::BinaryOp::Sub),
+            ("*", pst::expr::BinaryOp::Mul),
+            ("contains", pst::expr::BinaryOp::Contains),
+            ("containsAll", pst::expr::BinaryOp::ContainsAll),
+            ("containsAny", pst::expr::BinaryOp::ContainsAny),
+            ("getTag", pst::expr::BinaryOp::GetTag),
+            ("hasTag", pst::expr::BinaryOp::HasTag),
+        ];
+
+        for (op_str, expected_op) in test_cases {
+            let json = format!(
+                r#"{{"{}": {{"left": {{"Var": "principal"}}, "right": {{"Var": "resource"}}}}}}"#,
+                op_str
+            );
+            let est_expr: est::Expr = serde_json::from_str(&json).unwrap();
+            let pst_expr: Expr = est_expr.try_into().unwrap();
+            if let Expr::BinaryOp { op, .. } = pst_expr {
+                assert_eq!(op, expected_op, "Failed for operator {}", op_str);
+            } else {
+                panic!("Expected BinaryOp for {}", op_str);
+            }
+        }
+    }
+
+    #[test]
+    fn test_est_to_pst_is_empty() {
+        let arg = Arc::new(est::Expr::ExprNoExt(est::ExprNoExt::Var(
+            ast::Var::Principal,
+        )));
+        let est_expr = est::ExprNoExt::IsEmpty { arg };
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::UnaryOp {
+                op: UnaryOp::IsEmpty,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn test_est_to_pst_get_attr() {
+        let left = Arc::new(est::Expr::ExprNoExt(est::ExprNoExt::Var(
+            ast::Var::Principal,
+        )));
+        let est_expr = est::ExprNoExt::GetAttr {
+            left,
+            attr: "name".try_into().unwrap(),
+        };
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::GetAttr { .. }));
+    }
+
+    #[test]
+    fn test_est_to_pst_has_attr() {
+        let left = Arc::new(est::Expr::ExprNoExt(est::ExprNoExt::Var(
+            ast::Var::Principal,
+        )));
+        let est_expr = est::ExprNoExt::HasAttr(est::HasAttrRepr::Simple {
+            left,
+            attr: "name".try_into().unwrap(),
+        });
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::HasAttr { .. }));
+    }
+
+    #[test]
+    fn test_est_to_pst_like() {
+        let left = Arc::new(est::Expr::ExprNoExt(est::ExprNoExt::Var(
+            ast::Var::Principal,
+        )));
+        let pattern = vec![
+            est::PatternElem::Wildcard,
+            est::PatternElem::Literal("test".try_into().unwrap()),
+        ];
+        let est_expr = est::ExprNoExt::Like { left, pattern };
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Like { .. }));
+    }
+
+    #[test]
+    fn test_est_to_pst_is() {
+        let left = Arc::new(est::Expr::ExprNoExt(est::ExprNoExt::Var(
+            ast::Var::Principal,
+        )));
+        let est_expr = est::ExprNoExt::Is {
+            left,
+            entity_type: "User".try_into().unwrap(),
+            in_expr: None,
+        };
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(pst_expr, Expr::Is { .. }));
+    }
+
+    #[test]
+    fn test_est_to_pst_set() {
+        // Test set conversion
+        let est_expr = est::ExprNoExt::Set(vec![
+            est::Expr::ExprNoExt(est::ExprNoExt::Var(ast::Var::Principal)),
+            est::Expr::ExprNoExt(est::ExprNoExt::Var(ast::Var::Action)),
+        ]);
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        if let Expr::Set(elems) = pst_expr {
+            assert_eq!(elems.len(), 2);
+        } else {
+            panic!("Expected Set");
+        }
+    }
+
+    #[test]
+    fn test_est_policy_simple() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": {
+                "op": "==",
+                "entity": { "type": "User", "id": "alice" }
+            },
+            "action": {
+                "op": "==",
+                "entity": { "type": "Action", "id": "view" }
+            },
+            "resource": {
+                "op": "All"
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(pst_policy.effect, pst::Effect::Permit));
+    }
+
+    #[test]
+    fn test_est_policy_with_in_constraint() {
+        let json = r#"{
+            "effect": "forbid",
+            "principal": {
+                "op": "in",
+                "entity": { "type": "Group", "id": "admins" }
+            },
+            "action": {
+                "op": "All"
+            },
+            "resource": {
+                "op": "in",
+                "entity": { "type": "Folder", "id": "secrets" }
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(pst_policy.effect, pst::Effect::Forbid));
+        assert!(matches!(
+            pst_policy.principal,
+            pst::PrincipalConstraint::In(_)
+        ));
+        assert!(matches!(
+            pst_policy.resource,
+            pst::ResourceConstraint::In(_)
+        ));
+    }
+
+    #[test]
+    fn test_est_policy_with_conditions() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": { "op": "All" },
+            "resource": { "op": "All" },
+            "conditions": [
+                {
+                    "kind": "when",
+                    "body": {
+                        "==": {
+                            "left": { "Var": "principal" },
+                            "right": { "Var": "resource" }
+                        }
+                    }
+                }
+            ]
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert_eq!(pst_policy.clauses.len(), 1);
+        assert!(matches!(pst_policy.clauses[0], pst::Clause::When(..)));
+    }
+
+    #[test]
+    fn test_est_policy_with_action_set() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": {
+                "op": "in",
+                "entities": [
+                    { "type": "Action", "id": "read" },
+                    { "type": "Action", "id": "write" }
+                ]
+            },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        if let pst::ActionConstraint::In(actions) = pst_policy.action {
+            assert_eq!(actions.len(), 2);
+        } else {
+            panic!("Expected ActionConstraint::In");
+        }
+    }
+
+    #[test]
+    fn test_est_resource_constraint_eq() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": { "op": "All" },
+            "resource": {
+                "op": "==",
+                "entity": { "type": "File", "id": "doc.txt" }
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(
+            pst_policy.resource,
+            pst::ResourceConstraint::Eq(_)
+        ));
+    }
+
+    #[test]
+    fn test_est_resource_constraint_is() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": { "op": "All" },
+            "resource": {
+                "op": "is",
+                "entity_type": "File"
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(
+            pst_policy.resource,
+            pst::ResourceConstraint::Is(_)
+        ));
+    }
+
+    #[test]
+    fn test_est_resource_constraint_is_in() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": { "op": "All" },
+            "resource": {
+                "op": "is",
+                "entity_type": "File",
+                "in": { "entity": { "type": "Folder", "id": "docs" } }
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(
+            pst_policy.resource,
+            pst::ResourceConstraint::IsIn(..)
+        ));
+    }
+
+    #[test]
+    fn test_est_action_constraint_eq() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": {
+                "op": "==",
+                "entity": { "type": "Action", "id": "view" }
+            },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(pst_policy.action, pst::ActionConstraint::Eq(_)));
+    }
+
+    #[test]
+    fn test_est_action_constraint_in_single() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": {
+                "op": "in",
+                "entity": { "type": "Action", "id": "view" }
+            },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        if let pst::ActionConstraint::In(actions) = pst_policy.action {
+            assert_eq!(actions.len(), 1);
+        } else {
+            panic!("Expected ActionConstraint::In");
+        }
+    }
+
+    #[test]
+    fn test_est_action_constraint_slot_panics() {
+        use ast::SlotId;
+        let constraint = est::ActionConstraint::Eq(est::EqConstraint::Slot {
+            slot: SlotId::principal(),
+        });
+        let result: Result<pst::ActionConstraint, _> = constraint.try_into();
+        assert!(matches!(
+            result,
+            Err(PstConstructionError::ActionConstraintCannotHaveSlots(..))
+        ));
+    }
+
+    #[test]
+    fn test_est_principal_constraint_eq() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": {
+                "op": "==",
+                "entity": { "type": "User", "id": "alice" }
+            },
+            "action": { "op": "All" },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(
+            pst_policy.principal,
+            pst::PrincipalConstraint::Eq(_)
+        ));
+    }
+
+    #[test]
+    fn test_est_principal_constraint_is() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": {
+                "op": "is",
+                "entity_type": "User"
+            },
+            "action": { "op": "All" },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(
+            pst_policy.principal,
+            pst::PrincipalConstraint::Is(_)
+        ));
+    }
+
+    #[test]
+    fn test_est_principal_constraint_is_in() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": {
+                "op": "is",
+                "entity_type": "User",
+                "in": { "entity": { "type": "Group", "id": "admins" } }
+            },
+            "action": { "op": "All" },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        assert!(matches!(
+            pst_policy.principal,
+            pst::PrincipalConstraint::IsIn(..)
+        ));
+    }
+
+    #[test]
+    fn test_est_principal_constraint_slot() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": {
+                "op": "==",
+                "slot": "?principal"
+            },
+            "action": { "op": "All" },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        if let pst::PrincipalConstraint::Eq(pst::EntityOrSlot::Slot(_)) = pst_policy.principal {
+            // Success
+        } else {
+            panic!("Expected PrincipalConstraint::Eq with Slot");
+        }
+    }
+
+    #[test]
+    fn test_est_resource_constraint_slot() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": { "op": "All" },
+            "resource": {
+                "op": "in",
+                "slot": "?resource"
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        if let pst::ResourceConstraint::In(pst::EntityOrSlot::Slot(_)) = pst_policy.resource {
+            // Success
+        } else {
+            panic!("Expected ResourceConstraint::In with Slot");
+        }
+    }
+
+    #[test]
+    fn test_est_principal_constraint_is_in_slot() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": {
+                "op": "is",
+                "entity_type": "User",
+                "in": { "slot": "?principal" }
+            },
+            "action": { "op": "All" },
+            "resource": { "op": "All" },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        if let pst::PrincipalConstraint::IsIn(_, pst::EntityOrSlot::Slot(_)) = pst_policy.principal
+        {
+            // Success
+        } else {
+            panic!("Expected PrincipalConstraint::IsIn with Slot");
+        }
+    }
+
+    #[test]
+    fn test_est_resource_constraint_is_in_slot() {
+        let json = r#"{
+            "effect": "permit",
+            "principal": { "op": "All" },
+            "action": { "op": "All" },
+            "resource": {
+                "op": "is",
+                "entity_type": "File",
+                "in": { "slot": "?resource" }
+            },
+            "conditions": []
+        }"#;
+        let est_policy: est::Policy = serde_json::from_str(json).unwrap();
+        let pst_policy: pst::Policy = est_policy.try_into().unwrap();
+        if let pst::ResourceConstraint::IsIn(_, pst::EntityOrSlot::Slot(_)) = pst_policy.resource {
+            // Success
+        } else {
+            panic!("Expected ResourceConstraint::IsIn with Slot");
+        }
+    }
+
+    #[test]
+    fn test_est_expr_func_call() {
+        // Test unary function calls (single argument)
+        let json = r#"{"decimal": [{"Value": "1.23"}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::UnaryOp {
+                op: UnaryOp::Decimal,
+                ..
+            }
+        ));
+
+        let json = r#"{"datetime": [{"Value": "2025-10-10T10:01:10"}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::UnaryOp {
+                op: UnaryOp::Datetime,
+                ..
+            }
+        ));
+
+        let json = r#"{"ip": [{"Value": "192.168.0.1"}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::UnaryOp {
+                op: UnaryOp::Ip,
+                ..
+            }
+        ));
+
+        // Test binary function calls (two arguments)
+        let json = r#"{"durationSince": [
+          {"datetime": [{"Value": "2025-10-10T10:01:10"}]},
+          {"datetime": [{"Value": "2025-09-10T10:01:10"}]}
+         ]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let pst_expr: Expr = est_expr.try_into().unwrap();
+        assert!(matches!(
+            pst_expr,
+            Expr::BinaryOp {
+                op: pst::expr::BinaryOp::DurationSince,
+                ..
+            }
+        ));
+
+        // Complex argument (expression)
+        let json = r#"{"decimal": [{"&&": {"left": {"Value": true}, "right": {"Value": false}}}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        if let Expr::UnaryOp {
+            op: UnaryOp::Decimal,
+            expr,
+        } = est_expr.try_into().unwrap()
+        {
+            assert!(matches!(
+                *expr,
+                Expr::BinaryOp {
+                    op: pst::expr::BinaryOp::And,
+                    ..
+                }
+            ));
+        } else {
+            panic!("Expected UnaryOp::Decimal with complex arg");
+        }
+
+        // Nested function call
+        let json = r#"{"decimal": [{"ip": [{"Value": "192.168.0.1"}]}]}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        if let Expr::UnaryOp {
+            op: UnaryOp::Decimal,
+            expr,
+        } = est_expr.try_into().unwrap()
+        {
+            assert!(matches!(
+                *expr,
+                Expr::UnaryOp {
+                    op: UnaryOp::Ip,
+                    ..
+                }
+            ));
+        } else {
+            panic!("Expected UnaryOp::Decimal with nested UnaryOp::Ip");
+        }
+    }
+
+    #[test]
+    fn test_valid_est_invalid_cedar_is_invalid_pst() {
+        let json = r#"{"offset": []}"#;
+        let est_expr: est::Expr = serde_json::from_str(json).unwrap();
+        let result: Result<Expr, _> = est_expr.try_into();
+        assert!(matches!(result, Err(PstConstructionError::WrongArity(..))));
+    }
+}
+
+// ============================================================================
+// PST → EST Conversions
+// ============================================================================
+
+impl TryFrom<Policy> for est::Policy {
+    type Error = PstConstructionError;
+
+    fn try_from(policy: Policy) -> Result<Self, Self::Error> {
+        let mut annotations = est::Annotations::new();
+        for (k, v) in policy.annotations.into_iter() {
+            annotations.0.insert(
+                ast::AnyId::new_unchecked(k),
+                Some(ast::Annotation {
+                    val: v.into(),
+                    loc: None,
+                }),
+            );
+        }
+        Ok(est::Policy {
+            effect: match policy.effect {
+                Effect::Permit => ast::Effect::Permit,
+                Effect::Forbid => ast::Effect::Forbid,
+            },
+            principal: policy.principal.into(),
+            action: policy.action.into(),
+            resource: policy.resource.into(),
+            conditions: policy
+                .clauses
+                .into_iter()
+                .map(|c| c.try_into())
+                .collect::<Result<Vec<_>, _>>()?,
+            annotations,
+        })
+    }
+}
+
+impl TryFrom<Clause> for est::Clause {
+    type Error = PstConstructionError;
+
+    fn try_from(clause: Clause) -> Result<Self, Self::Error> {
+        Ok(match clause {
+            Clause::When(expr) => est::Clause::When(Arc::unwrap_or_clone(expr).try_into()?),
+            Clause::Unless(expr) => est::Clause::Unless(Arc::unwrap_or_clone(expr).try_into()?),
+        })
+    }
+}
+
+impl From<PrincipalConstraint> for est::PrincipalConstraint {
+    fn from(constraint: PrincipalConstraint) -> Self {
+        match constraint {
+            PrincipalConstraint::Any => est::PrincipalConstraint::All,
+            PrincipalConstraint::Eq(eos) => match eos {
+                EntityOrSlot::Entity(entity) => {
+                    est::PrincipalConstraint::Eq(est::EqConstraint::Entity {
+                        entity: entity.into(),
+                    })
+                }
+                EntityOrSlot::Slot(slot) => {
+                    est::PrincipalConstraint::Eq(est::EqConstraint::Slot { slot: slot.into() })
+                }
+            },
+            PrincipalConstraint::In(eos) => match eos {
+                EntityOrSlot::Entity(entity) => {
+                    est::PrincipalConstraint::In(est::PrincipalOrResourceInConstraint::Entity {
+                        entity: entity.into(),
+                    })
+                }
+                EntityOrSlot::Slot(slot) => {
+                    est::PrincipalConstraint::In(est::PrincipalOrResourceInConstraint::Slot {
+                        slot: slot.into(),
+                    })
+                }
+            },
+            PrincipalConstraint::Is(entity_type) => {
+                est::PrincipalConstraint::Is(est::PrincipalOrResourceIsConstraint {
+                    entity_type: entity_type.to_string().into(),
+                    in_entity: None,
+                })
+            }
+            PrincipalConstraint::IsIn(entity_type, eos) => {
+                let in_entity = match eos {
+                    EntityOrSlot::Entity(entity) => est::PrincipalOrResourceInConstraint::Entity {
+                        entity: entity.into(),
+                    },
+                    EntityOrSlot::Slot(slot) => {
+                        est::PrincipalOrResourceInConstraint::Slot { slot: slot.into() }
+                    }
+                };
+                est::PrincipalConstraint::Is(est::PrincipalOrResourceIsConstraint {
+                    entity_type: entity_type.to_string().into(),
+                    in_entity: Some(in_entity),
+                })
+            }
+        }
+    }
+}
+
+impl From<ResourceConstraint> for est::ResourceConstraint {
+    fn from(constraint: ResourceConstraint) -> Self {
+        match constraint {
+            ResourceConstraint::Any => est::ResourceConstraint::All,
+            ResourceConstraint::Eq(eos) => match eos {
+                EntityOrSlot::Entity(entity) => {
+                    est::ResourceConstraint::Eq(est::EqConstraint::Entity {
+                        entity: entity.into(),
+                    })
+                }
+                EntityOrSlot::Slot(slot) => {
+                    est::ResourceConstraint::Eq(est::EqConstraint::Slot { slot: slot.into() })
+                }
+            },
+            ResourceConstraint::In(eos) => match eos {
+                EntityOrSlot::Entity(entity) => {
+                    est::ResourceConstraint::In(est::PrincipalOrResourceInConstraint::Entity {
+                        entity: entity.into(),
+                    })
+                }
+                EntityOrSlot::Slot(slot) => {
+                    est::ResourceConstraint::In(est::PrincipalOrResourceInConstraint::Slot {
+                        slot: slot.into(),
+                    })
+                }
+            },
+            ResourceConstraint::Is(entity_type) => {
+                est::ResourceConstraint::Is(est::PrincipalOrResourceIsConstraint {
+                    entity_type: entity_type.to_string().into(),
+                    in_entity: None,
+                })
+            }
+            ResourceConstraint::IsIn(entity_type, eos) => {
+                let in_entity = match eos {
+                    EntityOrSlot::Entity(entity) => est::PrincipalOrResourceInConstraint::Entity {
+                        entity: entity.into(),
+                    },
+                    EntityOrSlot::Slot(slot) => {
+                        est::PrincipalOrResourceInConstraint::Slot { slot: slot.into() }
+                    }
+                };
+                est::ResourceConstraint::Is(est::PrincipalOrResourceIsConstraint {
+                    entity_type: entity_type.to_string().into(),
+                    in_entity: Some(in_entity),
+                })
+            }
+        }
+    }
+}
+
+#[expect(
+    clippy::fallible_impl_from,
+    reason = "not faillible, as the unwrap cannot fail"
+)]
+impl From<ActionConstraint> for est::ActionConstraint {
+    fn from(constraint: ActionConstraint) -> Self {
+        match constraint {
+            ActionConstraint::Any => est::ActionConstraint::All,
+            ActionConstraint::Eq(entity) => est::ActionConstraint::Eq(est::EqConstraint::Entity {
+                entity: entity.into(),
+            }),
+            ActionConstraint::In(entities) => {
+                if entities.len() == 1 {
+                    #[expect(
+                        clippy::unwrap_used,
+                        reason = "entities length checked to be 1 in this arm"
+                    )]
+                    est::ActionConstraint::In(est::ActionInConstraint::Single {
+                        entity: entities.into_iter().next().unwrap().into(),
+                    })
+                } else {
+                    est::ActionConstraint::In(est::ActionInConstraint::Set {
+                        entities: entities.into_iter().map(Into::into).collect(),
+                    })
+                }
+            }
+        }
+    }
+}
+
+impl From<EntityUID> for entities::EntityUidJson {
+    fn from(uid: EntityUID) -> Self {
+        entities::EntityUidJson::new(uid.ty.to_string(), uid.eid.to_string())
+    }
+}
+
+impl TryFrom<Literal> for CedarValueJson {
+    type Error = PstConstructionError;
+    fn try_from(lit: Literal) -> Result<Self, PstConstructionError> {
+        Ok(match lit {
+            Literal::Bool(b) => CedarValueJson::Bool(b),
+            Literal::Long(n) => CedarValueJson::Long(n),
+            Literal::String(s) => CedarValueJson::String(s),
+            Literal::EntityUID(uid) => CedarValueJson::EntityEscape {
+                __entity: uid.try_into()?,
+            },
+        })
+    }
+}
+
+impl From<PatternElem> for est::PatternElem {
+    fn from(elem: PatternElem) -> Self {
+        match elem {
+            PatternElem::Char(c) => est::PatternElem::Literal(c.to_string().into()),
+            PatternElem::Wildcard => est::PatternElem::Wildcard,
+        }
+    }
+}
+
+impl TryFrom<EntityUID> for entities::TypeAndId {
+    type Error = PstConstructionError;
+
+    fn try_from(uid: EntityUID) -> Result<Self, PstConstructionError> {
+        let ast_uid: ast::EntityUID = uid.try_into()?;
+        Ok(ast_uid.into())
+    }
+}

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -495,6 +495,19 @@ pub(crate) struct ErrorNode {
 }
 
 impl Expr {
+    /// Transform a function call with arguments into a PST expression given the [SmolStr] name
+    /// of the function.
+    /// Needs to construct a reprentation of the [SmolStr] name as an [ast::Name].
+    pub(crate) fn from_function_name_and_args(
+        name: SmolStr,
+        args: Vec<Arc<Expr>>,
+    ) -> Result<Expr, PstConstructionError> {
+        let ast_name = ast::Name::parse_unqualified_name(name.as_str()).map_err(|e| {
+            PstConstructionError::from(error_body::ParsingFailedError::new(e.to_string()))
+        })?;
+        Self::from_function_names_and_args(name, &ast_name, args)
+    }
+
     /// Transform a function call with arguments into a PST expression given the [`ast::Name`] of
     /// the function. Clones the string representation of the `ast::Name` given.
     pub(crate) fn from_function_ast_name_and_args(

--- a/cedar-policy-core/src/pst/mod.rs
+++ b/cedar-policy-core/src/pst/mod.rs
@@ -27,8 +27,10 @@
 //! - Uses `Arc<Expr>` for cheap cloning during manipulation
 
 pub(crate) mod ast_conversions;
+mod builders;
 mod constraints;
 mod err;
+pub(crate) mod est_conversions;
 mod expr;
 mod policy;
 


### PR DESCRIPTION
This PR adds the PST to EST, and EST to PST conversion functionality.
## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.