### PR TITLE
Made WriterSolver::check_sat_with_model more consistent with LocalSolver

### DIFF
--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -382,7 +382,7 @@ impl<W: tokio::io::AsyncWrite + Unpin + Send> Solver for WriterSolver<W> {
     }
     async fn check_sat_with_model(&mut self) -> Result<DecisionWithModel> {
         self.smtlib_input().check_sat().await?;
-        self.smtlib_input().get_model().await?;
+        // Since the decision is always `Unknown`, we should not emit get-model for consistency.
         self.w.flush().await?;
         Ok(DecisionWithModel::Unknown)
     }


### PR DESCRIPTION
## Description of changes
Updated `WriterSolver::check_sat_with_model` to remove the call to `get-model` for consistency with the Lean implementation and `LocalSolver` which will only emit get-model if check-sat comes back SAT.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.