### PR TITLE
Updated symcc changelog for patch

### DIFF
--- a/cedar-policy-symcc/CHANGELOG.md
+++ b/cedar-policy-symcc/CHANGELOG.md
@@ -8,10 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 Cedar Language Version: TBD
 
-### Added
-
-- `Display` impl for `Env` (#2182)
-
 ### Changed
 
 - Refactored `Solver` trait to include `check_sat_with_model()` instead of `get_model()`,
@@ -22,6 +18,10 @@ required when models are being enabled (#2192)
 
 ## [0.3.1] - Coming soon
 Cedar Language Version: 4.4
+
+### Added
+
+- `Display` impl for `Env` (#2182)
 
 ### Fixed
 


### PR DESCRIPTION
## Description of changes
Updated changelog to move entry for PR #2182 into the 0.3.1 SymCC release to match https://github.com/cedar-policy/cedar/pull/2207.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
