### PR TITLE
Reverted lalrpop upgrade

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
       # version or a later version.
       - dependency-name: "tsify"
         versions: ["0.5.5"]
+      # Due to an issue with cross-compilation in lalrpop 0.23.0, we are ignoring this version.
+      # Issue #2209 tracks an eventual upgrade to a later version.
+      - dependency-name: "lalrpop"
+        versions: ["0.23.0"]
     # Group all updates into one pull request
     groups:
       rust-dependencies:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,16 +1383,16 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.23.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e15283adc509c301924c886fcf9e0c8b0cdf4212c138edc7cca4bd89b31aa1c"
+checksum = "ba4ebbd48ce411c1d10fb35185f5a51a7bfa3d8b24b4e330d30c9e3a34129501"
 dependencies = [
  "ascii-canvas",
  "bit-set",
  "ena",
  "itertools 0.14.0",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.7.1",
  "pico-args",
  "regex",
  "regex-syntax",
@@ -1405,11 +1405,12 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.23.0"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3afd1d719c117a3801a2740840c22e40f59e13f51fcd631068fe80266a001d"
+checksum = "b5baa5e9ff84f1aefd264e6869907646538a52147a755d494517a8007fb48733"
 dependencies = [
  "regex-automata",
+ "rustversion",
 ]
 
 [[package]]
@@ -1794,6 +1795,16 @@ dependencies = [
 
 [[package]]
 name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.13.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
@@ -1805,9 +1816,9 @@ dependencies = [
 
 [[package]]
 name = "phf_shared"
-version = "0.13.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
@@ -1981,7 +1992,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
  "prost",
  "prost-types",
@@ -2529,9 +2540,9 @@ checksum = "d08889ec5408683408db66ad89e0e1f93dff55c73a4ccc71c427d5b277ee47e6"
 
 [[package]]
 name = "string_cache"
-version = "0.9.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",

--- a/cedar-policy-core/Cargo.toml
+++ b/cedar-policy-core/Cargo.toml
@@ -16,7 +16,7 @@ repository.workspace = true
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_with = { version = "3.17", features = ["json"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-lalrpop-util = { version = "0.23.0", features = ["lexer"] }
+lalrpop-util = { version = "0.22.2", features = ["lexer"] }
 either = "1.15"
 itertools = "0.14"
 ref-cast = "1.0"
@@ -67,7 +67,7 @@ tpe = []
 variadic-is-in-range = []
 
 [build-dependencies]
-lalrpop = "0.23.0"
+lalrpop = "0.22.2"
 
 [dev-dependencies]
 similar-asserts = "1.7.0"

--- a/cedar-policy-core/build.rs
+++ b/cedar-policy-core/build.rs
@@ -25,6 +25,10 @@ fn main() {
 )]
 fn generate_parsers() {
     lalrpop::Configuration::new()
-        .process_dir("src/")
+        .process_dir("src/parser/")
+        .expect("failed to run lalrpop");
+
+    lalrpop::Configuration::new()
+        .process_dir("src/validator/cedar_schema/")
         .expect("failed to run lalrpop");
 }

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -27,7 +27,7 @@ lalrpop_mod!(
     #[allow(clippy::allow_attributes, reason = "lalrpop allows this, and we are trusting lalrpop to generate correct code")]
     #[allow(clippy::allow_attributes_without_reason, reason = "lalrpop allows this, and we are trusting lalrpop to generate correct code")]
     pub grammar,
-    "/parser/grammar.rs"
+    "/src/parser/grammar.rs"
 );
 
 use super::*;

--- a/cedar-policy-core/src/validator/cedar_schema/parser.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/parser.rs
@@ -40,7 +40,7 @@ lalrpop_mod!(
     #[allow(clippy::allow_attributes, reason = "lalrpop allows this, and we are trusting lalrpop to generate correct code")]
     #[allow(clippy::allow_attributes_without_reason, reason = "lalrpop allows this, and we are trusting lalrpop to generate correct code")]
     pub grammar,
-    "/validator/cedar_schema/grammar.rs"
+    "/src/validator/cedar_schema/grammar.rs"
 );
 
 /// This helper function calls a generated parser, collects errors that could be


### PR DESCRIPTION
## Description of changes
As described in https://github.com/cedar-policy/cedar/issues/2209, upgrading to lalrpop 0.23.0 broke cross-compilation in cedar-java. This change reverted the upgrade.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.