### PR TITLE
refactor some builder functions into `_arc` version to save on clones

### DIFF
--- a/cedar-policy-core/src/ast/expr.rs
+++ b/cedar-policy-core/src/ast/expr.rs
@@ -1053,13 +1053,18 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     }
 
     /// Create a ternary (if-then-else) `Expr`.
-    ///
+    /// Takes `Arc`s instead of owned `Expr`s.
     /// `test_expr` must evaluate to a Bool type
-    fn ite(self, test_expr: Expr<T>, then_expr: Expr<T>, else_expr: Expr<T>) -> Expr<T> {
+    fn ite_arc(
+        self,
+        test_expr: Arc<Expr<T>>,
+        then_expr: Arc<Expr<T>>,
+        else_expr: Arc<Expr<T>>,
+    ) -> Expr<T> {
         self.with_expr_kind(ExprKind::If {
-            test_expr: Arc::new(test_expr),
-            then_expr: Arc::new(then_expr),
-            else_expr: Arc::new(else_expr),
+            test_expr,
+            then_expr,
+            else_expr,
         })
     }
 
@@ -1163,11 +1168,11 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     /// Create an 'in' expression. First argument must evaluate to Entity type.
     /// Second argument must evaluate to either Entity type or Set type where
     /// all set elements have Entity type.
-    fn is_in(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn is_in_arc(self, arg1: Arc<Expr<T>>, arg2: Arc<Expr<T>>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::In,
-            arg1: Arc::new(e1),
-            arg2: Arc::new(e2),
+            arg1,
+            arg2,
         })
     }
 
@@ -1286,22 +1291,16 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     /// Create an `Expr` which gets a given attribute of a given `Entity` or record.
     ///
     /// `expr` must evaluate to either Entity or Record type
-    fn get_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
-        self.with_expr_kind(ExprKind::GetAttr {
-            expr: Arc::new(expr),
-            attr,
-        })
+    fn get_attr_arc(self, expr: Arc<Expr<T>>, attr: SmolStr) -> Expr<T> {
+        self.with_expr_kind(ExprKind::GetAttr { expr, attr })
     }
 
     /// Create an `Expr` which tests for the existence of a given
     /// attribute on a given `Entity` or record.
     ///
     /// `expr` must evaluate to either Entity or Record type
-    fn has_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
-        self.with_expr_kind(ExprKind::HasAttr {
-            expr: Arc::new(expr),
-            attr,
-        })
+    fn has_attr_arc(self, expr: Arc<Expr<T>>, attr: SmolStr) -> Expr<T> {
+        self.with_expr_kind(ExprKind::HasAttr { expr, attr })
     }
 
     /// Create a 'like' expression.
@@ -1315,11 +1314,8 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprBuilder<T> {
     }
 
     /// Create an 'is' expression.
-    fn is_entity_type(self, expr: Expr<T>, entity_type: EntityType) -> Expr<T> {
-        self.with_expr_kind(ExprKind::Is {
-            expr: Arc::new(expr),
-            entity_type,
-        })
+    fn is_entity_type_arc(self, expr: Arc<Expr<T>>, entity_type: EntityType) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Is { expr, entity_type })
     }
 
     /// Don't support AST Error nodes - return the error right back
@@ -1334,22 +1330,6 @@ impl<T> ExprBuilder<T> {
     /// `ExprBuilder` and the given `ExprKind`.
     pub fn with_expr_kind(self, expr_kind: ExprKind<T>) -> Expr<T> {
         Expr::new(expr_kind, self.source_loc, self.data)
-    }
-
-    /// Create a ternary (if-then-else) `Expr`.
-    /// Takes `Arc`s instead of owned `Expr`s.
-    /// `test_expr` must evaluate to a Bool type
-    pub fn ite_arc(
-        self,
-        test_expr: Arc<Expr<T>>,
-        then_expr: Arc<Expr<T>>,
-        else_expr: Arc<Expr<T>>,
-    ) -> Expr<T> {
-        self.with_expr_kind(ExprKind::If {
-            test_expr,
-            then_expr,
-            else_expr,
-        })
     }
 
     /// Create an `Expr` which evaluates to a Record with the given key-value mapping.

--- a/cedar-policy-core/src/ast/expr_allows_errors.rs
+++ b/cedar-policy-core/src/ast/expr_allows_errors.rs
@@ -93,11 +93,16 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     /// Create a ternary (if-then-else) `Expr`.
     ///
     /// `test_expr` must evaluate to a Bool type
-    fn ite(self, test_expr: Expr<T>, then_expr: Expr<T>, else_expr: Expr<T>) -> Expr<T> {
+    fn ite_arc(
+        self,
+        test_expr: Arc<Self::Expr>,
+        then_expr: Arc<Self::Expr>,
+        else_expr: Arc<Self::Expr>,
+    ) -> Self::Expr {
         self.with_expr_kind(ExprKind::If {
-            test_expr: Arc::new(test_expr),
-            then_expr: Arc::new(then_expr),
-            else_expr: Arc::new(else_expr),
+            test_expr,
+            then_expr,
+            else_expr,
         })
     }
 
@@ -201,11 +206,11 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     /// Create an 'in' expression. First argument must evaluate to Entity type.
     /// Second argument must evaluate to either Entity type or Set type where
     /// all set elements have Entity type.
-    fn is_in(self, e1: Expr<T>, e2: Expr<T>) -> Expr<T> {
+    fn is_in_arc(self, arg1: Arc<Expr<T>>, arg2: Arc<Expr<T>>) -> Expr<T> {
         self.with_expr_kind(ExprKind::BinaryApp {
             op: BinaryOp::In,
-            arg1: Arc::new(e1),
-            arg2: Arc::new(e2),
+            arg1,
+            arg2,
         })
     }
 
@@ -324,22 +329,16 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     /// Create an `Expr` which gets a given attribute of a given `Entity` or record.
     ///
     /// `expr` must evaluate to either Entity or Record type
-    fn get_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
-        self.with_expr_kind(ExprKind::GetAttr {
-            expr: Arc::new(expr),
-            attr,
-        })
+    fn get_attr_arc(self, expr: Arc<Expr<T>>, attr: SmolStr) -> Expr<T> {
+        self.with_expr_kind(ExprKind::GetAttr { expr, attr })
     }
 
     /// Create an `Expr` which tests for the existence of a given
     /// attribute on a given `Entity` or record.
     ///
     /// `expr` must evaluate to either Entity or Record type
-    fn has_attr(self, expr: Expr<T>, attr: SmolStr) -> Expr<T> {
-        self.with_expr_kind(ExprKind::HasAttr {
-            expr: Arc::new(expr),
-            attr,
-        })
+    fn has_attr_arc(self, expr: Arc<Expr<T>>, attr: SmolStr) -> Expr<T> {
+        self.with_expr_kind(ExprKind::HasAttr { expr, attr })
     }
 
     /// Create a 'like' expression.
@@ -353,11 +352,8 @@ impl<T: Default + Clone> expr_builder::ExprBuilder for ExprWithErrsBuilder<T> {
     }
 
     /// Create an 'is' expression.
-    fn is_entity_type(self, expr: Expr<T>, entity_type: EntityType) -> Expr<T> {
-        self.with_expr_kind(ExprKind::Is {
-            expr: Arc::new(expr),
-            entity_type,
-        })
+    fn is_entity_type_arc(self, expr: Arc<Expr<T>>, entity_type: EntityType) -> Expr<T> {
+        self.with_expr_kind(ExprKind::Is { expr, entity_type })
     }
 
     fn new() -> Self

--- a/cedar-policy-core/src/est/expr.rs
+++ b/cedar-policy-core/src/est/expr.rs
@@ -541,11 +541,8 @@ impl ExprBuilder for Builder {
     }
 
     /// `in`
-    fn is_in(self, left: Expr, right: Expr) -> Expr {
-        Expr::ExprNoExt(ExprNoExt::In {
-            left: Arc::new(left),
-            right: Arc::new(right),
-        })
+    fn is_in_arc(self, left: Arc<Expr>, right: Arc<Expr>) -> Expr {
+        Expr::ExprNoExt(ExprNoExt::In { left, right })
     }
 
     /// `<`
@@ -675,12 +672,22 @@ impl ExprBuilder for Builder {
         })
     }
 
+    /// `left.attr` (with an Arc)
+    fn get_attr_arc(self, expr: Arc<Expr>, attr: SmolStr) -> Expr {
+        Expr::ExprNoExt(ExprNoExt::GetAttr { left: expr, attr })
+    }
+
     /// `left has attr`
     fn has_attr(self, expr: Expr, attr: SmolStr) -> Expr {
         Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Simple {
             left: Arc::new(expr),
             attr,
         }))
+    }
+
+    /// `left has attr` (with an Arc)
+    fn has_attr_arc(self, expr: Arc<Self::Expr>, attr: SmolStr) -> Self::Expr {
+        Expr::ExprNoExt(ExprNoExt::HasAttr(HasAttrRepr::Simple { left: expr, attr }))
     }
 
     /// `left like pattern`
@@ -692,9 +699,9 @@ impl ExprBuilder for Builder {
     }
 
     /// `left is entity_type`
-    fn is_entity_type(self, left: Expr, entity_type: ast::EntityType) -> Expr {
+    fn is_entity_type_arc(self, left: Arc<Expr>, entity_type: ast::EntityType) -> Expr {
         Expr::ExprNoExt(ExprNoExt::Is {
-            left: Arc::new(left),
+            left,
             entity_type: entity_type.to_smolstr(),
             in_expr: None,
         })
@@ -710,11 +717,16 @@ impl ExprBuilder for Builder {
     }
 
     /// `if cond_expr then then_expr else else_expr`
-    fn ite(self, cond_expr: Expr, then_expr: Expr, else_expr: Expr) -> Expr {
+    fn ite_arc(
+        self,
+        cond_expr: Arc<Self::Expr>,
+        then_expr: Arc<Self::Expr>,
+        else_expr: Arc<Self::Expr>,
+    ) -> Self::Expr {
         Expr::ExprNoExt(ExprNoExt::If {
-            cond_expr: Arc::new(cond_expr),
-            then_expr: Arc::new(then_expr),
-            else_expr: Arc::new(else_expr),
+            cond_expr,
+            then_expr,
+            else_expr,
         })
     }
 
@@ -1060,7 +1072,7 @@ impl Expr {
                     Ok(builder.has_attr(Arc::unwrap_or_clone(left).try_into_expr::<B>()?, attr))
                 }
                 HasAttrRepr::Extended { left, attr } => Ok(builder
-                    .extended_has_attr(Arc::unwrap_or_clone(left).try_into_expr::<B>()?, &attr)),
+                    .extended_has_attr(Arc::unwrap_or_clone(left).try_into_expr::<B>()?, attr)),
             },
             Expr::ExprNoExt(ExprNoExt::Like { left, pattern }) => Ok(builder.like(
                 Arc::unwrap_or_clone(left).try_into_expr::<B>()?,
@@ -1231,7 +1243,7 @@ impl Expr {
                     attr,
                 )),
                 HasAttrRepr::Extended { left, attr } => Ok(ast::ExprBuilder::new()
-                    .extended_has_attr(Arc::unwrap_or_clone(left).try_into_ast(id)?, &attr)),
+                    .extended_has_attr(Arc::unwrap_or_clone(left).try_into_ast(id)?, attr)),
             },
             Expr::ExprNoExt(ExprNoExt::Like { left, pattern }) => Ok(ast::Expr::like(
                 Arc::unwrap_or_clone(left).try_into_ast(id)?,

--- a/cedar-policy-core/src/expr_builder.rs
+++ b/cedar-policy-core/src/expr_builder.rs
@@ -31,6 +31,7 @@ use crate::{
 #[cfg(feature = "tolerant-ast")]
 use crate::parser::err::ParseErrors;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 /// Defines a generic interface for building different expression data
 /// structures.
@@ -109,8 +110,26 @@ pub trait ExprBuilder: Clone {
     fn slot(self, s: SlotId) -> Self::Expr;
 
     /// Create a ternary (if-then-else) `Expr`.
-    fn ite(self, test_expr: Self::Expr, then_expr: Self::Expr, else_expr: Self::Expr)
-        -> Self::Expr;
+    fn ite(
+        self,
+        test_expr: Self::Expr,
+        then_expr: Self::Expr,
+        else_expr: Self::Expr,
+    ) -> Self::Expr {
+        self.ite_arc(
+            Arc::new(test_expr),
+            Arc::new(then_expr),
+            Arc::new(else_expr),
+        )
+    }
+
+    /// Create a ternary (if-then-else) `Expr` using `Arc<Expr>` arguments.
+    fn ite_arc(
+        self,
+        cond_expr: Arc<Self::Expr>,
+        then_expr: Arc<Self::Expr>,
+        else_expr: Arc<Self::Expr>,
+    ) -> Self::Expr;
 
     /// Create a 'not' expression.
     fn not(self, e: Self::Expr) -> Self::Expr;
@@ -143,7 +162,12 @@ pub trait ExprBuilder: Clone {
     fn neg(self, e: Self::Expr) -> Self::Expr;
 
     /// Create an 'in' expression. First argument must evaluate to Entity type.
-    fn is_in(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
+    fn is_in(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr {
+        self.is_in_arc(Arc::new(e1), Arc::new(e2))
+    }
+
+    /// Create an 'in' expression. First argument must evaluate to Entity type.
+    fn is_in_arc(self, e1: Arc<Self::Expr>, e2: Arc<Self::Expr>) -> Self::Expr;
 
     /// Create a 'contains' expression.
     fn contains(self, e1: Self::Expr, e2: Self::Expr) -> Self::Expr;
@@ -191,24 +215,45 @@ pub trait ExprBuilder: Clone {
     }
 
     /// Create an `Expr` which gets a given attribute of a given `Entity` or record.
-    fn get_attr(self, expr: Self::Expr, attr: SmolStr) -> Self::Expr;
+    fn get_attr(self, expr: Self::Expr, attr: SmolStr) -> Self::Expr {
+        // builders usually implement the `_arc` version, and clients get this convenient wrapper
+        self.get_attr_arc(Arc::new(expr), attr)
+    }
+
+    /// Create an `Expr` which tests for the existence of a given
+    /// attribute on a given `Entity` or record using an `Arc<Expr>`.
+    fn get_attr_arc(self, expr: Arc<Self::Expr>, attr: SmolStr) -> Self::Expr;
 
     /// Create an `Expr` which tests for the existence of a given
     /// attribute on a given `Entity` or record.
-    fn has_attr(self, expr: Self::Expr, attr: SmolStr) -> Self::Expr;
+    fn has_attr(self, expr: Self::Expr, attr: SmolStr) -> Self::Expr {
+        // builders usually implement the `_arc` version, and clients get this convenient wrapper
+        self.has_attr_arc(Arc::new(expr), attr)
+    }
+
+    /// Create an `Expr` which tests for the existence of a given
+    /// attribute on a given `Entity` or record using an `Arc<Expr>`.
+    fn has_attr_arc(self, expr: Arc<Self::Expr>, attr: SmolStr) -> Self::Expr;
 
     /// Create an `Expr` which tests for the existence of a given
     /// non-empty list of attributes on a given `Entity` or record.
-    fn extended_has_attr(self, expr: Self::Expr, attrs: &NonEmpty<SmolStr>) -> Self::Expr {
-        // TODO: might move this to the trait implementers, since it will be a particular
-        // representation's choice on whether to desugar or not
-        let (first, rest) = attrs.split_first();
+    fn extended_has_attr(self, expr: Self::Expr, attrs: NonEmpty<SmolStr>) -> Self::Expr {
+        // builders usually implement the `_arc` version, and clients get this convenient wrapper
+        self.extended_has_attr_arc(Arc::new(expr), attrs)
+    }
+
+    /// Create an `Expr` which tests for the existence of a given
+    /// non-empty list of attributes on a given `Entity` or record.
+    fn extended_has_attr_arc(self, expr: Arc<Self::Expr>, attrs: NonEmpty<SmolStr>) -> Self::Expr {
+        // builders that can directly support extended has operator implement this directly.
         let has_expr = Self::new()
             .with_maybe_source_loc(self.loc())
-            .has_attr(expr.clone(), first.to_owned());
-        let get_expr = Self::new()
-            .with_maybe_source_loc(self.loc())
-            .get_attr(expr, first.to_owned());
+            .has_attr_arc(expr.clone(), attrs.head.clone());
+        let get_expr = Arc::new(
+            Self::new()
+                .with_maybe_source_loc(self.loc())
+                .get_attr_arc(expr, attrs.head),
+        );
         // Foldl on the attribute list
         // It produces the following for `principal has contactInfo.address.zip`
         //     Expr.and
@@ -230,18 +275,22 @@ pub trait ExprBuilder: Clone {
         //   (Expr.and
         //      (Expr.hasAttr (Expr.getAttr (Expr.var .principal) "contactInfo")"address")
         //      (Expr.hasAttr ..., "zip"))
-        rest.iter()
+        attrs
+            .tail
+            .into_iter()
             .fold((has_expr, get_expr), |(has_expr, get_expr), attr| {
                 (
                     Self::new().with_maybe_source_loc(self.loc()).and(
                         has_expr,
                         Self::new()
                             .with_maybe_source_loc(self.loc())
-                            .has_attr(get_expr.clone(), attr.to_owned()),
+                            .has_attr_arc(get_expr.clone(), attr.clone()),
                     ),
-                    Self::new()
-                        .with_maybe_source_loc(self.loc())
-                        .get_attr(get_expr, attr.to_owned()),
+                    Arc::new(
+                        Self::new()
+                            .with_maybe_source_loc(self.loc())
+                            .get_attr_arc(get_expr, attr),
+                    ),
                 )
             })
             .0
@@ -251,7 +300,12 @@ pub trait ExprBuilder: Clone {
     fn like(self, expr: Self::Expr, pattern: Pattern) -> Self::Expr;
 
     /// Create an 'is' expression.
-    fn is_entity_type(self, expr: Self::Expr, entity_type: EntityType) -> Self::Expr;
+    fn is_entity_type(self, expr: Self::Expr, entity_type: EntityType) -> Self::Expr {
+        self.is_entity_type_arc(Arc::new(expr), entity_type)
+    }
+
+    /// Create an 'is' expression from an `Arc<Self::Expr>` and `EntityType`.
+    fn is_entity_type_arc(self, expr: Arc<Self::Expr>, entity_type: EntityType) -> Self::Expr;
 
     /// Create an `_ is _ in _`  expression
     fn is_in_entity_type(
@@ -259,13 +313,23 @@ pub trait ExprBuilder: Clone {
         e1: Self::Expr,
         entity_type: EntityType,
         e2: Self::Expr,
+    ) -> Self::Expr {
+        self.is_in_entity_type_arc(Arc::new(e1), entity_type, Arc::new(e2))
+    }
+
+    /// Create an `_ is _ in _`  expression from `Arc<Self::Expr>` arguments.
+    fn is_in_entity_type_arc(
+        self,
+        e1: Arc<Self::Expr>,
+        entity_type: EntityType,
+        e2: Arc<Self::Expr>,
     ) -> Self::Expr
     where
         Self: Sized,
     {
         self.clone().and(
-            self.clone().is_entity_type(e1.clone(), entity_type),
-            self.is_in(e1, e2),
+            self.clone().is_entity_type_arc(e1.clone(), entity_type),
+            self.is_in_arc(e1, e2),
         )
     }
 

--- a/cedar-policy-core/src/parser/cst_to_ast.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast.rs
@@ -1390,15 +1390,15 @@ impl Node<Option<cst::Relation>> {
             }
             cst::Relation::Has { target, field } => {
                 let maybe_target = target.to_expr::<Build>();
-                let maybe_field = Ok(match field.to_has_rhs::<Build>()? {
+                let maybe_fields = Ok(match field.to_has_rhs::<Build>()? {
                     Either::Left(s) => nonempty![s],
                     Either::Right(ids) => ids.map(|id| id.into_smolstr()),
                 });
-                let (target, field) = flatten_tuple_2(maybe_target, maybe_field)?;
+                let (target, fields) = flatten_tuple_2(maybe_target, maybe_fields)?;
                 Ok(ExprOrSpecial::Expr {
                     expr: Build::new()
                         .with_maybe_source_loc(self.loc.as_ref())
-                        .extended_has_attr(target, &field),
+                        .extended_has_attr(target, fields),
                     loc: self.loc.clone(),
                 })
             }

--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -292,7 +292,7 @@ impl Expr {
             }
             Expr::HasAttr { expr, attrs } => {
                 Ok(builder
-                    .extended_has_attr(Arc::unwrap_or_clone(expr).try_into_expr::<B>()?, &attrs))
+                    .extended_has_attr(Arc::unwrap_or_clone(expr).try_into_expr::<B>()?, attrs))
             }
             Expr::Like { expr, pattern } => Ok(builder.like(
                 Arc::unwrap_or_clone(expr).try_into_expr::<B>()?,

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -600,11 +600,11 @@ impl ExprBuilder for PstBuilder {
         Expr::Slot(s.into())
     }
 
-    fn ite(self, test_expr: Expr, then_expr: Expr, else_expr: Expr) -> Expr {
+    fn ite_arc(self, cond: Arc<Expr>, then_expr: Arc<Expr>, else_expr: Arc<Expr>) -> Expr {
         Expr::IfThenElse {
-            cond: Arc::new(test_expr),
-            then_expr: Arc::new(then_expr),
-            else_expr: Arc::new(else_expr),
+            cond,
+            then_expr,
+            else_expr,
         }
     }
 
@@ -710,11 +710,11 @@ impl ExprBuilder for PstBuilder {
         }
     }
 
-    fn is_in(self, e1: Expr, e2: Expr) -> Expr {
+    fn is_in_arc(self, left: Arc<Expr>, right: Arc<Expr>) -> Expr {
         Expr::BinaryOp {
             op: BinaryOp::In,
-            left: Arc::new(e1),
-            right: Arc::new(e2),
+            left,
+            right,
         }
     }
 
@@ -805,25 +805,19 @@ impl ExprBuilder for PstBuilder {
         Expr::from_function_ast_name_and_args(&fn_name, args.into_iter().map(Arc::new).collect())
     }
 
-    fn get_attr(self, expr: Expr, attr: SmolStr) -> Expr {
-        Expr::GetAttr {
-            expr: Arc::new(expr),
-            attr,
-        }
+    fn get_attr_arc(self, expr: Arc<Expr>, attr: SmolStr) -> Expr {
+        Expr::GetAttr { expr, attr }
     }
 
-    fn has_attr(self, expr: Expr, attr: SmolStr) -> Expr {
+    fn has_attr_arc(self, expr: Arc<Expr>, attr: SmolStr) -> Expr {
         Expr::HasAttr {
-            expr: Arc::new(expr),
+            expr,
             attrs: nonempty::nonempty![attr],
         }
     }
 
-    fn extended_has_attr(self, expr: Expr, attrs: &nonempty::NonEmpty<SmolStr>) -> Expr {
-        Expr::HasAttr {
-            expr: Arc::new(expr),
-            attrs: attrs.clone(),
-        }
+    fn extended_has_attr_arc(self, expr: Arc<Expr>, attrs: nonempty::NonEmpty<SmolStr>) -> Expr {
+        Expr::HasAttr { expr, attrs }
     }
 
     fn like(self, expr: Expr, pattern: ast::Pattern) -> Expr {
@@ -833,9 +827,9 @@ impl ExprBuilder for PstBuilder {
         }
     }
 
-    fn is_entity_type(self, expr: Expr, entity_type: ast::EntityType) -> Expr {
+    fn is_entity_type_arc(self, expr: Arc<Expr>, entity_type: ast::EntityType) -> Expr {
         Expr::Is {
-            expr: Arc::new(expr),
+            expr,
             entity_type: entity_type.into(),
             in_expr: None,
         }


### PR DESCRIPTION
## Description of changes

Refactors some of `ExprBuilder`'s functions to require implementation with `Arc<..>` and then provide default without `Arc<..>`. The benefits are probably not very significant, but I noticed all implementations were using `Arc<..>`. 
- Adding `has_attr_arc` and `get_attr_arc` allows extended has to clone `Arc<..>`. 
- Adding `is_entity_type_arc` and `is_in_arc` allows `is_in_entity_type` to clone Arc. 
- `ite_arc` was in one of the implementations but not all, so I made it instead the required implementation instead of `ite`, and `ite` is provided by the trait default impl.

This doesn't simplify the `ExprBuilder` interface but does simplify the implementations.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
-  [x] Does not require updates because my change does not impact the Cedar language specification.
