### PR TITLE
symcc: reorder Op variants to alphabetical, like Term variants

### DIFF
--- a/cedar-policy-symcc/src/symcc/op.rs
+++ b/cedar-policy-symcc/src/symcc/op.rs
@@ -50,16 +50,15 @@ pub enum ExtOp {
     DurationOfBitVec,
 }
 
+/// Variants must be defined in alphabetical order, so that the derived `Ord`
+/// implementation matches the Lean ordering of the variants of this type.
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
 #[expect(missing_docs, reason = "existing code")]
 pub enum Op {
-    //   ---------- SMTLib core theory of equality with uninterpreted functions (`UF`) ----------
-    Not,
-    And,
-    Or,
-    Eq,
-    Ite,
-    Uuf(Arc<Uuf>),
+    // Since the variants must be defined in alphabetical order (see above),
+    // we can't sort them neatly by SMTLib theory here.
+    And, // SMTLib core theory of equality with uninterpreted functions (`UF`)
+
     //   ---------- SMTLib theory of finite bitvectors (`BV`) ----------
     Bvneg,
     Bvadd,
@@ -89,17 +88,23 @@ pub enum Op {
     Bvssubo,
     /// Bit-vector signed multiplication overflow predicate.
     Bvsmulo,
-    ZeroExtend(u32), // allowed to be 0
+
+    Eq,              // SMTLib core theory of equality with uninterpreted functions (`UF`)
+    Ext(ExtOp),      // Extension ADT operator with trusted mapping to SMT
+    Ite,             // SMTLib core theory of equality with uninterpreted functions (`UF`)
+    Not,             // SMTLib core theory of equality with uninterpreted functions (`UF`)
+    OptionGet,       // Core ADT operator with trusted mapping to SMT
+    Or,              // SMTLib core theory of equality with uninterpreted functions (`UF`)
+    RecordGet(Attr), // Core ADT operator with trusted mapping to SMT
+
     //   ---------- CVC theory of finite sets (`FS`) ----------
     SetMember,
     SetSubset,
     SetInter,
-    //   ---------- Core ADT operators with a trusted mapping to SMT ----------
-    OptionGet,
-    RecordGet(Attr),
-    StringLike(OrdPattern),
-    //   ---------- Extension ADT operators with a trusted mapping to SMT ----------
-    Ext(ExtOp),
+
+    StringLike(OrdPattern), // Core ADT operator with trusted mapping to SMT
+    Uuf(Arc<Uuf>),          // SMTLib core theory of equality with uninterpreted functions (`UF`)
+    ZeroExtend(u32), // allowed to be 0. This is from the `BV` theory, like the variants that begin with `Bv`
 }
 
 impl ExtOp {


### PR DESCRIPTION
## Description of changes

Similar to #2139, we need the ordering of Op variants to be the same in Rust and Lean to avoid spurious mismatches in the SMTLib scripts generated by Rust and Lean.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
