### PR TITLE
refactor: remove into_components, make ast policy fields pub(crate) 

### DIFF
--- a/cedar-policy-core/src/ast/policy.rs
+++ b/cedar-policy-core/src/ast/policy.rs
@@ -433,18 +433,18 @@ fn describe_arity_error(
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Policy {
     /// Reference to the template
-    template: Arc<Template>,
+    pub(crate) template: Arc<Template>,
     /// Id of this link
     ///
     /// None in the case that this is an instance of a Static Policy
-    link: Option<PolicyID>,
+    pub(crate) link: Option<PolicyID>,
     // INVARIANT (values total map)
     // All of the slots in `template` MUST be bound by `values`
     //
     /// values the slots are bound to.
     /// The constructor `new` is only visible in this module,
     /// so it is the responsibility of callers to maintain
-    values: HashMap<SlotId, EntityUID>,
+    pub(crate) values: HashMap<SlotId, EntityUID>,
 }
 
 impl Policy {
@@ -499,20 +499,9 @@ impl Policy {
         Self::new(Arc::new(t), None, SlotEnv::new())
     }
 
-    /// Get the owned template, link id (if this is a template-linked policy)
-    /// and slot environment.
-    pub(crate) fn into_components(self) -> (Arc<Template>, Option<PolicyID>, SlotEnv) {
-        (self.template, self.link, self.values)
-    }
-
     /// Get pointer to the template for this policy
     pub fn template(&self) -> &Template {
         &self.template
-    }
-
-    /// Get pointer to the template for this policy, as an `Arc`
-    pub(crate) fn template_arc(&self) -> Arc<Template> {
-        Arc::clone(&self.template)
     }
 
     /// Get the effect (forbid or permit) of this policy.
@@ -651,12 +640,12 @@ impl Policy {
 impl std::fmt::Display for Policy {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.is_static() {
-            write!(f, "{}", self.template())
+            write!(f, "{}", self.template)
         } else {
             write!(
                 f,
                 "Template Instance of {}, slots: [{}]",
-                self.template().id(),
+                self.template.id(),
                 display_slot_env(self.env())
             )
         }

--- a/cedar-policy-core/src/ast/policy_set.rs
+++ b/cedar-policy-core/src/ast/policy_set.rs
@@ -112,7 +112,7 @@ impl TryFrom<LiteralPolicySet> for PolicySet {
             template_to_links_map.insert(template.0.clone(), LinkedHashSet::new());
         }
         for (link_id, link) in &links {
-            let template = link.template().id();
+            let template = link.template.id();
             match template_to_links_map.entry(template.clone()) {
                 Entry::Occupied(t) => t.into_mut().insert(link_id.clone()),
                 Entry::Vacant(_) => return Err(ReificationError::NoSuchTemplate(template.clone())),
@@ -217,7 +217,7 @@ impl PolicySet {
 
     /// Add a `Policy` to the `PolicySet`.
     pub fn add(&mut self, policy: Policy) -> Result<(), PolicySetError> {
-        let t = policy.template_arc();
+        let t = policy.template.clone();
 
         // we need to check for all possible errors before making any
         // modifications to `self`.
@@ -384,7 +384,7 @@ impl PolicySet {
             // Now update the id of the referenced template if this is a link.
             // If it's static, then we updated this already by updating the
             // policy's own id.
-            let other_policy = match renaming.get(other_policy.template().id()) {
+            let other_policy = match renaming.get(other_policy.template.id()) {
                 #[expect(
                     clippy::unwrap_used,
                     reason = "`if` confirms that `other_policy` is a template link"
@@ -593,7 +593,7 @@ impl PolicySet {
         match self.links.remove(policy_id) {
             Some(p) => {
                 #[expect(clippy::panic, reason = "every linked policy should have a template")]
-                match self.template_to_links_map.entry(p.template().id().clone()) {
+                match self.template_to_links_map.entry(p.template.id().clone()) {
                     Entry::Occupied(t) => t.into_mut().remove(policy_id),
                     Entry::Vacant(_) => {
                         panic!("No template found for linked policy")
@@ -1012,7 +1012,7 @@ mod test {
         let v: Vec<_> = s.policies().collect();
 
         assert_eq!(v[0].id(), &lid);
-        assert_eq!(v[0].template().id(), &tid);
+        assert_eq!(v[0].template.id(), &tid);
     }
 
     #[test]
@@ -1074,7 +1074,7 @@ mod test {
 
         let link = s.get(&link_id).expect("Link should exist");
         assert_eq!(&link_id, link.id());
-        assert_eq!(&template_id, link.template().id());
+        assert_eq!(&template_id, link.template.id());
         assert_eq!(
             &entity,
             link.env()
@@ -1160,7 +1160,7 @@ mod test {
         assert_eq!(pset.get(&id2).expect("should find the policy").id(), &id2);
         assert_eq!(pset.get(&id3).expect("should find link").id(), &id3);
         assert_eq!(
-            pset.get(&id3).expect("should find link").template().id(),
+            pset.get(&id3).expect("should find link").template.id(),
             &tid2
         );
         assert!(pset.get(&tid2).is_none());

--- a/cedar-policy-core/src/est/policy_set.rs
+++ b/cedar-policy-core/src/est/policy_set.rs
@@ -235,7 +235,7 @@ mod test {
             .get_template_arc(&PolicyID::from_string("template"))
             .is_some());
         let link = ast_policy_set.get(&PolicyID::from_string("link")).unwrap();
-        assert_eq!(link.template().id(), &PolicyID::from_string("template"));
+        assert_eq!(link.template.id(), &PolicyID::from_string("template"));
         assert_eq!(
             link.env(),
             &HashMap::from_iter([(SlotId::principal(), r#"User::"bob""#.parse().unwrap())])

--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -647,16 +647,16 @@ impl TryFrom<ast::Policy> for Policy {
     type Error = PstConstructionError;
 
     fn try_from(policy: ast::Policy) -> Result<Self, PstConstructionError> {
-        let (template, id, values) = policy.into_components();
-        let pst_template: Template = Arc::unwrap_or_clone(template).try_into()?;
+        let pst_template: Template = Arc::unwrap_or_clone(policy.template).try_into()?;
         if pst_template.is_static() {
             Ok(Policy::Static(pst_template.try_into()?))
         } else {
-            let values = values
+            let values = policy
+                .values
                 .into_iter()
                 .map(|(k, v)| (k.into(), v.into()))
                 .collect();
-            if let Some(ast_id) = id {
+            if let Some(ast_id) = policy.link {
                 Ok(Policy::Linked(LinkedPolicy {
                     body: Arc::new(pst_template),
                     values,
@@ -1043,7 +1043,7 @@ mod tests {
         let ast_policy2: ast::Policy = pst_policy.try_into().expect("pst->ast failed");
         let expected =
             normalize(r#"permit( principal == ?principal, action, resource in ?resource );"#);
-        assert_eq!(normalize(&ast_policy2.template().to_string()), expected);
+        assert_eq!(normalize(&ast_policy2.template.to_string()), expected);
     }
 
     /// Test expressions that get desugared/normalized during AST conversion

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -48,14 +48,13 @@ pub(crate) fn policy_expr_map<'a>(
             return Err(NonstaticPolicyError.into());
         }
 
-        let t = p.template();
-
-        let errs: Vec<_> = Validator::validate_entity_types_and_literals(schema, t).collect();
+        let errs: Vec<_> =
+            Validator::validate_entity_types_and_literals(schema, &p.template).collect();
         if !errs.is_empty() {
             return Err(TpeError::Validation(errs));
         }
 
-        match tc.typecheck_by_single_request_env(t, &env) {
+        match tc.typecheck_by_single_request_env(&p.template, &env) {
             PolicyCheck::Success(expr) => {
                 exprs.insert(p.id(), expr);
             }

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -542,12 +542,11 @@ mod test {
         let expr = parse_expr(expr_str).unwrap();
         let policy_id = crate::ast::PolicyID::from_string("test");
         let policy = Policy::from_when_clause(Effect::Permit, expr, policy_id, None);
-        let t = policy.template();
 
         let schema = ValidatorSchema::from_cedarschema_str(r#"
             entity User in Organization { foo: Bool, str: String, num: Long, period: __cedar::duration, set: Set<String> } tags String;
             entity Organization;
-            entity Document in Organization; 
+            entity Document in Organization;
             action get appliesTo { principal: [User], resource: [Document] };"#,
             &Extensions::all_available(),
         )
@@ -572,11 +571,12 @@ mod test {
         .unwrap();
         let env = request.find_request_env(&schema).unwrap();
 
-        let errs: Vec<_> = Validator::validate_entity_types_and_literals(&schema, t).collect();
+        let errs: Vec<_> =
+            Validator::validate_entity_types_and_literals(&schema, &policy.template).collect();
         if !errs.is_empty() {
             panic!("unexpected type error in expression");
         }
-        match typechecker.typecheck_by_single_request_env(t, &env) {
+        match typechecker.typecheck_by_single_request_env(&policy.template, &env) {
             PolicyCheck::Success(expr) => Residual::try_from(&expr).unwrap(),
             PolicyCheck::Fail(errs) => {
                 println!("got {} type errors", errs.len());
@@ -606,9 +606,9 @@ mod test {
             parse_residual(
                 r#"
                 principal is User &&
-                principal in Organization::"foo" && 
-                action == Action::"get" && 
-                resource is Document && 
+                principal in Organization::"foo" &&
+                action == Action::"get" &&
+                resource is Document &&
                 resource in Organization::"foo"
                 "#
             )
@@ -633,8 +633,8 @@ mod test {
         assert_eq!(
             parse_residual(
                 r#"
-                if principal.hasTag("foo") then 
-                    principal in Organization::"foo" 
+                if principal.hasTag("foo") then
+                    principal in Organization::"foo"
                 else principal in Organization::"bar"
                 "#
             )
@@ -644,10 +644,10 @@ mod test {
         assert_eq!(
             parse_residual(
                 r#"
-                1 == 2 || 
-                !("a" == "b") && 
-                ["a", "b"].contains("a") && 
-                !["a", "b"].containsAll(["a"]) && 
+                1 == 2 ||
+                !("a" == "b") &&
+                ["a", "b"].contains("a") &&
+                !["a", "b"].containsAll(["a"]) &&
                 ["a", "b"].containsAny(["a"])
                 "#
             )
@@ -678,8 +678,8 @@ mod test {
             parse_residual(
                 r#"
                 !principal.set.isEmpty() && (
-                    principal.set.contains("foo") || 
-                    principal.set.containsAll(["foo", "bar"]) || 
+                    principal.set.contains("foo") ||
+                    principal.set.containsAll(["foo", "bar"]) ||
                     principal.set.containsAny(["foo", "bar"])
                 )"#
             )

--- a/cedar-policy-core/src/validator/typecheck/test/type_annotation.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/type_annotation.rs
@@ -277,7 +277,7 @@ fn non_idempotent() {
             template.id().clone(),
             template.loc().cloned(),
         );
-        assert_matches!(typechecker.typecheck_by_single_request_env(&transformed.template(), &req_env), PolicyCheck::Success(retransformed) => {
+        assert_matches!(typechecker.typecheck_by_single_request_env(&transformed.template, &req_env), PolicyCheck::Success(retransformed) => {
             // after re-typechecking, the policy is transformed into this:
             assert_eq!(retransformed.to_string(), r#"true && (true && (true && (true && ((action in [Action::"action"]) && ((resource is a) && (((true && (if (if (if true then true else true) then (if true then true else true) else (if true then true else true)) then (a::"".hasTag(if true then "" else "")) else (a::"".hasTag(if true then "" else "")))) && (if (a::"".hasTag(if true then "" else "")) then (if (if true then true else true) then (if true then true else true) else (if true then true else true)) else (if (if true then true else true) then (if true then true else true) else (if true then true else true)))) && (a::"".hasTag(""))))))))"#);
             // in particular, note that it no longer contains the `principal in a::""` term


### PR DESCRIPTION
Small refactor making ast Policy fields pub(crate), removing `into_components` and `template_arc`. Callers in the crate now deal with the `Arc<Template>` directly instead of calling `template()` / `template_arc()`. 

This is not necessarily a PR we need to merge: it makes it easier to create policies without checking the invariants in the crate, although I don't think there's a high risk.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.