### PR TITLE
Fix proto Entity decode: swap parents and indirect_ancestors (#2239)

### DIFF
--- a/cedar-policy/src/proto/ast.rs
+++ b/cedar-policy/src/proto/ast.rs
@@ -145,8 +145,8 @@ impl From<models::Entity> for ast::Entity {
         Self::new_with_attr_partial_value(
             ast::EntityUID::from(v.uid.expect("uid field should exist")),
             attrs,
-            ancestors,
             HashSet::new(),
+            ancestors,
             tags,
         )
     }
@@ -703,16 +703,18 @@ mod test {
         assert_eq!(euid3, ast::EntityUID::from(models::EntityUid::from(&euid3)));
 
         let attrs = (1..=7).map(|id| (format!("{id}").into(), ast::RestrictedExpr::val(true)));
+        let parent = ast::EntityUID::with_eid_and_type("Folder", "shared").unwrap();
         let entity = ast::Entity::new(
             r#"Foo::"bar""#.parse().unwrap(),
             attrs,
-            HashSet::new(),
+            HashSet::from([parent.clone()]),
             HashSet::new(),
             [],
             Extensions::none(),
         )
         .unwrap();
         assert_eq!(entity, ast::Entity::from(models::Entity::from(&entity)));
+        assert!(ast::Entity::from(models::Entity::from(&entity)).is_child_of(&parent));
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Fix proto `Entity` decode placing ancestors into `indirect_ancestors` instead of `parents` in `new_with_attr_partial_value`. This caused the `in` operator to fail when a proto-decoded entity was added to an `Entities` set via `add_entities`, because `TCComputation::ComputeNow` only reads the `parents` field.

The fix swaps the two arguments so ancestors go into `parents` and `indirect_ancestors` starts empty (to be computed by TC).


## Issue #, if available

#2239 

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [X] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
