### PR TITLE
fix entity name conversion in PST EST

### DIFF
--- a/cedar-policy-core/src/pst/est_conversions.rs
+++ b/cedar-policy-core/src/pst/est_conversions.rs
@@ -17,7 +17,7 @@
 //! Conversions between EST and PST representations.
 
 use super::{
-    ActionConstraint, Clause, Effect, EntityOrSlot, EntityType, EntityUID, Expr, Name, PolicyID,
+    ActionConstraint, Clause, Effect, EntityOrSlot, EntityType, EntityUID, Expr, PolicyID,
     PrincipalConstraint, PstConstructionError, ResourceConstraint, Template,
 };
 use crate::ast;
@@ -37,11 +37,9 @@ use std::sync::Arc;
 /// and error handling.
 fn parse_entity_type(s: &smol_str::SmolStr) -> Result<EntityType, PstConstructionError> {
     let ast_name = ast::Name::from_str(s).map_err(|e| {
-        PstConstructionError::ParsingFailed(error_body::ParsingFailedError {
-            description: e.to_string(),
-        })
+        PstConstructionError::ParsingFailed(error_body::ParsingFailedError::new(e.to_string()))
     })?;
-    Ok(EntityType::from_name(Name::from(ast_name)))
+    Ok(EntityType::from_name(ast_name))
 }
 
 #[doc(hidden)]
@@ -422,8 +420,8 @@ impl From<EntityUID> for entities::EntityUidJson {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::pst::{self, BinaryOp, UnaryOp};
-    use smol_str::SmolStr;
+    use crate::pst::{self, BinaryOp, Name, UnaryOp};
+    use smol_str::{format_smolstr, SmolStr};
     use std::collections::BTreeMap;
 
     fn roundtrips(e: Expr) {
@@ -436,6 +434,22 @@ mod tests {
         let est: est::Policy = p.clone().try_into().unwrap();
         let roundtrip_p: Template = est.try_into().unwrap();
         assert!(roundtrip_p == p)
+    }
+
+    #[test]
+    fn test_parse_entities() {
+        // Success case: unqualified entity type
+        let et = parse_entity_type(&format_smolstr!("A")).unwrap();
+        assert_eq!(et.0.id, "A");
+        assert_eq!(et.0.namespace.len(), 0);
+        // Success case: qualified entity type
+        let et = parse_entity_type(&format_smolstr!("A::a")).unwrap();
+        assert_eq!(et.0.id, "a");
+        assert_eq!(et.0.namespace.len(), 1);
+        assert_eq!(et.0.namespace[0], "A");
+        // Failure
+        let et = parse_entity_type(&format_smolstr!("!!A::a"));
+        matches!(et, Err(PstConstructionError::ParsingFailed(_)));
     }
 
     #[test]


### PR DESCRIPTION
## Description of changes

Fix a bug in EST to PST conversion where qualified names stored as a string in the EST would get converted into an unqualified name that is effectively the string of a qualified name. 
Found the bug while building fuzzing for roundtrip PST -> EST -> PST.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.