### PR TITLE
pst operators: explicit decimal lessThan, lessThanOrEqual, ...

### DIFF
--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -419,6 +419,14 @@ pub enum BinaryOp {
     Offset,
     /// `left.durationSince(right)`
     DurationSince,
+    /// `left.lessThan(right)` (decimal less than)
+    DecimalLessThan,
+    /// `left.lessThanOrEqual(right)` (decimal less than or equal)
+    DecimalLessEq,
+    /// `left.greaterThan(right)` (decimal greater than)
+    DecimalGreater,
+    /// `left.greaterThanOrEqual(right)` (decimal greater than or equal)
+    DecimalGreaterEq,
 }
 
 impl BinaryOp {
@@ -428,6 +436,12 @@ impl BinaryOp {
             BinaryOp::IsInRange => Some(&extensions::ipaddr::names::IS_IN_RANGE),
             BinaryOp::Offset => Some(&extensions::datetime::constants::OFFSET_METHOD_NAME),
             BinaryOp::DurationSince => Some(&extensions::datetime::constants::DURATION_SINCE_NAME),
+            BinaryOp::DecimalLessThan => Some(&extensions::decimal::constants::LESS_THAN),
+            BinaryOp::DecimalLessEq => Some(&extensions::decimal::constants::LESS_THAN_OR_EQUAL),
+            BinaryOp::DecimalGreater => Some(&extensions::decimal::constants::GREATER_THAN),
+            BinaryOp::DecimalGreaterEq => {
+                Some(&extensions::decimal::constants::GREATER_THAN_OR_EQUAL)
+            }
             // those are operators, not names
             BinaryOp::Eq
             | BinaryOp::NotEq
@@ -452,10 +466,10 @@ impl BinaryOp {
     /// Parse a binary operator from a function name
     pub(crate) fn from_function_name(name: &str) -> Option<Self> {
         match name {
-            "lessThan" => Some(BinaryOp::Less),
-            "lessThanOrEqual" => Some(BinaryOp::LessEq),
-            "greaterThan" => Some(BinaryOp::Greater),
-            "greaterThanOrEqual" => Some(BinaryOp::GreaterEq),
+            "lessThan" => Some(BinaryOp::DecimalLessThan),
+            "lessThanOrEqual" => Some(BinaryOp::DecimalLessEq),
+            "greaterThan" => Some(BinaryOp::DecimalGreater),
+            "greaterThanOrEqual" => Some(BinaryOp::DecimalGreaterEq),
             "isInRange" => Some(BinaryOp::IsInRange),
             "offset" => Some(BinaryOp::Offset),
             "durationSince" => Some(BinaryOp::DurationSince),
@@ -1206,6 +1220,8 @@ impl std::fmt::Display for Expr {
 )]
 #[cfg(test)]
 mod tests {
+    use cool_asserts::assertion_failure;
+
     use super::*;
     use std::str::FromStr;
 
@@ -1304,20 +1320,40 @@ mod tests {
                             "Expected unary unknown function to be Unknown expr",
                         );
                     } else {
-                        assert!(
-                            matches!(actual, Expr::UnaryOp { .. }),
-                            "Unary function {} should produce UnaryOp",
-                            name
-                        );
+                        match actual {
+                            Expr::UnaryOp { op, .. } => {
+                                let op_name = op.to_name();
+                                assert!(
+                                    op_name.is_some(),
+                                    "UnaryOp from extension {} should have known ast::Name",
+                                    name
+                                );
+                                assert_eq!(
+                                    UnaryOp::from_function_name(&name.as_ref().to_string()),
+                                    Some(op)
+                                );
+                            }
+                            _ => {
+                                assertion_failure!("Unary function  should produce BinaryOp", name:name)
+                            }
+                        }
                     }
                 }
-                2 => {
-                    assert!(
-                        matches!(actual, Expr::BinaryOp { .. }),
-                        "Binary function {} should produce BinaryOp",
-                        name
-                    );
-                }
+                2 => match actual {
+                    Expr::BinaryOp { op, .. } => {
+                        let op_name = op.to_name();
+                        assert!(
+                            op_name.is_some(),
+                            "BinaryOp from extension {} should have known ast::Name",
+                            name
+                        );
+                        assert_eq!(
+                            BinaryOp::from_function_name(&name.as_ref().to_string()),
+                            Some(op)
+                        );
+                    }
+                    _ => assertion_failure!("Binary function  should produce BinaryOp", name:name),
+                },
                 _ => (),
             }
         }


### PR DESCRIPTION
## Description of changes
Adds operators for the `decimal` `lessThan`, `lessThanOrEqual`, `greaterThan` and `greaterThanOrEqual` methods. Previously, all operations were translated to the `Less, LessEq, Greater, GreaterEq` (comparisons over the other types) but Cedar represents comparisons over decimals separately.

With this we can follow up on https://github.com/cedar-policy/cedar-spec/pull/913 to test AST roundtrip with PST (AST -> PST -> AST).

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
