### PR TITLE
fix: replace to_smolstr that escapes by into_smolstr that doesnt 

### DIFF
--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -16,8 +16,6 @@
 
 //! Conversions between PST and AST types
 
-use smol_str::ToSmolStr;
-
 use super::{
     ActionConstraint, BinaryOp, Clause, Effect, EntityOrSlot, EntityType, EntityUID, Expr,
     LinkedPolicy, Literal, Name, PatternElem, Policy, PolicyID, PrincipalConstraint,
@@ -632,7 +630,7 @@ impl TryFrom<ast::Template> for Template {
         ) = template
             .into_template_components_opt()
             .ok_or_else(|| InvalidConversionError::new("template contained errors".to_string()))?;
-        let id = PolicyID(id.to_smolstr());
+        let id = PolicyID(id.into_smolstr());
         let effect = effect.into();
         let principal = principal_constraint.into();
         let action = action_constraint.into();
@@ -956,9 +954,12 @@ mod tests {
     /// Test roundtrip: parse Cedar text -> ast::Template -> pst::Policy -> ast::Template
     /// and verify the string representation is preserved.
     fn assert_template_roundtrip(cedar_text: &str) {
-        let ast_template = parser::parse_template(None, cedar_text).expect("parse failed");
+        let ast_template =
+            parser::parse_template(Some(ast::PolicyID::from_string("id\n")), cedar_text)
+                .expect("parse failed");
         let pst_policy: Template = ast_template.clone().try_into().expect("ast->pst failed");
         let ast_template2: ast::Template = pst_policy.try_into().expect("pst->ast failed");
+        assert_eq!(ast_template.id(), ast_template2.id());
         assert_eq!(
             normalize(&ast_template.to_string()),
             normalize(&ast_template2.to_string()),


### PR DESCRIPTION
Pst conversion to Ast was using `to_smolstr`, which calls `debug_escape` and caused rountrip PST -> AST -> PST to fail.
Instead we should use `into_smolstr`.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.