### PR TITLE
AST error node conversion results in error in PST

### DIFF
--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -26,8 +26,10 @@ use super::{
 use crate::ast::IsInfallible;
 use crate::ast::{self, UnwrapInfallible};
 use crate::expr_builder;
+#[cfg(feature = "tolerant-ast")]
+use crate::pst::err::error_body::UnsupportedErrorNode;
 use crate::pst::err::error_body::{
-    InvalidConversionError, InvalidExpressionError, ParsingFailedError, UnsupportedErrorNode,
+    InvalidConversionError, InvalidExpressionError, ParsingFailedError,
 };
 use crate::pst::expr::PstBuilder;
 use itertools::Itertools;


### PR DESCRIPTION
## Description of changes

Fix behavior on converting AST error nodes when using `tolerant-ast` to PST, now results in error.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.) - PST not released

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
