### PR TITLE
tolerant-ast and protobuf should not be silently compatible

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,6 +15,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ### Added
 
 - Public syntax tree representation for `Policy`, `Template` and `PolicySet` allowing programmatic manipulation of Cedar syntax (#816, #366).
+- Explicit failure when using experimental features `tolerant-ast` and `protobuf` together: serialization of policies with error in action constraint fails.
 
 ## [4.10.0] - Coming soon
 

--- a/cedar-policy/src/proto/policy.rs
+++ b/cedar-policy/src/proto/policy.rs
@@ -354,14 +354,9 @@ impl From<&ast::ActionConstraint> for models::ActionConstraint {
                 )),
             },
             #[cfg(feature = "tolerant-ast")]
-            ast::ActionConstraint::ErrorConstraint =>
-            // Treat an error constraint as an Any constraint for Protobufs since Protobufs schema model has no Error
-            {
-                Self {
-                    data: Some(models::action_constraint::Data::Any(
-                        models::action_constraint::Any::Unit.into(),
-                    )),
-                }
+            #[expect(clippy::unimplemented, reason = "experimental feature")]
+            ast::ActionConstraint::ErrorConstraint => {
+                unimplemented!("tolerant-ast cannot be used with the protobuf feature")
             }
         }
     }


### PR DESCRIPTION
## Description of changes
Mark conversion of error node in action constraint `uninmplemented`, following same behavior in other locations where `tolerant-ast` and `protobufs` interact.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.