### PR TITLE
fix(smt): support Windows CRLF in SMT-LIB output parsing

### DIFF
--- a/cedar-policy-symcc/src/symcc/solver.rs
+++ b/cedar-policy-symcc/src/symcc/solver.rs
@@ -480,4 +480,40 @@ mod test {
         let status = my_solver.child.try_wait().unwrap();
         assert!(status.is_some());
     }
+
+    #[tokio::test]
+    async fn check_sat_crlf_test() {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", "read line && printf 'sat\r\n'"]);
+        let mut solver = LocalSolver::from_command(&mut cmd).unwrap();
+        let decision = solver.check_sat().await.unwrap();
+        assert_eq!(decision, Decision::Sat);
+    }
+
+    #[tokio::test]
+    async fn check_sat_with_model_crlf_test() {
+        let mut cmd = Command::new("sh");
+        cmd.args([
+            "-c",
+            "read line && printf 'sat\\r\\n' && read line && printf '(\\r\\n  define-fun x () Int 0\\r\\n)\\r\\n'",
+        ]);
+        let mut solver = LocalSolver::from_command(&mut cmd).unwrap();
+
+        let decision = solver.check_sat_with_model().await.unwrap();
+
+        assert_matches!(decision, DecisionWithModel::Sat { model } => {
+            assert_eq!(model, "(\r\n  define-fun x () Int 0\r\n)\r\n");
+        });
+    }
+
+    #[tokio::test]
+    async fn process_error_output_parse_error_no_line_ending_test() {
+        let mut solver = LocalSolver::cvc5().unwrap();
+        let res = solver
+            .process_error_output("(error \"Parse Error: mock windows error\")")
+            .await;
+        assert_matches!(res, SolverError::Solver(msg) => {
+            assert_eq!(msg, "Parse Error: mock windows error");
+        });
+    }
 }


### PR DESCRIPTION
## Description of changes

Windows-based SMT solvers (e.g., cvc5) typically output lines ending with `\r\n` (CRLF). The current implementation used strict string matching for solver responses like `sat\n`, `unsat\n`, `unknown\n`.

This PR introduces `.trim()` when matching the solver's stdout lines to ensure that trailing carriage returns do not cause parsing failures. Specifically:

+ Updated `check_sat()` to handle trimmed status strings.
+ Updated `check_sat_with_model()` to handle trimmed delimiters.

## Issue #, if available

N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] [UPD] For the consistency, I apply the same logic on [cedar-spec#914](https://github.com/cedar-policy/cedar-spec/pull/914)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.