### PR TITLE
update changelog 4.10.0 to account for new cherry-picks

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,7 +15,6 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ### Added
 
 - Public syntax tree representation for `Policy`, `Template` and `PolicySet` allowing programmatic manipulation of Cedar syntax (#816, #366).
-- Explicit failure when using experimental features `tolerant-ast` and `protobuf` together: serialization of policies with error in action constraint fails.
 
 ## [4.10.0] - Coming soon
 
@@ -23,7 +22,16 @@ Cedar Language Version: 4.5
 
 ### Added
 
-- Extended `has` operator in JSON policies, maintaining backwards-compatible desugaring of extended `has` in Cedar policies to json (#1889)
+- Extended `has` operator in JSON policies, maintaining backwards-compatible desugaring of extended `has` in Cedar policies to json (#1889).
+
+### Changed
+
+- Explicit failure when using experimental features `tolerant-ast` and `protobuf` together: serialization of policies with error in action constraint fails (#2248, #2247).
+
+### Fixed
+
+- Decoding entities with parents and indirect ancestors in `protobuf` (#2240).
+
 
 ## [4.9.1] - 2026-02-27
 


### PR DESCRIPTION
## Description of changes

Updates the changelog for 4.10.0 to account for new cherry-picks in #2257 .

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
