### PR TITLE
upgrade cvc5 1.2.1 -> 1.3.1

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,7 +31,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code -A unfulfilled_lint_expectations' # deny rustc warnings, except allow on unfulfilled_lint_expectations. note that none of this line affects _clippy_ warnings, only _rustc_ warnings
+      RUSTFLAGS: "-D warnings -F unsafe-code -A unfulfilled_lint_expectations" # deny rustc warnings, except allow on unfulfilled_lint_expectations. note that none of this line affects _clippy_ warnings, only _rustc_ warnings
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -80,19 +80,19 @@ jobs:
       - name: Install cvc5
         shell: bash
         run: |
-              ARCH=$(uname -m)
-              if [ "$ARCH" = "x86_64" ]; then
-                ARCH_NAME="x86_64"
-              elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-                ARCH_NAME="arm64"
-              else
-                echo "Unsupported architecture: $ARCH"
-                exit 1
-              fi
-              wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.2.1/cvc5-Linux-${ARCH_NAME}-static.zip
-              unzip cvc5-Linux-${ARCH_NAME}-static.zip
-              chmod +x cvc5-Linux-${ARCH_NAME}-static/bin/cvc5
-              echo "CVC5=$GITHUB_WORKSPACE/cvc5-Linux-${ARCH_NAME}-static/bin/cvc5" >> $GITHUB_ENV
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then
+            ARCH_NAME="x86_64"
+          elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+            ARCH_NAME="arm64"
+          else
+            echo "Unsupported architecture: $ARCH"
+            exit 1
+          fi
+          wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.1/cvc5-Linux-${ARCH_NAME}-static.zip
+          unzip cvc5-Linux-${ARCH_NAME}-static.zip
+          chmod +x cvc5-Linux-${ARCH_NAME}-static/bin/cvc5
+          echo "CVC5=$GITHUB_WORKSPACE/cvc5-Linux-${ARCH_NAME}-static/bin/cvc5" >> $GITHUB_ENV
 
       - run: cargo test --verbose
       - run: cargo test --verbose --benches
@@ -149,10 +149,10 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-    - uses: taiki-e/install-action@fe18b65ff0d7a76aced2f43aeace5de8f236b1f7 # cargo-hack
-    - run: sudo apt-get update && sudo apt-get install protobuf-compiler
-    - run: cargo hack check --rust-version --workspace --all-targets --ignore-private --all-features
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: taiki-e/install-action@fe18b65ff0d7a76aced2f43aeace5de8f236b1f7 # cargo-hack
+      - run: sudo apt-get update && sudo apt-get install protobuf-compiler
+      - run: cargo hack check --rust-version --workspace --all-targets --ignore-private --all-features
 
   wasm-build:
     name: run wasm build script
@@ -162,7 +162,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code'
+      RUSTFLAGS: "-D warnings -F unsafe-code"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/run_integration_tests_reusable.yml
+++ b/.github/workflows/run_integration_tests_reusable.yml
@@ -27,7 +27,7 @@ jobs:
     # Set `RUSTFLAGS` once for all cargo commands so that changing these flags
     # doesn't trigger a fresh build.
     env:
-      RUSTFLAGS: '-D warnings -F unsafe-code -A unfulfilled_lint_expectations' # deny rustc warnings, except allow on unfulfilled_lint_expectations. note that none of this line affects _clippy_ warnings, only _rustc_ warnings
+      RUSTFLAGS: "-D warnings -F unsafe-code -A unfulfilled_lint_expectations" # deny rustc warnings, except allow on unfulfilled_lint_expectations. note that none of this line affects _clippy_ warnings, only _rustc_ warnings
 
     steps:
       - name: Checkout cedar
@@ -55,23 +55,22 @@ jobs:
       - name: Install cvc5
         shell: bash
         run: |
-              ARCH=$(uname -m)
-              if [ "$ARCH" = "x86_64" ]; then
-                ARCH_NAME="x86_64"
-              elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
-                ARCH_NAME="arm64"
-              else
-                echo "Unsupported architecture: $ARCH"
-                exit 1
-              fi
-              wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.2.1/cvc5-Linux-${ARCH_NAME}-static.zip
-              unzip cvc5-Linux-${ARCH_NAME}-static.zip
-              chmod +x cvc5-Linux-${ARCH_NAME}-static/bin/cvc5
-              echo "CVC5=$GITHUB_WORKSPACE/cvc5-Linux-${ARCH_NAME}-static/bin/cvc5" >> $GITHUB_ENV
+          ARCH=$(uname -m)
+          if [ "$ARCH" = "x86_64" ]; then
+            ARCH_NAME="x86_64"
+          elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+            ARCH_NAME="arm64"
+          else
+            echo "Unsupported architecture: $ARCH"
+            exit 1
+          fi
+          wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.3.1/cvc5-Linux-${ARCH_NAME}-static.zip
+          unzip cvc5-Linux-${ARCH_NAME}-static.zip
+          chmod +x cvc5-Linux-${ARCH_NAME}-static/bin/cvc5
+          echo "CVC5=$GITHUB_WORKSPACE/cvc5-Linux-${ARCH_NAME}-static/bin/cvc5" >> $GITHUB_ENV
       - name: Run handwritten integration tests
         working-directory: ./cedar
         run: cargo test --verbose --features "integration-testing"
       - name: Run corpus tests
         working-directory: ./cedar
         run: cargo test --verbose --features "integration-testing" -- --ignored
-      

--- a/cedar-policy-symcc/README.md
+++ b/cedar-policy-symcc/README.md
@@ -20,10 +20,10 @@ produce a counterexample (a synthesized request and entity store) if the propert
 
 ## Setup
 
-To get started, first download or compile the [cvc5-1.2.1](https://github.com/cvc5/cvc5/releases/tag/cvc5-1.2.1) SMT solver.
+To get started, first download or compile the [cvc5-1.3.1](https://github.com/cvc5/cvc5/releases/tag/cvc5-1.3.1) SMT solver.
 The following example assumes that you have set the following environment variable:
 ```sh
-CVC5=<path to cvc5 1.2.1 executable>
+CVC5=<path to cvc5 1.3.1 executable>
 ```
 
 ## Example
@@ -85,7 +85,7 @@ To learn more about what you can do with SymCC, see the documentation of the `Ce
 To build and test this crate, run the following commands from the root of the repository:
 ```sh
 cargo build -p cedar-policy-symcc
-CVC5=<absolute path to cvc5 1.2.1 executable> cargo test -p cedar-policy-symcc
+CVC5=<absolute path to cvc5 1.3.1 executable> cargo test -p cedar-policy-symcc
 ```
 
 Structure of this crate:


### PR DESCRIPTION
## Description of changes

We can upgrade `cvc5` version `1.2.1` to `1.3.1` in CI and in documentation.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
