### PR TITLE
Refactor assert!(matches!(..)) -> assert_matches!(..) + fix two clipp…

### DIFF
--- a/cedar-policy-cli/src/lib.rs
+++ b/cedar-policy-cli/src/lib.rs
@@ -1599,7 +1599,7 @@ pub fn symcc(args: &SymccArgs) -> CedarExitCode {
 
 #[cfg(feature = "analyze")]
 fn initialize_solver(
-    cvc5_path: &Option<PathBuf>,
+    cvc5_path: Option<&PathBuf>,
 ) -> Result<cedar_policy_symcc::solver::LocalSolver> {
     match cvc5_path {
         Some(p) => cedar_policy_symcc::solver::LocalSolver::from_command(
@@ -1734,7 +1734,7 @@ fn build_request_env(args: &SymccArgs) -> Result<RequestEnv> {
 async fn symcc_async(args: &SymccArgs) -> Result<()> {
     use cedar_policy_symcc::{CedarSymCompiler, CompiledPolicy, CompiledPolicySet};
 
-    let solver = initialize_solver(&args.cvc5_path)?;
+    let solver = initialize_solver(args.cvc5_path.as_ref())?;
     let mut compiler = CedarSymCompiler::new(solver)
         .map_err(|e| miette!("Failed to initialize SymCC compiler: {e}"))?;
     let req_env = build_request_env(args)?;

--- a/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
+++ b/cedar-policy-core/src/parser/cst_to_ast/to_ref_or_refs.rs
@@ -493,13 +493,14 @@ mod test {
     use crate::parser::cst_to_ast::TolerantAstSetting;
     use crate::parser::Loc;
     use crate::parser::Node;
+    use cool_asserts::assert_matches;
 
     #[test]
     fn to_ref_or_refs_tolerant_ast() {
         let n = test_primary_name_node();
         let result =
             n.to_ref_or_refs::<SingleEntity>(ast::Var::Principal, TolerantAstSetting::Tolerant);
-        assert!(matches!(result.unwrap().0, EntityUID::Error));
+        assert_matches!(result.unwrap().0, EntityUID::Error);
 
         let n = test_primary_literal_node();
         let result =
@@ -514,17 +515,17 @@ mod test {
         let n = test_primary_expr_error_node();
         let result =
             n.to_ref_or_refs::<SingleEntity>(ast::Var::Principal, TolerantAstSetting::Tolerant);
-        assert!(matches!(result.unwrap().0, EntityUID::Error));
+        assert_matches!(result.unwrap().0, EntityUID::Error);
 
         let n = test_primary_expr_node();
         let result =
             n.to_ref_or_refs::<SingleEntity>(ast::Var::Principal, TolerantAstSetting::Tolerant);
-        assert!(matches!(result.unwrap().0, EntityUID::EntityUID(_)));
+        assert_matches!(result.unwrap().0, EntityUID::EntityUID(_));
 
         let n = test_primary_ref_node();
         let result =
             n.to_ref_or_refs::<SingleEntity>(ast::Var::Principal, TolerantAstSetting::Tolerant);
-        assert!(matches!(result.unwrap().0, EntityUID::EntityUID(_)));
+        assert_matches!(result.unwrap().0, EntityUID::EntityUID(_));
 
         let n = test_primary_elist_node();
         let result =

--- a/cedar-policy-core/src/parser/text_to_cst.rs
+++ b/cedar-policy-core/src/parser/text_to_cst.rs
@@ -186,14 +186,14 @@ pub fn parse_expr_tolerant(text: &str) -> Result<Node<Option<cst::Expr>>, err::P
 #[expect(clippy::indexing_slicing, reason = "unit test code")]
 #[cfg(test)]
 mod tests {
+    use super::*;
     #[cfg(feature = "tolerant-ast")]
     use crate::parser::cst::Expr;
     #[cfg(feature = "tolerant-ast")]
     use crate::parser::cst::Policy;
     use crate::parser::test_utils::*;
     use crate::test_utils::*;
-
-    use super::*;
+    use cool_asserts::assert_matches;
 
     #[track_caller]
     fn assert_parse_succeeds<T>(
@@ -1536,9 +1536,9 @@ mod tests {
         let policies = assert_parse_succeeds(parse_policies_tolerant, src);
         assert_eq!(policies.0.len(), 2);
         let (policy1, _) = policies.0[0].clone().into_inner();
-        assert!(matches!(policy1.unwrap(), Policy::PolicyError));
+        assert_matches!(policy1.unwrap(), Policy::PolicyError);
         let (policy2, _) = policies.0[1].clone().into_inner();
-        assert!(matches!(policy2.unwrap(), Policy::Policy(_)));
+        assert_matches!(policy2.unwrap(), Policy::Policy(_));
 
         let src = r#"
         permit(principal, action, resource);
@@ -1547,9 +1547,9 @@ mod tests {
         let policies = assert_parse_succeeds(parse_policies_tolerant, src);
         assert_eq!(policies.0.len(), 2);
         let (policy1, _) = policies.0[1].clone().into_inner();
-        assert!(matches!(policy1.unwrap(), Policy::PolicyError));
+        assert_matches!(policy1.unwrap(), Policy::PolicyError);
         let (policy2, _) = policies.0[0].clone().into_inner();
-        assert!(matches!(policy2.unwrap(), Policy::Policy(_)));
+        assert_matches!(policy2.unwrap(), Policy::Policy(_));
     }
 
     #[test]
@@ -1559,13 +1559,13 @@ mod tests {
             permit(principal, action, resource);
         "#;
         let policy = assert_parse_succeeds(parse_policy_tolerant, src);
-        assert!(matches!(policy, Policy::Policy(_)));
+        assert_matches!(policy, Policy::Policy(_));
 
         let src = r#"
             permit(principal, act;
         "#;
         let policy = assert_parse_succeeds(parse_policy_tolerant, src);
-        assert!(matches!(policy, Policy::PolicyError));
+        assert_matches!(policy, Policy::PolicyError);
     }
 
     #[test]
@@ -1575,24 +1575,24 @@ mod tests {
             x ==
         "#;
         let e = assert_parse_succeeds(parse_expr_tolerant, src);
-        assert!(matches!(e, Expr::ErrorExpr));
+        assert_matches!(e, Expr::ErrorExpr);
 
         let src = r#"
              == y
         "#;
         let e = assert_parse_succeeds(parse_expr_tolerant, src);
-        assert!(matches!(e, Expr::ErrorExpr));
+        assert_matches!(e, Expr::ErrorExpr);
 
         let src = r#"
             (1 + 2) -
         "#;
         let e = assert_parse_succeeds(parse_expr_tolerant, src);
-        assert!(matches!(e, Expr::ErrorExpr));
+        assert_matches!(e, Expr::ErrorExpr);
 
         let src = r#"
             x == y
         "#;
         let e = assert_parse_succeeds(parse_expr_tolerant, src);
-        assert!(matches!(e, Expr::Expr(_)));
+        assert_matches!(e, Expr::Expr(_));
     }
 }

--- a/cedar-policy-core/src/pst/err.rs
+++ b/cedar-policy-core/src/pst/err.rs
@@ -413,6 +413,7 @@ pub mod error_body {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cool_asserts::assert_matches;
 
     #[test]
     fn from_json_error_conversions() {
@@ -429,7 +430,7 @@ mod tests {
         let json_deser_err: crate::entities::json::err::JsonDeserializationError = serde_err.into();
         let err: PstConstructionError =
             FromJsonError::JsonDeserializationError(json_deser_err).into();
-        assert!(matches!(err, PstConstructionError::ParsingFailed(..)));
+        assert_matches!(err, PstConstructionError::ParsingFailed(..));
 
         // ActionSlot
         let err: PstConstructionError = FromJsonError::ActionSlot.into();
@@ -445,11 +446,11 @@ mod tests {
                 euids: nonempty::nonempty![std::sync::Arc::new(euid)],
             })
             .into();
-        assert!(matches!(err, PstConstructionError::InvalidEntityType(..)));
+        assert_matches!(err, PstConstructionError::InvalidEntityType(..));
 
         // InvalidSlotName
         let err: PstConstructionError = FromJsonError::InvalidSlotName.into();
-        assert!(matches!(err, PstConstructionError::ParsingFailed(..)));
+        assert_matches!(err, PstConstructionError::ParsingFailed(..));
 
         // TemplateToPolicy
         let err: PstConstructionError = FromJsonError::TemplateToPolicy(
@@ -461,7 +462,7 @@ mod tests {
             },
         )
         .into();
-        assert!(matches!(err, PstConstructionError::ContainsSlots(..)));
+        assert_matches!(err, PstConstructionError::ContainsSlots(..));
 
         // PolicyToTemplate
         let err: PstConstructionError = FromJsonError::PolicyToTemplate(
@@ -484,18 +485,18 @@ mod tests {
             },
         )
         .into();
-        assert!(matches!(err, PstConstructionError::ContainsSlots(..)));
+        assert_matches!(err, PstConstructionError::ContainsSlots(..));
 
         // MissingOperator
         let err: PstConstructionError = FromJsonError::MissingOperator.into();
-        assert!(matches!(err, PstConstructionError::InvalidExpression(..)));
+        assert_matches!(err, PstConstructionError::InvalidExpression(..));
 
         // MultipleOperators
         let err: PstConstructionError = FromJsonError::MultipleOperators {
             ops: vec!["a".into(), "b".into()],
         }
         .into();
-        assert!(matches!(err, PstConstructionError::InvalidExpression(..)));
+        assert_matches!(err, PstConstructionError::InvalidExpression(..));
     }
 
     #[test]
@@ -507,7 +508,7 @@ mod tests {
             },
         )
         .into();
-        assert!(matches!(err, PstConstructionError::DuplicateRecordKey(..)));
+        assert_matches!(err, PstConstructionError::DuplicateRecordKey(..));
     }
 
     #[test]
@@ -520,6 +521,6 @@ mod tests {
             },
         )
         .into();
-        assert!(matches!(err, PstConstructionError::UnknownFunction(..)));
+        assert_matches!(err, PstConstructionError::UnknownFunction(..));
     }
 }

--- a/cedar-policy-core/src/pst/est_conversions.rs
+++ b/cedar-policy-core/src/pst/est_conversions.rs
@@ -425,6 +425,7 @@ impl From<EntityUID> for entities::EntityUidJson {
 mod tests {
     use super::*;
     use crate::pst::{self, BinaryOp, Name, UnaryOp};
+    use cool_asserts::assert_matches;
     use smol_str::{format_smolstr, SmolStr};
     use std::collections::BTreeMap;
 
@@ -461,7 +462,7 @@ mod tests {
         let json = r#"{"Value": true}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Literal(_)));
+        assert_matches!(pst_expr, Expr::Literal(_));
         roundtrips(pst_expr);
     }
 
@@ -470,7 +471,7 @@ mod tests {
         let json = r#"{"Var": "principal"}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Var(pst::expr::Var::Principal)));
+        assert_matches!(pst_expr, Expr::Var(pst::expr::Var::Principal));
         roundtrips(pst_expr);
     }
 
@@ -479,7 +480,7 @@ mod tests {
         let json = r#"{"Slot": "?principal"}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.clone().try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Slot(_)));
+        assert_matches!(pst_expr, Expr::Slot(_));
         // Roundtrip: PST slot should convert back to EST slot
         let est_roundtrip: est::Expr = pst_expr.try_into().unwrap();
         assert_eq!(est_expr, est_roundtrip);
@@ -547,7 +548,7 @@ mod tests {
         }"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::IfThenElse { .. }));
+        assert_matches!(pst_expr, Expr::IfThenElse { .. });
         roundtrips(pst_expr);
     }
 
@@ -569,7 +570,7 @@ mod tests {
         let json = r#"{"Record": {"foo": {"Var": "principal"}}}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Record(_)));
+        assert_matches!(pst_expr, Expr::Record(_));
         roundtrips(pst_expr);
     }
 
@@ -578,7 +579,7 @@ mod tests {
         let json = r#"{".": {"left": {"Var": "principal"}, "attr": "name"}}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::GetAttr { .. }));
+        assert_matches!(pst_expr, Expr::GetAttr { .. });
         roundtrips(pst_expr);
     }
 
@@ -587,13 +588,13 @@ mod tests {
         let json = r#"{"has": {"left": {"Var": "principal"}, "attr": "name"}}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::HasAttr { .. }));
+        assert_matches!(pst_expr, Expr::HasAttr { .. });
         roundtrips(pst_expr);
         // Extended has attr — does not roundtrip because the EST builder desugars it
         let json2 = r#"{"has": {"left": {"Var": "principal"}, "attr": ["name", "nested"]}}"#;
         let est_expr2: est::Expr = serde_json::from_str(json2).unwrap();
         let pst_expr2: Expr = est_expr2.try_into().unwrap();
-        assert!(matches!(pst_expr2, Expr::HasAttr { .. }));
+        assert_matches!(pst_expr2, Expr::HasAttr { .. });
     }
 
     #[test]
@@ -601,7 +602,7 @@ mod tests {
         let json = r#"{"like": {"left": {"Var": "principal"}, "pattern": [{"Wildcard": null}, {"Literal": "@example.com"}]}}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Like { .. }));
+        assert_matches!(pst_expr, Expr::Like { .. });
         roundtrips(pst_expr);
     }
 
@@ -614,7 +615,7 @@ mod tests {
     }}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Is { in_expr: None, .. }));
+        assert_matches!(pst_expr, Expr::Is { in_expr: None, .. });
         roundtrips(pst_expr);
 
         // Test is with in - now uses is_in_entity_type
@@ -676,7 +677,7 @@ mod tests {
         // Test simple value conversion
         let est_expr = est::Expr::ExprNoExt(est::ExprNoExt::Var(ast::Var::Principal));
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Var(pst::expr::Var::Principal)));
+        assert_matches!(pst_expr, Expr::Var(pst::expr::Var::Principal));
         roundtrips(pst_expr);
     }
 
@@ -745,7 +746,7 @@ mod tests {
             attr: "name".try_into().unwrap(),
         });
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::GetAttr { .. }));
+        assert_matches!(pst_expr, Expr::GetAttr { .. });
         roundtrips(pst_expr);
     }
 
@@ -759,7 +760,7 @@ mod tests {
             attr: "name".try_into().unwrap(),
         }));
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::HasAttr { .. }));
+        assert_matches!(pst_expr, Expr::HasAttr { .. });
         roundtrips(pst_expr);
     }
 
@@ -774,7 +775,7 @@ mod tests {
         ];
         let est_expr = est::Expr::ExprNoExt(est::ExprNoExt::Like { left, pattern });
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Like { .. }));
+        assert_matches!(pst_expr, Expr::Like { .. });
         roundtrips(pst_expr);
     }
 
@@ -789,7 +790,7 @@ mod tests {
             in_expr: None,
         });
         let pst_expr: Expr = est_expr.try_into().unwrap();
-        assert!(matches!(pst_expr, Expr::Is { .. }));
+        assert_matches!(pst_expr, Expr::Is { .. });
         roundtrips(pst_expr);
     }
 
@@ -828,7 +829,7 @@ mod tests {
         }"#;
         let est_policy: est::Policy = serde_json::from_str(json).unwrap();
         let pst_policy: pst::Template = est_policy.try_into().unwrap();
-        assert!(matches!(pst_policy.effect, pst::Effect::Permit));
+        assert_matches!(pst_policy.effect, pst::Effect::Permit);
         policy_roundtrips(pst_policy);
     }
 
@@ -851,7 +852,7 @@ mod tests {
         }"#;
         let est_policy: est::Policy = serde_json::from_str(json).unwrap();
         let pst_policy: pst::Template = est_policy.try_into().unwrap();
-        assert!(matches!(pst_policy.effect, pst::Effect::Forbid));
+        assert_matches!(pst_policy.effect, pst::Effect::Forbid);
         assert!(matches!(
             pst_policy.principal,
             pst::PrincipalConstraint::In(_)
@@ -885,7 +886,7 @@ mod tests {
         let est_policy: est::Policy = serde_json::from_str(json).unwrap();
         let pst_policy: pst::Template = est_policy.try_into().unwrap();
         assert_eq!(pst_policy.clauses.len(), 1);
-        assert!(matches!(pst_policy.clauses[0], pst::Clause::When(..)));
+        assert_matches!(pst_policy.clauses[0], pst::Clause::When(..));
         policy_roundtrips(pst_policy);
     }
 
@@ -1016,7 +1017,7 @@ mod tests {
         }"#;
         let est_policy: est::Policy = serde_json::from_str(json).unwrap();
         let pst_policy: pst::Template = est_policy.try_into().unwrap();
-        assert!(matches!(pst_policy.action, pst::ActionConstraint::Eq(_)));
+        assert_matches!(pst_policy.action, pst::ActionConstraint::Eq(_));
         policy_roundtrips(pst_policy);
     }
 
@@ -1382,7 +1383,7 @@ mod tests {
         let json = r#"{"offset": []}"#;
         let est_expr: est::Expr = serde_json::from_str(json).unwrap();
         let result: Result<Expr, _> = est_expr.try_into();
-        assert!(matches!(result, Err(PstConstructionError::WrongArity(..))));
+        assert_matches!(result, Err(PstConstructionError::WrongArity(..)));
     }
 
     // ========================================================================

--- a/cedar-policy-core/src/pst/expr.rs
+++ b/cedar-policy-core/src/pst/expr.rs
@@ -1190,7 +1190,7 @@ impl std::fmt::Display for Expr {
 )]
 #[cfg(test)]
 mod tests {
-    use cool_asserts::assertion_failure;
+    use cool_asserts::{assert_matches, assertion_failure};
 
     use super::*;
     use std::str::FromStr;
@@ -1255,7 +1255,7 @@ mod tests {
         ];
 
         let result = Expr::from_function_ast_name_and_args(&name, args);
-        assert!(matches!(result, Err(PstConstructionError::WrongArity(..))));
+        assert_matches!(result, Err(PstConstructionError::WrongArity(..)));
     }
 
     #[test]
@@ -1346,13 +1346,13 @@ mod tests {
     fn test_builder_additional_methods() {
         // Test unknown
         let expr = PstBuilder::new().unknown(ast::Unknown::new_untyped("test"));
-        assert!(matches!(expr, Expr::Unknown { .. }));
+        assert_matches!(expr, Expr::Unknown { .. });
 
         // Test like
         let base = PstBuilder::new().val("test");
         let pattern = ast::Pattern::from(vec![ast::PatternElem::Char('a')]);
         let expr = PstBuilder::new().like(base, pattern);
-        assert!(matches!(expr, Expr::Like { .. }));
+        assert_matches!(expr, Expr::Like { .. });
 
         // Test is_in_entity_type
         let base = PstBuilder::new().var(ast::Var::Principal);

--- a/cedar-policy-symcc/src/symcc/solver_pool.rs
+++ b/cedar-policy-symcc/src/symcc/solver_pool.rs
@@ -45,7 +45,7 @@
 use super::smtlib_script::SmtLibScript;
 use super::solver::{Decision, DecisionWithModel, LocalSolver, Solver, SolverError};
 use miette::Diagnostic;
-use std::io::{self, ErrorKind};
+use std::io;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
@@ -79,7 +79,7 @@ struct FailedWriter;
 
 impl FailedWriter {
     fn error() -> io::Error {
-        io::Error::new(ErrorKind::Other, SolverError::SolverMarkedFailed)
+        io::Error::other(SolverError::SolverMarkedFailed)
     }
 }
 

--- a/cedar-policy-symcc/src/symcc/term_type.rs
+++ b/cedar-policy-symcc/src/symcc/term_type.rs
@@ -173,10 +173,10 @@ impl TermType {
     }
 
     fn of_record_type(attrs: &Attributes) -> Result<BTreeMap<SmolStr, TermType>, CompileError> {
-        Ok(attrs
+        attrs
             .iter()
             .map(|(k, v)| Ok((k.clone(), Self::of_qualified_type(v)?)))
-            .collect::<Result<_, CompileError>>()?)
+            .collect::<Result<_, CompileError>>()
     }
 
     fn of_qualified_type(qty: &AttributeType) -> Result<TermType, CompileError> {

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -10264,7 +10264,7 @@ when { principal in resource.admins };
             let mut loader = TestEntityLoader::new(&entities);
             let result = pset.is_authorized_batched(&request, &schema, &mut loader, 10);
 
-            assert!(matches!(result, Err(BatchedEvalError::PartialRequest(_))));
+            assert_matches!(result, Err(BatchedEvalError::PartialRequest(_)));
         }
 
         #[test]
@@ -10320,7 +10320,7 @@ when { principal in resource.admins };
             let mut loader = InvalidEntityLoader;
             let result = pset.is_authorized_batched(&request, &schema, &mut loader, 10);
 
-            assert!(matches!(result, Err(BatchedEvalError::Entities(_))));
+            assert_matches!(result, Err(BatchedEvalError::Entities(_)));
         }
 
         #[test]
@@ -11277,6 +11277,7 @@ mod has_non_scope_constraint {
 
 mod pst_api {
     use super::super::super::*;
+    use cool_asserts::assert_matches;
     use std::collections::{BTreeMap, HashMap};
     use std::str::FromStr;
     use std::sync::Arc;
@@ -11357,7 +11358,7 @@ mod pst_api {
         let pst = t.to_pst().expect("to_pst should succeed");
         assert!(pst.principal.has_slot());
         assert_eq!(pst.clauses().len(), 1);
-        assert!(matches!(pst.clauses()[0], pst::Clause::When(_)));
+        assert_matches!(pst.clauses()[0], pst::Clause::When(_));
         // also test try_into_pst
         let t2 = Template::parse(None, src).unwrap();
         let pst2 = t2.try_into_pst().expect("try_into_pst should succeed");
@@ -11408,7 +11409,7 @@ mod pst_api {
         let sp = pst::StaticPolicy::try_from(pst_static_template()).unwrap();
         let p = Policy::from_pst(sp.into()).unwrap();
         let recovered = p.to_pst().expect("should succeed");
-        assert!(matches!(recovered, pst::Policy::Static(_)));
+        assert_matches!(recovered, pst::Policy::Static(_));
     }
 
     #[test]
@@ -11416,7 +11417,7 @@ mod pst_api {
         let sp = pst::StaticPolicy::try_from(pst_static_template()).unwrap();
         let p = Policy::from_pst(sp.into()).unwrap();
         let recovered = p.try_into_pst().expect("should succeed");
-        assert!(matches!(recovered, pst::Policy::Static(_)));
+        assert_matches!(recovered, pst::Policy::Static(_));
     }
 
     #[test]
@@ -11441,16 +11442,16 @@ mod pst_api {
         let src = r#"permit(principal, action, resource) when { context.x > 5 } unless { resource == User::"bob" };"#;
         let p: Policy = src.parse().unwrap();
         let pst = p.to_pst().expect("to_pst should succeed");
-        assert!(matches!(&pst, pst::Policy::Static(_)));
+        assert_matches!(&pst, pst::Policy::Static(_));
         if let pst::Policy::Static(sp) = &pst {
             assert_eq!(sp.body.clauses().len(), 2);
-            assert!(matches!(sp.body.clauses()[0], pst::Clause::When(_)));
-            assert!(matches!(sp.body.clauses()[1], pst::Clause::Unless(_)));
+            assert_matches!(sp.body.clauses()[0], pst::Clause::When(_));
+            assert_matches!(sp.body.clauses()[1], pst::Clause::Unless(_));
         }
         // also test try_into_pst
         let p2: Policy = src.parse().unwrap();
         let pst2 = p2.try_into_pst().expect("try_into_pst should succeed");
-        assert!(matches!(pst2, pst::Policy::Static(_)));
+        assert_matches!(pst2, pst::Policy::Static(_));
     }
 
     // --- Text → Template → PST → other representations ---
@@ -11484,7 +11485,7 @@ mod pst_api {
         let pst = p.to_pst().expect("to_pst should succeed");
         if let pst::Policy::Static(sp) = &pst {
             assert_eq!(sp.body.effect, pst::Effect::Forbid);
-            assert!(matches!(sp.body.action, pst::ActionConstraint::Eq(_)));
+            assert_matches!(sp.body.action, pst::ActionConstraint::Eq(_));
             assert_eq!(sp.body.clauses().len(), 1);
         } else {
             panic!("expected static policy");
@@ -11498,7 +11499,7 @@ mod pst_api {
         // text → PST (try_into_pst)
         let p3: Policy = src.parse().unwrap();
         let pst2 = p3.try_into_pst().expect("try_into_pst should succeed");
-        assert!(matches!(pst2, pst::Policy::Static(_)));
+        assert_matches!(pst2, pst::Policy::Static(_));
     }
 
     // --- EST → PST ---
@@ -11523,7 +11524,7 @@ mod pst_api {
         // also test try_into_pst
         let p2 = Policy::from_json(None, json).unwrap();
         let pst2 = p2.try_into_pst().expect("try_into_pst should succeed");
-        assert!(matches!(pst2, pst::Policy::Static(_)));
+        assert_matches!(pst2, pst::Policy::Static(_));
     }
 
     #[test]
@@ -11539,7 +11540,7 @@ mod pst_api {
         let pst = t.to_pst().expect("to_pst should succeed");
         assert!(pst.principal.has_slot());
         assert_eq!(pst.clauses().len(), 1);
-        assert!(matches!(pst.clauses()[0], pst::Clause::Unless(_)));
+        assert_matches!(pst.clauses()[0], pst::Clause::Unless(_));
         // also test try_into_pst
         let t2 = Template::from_json(None, json).unwrap();
         let pst2 = t2.try_into_pst().expect("try_into_pst should succeed");
@@ -11572,13 +11573,13 @@ mod pst_api {
         .unwrap();
         let linked = pset.policy(&PolicyId::new("link1")).unwrap();
         let pst = linked.to_pst().expect("to_pst should succeed");
-        assert!(matches!(pst, pst::Policy::Linked(_)));
+        assert_matches!(pst, pst::Policy::Linked(_));
         // also test try_into_pst
         let pst2 = linked
             .clone()
             .try_into_pst()
             .expect("try_into_pst should succeed");
-        assert!(matches!(pst2, pst::Policy::Linked(_)));
+        assert_matches!(pst2, pst::Policy::Linked(_));
     }
 
     // ===== PolicySet PST tests =====
@@ -12280,8 +12281,8 @@ mod pst_api {
 
         assert_eq!(pst_set.policies.len(), 1);
         let sp = pst_set.policies.values().next().unwrap();
-        assert!(matches!(sp.body.principal, pst::PrincipalConstraint::Is(_)));
-        assert!(matches!(sp.body.action, pst::ActionConstraint::In(_)));
+        assert_matches!(sp.body.principal, pst::PrincipalConstraint::Is(_));
+        assert_matches!(sp.body.action, pst::ActionConstraint::In(_));
         assert!(matches!(
             sp.body.resource,
             pst::ResourceConstraint::In(pst::EntityOrSlot::Entity(_))
@@ -12344,7 +12345,7 @@ mod pst_api {
         assert_eq!(pst_set.policies.len(), 1);
         let sp = pst_set.policies.values().next().unwrap();
         assert_eq!(sp.body.effect, pst::Effect::Permit);
-        assert!(matches!(sp.body.action, pst::ActionConstraint::Eq(_)));
+        assert_matches!(sp.body.action, pst::ActionConstraint::Eq(_));
     }
 
     // --- Mixed: PST + text policies in same PolicySet → to_pst ---


### PR DESCRIPTION
Refactor `assert!(matches!(...))` to `assert_matches!(..)` and fix two clippy lints.


## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.