### PR TITLE
Fixed issue with SymCC silently ignoring template-linked polices

### DIFF
--- a/cedar-policy-symcc/src/err.rs
+++ b/cedar-policy-symcc/src/err.rs
@@ -65,9 +65,6 @@ pub enum Error {
     /// Empty-list of policies was passed to a function that expects at least one policy
     #[error("expected to have at least one policy")]
     NoPolicies,
-    /// Unsupported features.
-    #[error("unsupported feature in SymCC: {0}")]
-    UnsupportedFeature(String),
 }
 
 /// A result type that potentially returns a SymCC [`enum@Error`].

--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -712,9 +712,10 @@ pub fn well_typed_policies(
     schema: &Schema,
 ) -> Result<PolicySet> {
     if policies.policies().any(|p| !p.is_static()) {
-        return Err(Error::UnsupportedFeature(
+        return Err(CompileError::UnsupportedFeature(
             "template-linked policies are not supported".to_string(),
-        ));
+        )
+        .into());
     }
     let env = to_validator_request_env(env, schema.as_ref())
         .ok_or_else(|| Error::ActionNotInSchema(env.action().to_string()))?;

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -16,7 +16,9 @@ use std::str::FromStr;
  * limitations under the License.
  */
 use cedar_policy::{EntityUid, Policy, PolicyId, PolicySet, Schema, SlotId, Template, Validator};
-use cedar_policy_symcc::{solver::LocalSolver, CedarSymCompiler, CompiledPolicySet};
+use cedar_policy_symcc::{
+    err::CompileError, solver::LocalSolver, CedarSymCompiler, CompiledPolicySet,
+};
 use cool_asserts::assert_matches;
 use std::collections::HashMap;
 
@@ -2524,6 +2526,8 @@ async fn template_linked_policy_unsupported() {
     let result = CompiledPolicySet::compile(&pset, &envs.req_env, validator.schema());
     assert_matches!(
         result.err(),
-        Some(cedar_policy_symcc::err::Error::UnsupportedFeature { .. })
+        Some(cedar_policy_symcc::err::Error::CompileError(
+            CompileError::UnsupportedFeature(..)
+        ))
     );
 }


### PR DESCRIPTION
## Description of changes
Updated `well_type_policies` to return an `Err` if the input policies contain a template-linked policy instead of silently ignoring them ([slots are not supported by the symbolic compiler](https://github.com/cedar-policy/cedar/blob/036757e1313045670af8516cba4ff97ca0798f93/cedar-policy-symcc/src/symccopt/compiler.rs#L1050)).

I will make updates to the symcc CLI subcommand in another PR. I wanted this one clean so that it's easier to backport.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.
