### PR TITLE
fix template id lost through lossless text + action constraint valida…

### DIFF
--- a/cedar-policy-core/src/pst/ast_conversions.rs
+++ b/cedar-policy-core/src/pst/ast_conversions.rs
@@ -26,7 +26,7 @@ use crate::ast::{self, UnwrapInfallible};
 use crate::expr_builder;
 use crate::extensions;
 use crate::pst::err::error_body::{
-    PolicyMissingLinkIdError, UnsupportedErrorNode, WrongSlotPositionError,
+    InvalidEntityTypeError, PolicyMissingLinkIdError, UnsupportedErrorNode, WrongSlotPositionError,
 };
 use crate::pst::expr::{Id, PstBuilder};
 use std::collections::HashMap;
@@ -209,13 +209,33 @@ impl TryFrom<ActionConstraint> for ast::ActionConstraint {
     type Error = PstConstructionError;
 
     fn try_from(constraint: ActionConstraint) -> Result<Self, Self::Error> {
-        match constraint {
-            ActionConstraint::Any => Ok(ast::ActionConstraint::any()),
-            ActionConstraint::Eq(uid) => Ok(ast::ActionConstraint::is_eq(uid.into())),
-            ActionConstraint::In(uids) => Ok(ast::ActionConstraint::is_in(
-                uids.into_iter().map(ast::EntityUID::from),
-            )),
-        }
+        let ast_constraint = match constraint {
+            ActionConstraint::Any => ast::ActionConstraint::any(),
+            ActionConstraint::Eq(uid) => ast::ActionConstraint::is_eq(uid.into()),
+            ActionConstraint::In(uids) => {
+                ast::ActionConstraint::is_in(uids.into_iter().map(ast::EntityUID::from))
+            }
+        };
+        ast_constraint
+            .contains_only_action_types()
+            .map_err(|non_action_euids| {
+                let subject = if non_action_euids.len() > 1 {
+                    "entity uids"
+                } else {
+                    "an entity uid"
+                };
+                let entities = non_action_euids
+                    .iter()
+                    .map(|e| format!("`{e}`"))
+                    .collect::<Vec<_>>()
+                    .join(" and ");
+                InvalidEntityTypeError {
+                    description: format!(
+                        "expected {subject} with type `Action` but got {entities}"
+                    ),
+                }
+                .into()
+            })
     }
 }
 
@@ -1261,5 +1281,46 @@ mod tests {
             result,
             Err(PstConstructionError::ParsingFailed(..))
         ));
+    }
+
+    #[test]
+    fn test_non_action_entity_type_in_action_constraint_rejected() {
+        // Eq with non-Action type
+        let constraint = ActionConstraint::Eq(EntityUID::from(ast::EntityUID::from_components(
+            ast::EntityType::from_normalized_str("User").unwrap(),
+            ast::Eid::new("alice"),
+            None,
+        )));
+        let result: Result<ast::ActionConstraint, _> = constraint.try_into();
+        assert!(matches!(
+            result,
+            Err(PstConstructionError::InvalidEntityType(..))
+        ));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("expected an entity uid with type `Action`"));
+
+        // In with non-Action type
+        let constraint =
+            ActionConstraint::In(vec![EntityUID::from(ast::EntityUID::from_components(
+                ast::EntityType::from_normalized_str("Folder").unwrap(),
+                ast::Eid::new("docs"),
+                None,
+            ))]);
+        let result: Result<ast::ActionConstraint, _> = constraint.try_into();
+        assert!(matches!(
+            result,
+            Err(PstConstructionError::InvalidEntityType(..))
+        ));
+
+        // Action type should succeed
+        let constraint = ActionConstraint::Eq(EntityUID::from(ast::EntityUID::from_components(
+            ast::EntityType::from_normalized_str("Action").unwrap(),
+            ast::Eid::new("view"),
+            None,
+        )));
+        let result: Result<ast::ActionConstraint, _> = constraint.try_into();
+        assert!(result.is_ok());
     }
 }

--- a/cedar-policy-core/src/pst/policy.rs
+++ b/cedar-policy-core/src/pst/policy.rs
@@ -211,6 +211,11 @@ impl Template {
         }
     }
 
+    /// Return a copy of this template with a new id.
+    pub fn with_id(self, id: PolicyID) -> Self {
+        Self { id, ..self }
+    }
+
     /// Fill in any slots in this policy using the values in `vals`.
     /// Performing the link operation should result in a StaticPolicy.
     /// If there are unfilled slots, this results in an Error.

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -3479,6 +3479,7 @@ impl Template {
     pub fn to_pst(&self) -> Result<pst::Template, pst::PstConstructionError> {
         self.lossless
             .pst(|| pst::Template::try_from(self.ast.clone()))
+            .map(|t| t.with_id(self.ast.id().clone().into()))
     }
 
     /// Get an owned PST representation of this template.
@@ -4233,6 +4234,7 @@ impl Policy {
     pub fn to_pst(&self) -> Result<pst::Policy, pst::PstConstructionError> {
         self.lossless
             .pst(|| pst::Policy::try_from(self.ast.clone()))
+            .map(|p| p.new_id(self.ast.id().clone().into()))
     }
 
     /// Get an owned PST representation of this policy. May return an error when the policy

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -11333,6 +11333,53 @@ mod pst_api {
         assert!(err.to_string().contains("static policy"));
     }
 
+    #[test]
+    fn from_pst_rejects_non_action_entity_type() {
+        // Template with non-Action entity in action constraint
+        let t = pst::Template::new(
+            "t1",
+            pst::Effect::Permit,
+            pst::PrincipalConstraint::Eq(pst::EntityOrSlot::Slot(pst::SlotId::Principal)),
+            pst::ActionConstraint::Eq(pst::EntityUID::from(
+                cedar_policy_core::ast::EntityUID::from_components(
+                    // `User::"alice"` won't work here!
+                    cedar_policy_core::ast::EntityType::from_normalized_str("User").unwrap(),
+                    cedar_policy_core::ast::Eid::new("alice"),
+                    None,
+                ),
+            )),
+            pst::ResourceConstraint::Any,
+        );
+        let err = Template::from_pst(t).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid entity type: `expected an entity uid with type `Action` but got `User::\"alice\"``",
+            "expected Action type error, got: {err}"
+        );
+
+        // Static policy with non-Action entity in action constraint, just like building from JSON
+        let sp = pst::StaticPolicy::try_from(pst::Template::new(
+            "p1",
+            pst::Effect::Permit,
+            pst::PrincipalConstraint::Any,
+            pst::ActionConstraint::In(vec![pst::EntityUID::from(
+                cedar_policy_core::ast::EntityUID::from_components(
+                    cedar_policy_core::ast::EntityType::from_normalized_str("Folder").unwrap(),
+                    cedar_policy_core::ast::Eid::new("docs"),
+                    None,
+                ),
+            )]),
+            pst::ResourceConstraint::Any,
+        ))
+        .unwrap();
+        let err = Policy::from_pst(sp.into()).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid entity type: `expected an entity uid with type `Action` but got `Folder::\"docs\"``",
+            "expected Action type error, got: {err}"
+        );
+    }
+
     // --- Template::to_pst / try_into_pst ---
 
     #[test]
@@ -11349,6 +11396,27 @@ mod pst_api {
         let t = Template::from_pst(original.clone()).unwrap();
         let recovered = t.try_into_pst().expect("should succeed");
         assert_eq!(format!("{recovered}"), format!("{original}"));
+    }
+
+    #[test]
+    fn template_to_pst_preserves_id_from_text() {
+        let src = "permit(principal == ?principal, action, resource);";
+        let t = Template::parse(Some(PolicyId::new("my_template")), src).unwrap();
+        let pst = t.to_pst().expect("should succeed");
+        assert_eq!(pst.id, pst::PolicyID("my_template".into()));
+    }
+
+    #[test]
+    fn policy_to_pst_preserves_id_from_text() {
+        let src = "permit(principal, action, resource);";
+        // When text is parsed and parse given a policy id, we should preserve that id in the PST
+        let p = Policy::parse(Some(PolicyId::new("my_policy")), src).unwrap();
+        let pst = p.to_pst().expect("should succeed");
+        if let pst::Policy::Static(sp) = &pst {
+            assert_eq!(sp.body.id, pst::PolicyID("my_policy".into()));
+        } else {
+            panic!("expected static policy");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Fixes two issues with the PST:
- constructing a template/policy from text and a policy id, `to_pst` would lose the id.
- to match the behavior construction policy from JSON, `from_pst` should also validate that action entities are used in the action constraint.


## Description of changes
The change in this PR is (choose one, and delete the other options):
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.
