### PR TITLE
Fixed issue with SymCC silently ignoring template-linked policies SymCC 0.3.x

### DIFF
--- a/cedar-policy-symcc/src/symcc.rs
+++ b/cedar-policy-symcc/src/symcc.rs
@@ -717,6 +717,12 @@ pub fn well_typed_policies(
     env: &cedar_policy::RequestEnv,
     schema: &Schema,
 ) -> Result<PolicySet> {
+    if policies.policies().any(|p| !p.is_static()) {
+        return Err(CompileError::UnsupportedFeature(
+            "template-linked policies are not supported".to_string(),
+        )
+        .into());
+    }
     let env = to_validator_request_env(env, schema.as_ref())
         .ok_or_else(|| Error::ActionNotInSchema(env.action().to_string()))?;
     let typed_policies: Result<Vec<Policy>> = policies

--- a/cedar-policy-symcc/tests/integration_tests.rs
+++ b/cedar-policy-symcc/tests/integration_tests.rs
@@ -15,8 +15,12 @@ use std::str::FromStr;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-use cedar_policy::{Policy, PolicySet, Schema, Validator};
-use cedar_policy_symcc::{solver::LocalSolver, CedarSymCompiler};
+use cedar_policy::{EntityUid, Policy, PolicyId, PolicySet, Schema, SlotId, Template, Validator};
+use cedar_policy_symcc::{
+    err::CompileError, solver::LocalSolver, CedarSymCompiler, CompiledPolicySet,
+};
+use cool_asserts::assert_matches;
+use std::collections::HashMap;
 
 mod utils;
 use utils::Environments;
@@ -2486,4 +2490,44 @@ action "" appliesTo {
         &validator,
     );
     assert_does_not_always_deny(&mut compiler, &pset, &envs).await;
+}
+
+#[tokio::test]
+async fn template_linked_policy_unsupported() {
+    let schema = utils::schema_from_cedarstr(
+        r#"
+        entity Thing;
+        entity User;
+        action view appliesTo {
+            principal: [User],
+            resource: [Thing],
+            context: {}
+        };
+    "#,
+    );
+    let validator = Validator::new(schema);
+    let mut pset = utils::pset_from_text("permit(principal, action, resource);", &validator);
+    let tmpl = Template::parse(
+        Some(PolicyId::new("forbid_tmpl")),
+        "forbid(principal == ?principal, action, resource);",
+    )
+    .unwrap();
+    pset.add_template(tmpl).unwrap();
+    pset.link(
+        PolicyId::new("forbid_tmpl"),
+        PolicyId::new("forbid_alice"),
+        HashMap::from([(
+            SlotId::principal(),
+            EntityUid::from_type_name_and_id("User".parse().unwrap(), "alice".parse().unwrap()),
+        )]),
+    )
+    .unwrap();
+    let envs = Environments::new(validator.schema(), "User", r#"Action::"view""#, "Thing");
+    let result = CompiledPolicySet::compile(&pset, &envs.req_env, validator.schema());
+    assert_matches!(
+        result.err(),
+        Some(cedar_policy_symcc::err::Error::CompileError(
+            CompileError::UnsupportedFeature(..)
+        ))
+    );
 }


### PR DESCRIPTION
## Description of changes
Cherry-picked fix for SymCC silently ignoring template-linked polices (Commit 1801721fb6a80ff058aba4a06fc95832901a9aac) into release branch for SymCC 0.3.x.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Does not update the CHANGELOG because this is a release branch.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.

