### PR TITLE
feat: Add help text for function argument validation errors

### DIFF
--- a/cedar-policy-core/src/extensions/datetime.rs
+++ b/cedar-policy-core/src/extensions/datetime.rs
@@ -33,6 +33,14 @@ use crate::{
 
 const DATETIME_EXTENSION_NAME: &str = "datetime";
 
+/// Help text describing the valid datetime format, used as a fallback when a
+/// specific parse error does not carry its own help text.
+const VALID_DATETIME_HELP: &str = "valid datetime strings start with `YYYY-MM-DD` and may optionally include `THH:MM:SS` plus `Z`, `.SSSZ`, or an offset like `+0700`";
+
+/// Help text describing the valid duration format, used as a fallback when a
+/// specific parse error does not carry its own help text.
+const VALID_DURATION_HELP: &str = "valid duration strings are concatenated quantity-unit pairs with an optional leading `-`, for example `1d2h3m4s50ms`";
+
 #[expect(
     clippy::expect_used,
     clippy::unwrap_used,
@@ -142,7 +150,11 @@ fn datetime_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
             extension_err(
                 err.to_string(),
                 &constants::DATETIME_CONSTRUCTOR_NAME,
-                err.help().map(|v| v.to_string()),
+                Some(
+                    err.help()
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| VALID_DATETIME_HELP.to_string()),
+                ),
             )
         })
     })
@@ -415,7 +427,11 @@ fn duration_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
             extension_err(
                 err.to_string(),
                 &constants::DURATION_CONSTRUCTOR_NAME,
-                err.help().map(|v| v.to_string()),
+                Some(
+                    err.help()
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| VALID_DURATION_HELP.to_string()),
+                ),
             )
         })
     })
@@ -1279,8 +1295,7 @@ mod tests {
             Err(EvaluationError::FailedExtensionFunctionExecution(err)) => {
                 assert_eq!(err.extension_name, *DATETIME_CONSTRUCTOR_NAME);
                 assert_eq!(err.msg, "invalid date pattern".to_owned());
-                // TODO: figure out why it's none given the help annotations
-                assert_eq!(err.advice, None);
+                assert_eq!(err.advice, Some("valid datetime strings start with `YYYY-MM-DD` and may optionally include `THH:MM:SS` plus `Z`, `.SSSZ`, or an offset like `+0700`".to_owned()));
             }
         );
 
@@ -1456,8 +1471,7 @@ mod tests {
             Err(EvaluationError::FailedExtensionFunctionExecution(err)) => {
                 assert_eq!(err.extension_name, *DURATION_CONSTRUCTOR_NAME);
                 assert_eq!(err.msg, "invalid duration pattern".to_owned());
-                // TODO: figure out why it's none given the help annotations
-                assert_eq!(err.advice, None);
+                assert_eq!(err.advice, Some("valid duration strings are concatenated quantity-unit pairs with an optional leading `-`, for example `1d2h3m4s50ms`".to_owned()));
             }
         );
 

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -28,6 +28,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
 
+/// Help text describing the valid decimal format, used when a decimal parse error occurs.
+const VALID_DECIMAL_HELP: &str = "valid decimal strings look like `12.34`: digits are required on both sides of `.`, up to 4 fractional digits are allowed, and the value must be in range -922337203685477.5808 to 922337203685477.5807";
+
 /// Number of digits supported after the decimal
 const NUM_DIGITS: u32 = 4;
 
@@ -81,6 +84,7 @@ const ADVICE_MSG: &str = "maybe you forgot to apply the `decimal` constructor?";
 enum Error {
     /// Error parsing the input string as a decimal value
     #[error("`{0}` is not a well-formed decimal value")]
+    #[diagnostic(help("{VALID_DECIMAL_HELP}"))]
     FailedParse(String),
 
     /// Too many digits after the decimal point
@@ -90,6 +94,7 @@ enum Error {
 
     /// Overflow occurred when converting to a decimal value
     #[error("overflow when converting to decimal")]
+    #[diagnostic(help("the value must be in range -922337203685477.5808 to 922337203685477.5807"))]
     Overflow,
 }
 
@@ -198,8 +203,8 @@ fn extension_err(msg: impl Into<String>, advice: Option<String>) -> evaluator::E
 /// Cedar string
 fn decimal_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
-    let decimal =
-        Decimal::from_str(str.as_str()).map_err(|e| extension_err(e.to_string(), None))?;
+    let decimal = Decimal::from_str(str.as_str())
+        .map_err(|e| extension_err(e.to_string(), e.help().map(|h| h.to_string())))?;
     let arg_source_loc = arg.source_loc();
     let e = RepresentableExtensionValue::new(
         Arc::new(decimal),

--- a/cedar-policy-core/src/extensions/decimal.rs
+++ b/cedar-policy-core/src/extensions/decimal.rs
@@ -94,7 +94,9 @@ enum Error {
 
     /// Overflow occurred when converting to a decimal value
     #[error("overflow when converting to decimal")]
-    #[diagnostic(help("the value must be in range -922337203685477.5808 to 922337203685477.5807"))]
+    #[diagnostic(help(
+        "the value must be in range -922337203685477.5808 to 922337203685477.5807"
+    ))]
     Overflow,
 }
 

--- a/cedar-policy-core/src/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/extensions/ipaddr.rs
@@ -56,6 +56,9 @@ pub(crate) mod names {
 /// This error is likely due to confusion between "127.0.0.1" and ip("127.0.0.1").
 const ADVICE_MSG: &str = "maybe you forgot to apply the `ip` constructor?";
 
+/// Help text describing the valid IP address format, used when an IP parse error occurs.
+const VALID_IP_HELP: &str = "valid IP strings are IPv4/IPv6 addresses or CIDR ranges like `127.0.0.1`, `127.0.0.1/24`, or `ffee::/64`";
+
 /// Maximum prefix size for IpV4 addresses
 const PREFIX_MAX_LEN_V4: u8 = 32;
 /// Maximum prefix size for IpV6 addresses
@@ -254,12 +257,12 @@ impl ExtensionValue for IPAddr {
     }
 }
 
-fn extension_err(msg: impl Into<String>) -> evaluator::EvaluationError {
+fn extension_err(msg: impl Into<String>, advice: Option<String>) -> evaluator::EvaluationError {
     evaluator::EvaluationError::failed_extension_function_application(
         names::EXTENSION_NAME.clone(),
         msg.into(),
         None, // source loc will be added by the evaluator
-        None,
+        advice,
     )
 }
 
@@ -328,7 +331,10 @@ fn ip_from_str(arg: &Value) -> evaluator::Result<ExtensionOutputValue> {
     let str = arg.get_as_string()?;
     let arg_source_loc = arg.source_loc();
     let ipaddr = RepresentableExtensionValue::new(
-        Arc::new(IPAddr::from_str(str.as_str()).map_err(extension_err)?),
+        Arc::new(
+            IPAddr::from_str(str.as_str())
+                .map_err(|e| extension_err(e, Some(VALID_IP_HELP.to_string())))?,
+        ),
         names::IP_FROM_STR_NAME.clone(),
         vec![arg.clone().into()],
     );

--- a/cedar-policy-core/src/validator/diagnostics.rs
+++ b/cedar-policy-core/src/validator/diagnostics.rs
@@ -347,11 +347,13 @@ impl ValidationError {
         source_loc: Option<Loc>,
         policy_id: PolicyID,
         msg: String,
+        help: Option<String>,
     ) -> Self {
         validation_errors::FunctionArgumentValidation {
             source_loc,
             policy_id,
             msg,
+            help,
         }
         .into()
     }

--- a/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
+++ b/cedar-policy-core/src/validator/diagnostics/validation_errors.rs
@@ -465,10 +465,16 @@ pub struct FunctionArgumentValidation {
     pub policy_id: PolicyID,
     /// Error message
     pub msg: String,
+    /// Optional help for resolving the error
+    pub help: Option<String>,
 }
 
 impl Diagnostic for FunctionArgumentValidation {
     impl_diagnostic_from_source_loc_opt_field!(source_loc);
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.help.as_ref().map(|h| Box::new(h) as Box<dyn Display>)
+    }
 }
 
 /// Structure containing details about a hierarchy not respected error

--- a/cedar-policy-core/src/validator/extension_schema.rs
+++ b/cedar-policy-core/src/validator/extension_schema.rs
@@ -64,12 +64,31 @@ impl ExtensionSchema {
     }
 }
 
+/// Additional diagnostic details for custom extension argument validation.
+#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+pub(crate) struct ArgumentValidationError {
+    /// Main validation error message.
+    pub(crate) msg: String,
+    /// Optional help text describing valid input.
+    pub(crate) help: Option<String>,
+}
+
+impl ArgumentValidationError {
+    /// Create a new argument-validation error.
+    pub(crate) fn new(msg: impl Into<String>, help: Option<String>) -> Self {
+        Self {
+            msg: msg.into(),
+            help,
+        }
+    }
+}
+
 /// The type of a function used to perform custom argument validation on an
 /// extension function application. An `ArgumentCheckFn` is passed a slice
 /// containing the arguments to the extension function call and returns `Err` if
 /// it can statically determine that the arguments are invalid.
 pub(crate) type ArgumentCheckFn =
-    Box<dyn Fn(&[Expr]) -> Result<(), String> + Sync + Send + 'static>;
+    Box<dyn Fn(&[Expr]) -> Result<(), ArgumentValidationError> + Sync + Send + 'static>;
 
 /// Type information for a single extension function.
 pub struct ExtensionFunctionType {
@@ -119,7 +138,7 @@ impl ExtensionFunctionType {
     }
 
     /// Call the `check_arguments` function with the given args
-    pub fn check_arguments(&self, args: &[Expr]) -> Result<(), String> {
+    pub fn check_arguments(&self, args: &[Expr]) -> Result<(), ArgumentValidationError> {
         if let Some(f) = &self.check_arguments {
             return (f)(args);
         }

--- a/cedar-policy-core/src/validator/extensions/datetime.rs
+++ b/cedar-policy-core/src/validator/extensions/datetime.rs
@@ -20,9 +20,12 @@
 
 use crate::ast::{Expr, ExprKind, Literal, Name};
 use crate::extensions::datetime;
-use crate::validator::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
+use crate::validator::extension_schema::{
+    ArgumentCheckFn, ArgumentValidationError, ExtensionFunctionType, ExtensionSchema,
+};
 use crate::validator::types::{self, Type};
 use itertools::Itertools;
+use miette::Diagnostic;
 
 use super::eval_extension_constructor;
 
@@ -120,12 +123,19 @@ pub fn extension_schema() -> ExtensionSchema {
 /// Extra validation step for the `datetime` function.
 /// Note we already checked that `exprs` contains correct number of arguments,
 /// these arguments have the correct types, and that they are all literals.
-fn validate_datetime_string(datetime_constructor_name: Name, exprs: &[Expr]) -> Result<(), String> {
+fn validate_datetime_string(
+    datetime_constructor_name: Name,
+    exprs: &[Expr],
+) -> Result<(), ArgumentValidationError> {
     match exprs.iter().exactly_one().map(|a| a.expr_kind()) {
         Ok(ExprKind::Lit(lit_arg @ Literal::String(s))) => {
-            eval_extension_constructor(datetime_constructor_name, s.clone())
-                .map(|_| ())
-                .map_err(|_| format!("Failed to parse as a datetime value: `{lit_arg}`"))
+            match eval_extension_constructor(datetime_constructor_name, s.clone()) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(ArgumentValidationError::new(
+                    format!("failed to parse as a datetime value: `{lit_arg}`"),
+                    err.help().map(|h| h.to_string()),
+                )),
+            }
         }
         _ => Ok(()),
     }
@@ -134,12 +144,19 @@ fn validate_datetime_string(datetime_constructor_name: Name, exprs: &[Expr]) -> 
 /// Extra validation step for the `duration` function.
 /// Note we already checked that `exprs` contains correct number of arguments,
 /// these arguments have the correct types, and that they are all literals.
-fn validate_duration_string(duration_constructor_name: Name, exprs: &[Expr]) -> Result<(), String> {
+fn validate_duration_string(
+    duration_constructor_name: Name,
+    exprs: &[Expr],
+) -> Result<(), ArgumentValidationError> {
     match exprs.iter().exactly_one().map(|a| a.expr_kind()) {
         Ok(ExprKind::Lit(lit_arg @ Literal::String(s))) => {
-            eval_extension_constructor(duration_constructor_name, s.clone())
-                .map(|_| ())
-                .map_err(|_| format!("Failed to parse as a duration value: `{lit_arg}`"))
+            match eval_extension_constructor(duration_constructor_name, s.clone()) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(ArgumentValidationError::new(
+                    format!("failed to parse as a duration value: `{lit_arg}`"),
+                    err.help().map(|h| h.to_string()),
+                )),
+            }
         }
         _ => Ok(()),
     }

--- a/cedar-policy-core/src/validator/extensions/decimal.rs
+++ b/cedar-policy-core/src/validator/extensions/decimal.rs
@@ -20,9 +20,12 @@
 
 use crate::ast::{Expr, ExprKind, Literal, Name};
 use crate::extensions::decimal;
-use crate::validator::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
+use crate::validator::extension_schema::{
+    ArgumentCheckFn, ArgumentValidationError, ExtensionFunctionType, ExtensionSchema,
+};
 use crate::validator::types::{self, Type};
 use itertools::Itertools;
+use miette::Diagnostic;
 
 use super::eval_extension_constructor;
 
@@ -101,12 +104,19 @@ pub fn extension_schema() -> ExtensionSchema {
 /// Extra validation step for the `decimal` function.
 /// Note we already checked that `exprs` contains correct number of arguments,
 /// these arguments have the correct types, and that they are all literals.
-fn validate_decimal_string(decimal_constructor_name: Name, exprs: &[Expr]) -> Result<(), String> {
+fn validate_decimal_string(
+    decimal_constructor_name: Name,
+    exprs: &[Expr],
+) -> Result<(), ArgumentValidationError> {
     match exprs.iter().exactly_one().map(|a| a.expr_kind()) {
         Ok(ExprKind::Lit(lit_arg @ Literal::String(s))) => {
-            eval_extension_constructor(decimal_constructor_name, s.clone())
-                .map(|_| ())
-                .map_err(|_| format!("Failed to parse as a decimal value: `{lit_arg}`"))
+            match eval_extension_constructor(decimal_constructor_name, s.clone()) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(ArgumentValidationError::new(
+                    format!("failed to parse as a decimal value: `{lit_arg}`"),
+                    err.help().map(|h| h.to_string()),
+                )),
+            }
         }
         _ => Ok(()),
     }

--- a/cedar-policy-core/src/validator/extensions/ipaddr.rs
+++ b/cedar-policy-core/src/validator/extensions/ipaddr.rs
@@ -20,9 +20,12 @@
 
 use crate::ast::{Expr, ExprKind, Literal, Name};
 use crate::extensions::ipaddr;
-use crate::validator::extension_schema::{ArgumentCheckFn, ExtensionFunctionType, ExtensionSchema};
+use crate::validator::extension_schema::{
+    ArgumentCheckFn, ArgumentValidationError, ExtensionFunctionType, ExtensionSchema,
+};
 use crate::validator::types::{self, Type};
 use itertools::Itertools;
+use miette::Diagnostic;
 
 use super::eval_extension_constructor;
 
@@ -101,12 +104,19 @@ pub fn extension_schema() -> ExtensionSchema {
 /// Extra validation step for the `ip` function.
 /// Note we already checked that `exprs` contains correct number of arguments,
 /// these arguments have the correct types, and that they are all literals.
-fn validate_ip_string(ip_constructor_name: Name, exprs: &[Expr]) -> Result<(), String> {
+fn validate_ip_string(
+    ip_constructor_name: Name,
+    exprs: &[Expr],
+) -> Result<(), ArgumentValidationError> {
     match exprs.iter().exactly_one().map(|a| a.expr_kind()) {
         Ok(ExprKind::Lit(lit_arg @ Literal::String(s))) => {
-            eval_extension_constructor(ip_constructor_name, s.clone())
-                .map(|_| ())
-                .map_err(|_| format!("Failed to parse as IP address: `{lit_arg}`"))
+            match eval_extension_constructor(ip_constructor_name, s.clone()) {
+                Ok(_) => Ok(()),
+                Err(err) => Err(ArgumentValidationError::new(
+                    format!("failed to parse as IP address: `{lit_arg}`"),
+                    err.help().map(|h| h.to_string()),
+                )),
+            }
         }
         _ => Ok(()),
     }

--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -2245,11 +2245,12 @@ impl<'a> SingleEnvTypechecker<'a> {
                     ));
                     failed = true;
                 }
-                if let Err(msg) = efunc.check_arguments(args) {
+                if let Err(err) = efunc.check_arguments(args) {
                     type_errors.push(ValidationError::function_argument_validation(
                         ext_expr.source_loc().cloned(),
                         self.policy_id.clone(),
-                        msg,
+                        err.msg,
+                        err.help,
                     ));
                     failed = true;
                 }

--- a/cedar-policy-core/src/validator/typecheck/test/extensions.rs
+++ b/cedar-policy-core/src/validator/typecheck/test/extensions.rs
@@ -71,7 +71,10 @@ fn ip_extension_typecheck_fails() {
         ValidationError::function_argument_validation(
             get_loc(src, src),
             expr_id_placeholder(),
-            "Failed to parse as IP address: `\"foo\"`".into(),
+            "failed to parse as IP address: `\"foo\"`".into(),
+            Some(
+                "valid IP strings are IPv4/IPv6 addresses or CIDR ranges like `127.0.0.1`, `127.0.0.1/24`, or `ffee::/64`".into(),
+            ),
         )
     );
     let src = "ip(\"127.0.0.1\").isIpv4(3)";
@@ -189,7 +192,10 @@ fn decimal_extension_typecheck_fails() {
         ValidationError::function_argument_validation(
             get_loc(src, src),
             expr_id_placeholder(),
-            "Failed to parse as a decimal value: `\"foo\"`".into(),
+            "failed to parse as a decimal value: `\"foo\"`".into(),
+            Some(
+                "valid decimal strings look like `12.34`: digits are required on both sides of `.`, up to 4 fractional digits are allowed, and the value must be in range -922337203685477.5808 to 922337203685477.5807".into(),
+            ),
         )
     );
     let src = "decimal(\"1.23\").lessThan(3, 4)";
@@ -309,7 +315,10 @@ fn datetime_extension_typecheck_fails() {
         ValidationError::function_argument_validation(
             get_loc(src, src),
             expr_id_placeholder(),
-            "Failed to parse as a datetime value: `\"foo\"`".into(),
+            "failed to parse as a datetime value: `\"foo\"`".into(),
+            Some(
+                "valid datetime strings start with `YYYY-MM-DD` and may optionally include `THH:MM:SS` plus `Z`, `.SSSZ`, or an offset like `+0700`".into(),
+            ),
         )
     );
 
@@ -338,7 +347,30 @@ fn datetime_extension_typecheck_fails() {
         ValidationError::function_argument_validation(
             get_loc(src, src),
             expr_id_placeholder(),
-            "Failed to parse as a duration value: `\"foo\"`".into(),
+            "failed to parse as a duration value: `\"foo\"`".into(),
+            Some(
+                "valid duration strings are concatenated quantity-unit pairs with an optional leading `-`, for example `1d2h3m4s50ms`".into(),
+            ),
+        )
+    );
+
+    // "2024-13-01" matches the date pattern but has an invalid month (13),
+    // triggering DateTimeParseError::InvalidDate which has no help text.
+    // This exercises the fallback to VALID_DATETIME_HELP.
+    let src = r#"datetime("2024-13-01")"#;
+    let expr = Expr::from_str(src).expect("parsing should succeed");
+    let errors =
+        assert_typecheck_fails_empty_schema(&expr, &Type::extension(datetime_name.clone()));
+    let type_error = assert_exactly_one_diagnostic(errors);
+    assert_eq!(
+        type_error,
+        ValidationError::function_argument_validation(
+            get_loc(src, src),
+            expr_id_placeholder(),
+            "failed to parse as a datetime value: `\"2024-13-01\"`".into(),
+            Some(
+                "valid datetime strings start with `YYYY-MM-DD` and may optionally include `THH:MM:SS` plus `Z`, `.SSSZ`, or an offset like `+0700`".into(),
+            ),
         )
     );
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -21,6 +21,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ### Fixed
 
 - Improved Cedar schema parse help for two common syntax mistakes: forgetting `appliesTo` before an action block, and adding `;` after a namespace declaration. (#1043, #1044)
+- `FunctionArgumentValidation` errors now include a help message describing the expected format for extension function arguments: `decimal`, `ip`, `datetime`, and `duration`. (#834)
 
 ## [4.10.0] - Coming soon
 

--- a/cedar-policy/src/ffi/validate.rs
+++ b/cedar-policy/src/ffi/validate.rs
@@ -410,6 +410,44 @@ mod test {
     }
 
     #[test]
+    fn test_validation_errors_include_function_argument_help() {
+        let json = json!({
+            "schema": {
+                "": {
+                    "entityTypes": {
+                        "User": {},
+                        "Document": {}
+                    },
+                    "actions": {
+                        "view": {
+                            "appliesTo": {
+                                "principalTypes": ["User"],
+                                "resourceTypes": ["Document"]
+                            }
+                        }
+                    }
+                }
+            },
+            "policies": {
+                "staticPolicies": {
+                    "policy0": "permit(principal == User::\"alice\", action == Action::\"view\", resource == Document::\"doc\") when { decimal(\"foo\").lessThan(decimal(\"1.0\")) };"
+                }
+            }
+        });
+
+        let errs = assert_validates_with_errors(json);
+        assert_length_matches(&errs, 1);
+        assert_eq!(errs[0].policy_id, PolicyId::new("policy0"));
+        assert_error_matches(
+            &errs[0].error,
+            "for policy `policy0`, error during extension function argument validation: failed to parse as a decimal value: `\"foo\"`",
+            Some(
+                "valid decimal strings look like `12.34`: digits are required on both sides of `.`, up to 4 fractional digits are allowed, and the value must be in range -922337203685477.5808 to 922337203685477.5807",
+            ),
+        );
+    }
+
+    #[test]
     fn test_nontrivial_correct_policy_validates_without_errors_concatenated_policies() {
         let json = json!({
         "schema": { "": {

--- a/cedar-policy/src/test/test.rs
+++ b/cedar-policy/src/test/test.rs
@@ -5980,6 +5980,62 @@ permit(principal, action, resource) when { {"\n": 0} };"#,
         round_trip(r#"permit(principal, action, resource) when { Foo::"\n\r\\" };"#);
     }
 }
+
+mod function_argument_validation_help_tests {
+    use crate::{Policy, PolicySet, ValidationMode, Validator};
+    use cedar_policy_core::test_utils::{expect_err, ExpectedErrorMessageBuilder};
+    use miette::Report;
+    use serde_json::json;
+
+    use super::Schema;
+
+    #[test]
+    fn validator_surfaces_help_for_invalid_extension_constructor_arguments() {
+        let schema = Schema::from_json_value(json!({
+            "": {
+                "entityTypes": {
+                    "User": {},
+                    "Document": {},
+                },
+                "actions": {
+                    "view": {
+                        "appliesTo": {
+                            "principalTypes": ["User"],
+                            "resourceTypes": ["Document"],
+                        }
+                    }
+                }
+            }
+        }))
+        .unwrap();
+        let validator = Validator::new(schema);
+
+        let mut set = PolicySet::new();
+        let src = r#"permit(
+            principal == User::"alice",
+            action == Action::"view",
+            resource == Document::"doc"
+        ) when { decimal("foo").lessThan(decimal("1.0")) };"#;
+        let policy = Policy::parse(None, src).unwrap();
+        set.add(policy).unwrap();
+
+        let result = validator.validate(&set, ValidationMode::Strict);
+        let errors: Vec<_> = result.validation_errors().cloned().collect();
+        assert_eq!(errors.len(), 1, "unexpected validation errors: {errors:?}");
+
+        expect_err(
+            src,
+            &Report::new(errors[0].clone()),
+            &ExpectedErrorMessageBuilder::error(
+                "for policy `policy0`, error during extension function argument validation: failed to parse as a decimal value: `\"foo\"`",
+            )
+            .help("valid decimal strings look like `12.34`: digits are required on both sides of `.`, up to 4 fractional digits are allowed, and the value must be in range -922337203685477.5808 to 922337203685477.5807")
+            .exactly_one_underline(r#"decimal("foo").lessThan(decimal("1.0"))"#)
+            .build(),
+        );
+    }
+}
+
 mod issue_604 {
     use crate::Policy;
     use cedar_policy_core::parser::parse_policy_or_template_to_est;
@@ -7927,6 +7983,7 @@ mod context_tests {
             "",
             &Report::new(err),
             &ExpectedErrorMessageBuilder::error("error while evaluating `ipaddr` extension function: invalid IP address: not_an_ip_address")
+                .help("valid IP strings are IPv4/IPv6 addresses or CIDR ranges like `127.0.0.1`, `127.0.0.1/24`, or `ffee::/64`")
                 .build(),
         );
 


### PR DESCRIPTION
## Description of changes

Closes #834

This PR adds help text to `FunctionArgumentValidationError` so validator errors for invalid extension function arguments include human-readable format guidance when available.

Previously, these errors only surfaced a generic parse failure message. With this change, invalid arguments to extension functions such as `decimal`, `ip`, `datetime`, and `duration` can now also include help text describing the expected input format.

### What changed
- Updated extension argument validation to return structured validation errors instead of only raw strings
- Added optional help text propagation into `FunctionArgumentValidationError`
- Surfaced upstream parser help text when available, with fallback help text for cases where none is provided
- Added coverage for:
  - `ip`
  - `decimal`
  - `datetime`
  - `duration`
  - public API behavior
  - FFI behavior

This directly addresses the request in #834 to make these validator errors more actionable by explaining what valid extension function inputs should look like.

## Issue #, if available

Closes #834

## Checklist for requesting a review

The change in this PR is:

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR:

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)