### PR TITLE
Improve Cedar schema parse help for common syntax mistakes

### DIFF
--- a/cedar-policy-core/src/validator/cedar_schema/err.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/err.rs
@@ -111,9 +111,9 @@ static SCHEMA_TOKEN_CONFIG: LazyLock<ExpectedTokenConfig> = LazyLock::new(|| Exp
     first_set_sentinel: "\"{\"",
 });
 
-const MISSING_APPLIES_TO_HELP_MSG: &str =
+pub(crate) const MISSING_APPLIES_TO_HELP_MSG: &str =
     "action declarations require `appliesTo` before the `{ ... }` block";
-const TRAILING_NAMESPACE_SEMICOLON_HELP_MSG: &str =
+pub(crate) const TRAILING_NAMESPACE_SEMICOLON_HELP_MSG: &str =
     "namespace declarations are not followed by `;`; try removing this semicolon";
 
 /// For errors during parsing
@@ -153,12 +153,17 @@ impl ParseError {
         match &self.err {
             OwnedRawParseError::UnrecognizedToken {
                 token: (token_start, token, _),
-                ..
-            } if token == ";" => self
-                .src
-                .get(..*token_start)
-                .and_then(|prefix| prefix.chars().rev().find(|ch| !ch.is_whitespace()))
-                .and_then(|ch| (ch == '}').then_some(TRAILING_NAMESPACE_SEMICOLON_HELP_MSG)),
+                expected,
+            } if token == ";"
+                && expected.iter().any(|e| e == "NAMESPACE")
+                && self
+                    .src
+                    .get(..*token_start)
+                    .and_then(|prefix| prefix.chars().rev().find(|ch| !ch.is_whitespace()))
+                    == Some('}') =>
+            {
+                Some(TRAILING_NAMESPACE_SEMICOLON_HELP_MSG)
+            }
             _ => None,
         }
     }

--- a/cedar-policy-core/src/validator/cedar_schema/err.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/err.rs
@@ -111,6 +111,11 @@ static SCHEMA_TOKEN_CONFIG: LazyLock<ExpectedTokenConfig> = LazyLock::new(|| Exp
     first_set_sentinel: "\"{\"",
 });
 
+const MISSING_APPLIES_TO_HELP_MSG: &str =
+    "action declarations require `appliesTo` before the `{ ... }` block";
+const TRAILING_NAMESPACE_SEMICOLON_HELP_MSG: &str =
+    "namespace declarations are not followed by `;`; try removing this semicolon";
+
 /// For errors during parsing
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ParseError {
@@ -130,6 +135,32 @@ impl ParseError {
 
     pub(crate) fn from_raw_error_recovery(recovery: RawErrorRecovery<'_>, src: Arc<str>) -> Self {
         Self::from_raw_parse_error(recovery.error, src)
+    }
+
+    fn missing_applies_to_help(&self) -> Option<&'static str> {
+        match &self.err {
+            OwnedRawParseError::UnrecognizedToken {
+                token: (_, token, _),
+                expected,
+            } if token == "{" && expected.iter().any(|expected| expected == "APPLIESTO") => {
+                Some(MISSING_APPLIES_TO_HELP_MSG)
+            }
+            _ => None,
+        }
+    }
+
+    fn trailing_namespace_semicolon_help(&self) -> Option<&'static str> {
+        match &self.err {
+            OwnedRawParseError::UnrecognizedToken {
+                token: (token_start, token, _),
+                ..
+            } if token == ";" => self
+                .src
+                .get(..*token_start)
+                .and_then(|prefix| prefix.chars().rev().find(|ch| !ch.is_whitespace()))
+                .and_then(|ch| (ch == '}').then_some(TRAILING_NAMESPACE_SEMICOLON_HELP_MSG)),
+            _ => None,
+        }
     }
 }
 
@@ -177,6 +208,12 @@ impl std::error::Error for ParseError {}
 impl Diagnostic for ParseError {
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
         Some(&self.src as &dyn miette::SourceCode)
+    }
+
+    fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {
+        self.missing_applies_to_help()
+            .or_else(|| self.trailing_namespace_semicolon_help())
+            .map(|help| Box::new(help) as Box<dyn Display + 'a>)
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {

--- a/cedar-policy-core/src/validator/cedar_schema/test.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/test.rs
@@ -44,6 +44,21 @@ mod demo_tests {
     use itertools::Itertools;
     use miette::Diagnostic;
 
+    fn assert_schema_parse_help(src: &str, expected_error: &str, expected_help: &str) {
+        assert_matches!(
+            collect_warnings(json_schema::Fragment::from_cedarschema_str(
+                src,
+                Extensions::all_available(),
+            )),
+            Err(err) => {
+                let report = miette::Report::new(err);
+                assert_eq!(report.to_string(), expected_error);
+                let help = report.help().map(|help| help.to_string());
+                assert_eq!(help.as_deref(), Some(expected_help));
+            }
+        );
+    }
+
     #[test]
     fn no_applies_to() {
         let src = r#"
@@ -115,6 +130,38 @@ mod demo_tests {
                     .build(),
             );
         });
+    }
+
+    #[test]
+    fn missing_applies_to_help() {
+        let src = r#"
+        namespace NS1 {
+            entity User, Resource;
+            action Read { principal: [User], resource: [Resource], context: { foo: String }};
+        }
+        "#;
+
+        assert_schema_parse_help(
+            src,
+            "error parsing schema: unexpected token `{`",
+            "action declarations require `appliesTo` before the `{ ... }` block",
+        );
+    }
+
+    #[test]
+    fn namespace_trailing_semicolon_help() {
+        let src = r#"
+        namespace NS1 {
+            entity User, Resource;
+            action Read appliesTo { principal: [User], resource: [Resource], context: { foo: String }};
+        };
+        "#;
+
+        assert_schema_parse_help(
+            src,
+            "error parsing schema: unexpected token `;`",
+            "namespace declarations are not followed by `;`; try removing this semicolon",
+        );
     }
 
     #[test]

--- a/cedar-policy-core/src/validator/cedar_schema/test.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/test.rs
@@ -35,7 +35,12 @@ mod demo_tests {
     use smol_str::ToSmolStr;
 
     use crate::validator::{
-        cedar_schema::{self, err::NO_PR_HELP_MSG},
+        cedar_schema::{
+            self,
+            err::{
+                MISSING_APPLIES_TO_HELP_MSG, NO_PR_HELP_MSG, TRAILING_NAMESPACE_SEMICOLON_HELP_MSG,
+            },
+        },
         json_schema::{self, EntityType, EntityTypeKind},
         schema::test::utils::collect_warnings,
         CedarSchemaError, RawName,
@@ -43,21 +48,6 @@ mod demo_tests {
 
     use itertools::Itertools;
     use miette::Diagnostic;
-
-    fn assert_schema_parse_help(src: &str, expected_error: &str, expected_help: &str) {
-        assert_matches!(
-            collect_warnings(json_schema::Fragment::from_cedarschema_str(
-                src,
-                Extensions::all_available(),
-            )),
-            Err(err) => {
-                let report = miette::Report::new(err);
-                assert_eq!(report.to_string(), expected_error);
-                let help = report.help().map(|help| help.to_string());
-                assert_eq!(help.as_deref(), Some(expected_help));
-            }
-        );
-    }
 
     #[test]
     fn no_applies_to() {
@@ -141,11 +131,16 @@ mod demo_tests {
         }
         "#;
 
-        assert_schema_parse_help(
-            src,
-            "error parsing schema: unexpected token `{`",
-            "action declarations require `appliesTo` before the `{ ... }` block",
-        );
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: unexpected token `{`")
+                    .exactly_one_underline_with_label("{", "expected `,`, `;`, APPLIESTO, ATTRIBUTES, or `in`")
+                    .help(MISSING_APPLIES_TO_HELP_MSG)
+                    .build(),
+            );
+        });
     }
 
     #[test]
@@ -157,11 +152,16 @@ mod demo_tests {
         };
         "#;
 
-        assert_schema_parse_help(
-            src,
-            "error parsing schema: unexpected token `;`",
-            "namespace declarations are not followed by `;`; try removing this semicolon",
-        );
+        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
+            expect_err(
+                src,
+                &miette::Report::new(e),
+                &ExpectedErrorMessageBuilder::error("error parsing schema: unexpected token `;`")
+                    .exactly_one_underline_with_label(";", "expected `@`, `action`, `entity`, `namespace`, or `type`")
+                    .help(TRAILING_NAMESPACE_SEMICOLON_HELP_MSG)
+                    .build(),
+            );
+        });
     }
 
     #[test]

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - Public syntax tree representation for `Policy`, `Template` and `PolicySet` allowing programmatic manipulation of Cedar syntax (#816, #366).
 
+### Fixed
+
+- Improved Cedar schema parse help for two common syntax mistakes: forgetting `appliesTo` before an action block, and adding `;` after a namespace declaration. (#1043, #1044)
+
 ## [4.10.0] - Coming soon
 
 Cedar Language Version: 4.5


### PR DESCRIPTION
## Description of changes

This PR improves Cedar schema parse diagnostics for two common syntax mistakes in the human-readable schema format:

- forgetting appliesTo before an action block
- adding a trailing semicolon after a namespace declaration

The parser now surfaces targeted help text for both cases instead of only reporting an unexpected token.

This change is implemented in `cedar-policy-core/src/validator/cedar_schema/err.rs`, with regression coverage added in `cedar-policy-core/src/validator/cedar_schema/test.rs`.

## Issue #, if available

- Fixes #1043
- Fixes #1044

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A bug fix or other functionality change requiring a patch to `cedar-policy`.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
