### PR TITLE
feat(schema): accept empty principal/resource lists in human schema

### DIFF
--- a/cedar-policy-core/src/validator/cedar_schema/err.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/err.rs
@@ -560,7 +560,6 @@ impl ToJsonSchemaError {
         Self::NoPrincipalOrResource(NoPrincipalOrResource {
             kind: PR::Principal,
             name: name.to_smolstr(),
-            missing_or_empty: MissingOrEmpty::Missing,
             name_loc,
         })
     }
@@ -569,33 +568,6 @@ impl ToJsonSchemaError {
         Self::NoPrincipalOrResource(NoPrincipalOrResource {
             kind: PR::Resource,
             name: name.to_smolstr(),
-            missing_or_empty: MissingOrEmpty::Missing,
-            name_loc,
-        })
-    }
-
-    pub(crate) fn empty_principal(
-        name: &impl ToSmolStr,
-        name_loc: Option<Loc>,
-        loc: Option<Loc>,
-    ) -> Self {
-        Self::NoPrincipalOrResource(NoPrincipalOrResource {
-            kind: PR::Principal,
-            name: name.to_smolstr(),
-            missing_or_empty: MissingOrEmpty::Empty { loc },
-            name_loc,
-        })
-    }
-
-    pub(crate) fn empty_resource(
-        name: &impl ToSmolStr,
-        name_loc: Option<Loc>,
-        loc: Option<Loc>,
-    ) -> Self {
-        Self::NoPrincipalOrResource(NoPrincipalOrResource {
-            kind: PR::Resource,
-            name: name.to_smolstr(),
-            missing_or_empty: MissingOrEmpty::Empty { loc },
             name_loc,
         })
     }
@@ -714,31 +686,16 @@ impl Diagnostic for DuplicateDeclarations {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-#[error("{}", match .missing_or_empty {
-    MissingOrEmpty::Missing => format!("missing `{kind}` declaration for `{name}`"),
-    MissingOrEmpty::Empty { .. } => format!("for action `{name}`, `{kind}` is `[]`, which is invalid")
-})]
+#[error("missing `{kind}` declaration for `{name}`")]
 pub struct NoPrincipalOrResource {
     kind: PR,
     name: SmolStr,
-    missing_or_empty: MissingOrEmpty,
     /// Loc of the action name
     name_loc: Option<Loc>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-enum MissingOrEmpty {
-    /// The declaration was entirely missing
-    Missing,
-    /// The declaration was present but defined as `[]`
-    Empty {
-        /// `Loc` of the declaration
-        loc: Option<Loc>,
-    },
-}
-
 pub const NO_PR_HELP_MSG: &str =
-    "Every action must define both `principal` and `resource` targets, and the `principal` and `resource` lists must not be `[]`.";
+    "Every action must define both `principal` and `resource` targets. To declare that an action applies to no entities of a kind, use an empty list, e.g. `principal: []`.";
 
 impl Diagnostic for NoPrincipalOrResource {
     fn source_code(&self) -> Option<&dyn miette::SourceCode> {
@@ -748,27 +705,9 @@ impl Diagnostic for NoPrincipalOrResource {
     }
 
     fn labels(&self) -> Option<Box<dyn Iterator<Item = miette::LabeledSpan> + '_>> {
-        match &self.missing_or_empty {
-            MissingOrEmpty::Missing => self.name_loc.as_ref().map(|loc| {
-                Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span))) as _
-            }),
-            MissingOrEmpty::Empty { loc } => {
-                // also underline the bad declaration
-                let action_name = self.name_loc.as_ref().map(|loc| {
-                    miette::LabeledSpan::new_with_span(Some("for this action".into()), loc.span)
-                });
-                let decl = loc.as_ref().map(|loc| {
-                    miette::LabeledSpan::new_with_span(Some("must not be `[]`".into()), loc.span)
-                });
-                let spans: Vec<_> = [action_name, decl].into_iter().flatten().collect();
-
-                if spans.is_empty() {
-                    None
-                } else {
-                    Some(Box::new(spans.into_iter()))
-                }
-            }
-        }
+        self.name_loc
+            .as_ref()
+            .map(|loc| Box::new(std::iter::once(miette::LabeledSpan::underline(loc.span))) as _)
     }
 
     fn help<'a>(&'a self) -> Option<Box<dyn Display + 'a>> {

--- a/cedar-policy-core/src/validator/cedar_schema/fmt.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/fmt.rs
@@ -238,6 +238,16 @@ fn fmt_non_empty_slice<T: Display>(
     write!(f, "]")
 }
 
+fn fmt_slice_or_empty<T: Display>(
+    f: &mut std::fmt::Formatter<'_>,
+    slice: &[T],
+) -> std::fmt::Result {
+    match slice.split_first() {
+        None => write!(f, "[]"),
+        Some(split) => fmt_non_empty_slice(f, split),
+    }
+}
+
 impl<N: Display> Display for json_schema::EntityType<N> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.fmt_indented(f, &BaseIndentation::none())
@@ -312,37 +322,23 @@ impl<N: Display> IndentedDisplay for json_schema::ActionType<N> {
             fmt_non_empty_slice(f, parents)?;
         }
         if let Some(spec) = &self.applies_to {
-            match (
-                spec.principal_types.split_first(),
-                spec.resource_types.split_first(),
-            ) {
-                // One of the lists is empty
-                // This can only be represented by the empty action
-                // This implies an action group
-                (None, _) | (_, None) => {
-                    write!(f, "")?;
-                }
-                // Both list are non empty
-                (Some(ps), Some(rs)) => {
-                    let member_indent = base_indentation.next();
-                    write!(f, " appliesTo {{")?;
-                    write!(f, "\n{member_indent}principal: ")?;
-                    fmt_non_empty_slice(f, ps)?;
-                    write!(f, ",\n{member_indent}resource: ")?;
-                    fmt_non_empty_slice(f, rs)?;
-                    if spec.context.0.is_empty_record() {
-                        write!(f, ",\n{member_indent}context: {{}}")?;
-                    } else {
-                        write!(
-                            f,
-                            ",\n{member_indent}context: {}",
-                            Indented(&spec.context.0, &member_indent)
-                        )?;
-                    }
-
-                    write!(f, "\n{base_indentation}}}")?;
-                }
+            let member_indent = base_indentation.next();
+            write!(f, " appliesTo {{")?;
+            write!(f, "\n{member_indent}principal: ")?;
+            fmt_slice_or_empty(f, &spec.principal_types)?;
+            write!(f, ",\n{member_indent}resource: ")?;
+            fmt_slice_or_empty(f, &spec.resource_types)?;
+            if spec.context.0.is_empty_record() {
+                write!(f, ",\n{member_indent}context: {{}}")?;
+            } else {
+                write!(
+                    f,
+                    ",\n{member_indent}context: {}",
+                    Indented(&spec.context.0, &member_indent)
+                )?;
             }
+
+            write!(f, "\n{base_indentation}}}")?;
         }
         // No `appliesTo` key: action does not apply to anything
         Ok(())

--- a/cedar-policy-core/src/validator/cedar_schema/test.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/test.rs
@@ -248,6 +248,8 @@ mod demo_tests {
 
     #[test]
     fn empty_principal() {
+        // Per RFC: an empty `principal` list is accepted and means the action
+        // applies to no principal entity types.
         let src = r#"
             entity a;
             entity b;
@@ -256,15 +258,16 @@ mod demo_tests {
                 resource: [a, b]
             };
         "#;
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: for action `Foo`, `principal` is `[]`, which is invalid")
-                    .with_underlines_or_labels([("Foo", Some("for this action")), ("principal: []", Some("must not be `[]`"))])
-                    .help(NO_PR_HELP_MSG)
-                    .build(),
-            );
+        let (schema, _) =
+            json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available()).unwrap();
+        let unqual = schema.0.get(&None).unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(&foo, json_schema::ActionType {
+            applies_to: Some(json_schema::ApplySpec { resource_types, principal_types, .. }),
+            ..
+        } => {
+            assert!(principal_types.is_empty());
+            assert_eq!(resource_types.len(), 2);
         });
     }
 
@@ -278,15 +281,37 @@ mod demo_tests {
                 resource: []
             };
         "#;
-        assert_matches!(collect_warnings(json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available())), Err(e) => {
-            expect_err(
-                src,
-                &miette::Report::new(e),
-                &ExpectedErrorMessageBuilder::error("error parsing schema: for action `Foo`, `resource` is `[]`, which is invalid")
-                    .with_underlines_or_labels([("Foo", Some("for this action")), ("resource: []", Some("must not be `[]`"))])
-                    .help(NO_PR_HELP_MSG)
-                    .build(),
-            );
+        let (schema, _) =
+            json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available()).unwrap();
+        let unqual = schema.0.get(&None).unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(&foo, json_schema::ActionType {
+            applies_to: Some(json_schema::ApplySpec { resource_types, principal_types, .. }),
+            ..
+        } => {
+            assert_eq!(principal_types.len(), 2);
+            assert!(resource_types.is_empty());
+        });
+    }
+
+    #[test]
+    fn both_empty() {
+        let src = r#"
+            action Foo appliesTo {
+                principal: [],
+                resource: []
+            };
+        "#;
+        let (schema, _) =
+            json_schema::Fragment::from_cedarschema_str(src, Extensions::all_available()).unwrap();
+        let unqual = schema.0.get(&None).unwrap();
+        let foo = unqual.actions.get("Foo").unwrap();
+        assert_matches!(&foo, json_schema::ActionType {
+            applies_to: Some(json_schema::ApplySpec { resource_types, principal_types, .. }),
+            ..
+        } => {
+            assert!(principal_types.is_empty());
+            assert!(resource_types.is_empty());
         });
     }
 
@@ -526,7 +551,10 @@ namespace Baz {action "Foo" appliesTo {
         );
         let fragment = json_schema::Fragment(BTreeMap::from([(None, namespace)]));
         let src = fragment.to_cedarschema().unwrap();
-        assert!(src.contains(r#"action "j";"#), "schema was: `{src}`")
+        // An empty `resource_types` list is now represented explicitly as
+        // `resource: []` in the human schema (see RFC: accept empty principal/resource lists).
+        assert!(src.contains("principal: [a]"), "schema was: `{src}`");
+        assert!(src.contains("resource: []"), "schema was: `{src}`");
     }
 
     #[test]

--- a/cedar-policy-core/src/validator/cedar_schema/to_json_schema.rs
+++ b/cedar-policy-core/src/validator/cedar_schema/to_json_schema.rs
@@ -314,22 +314,13 @@ fn convert_app_decls(
                     )
                     .into());
                 }
-                None => match entity_tys {
-                    None => {
-                        return Err(ToJsonSchemaError::empty_principal(
-                            name,
-                            name_loc.cloned(),
-                            loc,
-                        )
-                        .into())
-                    }
-                    Some(entity_tys) => {
-                        principal_types = Some(Node::with_maybe_source_loc(
-                            entity_tys.iter().map(|n| n.clone().into()).collect(),
-                            loc,
-                        ))
-                    }
-                },
+                None => {
+                    let tys: Vec<RawName> = match entity_tys {
+                        None => Vec::new(),
+                        Some(entity_tys) => entity_tys.iter().map(|n| n.clone().into()).collect(),
+                    };
+                    principal_types = Some(Node::with_maybe_source_loc(tys, loc));
+                }
             },
             Node {
                 node:
@@ -347,19 +338,13 @@ fn convert_app_decls(
                         ToJsonSchemaError::duplicate_resource(name, existing_tys.loc, loc).into(),
                     );
                 }
-                None => match entity_tys {
-                    None => {
-                        return Err(
-                            ToJsonSchemaError::empty_resource(name, name_loc.cloned(), loc).into(),
-                        )
-                    }
-                    Some(entity_tys) => {
-                        resource_types = Some(Node::with_maybe_source_loc(
-                            entity_tys.iter().map(|n| n.clone().into()).collect(),
-                            loc,
-                        ))
-                    }
-                },
+                None => {
+                    let tys: Vec<RawName> = match entity_tys {
+                        None => Vec::new(),
+                        Some(entity_tys) => entity_tys.iter().map(|n| n.clone().into()).collect(),
+                    };
+                    resource_types = Some(Node::with_maybe_source_loc(tys, loc));
+                }
             },
         }
     }

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -16,6 +16,10 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - Public syntax tree representation for `Policy`, `Template` and `PolicySet` allowing programmatic manipulation of Cedar syntax (#816, #366).
 
+### Changed
+
+- (*) The human-readable schema syntax now accepts empty `principal` / `resource` lists in an action's `appliesTo` clause (e.g. `principal: []`), matching the semantics already defined by RFC 55 for the JSON schema: such an action applies to no entities of that kind. Omitting the `principal` / `resource` clause remains a parse error. The schema formatter now emits `principal: []` / `resource: []` explicitly when the corresponding list is empty, restoring JSON-to-human round-tripping for those schemas. (cedar-policy/rfcs#113)
+
 ### Fixed
 
 - Improved Cedar schema parse help for two common syntax mistakes: forgetting `appliesTo` before an action block, and adding `;` after a namespace declaration. (#1043, #1044)


### PR DESCRIPTION
## Description of changes

Align the human-readable schema parser with [RFC 55](https://github.com/cedar-policy/rfcs/blob/main/text/0055-remove-unspecified.md) semantics, which already define an empty `principal` / `resource` list as *"the action applies to no entities of that kind"* and are honored by the JSON parser and the validator. Before this change, the human parser alone rejected `principal: []` / `resource: []` with `"is '[]', which is invalid"`, breaking JSON ⇄ human round-tripping and forcing downstream users of partial authorization (e.g. multi-issuer flows calling `is_authorized_partial`) to declare a sentinel entity solely to pacify the parser.

**What changes:**

- `to_json_schema.rs`: accept an empty `entity_tys` and lower it to `principal_types: vec![]` / `resource_types: vec![]`.
- `err.rs`: drop the `MissingOrEmpty::Empty` variant and the `empty_principal` / `empty_resource` constructors. `NoPrincipalOrResource` now covers only the still-rejected "clause omitted" case. Help text updated to suggest `principal: []` when that is the author's intent.
- `fmt.rs`: when `principal_types` or `resource_types` is empty, emit the explicit `[]` form rather than suppressing the entire `appliesTo` block. Restores round-trippability for JSON schemas that use empty lists.
- `test.rs`: invert `empty_principal` / `empty_resource` rejection assertions into acceptance assertions; add a `both_empty` test; update `print_actions` to assert the new formatter output.

**Scope guarantees:**

- Omitting the `principal` / `resource` clause entirely **remains a parse error**, per RFC 55.
- No change to JSON schema parsing, validator, evaluator, or authorization APIs.
- No currently-valid schema changes meaning. No currently-valid schema becomes invalid.

This is the **reference implementation for [cedar-policy/rfcs#113](https://github.com/cedar-policy/rfcs/pull/113)**. Please do not merge until that RFC is accepted; I'm opening this PR as a draft so maintainers have code to discuss alongside the RFC.

## Issue #, if available

Related: #1335 (improved the error message for this case but did not revisit the rejection), #351 (predecessor discussion, `requires-RFC`).

## Checklist for requesting a review

The change in this PR is:

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

Note: marked as the closest-fitting option because this is a human-schema parser change in `cedar-policy-core`, with no `cedar-policy` Rust API change. It *is* a language-level behavior change (a schema form that used to fail to parse now parses), so I have marked the CHANGELOG entry with `(*)` per the repo convention.

I confirm that this PR:

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec):

- [x] I'm not sure how my change impacts `cedar-spec`.

The formal model in `cedar-spec` covers authorization; the human-schema parser is outside that scope, but I'd like confirmation from maintainers whether the Lean formalization of the schema surface syntax needs updating.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/):

- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)

Once this PR and RFC #113 are accepted, I will open a companion PR in `cedar-docs` updating the schema-syntax reference to document the accepted `principal: []` / `resource: []` form and the motivating partial-authorization use case.
