### PR TITLE
Support template links in TPE

### DIFF
--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1702,6 +1702,90 @@ fn test_tpe() {
         .code(0);
 }
 
+#[test]
+#[cfg(feature = "tpe")]
+fn test_tpe_link() {
+    let entities: &str = "sample-data/tpe_rfc/entities.json";
+    let schema: &str = "sample-data/tpe_rfc/schema.cedarschema";
+
+    let mut template_file = tempfile::NamedTempFile::new().expect("Failed to create template file");
+    writeln!(
+        template_file,
+        r#"@id("ViewTemplate")
+permit (
+  principal == ?principal,
+  action == Action::"View",
+  resource
+)
+when {{ resource.isPublic }};"#
+    )
+    .expect("Failed to write template file");
+
+    let links_file = tempfile::NamedTempFile::new().expect("Failed to create links file");
+    let template_path = template_file.path().to_str().unwrap().to_string();
+    let links_path = links_file.path().to_str().unwrap().to_string();
+
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("link")
+        .arg("-p")
+        .arg(&template_path)
+        .arg("--template-linked")
+        .arg(&links_path)
+        .arg("--template-id")
+        .arg("ViewTemplate")
+        .arg("--new-id")
+        .arg("AliceView")
+        .arg("-a")
+        .arg(r#"{"?principal": "User::\"Alice\""}"#)
+        .assert()
+        .code(0);
+
+    // TPE with linked template. No resource eid, so decision is unknown
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("tpe")
+        .arg("--principal-type")
+        .arg("User")
+        .arg("--principal-eid")
+        .arg("Alice")
+        .arg("-a")
+        .arg(r#"Action::"View""#)
+        .arg("--resource-type")
+        .arg("Document")
+        .arg("-p")
+        .arg(&template_path)
+        .arg("--template-linked")
+        .arg(&links_path)
+        .arg("--entities")
+        .arg(entities)
+        .arg("-s")
+        .arg(schema)
+        .assert()
+        .stdout(predicate::str::contains("UNKNOWN"))
+        .code(0);
+
+    // Still no resource eid, but request is for bob, so deny
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("tpe")
+        .arg("--principal-type")
+        .arg("User")
+        .arg("--principal-eid")
+        .arg("Bob")
+        .arg("-a")
+        .arg(r#"Action::"View""#)
+        .arg("--resource-type")
+        .arg("Document")
+        .arg("-p")
+        .arg(&template_path)
+        .arg("--template-linked")
+        .arg(&links_path)
+        .arg("--entities")
+        .arg(entities)
+        .arg("-s")
+        .arg(schema)
+        .assert()
+        .code(2);
+}
+
 #[rstest]
 #[case("principal")]
 #[case("1 + 1")]

--- a/cedar-policy-cli/tests/sample.rs
+++ b/cedar-policy-cli/tests/sample.rs
@@ -1648,6 +1648,14 @@ fn test_tpe() {
     let request_json_file: &str = "sample-data/tpe_rfc/request.json";
     let context_file: &str = "sample-data/tpe_rfc/context.json";
 
+    let contains_residuals = || {
+        use predicate::str::contains;
+        contains("UNKNOWN")
+            .and(contains("permit(principal, action, resource) when { resource.isPublic };"))
+            .and(contains("permit(principal, action, resource) when { false };"))
+            .and(contains(r#"permit(principal, action, resource) when { (context.hasMFA) && ((resource.owner) == User::"Alice") };"#))
+    };
+
     cargo::cargo_bin_cmd!("cedar")
         .arg("tpe")
         .arg("--principal-type")
@@ -1665,6 +1673,7 @@ fn test_tpe() {
         .arg("-s")
         .arg(schema)
         .assert()
+        .stdout(contains_residuals())
         .code(0);
 
     cargo::cargo_bin_cmd!("cedar")
@@ -1686,6 +1695,7 @@ fn test_tpe() {
         .arg("--context")
         .arg(context_file)
         .assert()
+        .stdout(predicate::str::contains("DENY"))
         .code(2);
 
     cargo::cargo_bin_cmd!("cedar")
@@ -1699,6 +1709,7 @@ fn test_tpe() {
         .arg("-s")
         .arg(schema)
         .assert()
+        .stdout(contains_residuals())
         .code(0);
 }
 
@@ -1722,8 +1733,8 @@ when {{ resource.isPublic }};"#
     .expect("Failed to write template file");
 
     let links_file = tempfile::NamedTempFile::new().expect("Failed to create links file");
-    let template_path = template_file.path().to_str().unwrap().to_string();
-    let links_path = links_file.path().to_str().unwrap().to_string();
+    let template_path = template_file.path().to_str().unwrap();
+    let links_path = links_file.path().to_str().unwrap();
 
     cargo::cargo_bin_cmd!("cedar")
         .arg("link")
@@ -1740,7 +1751,33 @@ when {{ resource.isPublic }};"#
         .assert()
         .code(0);
 
-    // TPE with linked template. No resource eid, so decision is unknown
+    // Template link value has been substituted in residual
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("tpe")
+        .arg("--principal-type")
+        .arg("User")
+        .arg("-a")
+        .arg(r#"Action::"View""#)
+        .arg("--resource-type")
+        .arg("Document")
+        .arg("-p")
+        .arg(template_path)
+        .arg("--template-linked")
+        .arg(links_path)
+        .arg("--entities")
+        .arg(entities)
+        .arg("-s")
+        .arg(schema)
+        .assert()
+        .stdout(
+            predicate::str::contains("UNKNOWN").and(predicate::str::contains(
+                r#"permit(principal, action, resource) when { (principal == User::"Alice") && (resource.isPublic) };"#
+            )),
+        )
+        .code(0);
+
+    // Now providing principal eid, equality between slot and principal
+    // evaluates, but we still have a residual
     cargo::cargo_bin_cmd!("cedar")
         .arg("tpe")
         .arg("--principal-type")
@@ -1752,18 +1789,22 @@ when {{ resource.isPublic }};"#
         .arg("--resource-type")
         .arg("Document")
         .arg("-p")
-        .arg(&template_path)
+        .arg(template_path)
         .arg("--template-linked")
-        .arg(&links_path)
+        .arg(links_path)
         .arg("--entities")
         .arg(entities)
         .arg("-s")
         .arg(schema)
         .assert()
-        .stdout(predicate::str::contains("UNKNOWN"))
+        .stdout(
+            predicate::str::contains("UNKNOWN").and(predicate::str::contains(
+                "permit(principal, action, resource) when { resource.isPublic };",
+            )),
+        )
         .code(0);
 
-    // Still no resource eid, but request is for bob, so deny
+    // Still no resource eid, but slot/principal equality is false for Bob, so deny
     cargo::cargo_bin_cmd!("cedar")
         .arg("tpe")
         .arg("--principal-type")
@@ -1775,15 +1816,54 @@ when {{ resource.isPublic }};"#
         .arg("--resource-type")
         .arg("Document")
         .arg("-p")
-        .arg(&template_path)
+        .arg(template_path)
         .arg("--template-linked")
-        .arg(&links_path)
+        .arg(links_path)
         .arg("--entities")
         .arg(entities)
         .arg("-s")
         .arg(schema)
         .assert()
+        .stdout(predicate::str::contains("DENY"))
         .code(2);
+
+    // Fully concrete request for Alice and a public doc, so allow
+    let entities = serde_json::json!(
+    [{
+        "uid": { "type": "Document", "id": "public" },
+        "attrs": {
+            "isPublic": true,
+            "owner": { "__entity": { "type": "User", "id": "Alice" } }
+        },
+        "parents": []
+    }]);
+    let mut entities_file = tempfile::NamedTempFile::new().expect("Failed to create entities file");
+    serde_json::to_writer(&mut entities_file, &entities).unwrap();
+    let entities_path = entities_file.path().to_str().unwrap();
+
+    cargo::cargo_bin_cmd!("cedar")
+        .arg("tpe")
+        .arg("--principal-type")
+        .arg("User")
+        .arg("--principal-eid")
+        .arg("Alice")
+        .arg("-a")
+        .arg(r#"Action::"View""#)
+        .arg("--resource-type")
+        .arg("Document")
+        .arg("--resource-eid")
+        .arg("public")
+        .arg("-p")
+        .arg(template_path)
+        .arg("--template-linked")
+        .arg(links_path)
+        .arg("--entities")
+        .arg(entities_path)
+        .arg("-s")
+        .arg(schema)
+        .assert()
+        .stdout(predicate::str::contains("ALLOW"))
+        .code(0);
 }
 
 #[rstest]

--- a/cedar-policy-core/src/batched_evaluator.rs
+++ b/cedar-policy-core/src/batched_evaluator.rs
@@ -92,14 +92,13 @@ pub fn is_authorized_batched(
     max_iters: u32,
 ) -> Result<Decision, BatchedEvalError> {
     let request = concrete_request_to_partial(request, schema)?;
-    let exprs = policy_residual_map(&request, ps, schema)?;
     let mut entities = PartialEntities::default();
     let initial_evaluator = Evaluator {
         request: &request,
         entities: &entities,
         extensions: Extensions::all_available(),
     };
-    let residuals_res: Result<Vec<ResidualPolicy>, BatchedEvalError> = exprs
+    let mut residuals: Vec<ResidualPolicy> = policy_residual_map(&request, ps, schema)?
         .into_iter()
         .map(|(id, expr)| {
             let residual = initial_evaluator.interpret(&expr);
@@ -107,18 +106,10 @@ pub fn is_authorized_batched(
                 clippy::unwrap_used,
                 reason = "exprs and policy set contain the same policy ids"
             )]
-            Ok(ResidualPolicy::new(
-                Arc::new(residual),
-                Arc::new(ps.get(id).unwrap().clone()),
-            ))
+            ResidualPolicy::new(Arc::new(residual), Arc::new(ps.get(id).unwrap().clone()))
         })
         .collect();
-    let mut residuals = residuals_res?;
 
-    #[expect(
-        clippy::unwrap_used,
-        reason = "residuals and policy set contain the same policy ids"
-    )]
     for _i in 0..max_iters {
         let ids = residuals.iter().flat_map(|r| r.all_literal_uids());
         let mut to_load = HashSet::new();
@@ -156,10 +147,15 @@ pub fn is_authorized_batched(
             entities: &entities,
             extensions: Extensions::all_available(),
         };
+
         // perform partial evaluation again
         residuals = residuals
             .into_iter()
             .map(|residual| {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "residuals and policy set contain the same policy ids"
+                )]
                 ResidualPolicy::new(
                     Arc::new(evaluator.interpret(&residual.get_residual())),
                     Arc::new(ps.get(&residual.get_policy_id()).unwrap().clone()),

--- a/cedar-policy-core/src/batched_evaluator.rs
+++ b/cedar-policy-core/src/batched_evaluator.rs
@@ -27,8 +27,8 @@ use crate::authorizer::Decision;
 use crate::batched_evaluator::err::{BatchedEvalError, InsufficientIterationsError};
 use crate::entities::TCComputation;
 use crate::tpe::entities::PartialEntity;
-use crate::tpe::err::{PartialRequestError, TpeError};
-use crate::tpe::policy_expr_map;
+use crate::tpe::err::PartialRequestError;
+use crate::tpe::policy_residual_map;
 use crate::tpe::request::{PartialEntityUID, PartialRequest};
 use crate::tpe::residual::Residual;
 use crate::tpe::response::{ResidualPolicy, Response};
@@ -92,7 +92,7 @@ pub fn is_authorized_batched(
     max_iters: u32,
 ) -> Result<Decision, BatchedEvalError> {
     let request = concrete_request_to_partial(request, schema)?;
-    let exprs = policy_expr_map(&request, ps, schema)?;
+    let exprs = policy_residual_map(&request, ps, schema)?;
     let mut entities = PartialEntities::default();
     let initial_evaluator = Evaluator {
         request: &request,
@@ -102,9 +102,7 @@ pub fn is_authorized_batched(
     let residuals_res: Result<Vec<ResidualPolicy>, BatchedEvalError> = exprs
         .into_iter()
         .map(|(id, expr)| {
-            let residual = initial_evaluator
-                .interpret_expr(&expr)
-                .map_err(TpeError::from)?;
+            let residual = initial_evaluator.interpret(&expr);
             #[expect(
                 clippy::unwrap_used,
                 reason = "exprs and policy set contain the same policy ids"

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -40,7 +40,7 @@ pub(crate) fn policy_residual_map<'a>(
     ps: &'a PolicySet,
     schema: &ValidatorSchema,
 ) -> std::result::Result<HashMap<&'a PolicyID, Residual>, TpeError> {
-    let mut exprs = HashMap::new();
+    let mut residuals = HashMap::new();
     let tc = Typechecker::new(schema, crate::validator::ValidationMode::Strict);
     let env = request.find_request_env(schema)?;
     for p in ps.policies() {
@@ -56,21 +56,21 @@ pub(crate) fn policy_residual_map<'a>(
         let env = env.clone().link_slot_env(p.env());
         match tc.typecheck_by_single_request_env(t, &env) {
             PolicyCheck::Success(expr) => {
-                exprs.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
+                residuals.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
             }
             PolicyCheck::Fail(errs) => {
                 return Err(TpeError::Validation(errs));
             }
             PolicyCheck::Irrelevant(errs, expr) => {
                 if errs.is_empty() {
-                    exprs.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
+                    residuals.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
                 } else {
                     return Err(TpeError::Validation(errs));
                 }
             }
         }
     }
-    Ok(exprs)
+    Ok(residuals)
 }
 
 /// Type-aware partial-evaluation on a `PolicySet`.

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -83,13 +83,12 @@ pub fn is_authorized<'a>(
     entities: &'a PartialEntities,
     schema: &'a ValidatorSchema,
 ) -> std::result::Result<Response<'a>, TpeError> {
-    let exprs = policy_residual_map(request, ps, schema)?;
     let evaluator = Evaluator {
         request,
         entities,
         extensions: Extensions::all_available(),
     };
-    let residuals: Vec<_> = exprs
+    let residuals = policy_residual_map(request, ps, schema)?
         .into_iter()
         .map(|(id, residual)| {
             let residual = evaluator.interpret(&residual);
@@ -98,15 +97,9 @@ pub fn is_authorized<'a>(
                 reason = "exprs and policy set contain the same policy ids"
             )]
             ResidualPolicy::new(Arc::new(residual), Arc::new(ps.get(id).unwrap().clone()))
-        })
-        .collect();
+        });
 
-    Ok(Response::new(
-        residuals.into_iter(),
-        request,
-        entities,
-        schema,
-    ))
+    Ok(Response::new(residuals, request, entities, schema))
 }
 
 #[cfg(test)]

--- a/cedar-policy-core/src/tpe.rs
+++ b/cedar-policy-core/src/tpe.rs
@@ -25,29 +25,25 @@ pub mod response;
 
 use std::{collections::HashMap, sync::Arc};
 
-use crate::ast::{Expr, PolicyID};
-use crate::tpe::err::{NonstaticPolicyError, TpeError};
+use crate::ast::PolicyID;
+use crate::tpe::err::TpeError;
+use crate::tpe::residual::Residual;
 use crate::tpe::response::{ResidualPolicy, Response};
-use crate::validator::types::Type;
 use crate::validator::Validator;
 use crate::validator::{typecheck::PolicyCheck, typecheck::Typechecker, ValidatorSchema};
 use crate::{ast::PolicySet, extensions::Extensions};
 
 use crate::tpe::{entities::PartialEntities, evaluator::Evaluator, request::PartialRequest};
 
-pub(crate) fn policy_expr_map<'a>(
+pub(crate) fn policy_residual_map<'a>(
     request: &'a PartialRequest,
     ps: &'a PolicySet,
     schema: &ValidatorSchema,
-) -> std::result::Result<HashMap<&'a PolicyID, Expr<Option<Type>>>, TpeError> {
+) -> std::result::Result<HashMap<&'a PolicyID, Residual>, TpeError> {
     let mut exprs = HashMap::new();
     let tc = Typechecker::new(schema, crate::validator::ValidationMode::Strict);
     let env = request.find_request_env(schema)?;
     for p in ps.policies() {
-        if !p.is_static() {
-            return Err(NonstaticPolicyError.into());
-        }
-
         let t = p.template();
 
         let errs: Vec<_> = Validator::validate_entity_types_and_literals(schema, t).collect();
@@ -55,16 +51,19 @@ pub(crate) fn policy_expr_map<'a>(
             return Err(TpeError::Validation(errs));
         }
 
+        // Get an environment using the actual types of the entities linked with
+        // this template. If static, the slot env is empty and this is a no-op.
+        let env = env.clone().link_slot_env(p.env());
         match tc.typecheck_by_single_request_env(t, &env) {
             PolicyCheck::Success(expr) => {
-                exprs.insert(p.id(), expr);
+                exprs.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
             }
             PolicyCheck::Fail(errs) => {
                 return Err(TpeError::Validation(errs));
             }
             PolicyCheck::Irrelevant(errs, expr) => {
                 if errs.is_empty() {
-                    exprs.insert(p.id(), expr);
+                    exprs.insert(p.id(), Residual::try_from_typed_expr(&expr, p.env())?);
                 } else {
                     return Err(TpeError::Validation(errs));
                 }
@@ -84,29 +83,26 @@ pub fn is_authorized<'a>(
     entities: &'a PartialEntities,
     schema: &'a ValidatorSchema,
 ) -> std::result::Result<Response<'a>, TpeError> {
-    let exprs = policy_expr_map(request, ps, schema)?;
+    let exprs = policy_residual_map(request, ps, schema)?;
     let evaluator = Evaluator {
         request,
         entities,
         extensions: Extensions::all_available(),
     };
-    let residuals: Result<Vec<_>, TpeError> = exprs
+    let residuals: Vec<_> = exprs
         .into_iter()
-        .map(|(id, expr)| {
-            let residual = evaluator.interpret_expr(&expr)?;
+        .map(|(id, residual)| {
+            let residual = evaluator.interpret(&residual);
             #[expect(
                 clippy::unwrap_used,
                 reason = "exprs and policy set contain the same policy ids"
             )]
-            Ok(ResidualPolicy::new(
-                Arc::new(residual),
-                Arc::new(ps.get(id).unwrap().clone()),
-            ))
+            ResidualPolicy::new(Arc::new(residual), Arc::new(ps.get(id).unwrap().clone()))
         })
         .collect();
 
     Ok(Response::new(
-        residuals?.into_iter(),
+        residuals.into_iter(),
         request,
         entities,
         schema,

--- a/cedar-policy-core/src/tpe/err.rs
+++ b/cedar-policy-core/src/tpe/err.rs
@@ -28,7 +28,7 @@ use crate::{
         conformance::err::{EntitySchemaConformanceError, InvalidEnumEntityError},
         err::Duplicate,
     },
-    evaluator::EvaluationError,
+    evaluator::{evaluation_errors::UnlinkedSlotError, EvaluationError},
     transitive_closure::TcError,
     validator::{RequestValidationError, ValidationError},
 };
@@ -119,7 +119,7 @@ pub enum ExprToResidualError {
     MissingTypeAnnotation(#[from] MissingTypeAnnotationError),
     /// Expression contains a slot which is not supported in residuals
     #[error(transparent)]
-    SlotNotSupported(#[from] SlotNotSupportedError),
+    UnlinkedSlotError(#[from] UnlinkedSlotError),
     /// Expression contains an unknown which is not supported in residuals
     #[error(transparent)]
     UnknownNotSupported(#[from] UnknownNotSupportedError),
@@ -132,11 +132,6 @@ pub enum ExprToResidualError {
 #[derive(Debug, Error)]
 #[error("Expression is missing type annotation")]
 pub struct MissingTypeAnnotationError;
-
-/// Error thrown when expression contains a slot which is not supported in residuals
-#[derive(Debug, Error)]
-#[error("Expression contains a slot which is not supported in residuals")]
-pub struct SlotNotSupportedError;
 
 /// Error thrown when expression contains an unknown which is not supported in residuals
 #[derive(Debug, Error)]

--- a/cedar-policy-core/src/tpe/evaluator.rs
+++ b/cedar-policy-core/src/tpe/evaluator.rs
@@ -18,10 +18,8 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use crate::tpe::err::ExprToResidualError;
-use crate::validator::types::Type;
 use crate::{
-    ast::{self, BinaryOp, EntityUID, Expr, PartialValue, Set, Value, ValueKind, Var},
+    ast::{self, BinaryOp, EntityUID, PartialValue, Set, Value, ValueKind, Var},
     evaluator::stack_size_check,
     extensions::Extensions,
 };
@@ -41,11 +39,6 @@ pub struct Evaluator<'e> {
 }
 
 impl Evaluator<'_> {
-    /// Interpret a typed expression by converting to a [`Residual`]
-    pub fn interpret_expr(&self, e: &Expr<Option<Type>>) -> Result<Residual, ExprToResidualError> {
-        Ok(self.interpret(&Residual::try_from(e)?))
-    }
-
     /// Interpret a typed expression into a residual
     /// This function always succeeds because it wraps an error encountered
     /// into a `ResidualKind::Error`
@@ -636,7 +629,8 @@ fn normalize_ext_value(value: Value) -> Value {
 mod tests {
     use std::collections::{BTreeMap, HashSet};
 
-    use crate::ast::UnwrapInfallible;
+    use crate::ast::{Expr, SlotEnv, UnwrapInfallible};
+    use crate::tpe::err::ExprToResidualError;
     use crate::validator::types::Type;
     use crate::{
         ast::{
@@ -666,6 +660,18 @@ mod tests {
     #[track_caller]
     fn dummy_uid() -> EntityUID {
         r#"E::"""#.parse().unwrap()
+    }
+
+    impl Evaluator<'_> {
+        /// Interpret a typed expression by converting to a [`Residual`] with an empty slot environment.
+        ///
+        /// This is a test-only utility because other callers should generally
+        /// be interpreting a residual with slots bounds appropriately by
+        /// `policy_residual_map` or else explicitly bindings slots (with an
+        /// empty environment or otherwise).
+        fn interpret_expr(&self, e: &Expr<Option<Type>>) -> Result<Residual, ExprToResidualError> {
+            Ok(self.interpret(&Residual::try_from_typed_expr(e, &SlotEnv::new())?))
+        }
     }
 
     #[test]

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -20,14 +20,12 @@ use std::collections::HashSet;
 use std::{collections::BTreeMap, sync::Arc, sync::LazyLock};
 
 use crate::ast::{
-    Annotations, Effect, EntityUID, Literal, Policy, PolicyID, UnwrapInfallible, ValueKind,
+    Annotations, Effect, EntityUID, Literal, Policy, PolicyID, SlotEnv, UnwrapInfallible, ValueKind,
 };
+use crate::evaluator::evaluation_errors;
 #[cfg(feature = "tolerant-ast")]
 use crate::tpe::err::ErrorNotSupportedError;
-use crate::tpe::err::{
-    ExprToResidualError, MissingTypeAnnotationError, SlotNotSupportedError,
-    UnknownNotSupportedError,
-};
+use crate::tpe::err::{ExprToResidualError, MissingTypeAnnotationError, UnknownNotSupportedError};
 use crate::validator::types::Type;
 use crate::{
     ast::{self, BinaryOp, EntityType, Expr, Name, Pattern, UnaryOp, Value, Var},
@@ -180,9 +178,16 @@ impl TryFrom<Residual> for Value {
     }
 }
 
-impl TryFrom<&Expr<Option<Type>>> for Residual {
-    type Error = ExprToResidualError;
-    fn try_from(expr: &Expr<Option<Type>>) -> std::result::Result<Self, ExprToResidualError> {
+impl Residual {
+    /// Convert a typed expression to a residual.
+    ///
+    /// Takes a `SlotEnv` used to resolve template slots to their values. Each
+    /// template slot expression becomes an entityUID literal for the binding of
+    /// that slot in the environment.
+    pub fn try_from_typed_expr(
+        expr: &Expr<Option<Type>>,
+        env: &SlotEnv,
+    ) -> std::result::Result<Self, ExprToResidualError> {
         let ty = expr.data().clone().ok_or(MissingTypeAnnotationError)?;
 
         // Otherwise, convert to a partial residual
@@ -193,59 +198,64 @@ impl TryFrom<&Expr<Option<Type>>> for Residual {
                 then_expr,
                 else_expr,
             } => ResidualKind::If {
-                test_expr: Arc::new(Self::try_from(test_expr.as_ref())?),
-                then_expr: Arc::new(Self::try_from(then_expr.as_ref())?),
-                else_expr: Arc::new(Self::try_from(else_expr.as_ref())?),
+                test_expr: Arc::new(Self::try_from_typed_expr(test_expr.as_ref(), env)?),
+                then_expr: Arc::new(Self::try_from_typed_expr(then_expr.as_ref(), env)?),
+                else_expr: Arc::new(Self::try_from_typed_expr(else_expr.as_ref(), env)?),
             },
             ast::ExprKind::And { left, right } => ResidualKind::And {
-                left: Arc::new(Self::try_from(left.as_ref())?),
-                right: Arc::new(Self::try_from(right.as_ref())?),
+                left: Arc::new(Self::try_from_typed_expr(left.as_ref(), env)?),
+                right: Arc::new(Self::try_from_typed_expr(right.as_ref(), env)?),
             },
             ast::ExprKind::Or { left, right } => ResidualKind::Or {
-                left: Arc::new(Self::try_from(left.as_ref())?),
-                right: Arc::new(Self::try_from(right.as_ref())?),
+                left: Arc::new(Self::try_from_typed_expr(left.as_ref(), env)?),
+                right: Arc::new(Self::try_from_typed_expr(right.as_ref(), env)?),
             },
             ast::ExprKind::UnaryApp { op, arg } => ResidualKind::UnaryApp {
                 op: *op,
-                arg: Arc::new(Self::try_from(arg.as_ref())?),
+                arg: Arc::new(Self::try_from_typed_expr(arg.as_ref(), env)?),
             },
             ast::ExprKind::BinaryApp { op, arg1, arg2 } => ResidualKind::BinaryApp {
                 op: *op,
-                arg1: Arc::new(Self::try_from(arg1.as_ref())?),
-                arg2: Arc::new(Self::try_from(arg2.as_ref())?),
+                arg1: Arc::new(Self::try_from_typed_expr(arg1.as_ref(), env)?),
+                arg2: Arc::new(Self::try_from_typed_expr(arg2.as_ref(), env)?),
             },
             ast::ExprKind::ExtensionFunctionApp { fn_name, args } => {
-                let residual_args: Result<Vec<_>, _> = args.iter().map(Self::try_from).collect();
+                let residual_args: Result<Vec<_>, _> = args
+                    .iter()
+                    .map(|e| Self::try_from_typed_expr(e, env))
+                    .collect();
                 ResidualKind::ExtensionFunctionApp {
                     fn_name: fn_name.clone(),
                     args: Arc::new(residual_args?),
                 }
             }
             ast::ExprKind::GetAttr { expr, attr } => ResidualKind::GetAttr {
-                expr: Arc::new(Self::try_from(expr.as_ref())?),
+                expr: Arc::new(Self::try_from_typed_expr(expr.as_ref(), env)?),
                 attr: attr.clone(),
             },
             ast::ExprKind::HasAttr { expr, attr } => ResidualKind::HasAttr {
-                expr: Arc::new(Self::try_from(expr.as_ref())?),
+                expr: Arc::new(Self::try_from_typed_expr(expr.as_ref(), env)?),
                 attr: attr.clone(),
             },
             ast::ExprKind::Like { expr, pattern } => ResidualKind::Like {
-                expr: Arc::new(Self::try_from(expr.as_ref())?),
+                expr: Arc::new(Self::try_from_typed_expr(expr.as_ref(), env)?),
                 pattern: pattern.clone(),
             },
             ast::ExprKind::Is { expr, entity_type } => ResidualKind::Is {
-                expr: Arc::new(Self::try_from(expr.as_ref())?),
+                expr: Arc::new(Self::try_from_typed_expr(expr.as_ref(), env)?),
                 entity_type: entity_type.clone(),
             },
             ast::ExprKind::Set(elements) => {
-                let residual_elements: Result<Vec<_>, _> =
-                    elements.iter().map(Self::try_from).collect();
+                let residual_elements: Result<Vec<_>, _> = elements
+                    .iter()
+                    .map(|e| Self::try_from_typed_expr(e, env))
+                    .collect();
                 ResidualKind::Set(Arc::new(residual_elements?))
             }
             ast::ExprKind::Record(map) => {
                 let residual_map: Result<BTreeMap<_, _>, ExprToResidualError> = map
                     .iter()
-                    .map(|(k, v)| Ok((k.clone(), Self::try_from(v)?)))
+                    .map(|(k, v)| Ok((k.clone(), Self::try_from_typed_expr(v, env)?)))
                     .collect();
                 ResidualKind::Record(Arc::new(residual_map?))
             }
@@ -254,8 +264,21 @@ impl TryFrom<&Expr<Option<Type>>> for Residual {
                 let value = Value::new(lit.clone(), None);
                 return Ok(Residual::Concrete { value, ty });
             }
-            // These are not supported in residuals
-            ast::ExprKind::Slot(_) => return Err(SlotNotSupportedError.into()),
+            // Slots are resolved to their linked values in translation to residual
+            ast::ExprKind::Slot(slot) => match env.get(slot) {
+                Some(euid) => {
+                    let value = Value::from(euid.clone());
+                    return Ok(Residual::Concrete { value, ty });
+                }
+                None => {
+                    // Any slot not bound in the env is an error now rather than waiting for evaluation
+                    return Err(evaluation_errors::UnlinkedSlotError {
+                        slot: *slot,
+                        source_loc: None,
+                    }
+                    .into());
+                }
+            },
             ast::ExprKind::Unknown(_) => return Err(UnknownNotSupportedError.into()),
             #[cfg(feature = "tolerant-ast")]
             ast::ExprKind::Error { .. } => {
@@ -539,20 +562,30 @@ impl From<Residual> for Expr {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::ast::{ActionConstraint, PrincipalConstraint, ResourceConstraint, SlotId, Template};
     use crate::extensions::Extensions;
     use crate::parser::parse_expr;
     use crate::tpe::request::{PartialEntityUID, PartialRequest};
     use crate::validator::typecheck::{PolicyCheck, Typechecker};
     use crate::validator::types::BoolType;
     use crate::validator::{ValidationMode, Validator, ValidatorSchema};
+    use cool_asserts::assert_matches;
     use similar_asserts::assert_eq;
 
     #[track_caller]
-    fn parse_residual(expr_str: &str) -> Residual {
+    fn parse_typed_expr(expr_str: &str, slot_env: &SlotEnv) -> Expr<Option<Type>> {
         let expr = parse_expr(expr_str).unwrap();
         let policy_id = crate::ast::PolicyID::from_string("test");
-        let policy = Policy::from_when_clause(Effect::Permit, expr, policy_id, None);
-        let t = policy.template();
+        let t = Template::new_shared(
+            policy_id,
+            None,
+            Arc::new(Annotations::default()),
+            Effect::Permit,
+            PrincipalConstraint::any(),
+            ActionConstraint::any(),
+            ResourceConstraint::any(),
+            Some(Arc::new(expr)),
+        );
 
         let schema = ValidatorSchema::from_cedarschema_str(r#"
             entity User in Organization { foo: Bool, str: String, num: Long, period: __cedar::duration, set: Set<String> } tags String;
@@ -580,14 +613,17 @@ mod test {
             &schema,
         )
         .unwrap();
-        let env = request.find_request_env(&schema).unwrap();
+        let env = request
+            .find_request_env(&schema)
+            .unwrap()
+            .link_slot_env(slot_env);
 
-        let errs: Vec<_> = Validator::validate_entity_types_and_literals(&schema, t).collect();
+        let errs: Vec<_> = Validator::validate_entity_types_and_literals(&schema, &t).collect();
         if !errs.is_empty() {
             panic!("unexpected type error in expression");
         }
-        match typechecker.typecheck_by_single_request_env(t, &env) {
-            PolicyCheck::Success(expr) => Residual::try_from(&expr).unwrap(),
+        match typechecker.typecheck_by_single_request_env(&t, &env) {
+            PolicyCheck::Success(expr) => expr,
             PolicyCheck::Fail(errs) => {
                 println!("got {} type errors", errs.len());
                 for e in errs {
@@ -597,7 +633,7 @@ mod test {
             }
             PolicyCheck::Irrelevant(errs, expr) => {
                 if errs.is_empty() {
-                    Residual::try_from(&expr).unwrap()
+                    expr
                 } else {
                     println!("got {} type errors", errs.len());
                     for e in errs {
@@ -607,6 +643,54 @@ mod test {
                 }
             }
         }
+    }
+
+    #[track_caller]
+    fn parse_residual(expr_str: &str) -> Residual {
+        let typed_expr = parse_typed_expr(expr_str, &SlotEnv::new());
+        Residual::try_from_typed_expr(&typed_expr, &SlotEnv::new()).unwrap()
+    }
+
+    #[test]
+    fn slot_to_residual() {
+        let env = SlotEnv::from([
+            (SlotId::principal(), r#"User::"alice""#.parse().unwrap()),
+            (
+                SlotId::resource(),
+                r#"Organization::"org""#.parse().unwrap(),
+            ),
+        ]);
+
+        assert_eq!(
+            Expr::from(
+                Residual::try_from_typed_expr(
+                    &parse_typed_expr(
+                        "principal == ?principal && resource in ?resource",
+                        &env
+                    ),
+                    &env
+                )
+                .unwrap()
+            ),
+            // extra `true &&` because `parse_type_expr` constructs a policy for typechecking
+            parse_expr(r#"true && (true && (true && (principal == User::"alice" && resource in Organization::"org")))"#)
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn to_residual_missing_slot() {
+        let env = SlotEnv::new();
+
+        assert_matches!(
+            Residual::try_from_typed_expr(&parse_typed_expr("principal in ?principal", &env), &env),
+            Err(ExprToResidualError::UnlinkedSlotError(_))
+        );
+
+        assert_matches!(
+            Residual::try_from_typed_expr(&parse_typed_expr("resource in ?resource", &env), &env),
+            Err(ExprToResidualError::UnlinkedSlotError(_))
+        );
     }
 
     #[test]

--- a/cedar-policy-core/src/tpe/residual.rs
+++ b/cedar-policy-core/src/tpe/residual.rs
@@ -274,7 +274,7 @@ impl Residual {
                     // Any slot not bound in the env is an error now rather than waiting for evaluation
                     return Err(evaluation_errors::UnlinkedSlotError {
                         slot: *slot,
-                        source_loc: None,
+                        source_loc: expr.source_loc().cloned(),
                     }
                     .into());
                 }

--- a/cedar-policy-core/src/validator/typecheck.rs
+++ b/cedar-policy-core/src/validator/typecheck.rs
@@ -236,11 +236,9 @@ impl<'a> Typechecker<'a> {
     ) -> Box<dyn Iterator<Item = RequestEnv<'b>> + 'c> {
         match env {
             RequestEnv::UndeclaredAction => Box::new(std::iter::once(RequestEnv::UndeclaredAction)),
-            RequestEnv::DeclaredAction {
+            env @ RequestEnv::DeclaredAction {
                 principal,
-                action,
                 resource,
-                context,
                 ..
             } => Box::new(
                 self.possible_slot_links(
@@ -256,14 +254,7 @@ impl<'a> Typechecker<'a> {
                         resource,
                         t.resource_constraint().as_inner(),
                     )
-                    .map(move |r_slot| RequestEnv::DeclaredAction {
-                        principal,
-                        action,
-                        resource,
-                        context,
-                        principal_slot: p_slot.clone(),
-                        resource_slot: r_slot,
-                    })
+                    .map(move |r_slot| env.clone().link(p_slot.clone(), r_slot))
                 }),
             ),
         }

--- a/cedar-policy-core/src/validator/types/request_env.rs
+++ b/cedar-policy-core/src/validator/types/request_env.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use crate::ast::{EntityType, EntityUID, RequestType};
+use crate::ast::{EntityType, EntityUID, RequestType, SlotEnv, SlotId};
 
 use crate::validator::ValidatorSchema;
 
@@ -66,6 +66,46 @@ impl<'a> RequestEnv<'a> {
                 resource: (*resource).clone(),
             }),
             RequestEnv::UndeclaredAction => None,
+        }
+    }
+
+    /// Create a linked request environment with type bindings derived from the
+    /// actual types of the entity bound in the argument environment.
+    pub fn link_slot_env(self, slot_env: &SlotEnv) -> RequestEnv<'a> {
+        self.link(
+            slot_env
+                .get(&SlotId::principal())
+                .map(|e| e.entity_type().clone()),
+            slot_env
+                .get(&SlotId::resource())
+                .map(|e| e.entity_type().clone()),
+        )
+    }
+
+    /// Create a linked request environment with type bindings for principal and
+    /// resource slots and with the same principal, action, resource and context
+    /// types.
+    pub fn link(
+        self,
+        principal_slot: Option<EntityType>,
+        resource_slot: Option<EntityType>,
+    ) -> RequestEnv<'a> {
+        match self {
+            RequestEnv::DeclaredAction {
+                principal,
+                action,
+                resource,
+                context,
+                ..
+            } => RequestEnv::DeclaredAction {
+                principal,
+                action,
+                resource,
+                context,
+                principal_slot,
+                resource_slot,
+            },
+            RequestEnv::UndeclaredAction => RequestEnv::UndeclaredAction,
         }
     }
 

--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -15,6 +15,8 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 ### Added
 
 - Public syntax tree representation for `Policy`, `Template` and `PolicySet` allowing programmatic manipulation of Cedar syntax (#816, #366).
+- The Type-aware partial evaluation (TPE) experimental feature now supports template-linked policies. This would previously return a `SlotNotSupportedError` error.
+  This error variant is removed and replaced with `UnlinkedSlotError` (#2314).
 
 ### Fixed
 

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -2781,4 +2781,137 @@ when { principal in resource.admins };
             "residual expression should contain an error node"
         );
     }
+
+    mod template_links {
+        use std::{collections::HashMap, str::FromStr, sync::Arc};
+
+        use crate::{
+            pst, Decision, EntityUid, PartialEntities, PartialEntityUid, PartialRequest, PolicyId,
+            PolicySet, Schema, SlotId, Template,
+        };
+
+        fn schema() -> Schema {
+            Schema::from_str(
+                "entity User { age: Long }; entity Photo; action view appliesTo { principal: User, resource: Photo};",
+            )
+            .unwrap()
+        }
+
+        fn template_policy_set() -> PolicySet {
+            let mut policies = PolicySet::new();
+            let template = Template::parse(
+                Some(PolicyId::new("t0").clone()),
+                "permit(principal == ?principal, action, resource);",
+            )
+            .unwrap();
+            policies.add_template(template).unwrap();
+            let template = Template::parse(
+                Some(PolicyId::new("t1").clone()),
+                "permit(principal, action, resource == ?resource);",
+            )
+            .unwrap();
+            policies.add_template(template).unwrap();
+            policies
+        }
+
+        fn partial_req() -> PartialRequest {
+            PartialRequest::new(
+                PartialEntityUid::from_concrete(r#"User::"alice""#.parse().unwrap()),
+                r#"Action::"view""#.parse().unwrap(),
+                PartialEntityUid::new("Photo".parse().unwrap(), None),
+                None,
+                &schema(),
+            )
+            .unwrap()
+        }
+
+        #[test]
+        fn concrete_allow() {
+            let schema = schema();
+            let mut policies = template_policy_set();
+            policies
+                .link(
+                    PolicyId::new("t0"),
+                    PolicyId::new("l"),
+                    HashMap::from([(
+                        SlotId::principal(),
+                        EntityUid::from_str(r#"User::"alice""#).unwrap(),
+                    )]),
+                )
+                .unwrap();
+
+            let request = partial_req();
+            let es = PartialEntities::empty();
+            let response = policies.tpe(&request, &es, &schema).unwrap();
+
+            assert_eq!(response.decision(), Some(Decision::Allow));
+        }
+
+        #[test]
+        fn concrete_deny() {
+            let schema = schema();
+            let mut policies = template_policy_set();
+            policies
+                .link(
+                    PolicyId::new("t0"),
+                    PolicyId::new("l"),
+                    HashMap::from([(
+                        SlotId::principal(),
+                        EntityUid::from_str(r#"User::"bob""#).unwrap(),
+                    )]),
+                )
+                .unwrap();
+
+            let request = partial_req();
+            let es = PartialEntities::empty();
+            let response = policies.tpe(&request, &es, &schema).unwrap();
+
+            assert_eq!(response.decision(), Some(Decision::Deny));
+        }
+
+        #[test]
+        fn residual() {
+            let schema = schema();
+            let mut policies = template_policy_set();
+            policies
+                .link(
+                    PolicyId::new("t1"),
+                    PolicyId::new("l"),
+                    HashMap::from([(
+                        SlotId::resource(),
+                        EntityUid::from_str(r#"Photo::"p""#).unwrap(),
+                    )]),
+                )
+                .unwrap();
+
+            let request = partial_req();
+            let es = PartialEntities::empty();
+            let response = policies.tpe(&request, &es, &schema).unwrap();
+
+            assert_eq!(response.decision(), None);
+
+            let expected = pst::Template::new(
+                "l",
+                pst::Effect::Permit,
+                pst::PrincipalConstraint::Any,
+                pst::ActionConstraint::Any,
+                pst::ResourceConstraint::Any,
+            )
+            .try_with_clauses([pst::Clause::When(Arc::new(pst::Expr::BinaryOp {
+                op: pst::BinaryOp::Eq,
+                left: Arc::new(pst::Expr::Var(pst::Var::Resource)),
+                right: Arc::new(pst::Expr::Literal(pst::Literal::EntityUID(
+                    pst::EntityUID {
+                        ty: pst::EntityType::from_name(pst::Name::unqualified("Photo").unwrap()),
+                        eid: "p".into(),
+                    },
+                ))),
+            }))])
+            .unwrap();
+
+            let residuals: Vec<_> = response.nontrivial_residual_policies().collect();
+            assert_eq!(residuals[0].to_pst().unwrap().body(), &expected);
+            assert_eq!(residuals.len(), 1);
+        }
+    }
 }

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -2783,11 +2783,11 @@ when { principal in resource.admins };
     }
 
     mod template_links {
-        use std::{collections::HashMap, str::FromStr, sync::Arc};
+        use std::{collections::HashMap, str::FromStr};
 
         use crate::{
-            pst, Decision, EntityUid, PartialEntities, PartialEntityUid, PartialRequest, PolicyId,
-            PolicySet, Schema, SlotId, Template,
+            pst, Decision, EntityUid, PartialEntities, PartialEntityUid, PartialRequest, Policy,
+            PolicyId, PolicySet, Schema, SlotId, Template,
         };
 
         fn schema() -> Schema {
@@ -2848,6 +2848,18 @@ when { principal in resource.admins };
         }
 
         #[test]
+        fn templates_no_links_deny() {
+            let schema = schema();
+            let policies = template_policy_set();
+
+            let request = partial_req();
+            let es = PartialEntities::empty();
+            let response = policies.tpe(&request, &es, &schema).unwrap();
+
+            assert_eq!(response.decision(), Some(Decision::Deny));
+        }
+
+        #[test]
         fn concrete_deny() {
             let schema = schema();
             let mut policies = template_policy_set();
@@ -2888,29 +2900,17 @@ when { principal in resource.admins };
             let es = PartialEntities::empty();
             let response = policies.tpe(&request, &es, &schema).unwrap();
 
-            assert_eq!(response.decision(), None);
-
-            let expected = pst::Template::new(
-                "l",
-                pst::Effect::Permit,
-                pst::PrincipalConstraint::Any,
-                pst::ActionConstraint::Any,
-                pst::ResourceConstraint::Any,
+            let expected: pst::Policy = Policy::parse(
+                Some(PolicyId::new("l")),
+                r#"permit(principal, action, resource) when { resource == Photo::"p" };"#,
             )
-            .try_with_clauses([pst::Clause::When(Arc::new(pst::Expr::BinaryOp {
-                op: pst::BinaryOp::Eq,
-                left: Arc::new(pst::Expr::Var(pst::Var::Resource)),
-                right: Arc::new(pst::Expr::Literal(pst::Literal::EntityUID(
-                    pst::EntityUID {
-                        ty: pst::EntityType::from_name(pst::Name::unqualified("Photo").unwrap()),
-                        eid: "p".into(),
-                    },
-                ))),
-            }))])
+            .unwrap()
+            .to_pst()
             .unwrap();
 
             let residuals: Vec<_> = response.nontrivial_residual_policies().collect();
-            assert_eq!(residuals[0].to_pst().unwrap().body(), &expected);
+            assert_eq!(residuals[0].to_pst().unwrap().body(), expected.body());
+            assert_eq!(response.decision(), None);
             assert_eq!(residuals.len(), 1);
         }
     }


### PR DESCRIPTION
## Description of changes

Resolves #2314 by adding support for type-aware partial evaluation with template links.

I decided to implement this by substituting the link values into the expression (rather than passing along the slot environment) because TPE already needs to translate the `Expr` into a `Residual`, so it is simpler to handle the bindings there and then not need to add a slot variant to residuals.

This changes the public API for TPE by removing the `SlotNotSupported` error variant and adding `UnlinkedSlotError`.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [ ] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [x] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
