### PR TITLE
witness json error node serialization works

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -22,6 +22,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 
 - Improved Cedar schema parse help for two common syntax mistakes: forgetting `appliesTo` before an action block, and adding `;` after a namespace declaration. (#1043, #1044)
 - `FunctionArgumentValidation` errors now include a help message describing the expected format for extension function arguments: `decimal`, `ip`, `datetime`, and `duration`. (#834)
+- Serialization of residual policies with `error()` nodes does not fail, instead results in JSON with `{"error": []}`. (#2202)
 
 ## [4.10.0] - Coming soon
 

--- a/cedar-policy/src/api/tpe.rs
+++ b/cedar-policy/src/api/tpe.rs
@@ -2710,7 +2710,7 @@ when { principal in resource.admins };
     /// `Policy::to_pst()`, with the error node represented as
     /// `pst::Expr::ResidualError`.
     #[test]
-    fn residual_error_to_pst() {
+    fn residual_error_to_pst_and_json() {
         use cedar_policy_core::pst;
         use std::str::FromStr;
 
@@ -2776,7 +2776,6 @@ when { principal in resource.admins };
         let response = policies
             .tpe(&request, &partial_entities, &schema)
             .expect("tpe should succeed");
-
         // There should be exactly one nontrivial residual
         let residual_policies: Vec<_> = response.nontrivial_residual_policies().collect();
         assert_eq!(
@@ -2792,7 +2791,12 @@ when { principal in resource.admins };
 
         let policy = &residual_policies[0];
 
-        // Convert to PST
+        // We can serialize a policy with residual error to json
+        let json_res = policy.to_json();
+        assert!(json_res.is_ok());
+        assert!(json_res.unwrap().to_string().contains(r#"{"error":[]}"#));
+
+        // We can also convert it to PST
         let pst_policy = policy.to_pst().expect("to_pst should succeed");
         let clauses = pst_policy.body().clauses();
         assert_eq!(clauses.len(), 1);


### PR DESCRIPTION
Witnesses that https://github.com/cedar-policy/cedar/issues/2202 doesn't occur anymore.

I also tested the actual example proposed in the issue for reproduction, and can confirm it also doesn't show a bug.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):
- [x] Updates the CHANGELOG to document the fix, although fix was in another change.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):
- [x] Does not require updates because my change does not impact the Cedar language specification.