### PR TITLE
Enabling tracing the smt-lib output sent to the SMT solver.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -464,6 +464,7 @@ dependencies = [
  "smol_str",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,7 @@ dependencies = [
  "cool_asserts",
  "insta",
  "itertools 0.14.0",
+ "log",
  "miette",
  "nonempty",
  "num-bigint",
@@ -464,7 +465,6 @@ dependencies = [
  "smol_str",
  "thiserror",
  "tokio",
- "tracing",
 ]
 
 [[package]]

--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -24,6 +24,7 @@ num-traits = "0.2"
 chrono = "0.4.44"
 miette = "7.6.0"
 nonempty = "0.12.0"
+tracing = "0.1"
 
 [dev-dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }

--- a/cedar-policy-symcc/Cargo.toml
+++ b/cedar-policy-symcc/Cargo.toml
@@ -24,7 +24,7 @@ num-traits = "0.2"
 chrono = "0.4.44"
 miette = "7.6.0"
 nonempty = "0.12.0"
-tracing = "0.1"
+log = "0.4"
 
 [dev-dependencies]
 miette = { version = "7.6.0", features = ["fancy"] }

--- a/cedar-policy-symcc/src/symcc/smtlib_script.rs
+++ b/cedar-policy-symcc/src/symcc/smtlib_script.rs
@@ -23,7 +23,7 @@ async fn emitln(
     w: &mut (impl tokio::io::AsyncWrite + Unpin + ?Sized),
     str: &str,
 ) -> tokio::io::Result<()> {
-    tracing::trace!(target: "smtlib", "{str}");
+    log::trace!(target: "smtlib", "{}", str);
     w.write_all(str.as_bytes()).await?;
     w.write_all(b"\n").await?;
     Ok(())

--- a/cedar-policy-symcc/src/symcc/smtlib_script.rs
+++ b/cedar-policy-symcc/src/symcc/smtlib_script.rs
@@ -23,6 +23,7 @@ async fn emitln(
     w: &mut (impl tokio::io::AsyncWrite + Unpin + ?Sized),
     str: &str,
 ) -> tokio::io::Result<()> {
+    tracing::trace!(target: "smtlib", "{str}");
     w.write_all(str.as_bytes()).await?;
     w.write_all(b"\n").await?;
     Ok(())


### PR DESCRIPTION
## Description of changes

Enabling tracing the smt-lib output sent to the SMT solver. To trace the output sent to the SMT solver run with `RUST_LOG=tracing=smtlib`.

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)

I confirm that this PR (choose one, and delete the other options):

- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.