### PR TITLE
Nicer encoding for set literal terms

### DIFF
--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -329,7 +329,6 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
         ty_enc: &str,
         t_encs: impl ExactSizeIterator<Item = &'s str>,
     ) -> Result<SmolStr> {
-        // Currently sets must be non-empty, but we'll still handle the empty case
         let set_term = if t_encs.len() == 0 {
             format!("(as set.empty {ty_enc})")
         } else {

--- a/cedar-policy-symcc/src/symcc/encoder.rs
+++ b/cedar-policy-symcc/src/symcc/encoder.rs
@@ -327,14 +327,19 @@ impl<S: tokio::io::AsyncWrite + Unpin + Send> Encoder<'_, S> {
     pub async fn define_set<'s>(
         &mut self,
         ty_enc: &str,
-        t_encs: impl IntoIterator<Item = &'s str>,
+        t_encs: impl ExactSizeIterator<Item = &'s str>,
     ) -> Result<SmolStr> {
-        let members = t_encs
-            .into_iter()
-            .fold(format_smolstr!("(as set.empty {ty_enc})"), |acc, t| {
-                format_smolstr!("(set.insert {t} {acc})")
-            });
-        self.define_term(ty_enc, &members).await
+        // Currently sets must be non-empty, but we'll still handle the empty case
+        let set_term = if t_encs.len() == 0 {
+            format!("(as set.empty {ty_enc})")
+        } else {
+            format!(
+                "(set.insert {} (as set.empty {}))",
+                t_encs.format(" "),
+                ty_enc
+            )
+        };
+        self.define_term(ty_enc, &set_term).await
     }
 
     pub async fn define_record<'s>(


### PR DESCRIPTION
## Description of changes

Emit smtlib like `(set.insert t2 t3 t4 (as set.empty (Set E0)))` instead of `(set.insert t2 (set.insert t3 (set.insert t4 (as set.empty (Set E0)))))` which helps with reading some large sets we might see in examples from differential testing.

I don't expect any change to solver performance, but I think the Rust code avoids some intermediate string allocations, and the encoding is just fewer bytes than before, which should be a small optimization. 

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [ ] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [x] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [ ] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [x] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
