### PR TITLE
Add tests for decodings models with unsimplified terms

### DIFF
--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -1431,3 +1431,140 @@ mod test_sexpr_parse {
         assert_matches!(parse_sexpr(b"; comment\n"), Err(DecodeError::UnexpectedEnd));
     }
 }
+
+#[cfg(test)]
+mod test_decode {
+    use std::{collections::BTreeMap, num::NonZeroU32, sync::LazyLock};
+
+    use cedar_policy::{RequestEnv, Schema};
+    use smol_str::SmolStr;
+
+    use crate::{
+        bitvec::BitVec,
+        err::Term,
+        symcc::decoder::{parse_sexpr, IdMaps},
+        term::TermVar,
+        term_type::TermType,
+        SymEnv,
+    };
+
+    static TEST_ENV: LazyLock<SymEnv> = LazyLock::new(|| {
+        SymEnv::new(
+            &Schema::from_cedarschema_str(
+                "entity E; action A appliesTo { principal: [E], resource: [E] };",
+            )
+            .unwrap()
+            .0,
+            &RequestEnv::new(
+                "E".parse().unwrap(),
+                "Action::\"A\"".parse().unwrap(),
+                "E".parse().unwrap(),
+            ),
+        )
+        .expect("Malformed sym env.")
+    });
+
+    #[track_caller]
+    fn assert_decode_var(model: &str, var: SmolStr, ty: TermType, expected: impl Into<Term>) {
+        let sexpr = parse_sexpr(model.as_bytes()).expect("failed to parse model sexpr");
+        let var = TermVar { id: var, ty };
+        let actual = sexpr
+            .decode_model(
+                &TEST_ENV,
+                &IdMaps {
+                    types: BTreeMap::new(),
+                    vars: BTreeMap::from([(&var.id, &var)]),
+                    uufs: BTreeMap::new(),
+                    enums: BTreeMap::new(),
+                },
+            )
+            .expect("failed to decode model")
+            .vars
+            .get(&var)
+            .expect("could not find expected var in model")
+            .clone();
+        assert_eq!(actual, expected.into());
+    }
+
+    #[test]
+    fn decode_literals() {
+        assert_decode_var(
+            "((define-fun x () Bool true))",
+            "x".into(),
+            TermType::Bool,
+            true,
+        );
+        assert_decode_var(
+            "((define-fun x () Bool false))",
+            "x".into(),
+            TermType::Bool,
+            false,
+        );
+        assert_decode_var(
+            "((define-fun x () (_ BitVec 2) #b11))",
+            "x".into(),
+            TermType::Bitvec {
+                n: NonZeroU32::new(2).unwrap(),
+            },
+            BitVec::of_i128(NonZeroU32::new(2).unwrap(), 3),
+        );
+        assert_decode_var(
+            r#"((define-fun x () String "foo"))"#,
+            "x".into(),
+            TermType::String,
+            SmolStr::new_static("foo"),
+        );
+    }
+
+    #[test]
+    fn decode_application() {
+        assert_decode_var(
+            "((define-fun x () Bool (not true)))",
+            "x".into(),
+            TermType::Bool,
+            false,
+        );
+        assert_decode_var(
+            "((define-fun x () Bool (not (not true)))",
+            "x".into(),
+            TermType::Bool,
+            true,
+        );
+        assert_decode_var(
+            "((define-fun x () Bool (or false true)))",
+            "x".into(),
+            TermType::Bool,
+            true,
+        );
+        assert_decode_var(
+            "((define-fun x () Bool (= true false)))",
+            "x".into(),
+            TermType::Bool,
+            false,
+        );
+        assert_decode_var(
+            r#"((define-fun x () String (ite false "foo" "bar")))"#,
+            "x".into(),
+            TermType::String,
+            SmolStr::new_static("bar"),
+        );
+        assert_decode_var(
+            "((define-fun x () Bool (bvnego #b10)))",
+            "x".into(),
+            TermType::Bool,
+            true,
+        );
+        assert_decode_var(
+            "((define-fun x () Bool (bvsaddo #b01 #b01)))",
+            "x".into(),
+            TermType::Bool,
+            true,
+        );
+        assert_decode_var(
+            "((define-fun x () Bool (bvsmulo #b010 #b010)))",
+            "x".into(),
+            TermType::Bool,
+            true,
+        );
+    }
+}

--- a/cedar-policy-symcc/src/symcc/decoder.rs
+++ b/cedar-policy-symcc/src/symcc/decoder.rs
@@ -1525,7 +1525,7 @@ mod test_decode {
             false,
         );
         assert_decode_var(
-            "((define-fun x () Bool (not (not true)))",
+            "((define-fun x () Bool (not (not true))))",
             "x".into(),
             TermType::Bool,
             true,


### PR DESCRIPTION
## Description of changes

Model decoding for symcc handles some cases where a variable isn't fully simplified (e.g., `(not true)`), linking to a case where cvc5 has previously left some terms unsimplified. However, none of these cases are exercised by any of our tests that decode actual models returned by CVC5.

## Issue #, if available

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [ ] A breaking change requiring a major version bump to `cedar-policy` (e.g., changes to the signature of an existing API).
- [ ] A backwards-compatible change requiring a minor version bump to `cedar-policy` (e.g., addition of a new API).
- [ ] A bug fix or other functionality change requiring a patch to `cedar-policy`.
- [x] A change "invisible" to users (e.g., documentation, changes to "internal" crates like `cedar-policy-core`, `cedar-validator`, etc.)
- [ ] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [x] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).
- [ ] Does not update the CHANGELOG because my change does not significantly impact released code.

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in `cedar-spec`, and how you have tested that your updates are correct.)
- [ ] Requires updates, but I do not plan to make them in the near future. (Make sure that your changes are hidden behind a feature flag to mark them as experimental.)
- [ ] I'm not sure how my change impacts `cedar-spec`. (Post your PR anyways, and we'll discuss in the comments.)

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [x] Does not require updates because my change does not impact the Cedar language specification.
- [ ] Requires updates, and I have made / will make these updates myself. (Please include in your description a timeline or link to the relevant PR in [`cedar-docs`](https://github.com/cedar-policy/cedar-docs). PRs should be targeted at a `staging-X.Y` branch, not `main`.)
- [ ] I'm not sure how my change impacts the documentation. (Post your PR anyways, and we'll discuss in the comments.)
