### PR TITLE
Fixed conversion of protobuf to API policysets

### DIFF
--- a/cedar-policy/CHANGELOG.md
+++ b/cedar-policy/CHANGELOG.md
@@ -23,6 +23,7 @@ Starting with version 3.2.4, changes marked with a star (*) are _language breaki
 - Improved Cedar schema parse help for two common syntax mistakes: forgetting `appliesTo` before an action block, and adding `;` after a namespace declaration. (#1043, #1044)
 - `FunctionArgumentValidation` errors now include a help message describing the expected format for extension function arguments: `decimal`, `ip`, `datetime`, and `duration`. (#834)
 - Serialization of residual policies with `error()` nodes does not fail, instead results in JSON with `{"error": []}`. (#2202)
+- Fixed conversion from `protobuf` policy sets to public type for policy sets containing templates and template-linked policies. (#2330)
 
 ## [4.10.0] - 2026-04-23
 

--- a/cedar-policy/src/api.rs
+++ b/cedar-policy/src/api.rs
@@ -2627,7 +2627,21 @@ impl PolicySet {
 
     /// Build the [`PolicySet`] from just the AST information
     pub(crate) fn from_ast(ast: ast::PolicySet) -> Result<Self, PolicySetError> {
-        Self::from_policies(ast.into_policies().map(Policy::from_ast))
+        let templates = ast
+            .templates()
+            .cloned()
+            .map(|t| (PolicyId::new(t.id().clone()), t.into()))
+            .collect();
+        let policies = ast
+            .policies()
+            .cloned()
+            .map(|p| (PolicyId::new(p.id().clone()), p.into()))
+            .collect();
+        Ok(Self {
+            ast,
+            policies,
+            templates,
+        })
     }
 
     /// Construct a [`PolicySet`] from a PST [`pst::PolicySet`].

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -152,3 +152,224 @@ impl traits::Protobuf for api::PolicySet {
             .expect("protobuf-encoded policy set should be a valid policy set"))
     }
 }
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, str::FromStr};
+
+    use prost::Message as _;
+
+    /// Performs a series of conversions: API -> Protobuf model -> Protobuf bytes -> Protobuf model -> API.
+    /// Checks that the input API policy set is equal to the converted policy set.
+    fn roundtrip_policies(policies: crate::PolicySet) {
+        // API -> Protobuf model
+        let policies_proto = crate::proto::models::PolicySet::from(&policies);
+        // Protobuf model -> Protobuf bytes
+        let buf = policies_proto.encode_to_vec();
+        // Protobuf bytes -> Protobuf model
+        let roundtripped_proto = crate::proto::models::PolicySet::decode(&buf[..])
+            .expect("Failed to deserialize PolicySet from protobuf");
+        // -> Protobuf model -> API
+        let roundtripped = crate::PolicySet::try_from(roundtripped_proto)
+            .expect("Failed to convert from protobuf to PolicySet");
+        similar_asserts::assert_eq!(policies, roundtripped);
+    }
+
+    fn roundtrip_policies_text(text: &str) {
+        let pset = crate::PolicySet::from_str(text).expect("Failed to parse policy set");
+        roundtrip_policies(pset);
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_template_link() {
+        let mut pset = crate::PolicySet::from_str(
+            r#"
+            @id("template0")
+            permit(principal == ?principal, action, resource);
+            "#,
+        )
+        .expect("Failed to parse policy set");
+        pset.link(
+            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("link0"),
+            HashMap::from([(
+                crate::SlotId::principal(),
+                crate::EntityUid::from_strs("User", "alice"),
+            )]),
+        )
+        .expect("Failed to link template");
+        roundtrip_policies(pset);
+    }
+
+    #[test]
+    fn roundtrip_policyset_empty() {
+        roundtrip_policies_text("");
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_static_policy() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            permit(principal, action, resource);
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_multiple_static_policies() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            permit(principal, action, resource);
+
+            @id("policy1")
+            forbid(principal, action, resource) when { context.is_restricted };
+
+            @id("policy2")
+            permit(principal == User::"alice", action == Action::"read", resource in Folder::"shared");
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_when_and_unless() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            permit(principal, action, resource)
+                when { resource.owner == principal }
+                unless { principal.suspended };
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_annotations() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            @advice("allow owner access")
+            permit(principal, action == Action::"write", resource)
+            when { resource.owner == principal };
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_multiple_template_links() {
+        let mut pset = crate::PolicySet::from_str(
+            r#"
+            @id("template0")
+            permit(principal == ?principal, action, resource in ?resource);
+            "#,
+        )
+        .expect("Failed to parse policy set");
+        pset.link(
+            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("link0"),
+            HashMap::from([
+                (
+                    crate::SlotId::principal(),
+                    crate::EntityUid::from_strs("User", "alice"),
+                ),
+                (
+                    crate::SlotId::resource(),
+                    crate::EntityUid::from_strs("Folder", "shared"),
+                ),
+            ]),
+        )
+        .expect("Failed to link template");
+        pset.link(
+            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("link1"),
+            HashMap::from([
+                (
+                    crate::SlotId::principal(),
+                    crate::EntityUid::from_strs("User", "bob"),
+                ),
+                (
+                    crate::SlotId::resource(),
+                    crate::EntityUid::from_strs("Folder", "private"),
+                ),
+            ]),
+        )
+        .expect("Failed to link template");
+        roundtrip_policies(pset);
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_static_and_templates() {
+        let mut pset = crate::PolicySet::from_str(
+            r#"
+            @id("static0")
+            forbid(principal, action, resource) unless { context.authenticated };
+
+            @id("template0")
+            permit(principal == ?principal, action, resource);
+            "#,
+        )
+        .expect("Failed to parse policy set");
+        pset.link(
+            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("link0"),
+            HashMap::from([(
+                crate::SlotId::principal(),
+                crate::EntityUid::from_strs("User", "admin"),
+            )]),
+        )
+        .expect("Failed to link template");
+        roundtrip_policies(pset);
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_is_constraint() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            permit(principal is User, action, resource is Folder);
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_is_in_constraint() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            permit(principal is User in Group::"admins", action, resource);
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_action_in_set() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            permit(principal, action in [Action::"read", Action::"list"], resource);
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_extension_functions() {
+        roundtrip_policies_text(
+            r#"
+            @id("policy0")
+            forbid(principal, action, resource)
+                when { !context.src_ip.isInRange(ip("10.0.0.0/8")) };
+            "#,
+        );
+    }
+
+    #[test]
+    fn roundtrip_policyset_with_unlinked_template() {
+        roundtrip_policies_text(
+            r#"
+            @id("template0")
+            permit(principal == ?principal, action, resource);
+            "#,
+        );
+    }
+}

--- a/cedar-policy/src/proto/api.rs
+++ b/cedar-policy/src/proto/api.rs
@@ -184,13 +184,12 @@ mod test {
     fn roundtrip_policyset_with_template_link() {
         let mut pset = crate::PolicySet::from_str(
             r#"
-            @id("template0")
             permit(principal == ?principal, action, resource);
             "#,
         )
         .expect("Failed to parse policy set");
         pset.link(
-            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("policy0"),
             crate::PolicyId::new("link0"),
             HashMap::from([(
                 crate::SlotId::principal(),
@@ -210,7 +209,6 @@ mod test {
     fn roundtrip_policyset_with_static_policy() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             permit(principal, action, resource);
             "#,
         );
@@ -220,13 +218,10 @@ mod test {
     fn roundtrip_policyset_with_multiple_static_policies() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             permit(principal, action, resource);
 
-            @id("policy1")
             forbid(principal, action, resource) when { context.is_restricted };
 
-            @id("policy2")
             permit(principal == User::"alice", action == Action::"read", resource in Folder::"shared");
             "#,
         );
@@ -236,7 +231,6 @@ mod test {
     fn roundtrip_policyset_with_when_and_unless() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             permit(principal, action, resource)
                 when { resource.owner == principal }
                 unless { principal.suspended };
@@ -248,7 +242,6 @@ mod test {
     fn roundtrip_policyset_with_annotations() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             @advice("allow owner access")
             permit(principal, action == Action::"write", resource)
             when { resource.owner == principal };
@@ -260,13 +253,12 @@ mod test {
     fn roundtrip_policyset_with_multiple_template_links() {
         let mut pset = crate::PolicySet::from_str(
             r#"
-            @id("template0")
             permit(principal == ?principal, action, resource in ?resource);
             "#,
         )
         .expect("Failed to parse policy set");
         pset.link(
-            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("policy0"),
             crate::PolicyId::new("link0"),
             HashMap::from([
                 (
@@ -281,7 +273,7 @@ mod test {
         )
         .expect("Failed to link template");
         pset.link(
-            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("policy0"),
             crate::PolicyId::new("link1"),
             HashMap::from([
                 (
@@ -302,16 +294,15 @@ mod test {
     fn roundtrip_policyset_with_static_and_templates() {
         let mut pset = crate::PolicySet::from_str(
             r#"
-            @id("static0")
             forbid(principal, action, resource) unless { context.authenticated };
 
-            @id("template0")
             permit(principal == ?principal, action, resource);
             "#,
         )
         .expect("Failed to parse policy set");
+        println!("{:?}", pset);
         pset.link(
-            crate::PolicyId::new("template0"),
+            crate::PolicyId::new("policy1"),
             crate::PolicyId::new("link0"),
             HashMap::from([(
                 crate::SlotId::principal(),
@@ -326,7 +317,6 @@ mod test {
     fn roundtrip_policyset_with_is_constraint() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             permit(principal is User, action, resource is Folder);
             "#,
         );
@@ -336,7 +326,6 @@ mod test {
     fn roundtrip_policyset_with_is_in_constraint() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             permit(principal is User in Group::"admins", action, resource);
             "#,
         );
@@ -346,7 +335,6 @@ mod test {
     fn roundtrip_policyset_with_action_in_set() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             permit(principal, action in [Action::"read", Action::"list"], resource);
             "#,
         );
@@ -356,7 +344,6 @@ mod test {
     fn roundtrip_policyset_with_extension_functions() {
         roundtrip_policies_text(
             r#"
-            @id("policy0")
             forbid(principal, action, resource)
                 when { !context.src_ip.isInRange(ip("10.0.0.0/8")) };
             "#,
@@ -367,7 +354,6 @@ mod test {
     fn roundtrip_policyset_with_unlinked_template() {
         roundtrip_policies_text(
             r#"
-            @id("template0")
             permit(principal == ?principal, action, resource);
             "#,
         );


### PR DESCRIPTION
## Description of changes
Fixed conversion from `protobuf` policy sets to public type for policy sets containing templates and template-linked policies.

## Issue #, if available
N/A

## Checklist for requesting a review

The change in this PR is (choose one, and delete the other options):

- [X] A change (breaking or otherwise) that only impacts unreleased or experimental code.

I confirm that this PR (choose one, and delete the other options):

- [X] Updates the "Unreleased" section of the CHANGELOG with a description of my change (required for major/minor version bumps).

I confirm that [`cedar-spec`](https://github.com/cedar-policy/cedar-spec) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar formal model or DRT infrastructure.

I confirm that [`docs.cedarpolicy.com`](https://docs.cedarpolicy.com/) (choose one, and delete the other options):

- [X] Does not require updates because my change does not impact the Cedar language specification.